### PR TITLE
IMAP: fetch and parse email messages (backend, part 1 of #2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashify"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1246c0e5493286aeb2dde35b1f4eb9c4ce00e628641210a5e553fc001a1f26"
+dependencies = [
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mail-parser"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
+dependencies = [
+ "hashify",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,7 +2534,9 @@ dependencies = [
  "async-imap",
  "async-native-tls",
  "async-std",
+ "chrono",
  "futures",
+ "mail-parser",
  "nimbus-core",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ async-std = { version = "1.13", features = ["attributes"] }
 futures = "0.3"
 # SMTP
 lettre = { version = "0.11", default-features = false, features = ["tokio1-rustls-tls", "smtp-transport", "builder"] }
+# MIME / email parsing (headers, bodies, encodings)
+mail-parser = "0.11"
 # Internal crates
 nimbus-core = { path = "crates/nimbus-core" }
 nimbus-imap = { path = "crates/nimbus-imap" }

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -16,6 +16,25 @@ pub struct Account {
     pub use_jmap: bool,
 }
 
+/// Lightweight email metadata for list views.
+///
+/// This is what we fetch when populating the mail list sidebar — just
+/// enough to render a row. Full body / HTML / attachments come from
+/// a separate `fetch_message` call when the user clicks an email.
+///
+/// `uid` is the IMAP UID within the folder and uniquely identifies the
+/// message across sessions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmailEnvelope {
+    pub uid: u32,
+    pub folder: String,
+    pub from: String,
+    pub subject: String,
+    pub date: DateTime<Utc>,
+    pub is_read: bool,
+    pub is_starred: bool,
+}
+
 /// Represents an email message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Email {

--- a/crates/nimbus-imap/Cargo.toml
+++ b/crates/nimbus-imap/Cargo.toml
@@ -12,3 +12,5 @@ async-imap.workspace = true
 async-native-tls.workspace = true
 async-std.workspace = true
 futures.workspace = true
+mail-parser.workspace = true
+chrono.workspace = true

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -4,10 +4,12 @@
 use async_imap::Session;
 use async_native_tls::TlsStream;
 use async_std::net::TcpStream;
+use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
+use mail_parser::MessageParser;
 use nimbus_core::error::NimbusError;
-use nimbus_core::models::Folder;
-use tracing::{debug, info};
+use nimbus_core::models::{Email, EmailEnvelope, Folder};
+use tracing::{debug, info, warn};
 
 /// An authenticated IMAP session, ready to interact with mailboxes.
 ///
@@ -140,6 +142,277 @@ impl ImapClient {
         Ok(folders)
     }
 
+    /// Select a folder for reading (uses EXAMINE — read-only, no state changes).
+    ///
+    /// In IMAP you must SELECT (or EXAMINE) a folder before you can fetch messages
+    /// from it. EXAMINE is like SELECT but opens the mailbox read-only, so marking
+    /// messages as seen, etc. won't happen as a side effect. Returns the number
+    /// of messages in the folder (the `exists` count from the server).
+    async fn select_folder(&mut self, folder: &str) -> Result<u32, NimbusError> {
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        let mailbox = session.examine(folder).await.map_err(|e| {
+            NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
+        })?;
+
+        debug!("Selected '{folder}' ({} messages)", mailbox.exists);
+        Ok(mailbox.exists)
+    }
+
+    /// Fetch lightweight envelope data for the newest `limit` messages in a folder.
+    ///
+    /// This is what populates the mail list view — it's deliberately cheap:
+    /// no message bodies, just the headers + flags. For a 10,000-message inbox
+    /// we only pull the newest 50 or so at a time.
+    ///
+    /// IMAP messages have two kinds of identifiers:
+    /// - **sequence numbers**: 1..N in current session, change as messages are deleted
+    /// - **UIDs**: stable across sessions — this is what we store and return
+    ///
+    /// We fetch by sequence number (easier to ask "the last 50") but expose the UID.
+    pub async fn fetch_envelopes(
+        &mut self,
+        folder: &str,
+        limit: u32,
+    ) -> Result<Vec<EmailEnvelope>, NimbusError> {
+        let total = self.select_folder(folder).await?;
+        if total == 0 {
+            return Ok(Vec::new());
+        }
+
+        // Take the newest `limit` messages. IMAP sequence numbers start at 1
+        // and higher numbers = newer messages, so we want `start..=total`.
+        let start = total.saturating_sub(limit.saturating_sub(1)).max(1);
+        let range = format!("{start}:{total}");
+
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        // Ask for: UID, flags, internal date, and the envelope (which contains
+        // parsed From/To/Subject/Date already — the server does this work for us).
+        let fetches: Vec<_> = session
+            .fetch(&range, "(UID FLAGS INTERNALDATE ENVELOPE)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("FETCH failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read FETCH response: {e}")))?;
+
+        let mut envelopes: Vec<EmailEnvelope> = fetches
+            .iter()
+            .filter_map(|fetch| {
+                let uid = fetch.uid?;
+                let envelope = fetch.envelope()?;
+
+                // Subject — decode the RFC 2047 header if needed. async-imap
+                // returns raw bytes; mail-parser's header_to_string handles
+                // the encoded-word decoding for us.
+                let subject = envelope
+                    .subject
+                    .as_ref()
+                    .map(|s| decode_header(s))
+                    .unwrap_or_default();
+
+                // From — take the first address, formatted as "Name <addr>"
+                let from = envelope
+                    .from
+                    .as_ref()
+                    .and_then(|addrs| addrs.first())
+                    .map(format_address)
+                    .unwrap_or_default();
+
+                let date = envelope
+                    .date
+                    .as_ref()
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .and_then(parse_rfc2822)
+                    .or_else(|| {
+                        fetch.internal_date().map(|dt| {
+                            // INTERNALDATE is a chrono::DateTime<FixedOffset>; convert to UTC
+                            dt.with_timezone(&Utc)
+                        })
+                    })
+                    .unwrap_or_else(Utc::now);
+
+                // Flags: \Seen means read, \Flagged means starred
+                let mut is_read = false;
+                let mut is_starred = false;
+                for flag in fetch.flags() {
+                    match flag {
+                        async_imap::types::Flag::Seen => is_read = true,
+                        async_imap::types::Flag::Flagged => is_starred = true,
+                        _ => {}
+                    }
+                }
+
+                Some(EmailEnvelope {
+                    uid,
+                    folder: folder.to_string(),
+                    from,
+                    subject,
+                    date,
+                    is_read,
+                    is_starred,
+                })
+            })
+            .collect();
+
+        // Server returns oldest-first within our range; reverse so newest is first
+        envelopes.reverse();
+
+        info!("Fetched {} envelopes from '{folder}'", envelopes.len());
+        Ok(envelopes)
+    }
+
+    /// Fetch a single full message (headers + body) by its UID.
+    ///
+    /// This uses UID FETCH BODY.PEEK[] to grab the entire raw RFC 5322 message,
+    /// then hands it to `mail-parser` to split out text/HTML parts, decode
+    /// transfer encodings (base64, quoted-printable), and convert charsets.
+    ///
+    /// BODY.PEEK[] is used instead of BODY[] so the server does NOT mark the
+    /// message as \Seen — we want marking-as-read to be an explicit action.
+    pub async fn fetch_message(
+        &mut self,
+        folder: &str,
+        uid: u32,
+        account_id: &str,
+    ) -> Result<Email, NimbusError> {
+        self.select_folder(folder).await?;
+
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        let fetches: Vec<_> = session
+            .uid_fetch(uid.to_string(), "(UID FLAGS INTERNALDATE BODY.PEEK[])")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID FETCH failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID FETCH: {e}")))?;
+
+        let fetch = fetches
+            .into_iter()
+            .next()
+            .ok_or_else(|| NimbusError::Protocol(format!("No message with UID {uid}")))?;
+
+        let raw = fetch
+            .body()
+            .ok_or_else(|| NimbusError::Protocol("FETCH returned no body".into()))?;
+
+        // mail-parser does the heavy lifting: MIME tree, charset decoding, etc.
+        let parsed = MessageParser::default()
+            .parse(raw)
+            .ok_or_else(|| NimbusError::Protocol("Failed to parse message".into()))?;
+
+        let subject = parsed.subject().unwrap_or("").to_string();
+        let from = parsed
+            .from()
+            .and_then(|list| list.first())
+            .map(|addr| {
+                let name = addr.name().unwrap_or("");
+                let email = addr.address().unwrap_or("");
+                if name.is_empty() {
+                    email.to_string()
+                } else {
+                    format!("{name} <{email}>")
+                }
+            })
+            .unwrap_or_default();
+
+        let to = parsed
+            .to()
+            .map(|list| {
+                list.iter()
+                    .filter_map(|a| a.address().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let cc = parsed
+            .cc()
+            .map(|list| {
+                list.iter()
+                    .filter_map(|a| a.address().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // body_text: concatenate all text/plain parts (usually just one).
+        // body_html: same for text/html. Either may be absent.
+        let body_text = (0..parsed.text_body_count())
+            .filter_map(|i| parsed.body_text(i).map(|s| s.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body_text = if body_text.is_empty() {
+            None
+        } else {
+            Some(body_text)
+        };
+
+        let body_html = (0..parsed.html_body_count())
+            .filter_map(|i| parsed.body_html(i).map(|s| s.to_string()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body_html = if body_html.is_empty() {
+            None
+        } else {
+            Some(body_html)
+        };
+
+        let has_attachments = parsed.attachment_count() > 0;
+
+        let date = parsed
+            .date()
+            .and_then(|d| {
+                // mail_parser::DateTime -> RFC3339 string -> chrono
+                DateTime::parse_from_rfc3339(&d.to_rfc3339())
+                    .ok()
+                    .map(|dt| dt.with_timezone(&Utc))
+            })
+            .or_else(|| fetch.internal_date().map(|dt| dt.with_timezone(&Utc)))
+            .unwrap_or_else(Utc::now);
+
+        let mut is_read = false;
+        let mut is_starred = false;
+        for flag in fetch.flags() {
+            match flag {
+                async_imap::types::Flag::Seen => is_read = true,
+                async_imap::types::Flag::Flagged => is_starred = true,
+                _ => {}
+            }
+        }
+
+        info!(
+            "Fetched message UID {uid} from '{folder}' ({} bytes, {} attachments)",
+            raw.len(),
+            parsed.attachment_count()
+        );
+
+        Ok(Email {
+            id: format!("{folder}:{uid}"),
+            account_id: account_id.to_string(),
+            folder: folder.to_string(),
+            from,
+            to,
+            cc,
+            subject,
+            body_text,
+            body_html,
+            date,
+            is_read,
+            is_starred,
+            has_attachments,
+        })
+    }
+
     /// Log out from the IMAP server and close the connection cleanly.
     ///
     /// Always call this when you're done — it sends the LOGOUT command
@@ -153,5 +426,61 @@ impl ImapClient {
             info!("Logged out from IMAP server");
         }
         Ok(())
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/// Decode a possibly RFC 2047-encoded header value (e.g. `=?UTF-8?B?...?=`).
+fn decode_header(bytes: &[u8]) -> String {
+    // We reuse mail-parser's header decoding by wrapping the value in a
+    // fake "Subject:" header and parsing. This handles encoded-word decoding
+    // for us. If parsing fails, fall back to lossy UTF-8.
+    let raw = format!("Subject: {}\r\n\r\n", String::from_utf8_lossy(bytes));
+    MessageParser::default()
+        .parse(raw.as_bytes())
+        .and_then(|m| m.subject().map(str::to_string))
+        .unwrap_or_else(|| String::from_utf8_lossy(bytes).into_owned())
+}
+
+/// Format an IMAP envelope address as "Name <user@host>" (or just the address).
+fn format_address(addr: &async_imap::imap_proto::types::Address<'_>) -> String {
+    let name = addr
+        .name
+        .as_ref()
+        .and_then(|b| std::str::from_utf8(b).ok())
+        .unwrap_or("");
+    let mailbox = addr
+        .mailbox
+        .as_ref()
+        .and_then(|b| std::str::from_utf8(b).ok())
+        .unwrap_or("");
+    let host = addr
+        .host
+        .as_ref()
+        .and_then(|b| std::str::from_utf8(b).ok())
+        .unwrap_or("");
+
+    let email = if mailbox.is_empty() || host.is_empty() {
+        String::new()
+    } else {
+        format!("{mailbox}@{host}")
+    };
+
+    match (name.is_empty(), email.is_empty()) {
+        (true, _) => email,
+        (false, true) => decode_header(name.as_bytes()),
+        (false, false) => format!("{} <{email}>", decode_header(name.as_bytes())),
+    }
+}
+
+/// Parse an RFC 2822 date string (as found in Date: headers) to chrono UTC.
+fn parse_rfc2822(s: &str) -> Option<DateTime<Utc>> {
+    match DateTime::parse_from_rfc2822(s) {
+        Ok(dt) => Some(dt.with_timezone(&Utc)),
+        Err(e) => {
+            warn!("Failed to parse date '{s}': {e}");
+            None
+        }
     }
 }

--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -7,8 +7,8 @@
 
 use std::path::PathBuf;
 
-use nimbus_core::models::Account;
 use nimbus_core::NimbusError;
+use nimbus_core::models::Account;
 use tracing::{debug, info};
 
 /// Returns the path to the accounts JSON file.
@@ -31,7 +31,10 @@ pub fn load_accounts() -> Result<Vec<Account>, NimbusError> {
     let path = accounts_file_path()?;
 
     if !path.exists() {
-        debug!("No accounts file found at {}, returning empty list", path.display());
+        debug!(
+            "No accounts file found at {}, returning empty list",
+            path.display()
+        );
         return Ok(Vec::new());
     }
 
@@ -41,7 +44,11 @@ pub fn load_accounts() -> Result<Vec<Account>, NimbusError> {
     let accounts: Vec<Account> = serde_json::from_str(&data)
         .map_err(|e| NimbusError::Storage(format!("failed to parse accounts file: {e}")))?;
 
-    info!("Loaded {} account(s) from {}", accounts.len(), path.display());
+    info!(
+        "Loaded {} account(s) from {}",
+        accounts.len(),
+        path.display()
+    );
     Ok(accounts)
 }
 
@@ -77,7 +84,10 @@ pub fn add_account(account: Account) -> Result<(), NimbusError> {
         )));
     }
 
-    info!("Adding account '{}' ({})", account.display_name, account.email);
+    info!(
+        "Adding account '{}' ({})",
+        account.display_name, account.email
+    );
     accounts.push(account);
     save_accounts(&accounts)
 }
@@ -89,7 +99,9 @@ pub fn remove_account(id: &str) -> Result<(), NimbusError> {
     accounts.retain(|a| a.id != id);
 
     if accounts.len() == before {
-        return Err(NimbusError::Storage(format!("no account found with id '{id}'")));
+        return Err(NimbusError::Storage(format!(
+            "no account found with id '{id}'"
+        )));
     }
 
     info!("Removed account '{id}'");
@@ -103,9 +115,14 @@ pub fn update_account(updated: Account) -> Result<(), NimbusError> {
     let existing = accounts
         .iter_mut()
         .find(|a| a.id == updated.id)
-        .ok_or_else(|| NimbusError::Storage(format!("no account found with id '{}'", updated.id)))?;
+        .ok_or_else(|| {
+            NimbusError::Storage(format!("no account found with id '{}'", updated.id))
+        })?;
 
-    info!("Updating account '{}' ({})", updated.display_name, updated.email);
+    info!(
+        "Updating account '{}' ({})",
+        updated.display_name, updated.email
+    );
     *existing = updated;
     save_accounts(&accounts)
 }
@@ -131,7 +148,10 @@ mod tests {
     #[test]
     fn accounts_file_path_is_valid() {
         let path = accounts_file_path().expect("should resolve path");
-        assert!(path.ends_with("nimbus-mail/accounts.json") || path.ends_with("nimbus-mail\\accounts.json"));
+        assert!(
+            path.ends_with("nimbus-mail/accounts.json")
+                || path.ends_with("nimbus-mail\\accounts.json")
+        );
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,8 +6,8 @@
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use nimbus_core::models::Account;
 use nimbus_core::NimbusError;
+use nimbus_core::models::Account;
 use nimbus_store::account_store;
 
 // ── Tauri commands ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Backend-only work for issue #2 — adds the IMAP fetching primitives the UI will need to show real mail. Wiring the frontend (Tauri commands + replacing the mock data in `MailList.svelte`/`MailView.svelte`) is deliberately left for a follow-up PR so this one stays reviewable.

## What's new
- **`nimbus-core::EmailEnvelope`** — lightweight list-view type (uid, folder, from, subject, date, `is_read`, `is_starred`). Separate from `Email` so we don't pay for body parsing when rendering a 50-row list.
- **`ImapClient::select_folder`** (private) — EXAMINE-based read-only folder select, shared by the fetch methods.
- **`ImapClient::fetch_envelopes(folder, limit)`** — pulls the newest `limit` messages' headers and flags in one round-trip.
- **`ImapClient::fetch_message(folder, uid, account_id)`** — full body via `mail-parser`: MIME tree, transfer encodings (base64, quoted-printable), charset conversion, RFC 2047 encoded-word headers, attachment detection.

## Design notes
- **UID vs sequence number** — fetches the list by sequence number (easier to say "last 50") but returns/stores UIDs, which are stable across sessions.
- **`BODY.PEEK[]` not `BODY[]`** — prevents the server auto-marking messages as `\Seen`. Marking-as-read will be an explicit user action.
- **Newest-first** — IMAP returns results in ascending sequence order; we reverse so the newest is at index 0.
- **`mail-parser` crate** — chosen over rolling our own MIME parser because MIME is genuinely nasty (nested multiparts, many encodings, many charsets). Stalwart's `mail-parser` is pure-Rust and widely used.

## Not in this PR (deferred to part 2)
- Tauri commands for the frontend (`fetch_envelopes`, `fetch_message`)
- Replacing mock data in `MailList.svelte` / `MailView.svelte`
- Attachment download on demand
- Pagination beyond "newest N"

## Test plan
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace`
- [ ] Manual smoke test against a real IMAP server (Gmail/Fastmail/etc.) — deferred until UI wiring is in place

Part of #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)