### PR TITLE
Incremental IMAP sync + UIDVALIDITY handling (closes #4)

### DIFF
--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -25,6 +25,18 @@ pub struct ImapClient {
     session: Option<Session<TlsStream<TcpStream>>>,
 }
 
+/// Result of a sync fetch — envelopes plus the folder's `UIDVALIDITY`.
+///
+/// Callers store the `uidvalidity` alongside the envelopes. On the next
+/// sync they compare the server's value against the stored one; if it
+/// changed, the cached UIDs point at different messages (or no messages)
+/// and the folder's local cache must be wiped and rebuilt.
+#[derive(Debug, Clone)]
+pub struct EnvelopeBatch {
+    pub uidvalidity: Option<u32>,
+    pub envelopes: Vec<EmailEnvelope>,
+}
+
 impl ImapClient {
     /// Connect to an IMAP server over TLS and log in.
     ///
@@ -147,8 +159,11 @@ impl ImapClient {
     /// In IMAP you must SELECT (or EXAMINE) a folder before you can fetch messages
     /// from it. EXAMINE is like SELECT but opens the mailbox read-only, so marking
     /// messages as seen, etc. won't happen as a side effect. Returns the number
-    /// of messages in the folder (the `exists` count from the server).
-    async fn select_folder(&mut self, folder: &str) -> Result<u32, NimbusError> {
+    /// of messages (`exists`) and the folder's `UIDVALIDITY` — a server-assigned
+    /// counter that changes whenever the folder is recreated or its UID space
+    /// resets. Callers compare this against a cached copy to detect when their
+    /// cached UIDs are no longer valid.
+    async fn select_folder(&mut self, folder: &str) -> Result<(u32, Option<u32>), NimbusError> {
         let session = self
             .session
             .as_mut()
@@ -158,50 +173,84 @@ impl ImapClient {
             NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
 
-        info!("Selected '{folder}' ({} messages)", mailbox.exists);
-        Ok(mailbox.exists)
+        info!(
+            "Selected '{folder}' ({} messages, uidvalidity={:?})",
+            mailbox.exists, mailbox.uid_validity
+        );
+        Ok((mailbox.exists, mailbox.uid_validity))
     }
 
-    /// Fetch lightweight envelope data for the newest `limit` messages in a folder.
+    /// Fetch envelopes for the mail list.
     ///
-    /// This is what populates the mail list view — it's deliberately cheap:
-    /// no message bodies, just the headers + flags. For a 10,000-message inbox
-    /// we only pull the newest 50 or so at a time.
+    /// `since_uid` toggles the strategy:
+    ///
+    /// - `None` → full mode: pull the newest `limit` messages by sequence number.
+    ///   Used on a cold cache or after a UIDVALIDITY reset.
+    /// - `Some(u)` → incremental mode: pull everything with UID `> u` via
+    ///   `UID FETCH (u+1):*`. Cheap because only genuinely new messages come
+    ///   back; the cache already has everything up to `u`.
+    ///
+    /// Returns the folder's `UIDVALIDITY` alongside the envelopes so the caller
+    /// can notice when the server has invalidated its cached UIDs.
     ///
     /// IMAP messages have two kinds of identifiers:
     /// - **sequence numbers**: 1..N in current session, change as messages are deleted
     /// - **UIDs**: stable across sessions — this is what we store and return
-    ///
-    /// We fetch by sequence number (easier to ask "the last 50") but expose the UID.
     pub async fn fetch_envelopes(
         &mut self,
         folder: &str,
         limit: u32,
-    ) -> Result<Vec<EmailEnvelope>, NimbusError> {
-        let total = self.select_folder(folder).await?;
+        since_uid: Option<u32>,
+    ) -> Result<EnvelopeBatch, NimbusError> {
+        let (total, uidvalidity) = self.select_folder(folder).await?;
         if total == 0 {
-            return Ok(Vec::new());
+            return Ok(EnvelopeBatch {
+                uidvalidity,
+                envelopes: Vec::new(),
+            });
         }
-
-        // Take the newest `limit` messages. IMAP sequence numbers start at 1
-        // and higher numbers = newer messages, so we want `start..=total`.
-        let start = total.saturating_sub(limit.saturating_sub(1)).max(1);
-        let range = format!("{start}:{total}");
 
         let session = self
             .session
             .as_mut()
             .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
 
-        // Ask for: UID, flags, internal date, and the envelope (which contains
-        // parsed From/To/Subject/Date already — the server does this work for us).
-        let fetches: Vec<_> = session
-            .fetch(&range, "(UID FLAGS INTERNALDATE ENVELOPE)")
-            .await
-            .map_err(|e| NimbusError::Protocol(format!("FETCH failed: {e}")))?
-            .try_collect()
-            .await
-            .map_err(|e| NimbusError::Protocol(format!("Failed to read FETCH response: {e}")))?;
+        // Two FETCH forms depending on mode. `uid_fetch` uses UIDs directly
+        // (survives server-side deletions), while `fetch` uses sequence numbers
+        // — the only way to say "newest N" without knowing UIDs in advance.
+        let fetches: Vec<_> = match since_uid {
+            Some(hi) => {
+                // `hi+1:*` — everything strictly newer than the last UID we saw.
+                // `*` means "the largest UID in the folder", so this always
+                // terminates even when there's nothing new (returns empty).
+                let range = format!("{}:*", hi.saturating_add(1));
+                debug!("Incremental UID FETCH {folder} range={range}");
+                session
+                    .uid_fetch(range, "(UID FLAGS INTERNALDATE ENVELOPE)")
+                    .await
+                    .map_err(|e| NimbusError::Protocol(format!("UID FETCH failed: {e}")))?
+                    .try_collect()
+                    .await
+                    .map_err(|e| {
+                        NimbusError::Protocol(format!("Failed to read UID FETCH: {e}"))
+                    })?
+            }
+            None => {
+                // Newest `limit` by sequence number. Higher seq = newer.
+                let start = total.saturating_sub(limit.saturating_sub(1)).max(1);
+                let range = format!("{start}:{total}");
+                debug!("Full FETCH {folder} range={range}");
+                session
+                    .fetch(&range, "(UID FLAGS INTERNALDATE ENVELOPE)")
+                    .await
+                    .map_err(|e| NimbusError::Protocol(format!("FETCH failed: {e}")))?
+                    .try_collect()
+                    .await
+                    .map_err(|e| {
+                        NimbusError::Protocol(format!("Failed to read FETCH response: {e}"))
+                    })?
+            }
+        };
 
         let mut envelopes: Vec<EmailEnvelope> = fetches
             .iter()
@@ -265,8 +314,19 @@ impl ImapClient {
         // Server returns oldest-first within our range; reverse so newest is first
         envelopes.reverse();
 
-        info!("Fetched {} envelopes from '{folder}'", envelopes.len());
-        Ok(envelopes)
+        info!(
+            "Fetched {} envelopes from '{folder}' ({})",
+            envelopes.len(),
+            if since_uid.is_some() {
+                "incremental"
+            } else {
+                "full"
+            }
+        );
+        Ok(EnvelopeBatch {
+            uidvalidity,
+            envelopes,
+        })
     }
 
     /// Fetch a single full message (headers + body) by its UID.
@@ -283,7 +343,7 @@ impl ImapClient {
         uid: u32,
         account_id: &str,
     ) -> Result<Email, NimbusError> {
-        self.select_folder(folder).await?;
+        let _ = self.select_folder(folder).await?;
 
         let session = self
             .session

--- a/crates/nimbus-imap/src/lib.rs
+++ b/crates/nimbus-imap/src/lib.rs
@@ -5,4 +5,4 @@
 
 mod client;
 
-pub use client::ImapClient;
+pub use client::{EnvelopeBatch, ImapClient};

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -123,6 +123,26 @@ impl Cache {
         Ok(())
     }
 
+    /// Clear all cached rows for a single folder — used when the server's
+    /// `UIDVALIDITY` for that folder has changed, meaning every UID we had
+    /// cached now refers to a different message (or none at all).
+    ///
+    /// `ON DELETE CASCADE` handles the bodies; we explicitly drop the
+    /// `folder_sync_state` row too so the next sync starts from scratch.
+    pub fn wipe_folder(&self, account_id: &str, folder: &str) -> Result<(), CacheError> {
+        let conn = self.pool.get()?;
+        conn.execute(
+            "DELETE FROM messages WHERE account_id = ?1 AND folder = ?2",
+            params![account_id, folder],
+        )?;
+        conn.execute(
+            "DELETE FROM folder_sync_state WHERE account_id = ?1 AND folder = ?2",
+            params![account_id, folder],
+        )?;
+        info!("Wiped cache for '{account_id}' / '{folder}' (UIDVALIDITY reset)");
+        Ok(())
+    }
+
     // ── Folders ─────────────────────────────────────────────────
 
     /// Replace the cached folder list for an account.
@@ -607,6 +627,34 @@ mod tests {
 
         assert!(cache.get_envelopes("acc", "INBOX", 5).unwrap().is_empty());
         assert!(cache.get_message("acc", "INBOX", 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn wipe_folder_is_scoped() {
+        let cache = open_test_cache();
+        cache.upsert_message(&make_email(1, "INBOX")).unwrap();
+        cache.upsert_message(&make_email(2, "Sent")).unwrap();
+        cache
+            .set_sync_state(
+                "acc",
+                "INBOX",
+                &SyncState {
+                    uidvalidity: Some(1),
+                    highest_uid_seen: Some(1),
+                    last_synced_at: Some(Utc::now()),
+                },
+            )
+            .unwrap();
+
+        cache.wipe_folder("acc", "INBOX").unwrap();
+
+        // INBOX is gone…
+        assert!(cache.get_envelopes("acc", "INBOX", 5).unwrap().is_empty());
+        assert!(cache.get_message("acc", "INBOX", 1).unwrap().is_none());
+        assert!(cache.get_sync_state("acc", "INBOX").unwrap().is_none());
+        // …but Sent is untouched.
+        assert_eq!(cache.get_envelopes("acc", "Sent", 5).unwrap().len(), 1);
+        assert!(cache.get_message("acc", "Sent", 2).unwrap().is_some());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -134,30 +134,71 @@ async fn fetch_envelopes_inner(
 ) -> Result<Vec<EmailEnvelope>, NimbusError> {
     let account = load_account(account_id)?;
     let mut client = connect_imap(&account).await?;
-    let envelopes = client.fetch_envelopes(folder, limit).await?;
+
+    // Consult the cache so we know whether to do an incremental or full sync.
+    // An error reading sync state is not fatal — we just fall back to full.
+    let prior = cache.get_sync_state(account_id, folder).ok().flatten();
+    let since_uid = prior.as_ref().and_then(|s| s.highest_uid_seen);
+
+    let mut batch = client.fetch_envelopes(folder, limit, since_uid).await?;
+
+    // UIDVALIDITY check. If the server has rotated it, every cached UID
+    // for this folder now points at a different (or deleted) message —
+    // wipe the folder and redo the fetch in full mode so the cache
+    // reflects reality.
+    let uidvalidity_changed = matches!(
+        (prior.as_ref().and_then(|s| s.uidvalidity), batch.uidvalidity),
+        (Some(old), Some(new)) if old != new,
+    );
+    if uidvalidity_changed {
+        tracing::warn!(
+            "UIDVALIDITY changed for '{account_id}'/'{folder}' \
+             (was {:?}, now {:?}) — wiping folder cache",
+            prior.as_ref().and_then(|s| s.uidvalidity),
+            batch.uidvalidity,
+        );
+        if let Err(e) = cache.wipe_folder(account_id, folder) {
+            tracing::warn!("cache.wipe_folder failed: {e}");
+        }
+        // Redo the fetch with no `since_uid` so we get the newest `limit`
+        // messages under the new UID space.
+        batch = client.fetch_envelopes(folder, limit, None).await?;
+    }
+
     let _ = client.logout().await;
 
-    // Write-through. If the cache write fails we still return the live
-    // data — the cache is an optimisation, not a correctness requirement,
-    // so it should never block a successful response.
-    if let Err(e) = cache.upsert_envelopes_for_account(account_id, &envelopes) {
+    // Write-through. Cache failures are logged but don't block the return:
+    // the cache is an optimisation, not a correctness requirement.
+    if let Err(e) = cache.upsert_envelopes_for_account(account_id, &batch.envelopes) {
         tracing::warn!("cache.upsert_envelopes failed: {e}");
     }
-    // Track the highest UID we just saw so a future incremental sync can
-    // start from there. `uidvalidity` is still unknown (IMAP client does
-    // not yet expose it); leave it None until #4 Part B.
-    if let Some(highest) = envelopes.iter().map(|e| e.uid).max() {
-        let state = SyncState {
-            uidvalidity: None,
-            highest_uid_seen: Some(highest),
-            last_synced_at: Some(chrono::Utc::now()),
-        };
-        if let Err(e) = cache.set_sync_state(account_id, folder, &state) {
-            tracing::warn!("cache.set_sync_state failed: {e}");
-        }
+
+    // Update sync bookmarks. `highest_uid_seen` is max(prior, newly-fetched)
+    // so an empty incremental response doesn't accidentally rewind it.
+    let new_highest = batch
+        .envelopes
+        .iter()
+        .map(|e| e.uid)
+        .max()
+        .into_iter()
+        .chain(prior.as_ref().and_then(|s| s.highest_uid_seen))
+        .max();
+    let state = SyncState {
+        uidvalidity: batch.uidvalidity,
+        highest_uid_seen: new_highest,
+        last_synced_at: Some(chrono::Utc::now()),
+    };
+    if let Err(e) = cache.set_sync_state(account_id, folder, &state) {
+        tracing::warn!("cache.set_sync_state failed: {e}");
     }
 
-    Ok(envelopes)
+    // Return the newest `limit` from the cache, not just what the server
+    // sent back — an incremental sync only ships new messages, but the
+    // UI expects a full list. Cache read is cheap (indexed by
+    // `(account_id, folder, internal_date DESC)`).
+    cache
+        .get_envelopes(account_id, folder, limit)
+        .map_err(Into::into)
 }
 
 /// Fetch a full message (headers + body) by folder + UID.


### PR DESCRIPTION
## Summary
- `ImapClient::fetch_envelopes` now takes `since_uid: Option<u32>` and returns an `EnvelopeBatch { uidvalidity, envelopes }`. `None` → full newest-N; `Some(u)` → `UID FETCH (u+1):*` for cheap incremental refresh.
- `Cache::wipe_folder` drops rows for a single folder (messages, cascaded bodies, sync state) — used when UIDVALIDITY changes so one folder can reset without nuking the whole account.
- `fetch_envelopes_inner` now reads cached sync state, compares UIDVALIDITY with the server, wipes + refetches on mismatch, otherwise does an incremental pull, then rolls `highest_uid_seen` forward as `max(prior, new)`. Returns cached newest-N so the UI still gets a full list even when the network slice is tiny.

Closes the two open items on #4 — UIDVALIDITY detection and incremental sync — so this PR closes the issue.

## Test plan
- [x] `cargo test --workspace` passes (10 tests in nimbus-store incl. new `wipe_folder_is_scoped`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Launch twice against a live server — confirm second launch does a small incremental FETCH (check logs for "incremental")
- [ ] Force UIDVALIDITY change (e.g. delete + recreate INBOX on server) — confirm wipe+refetch happens
- [ ] New mail on the server arrives in the list after refresh without a full re-pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)