### PR TITLE
Real IMAP probe on account save (closes #6)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -63,15 +63,28 @@ fn update_account(account: Account) -> Result<(), NimbusError> {
     account_store::update_account(account)
 }
 
-/// Stub: "test" a connection to the given server.
+/// Validate IMAP credentials by actually logging in.
 ///
-/// Real IMAP/SMTP connection testing will come when we wire this up to
-/// the new `ImapClient::connect` — for now this just lets the setup UI
-/// render a success message.
+/// The setup wizard calls this before it asks the store to persist the
+/// account — an early TCP/TLS/LOGIN round-trip surfaces wrong hostnames,
+/// wrong ports, and bad passwords as a structured `NimbusError` with a
+/// specific variant (`Network`, `Auth`, `Protocol`) so the UI can phrase
+/// the failure clearly instead of saving a dead account and confusing
+/// the user on first fetch.
+///
+/// The session is immediately torn down — this is a probe, not a real
+/// fetch; nothing is cached.
 #[tauri::command]
-fn test_connection(host: String, port: u16) -> Result<String, NimbusError> {
-    tracing::info!("Test connection to {host}:{port} (stub — always succeeds)");
-    Ok(format!("Connection to {host}:{port} OK (stub)"))
+async fn test_connection(
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+) -> Result<String, NimbusError> {
+    tracing::info!("Testing IMAP connection to {host}:{port} as {username}");
+    let client = ImapClient::connect(&host, port, &username, &password).await?;
+    let _ = client.logout().await;
+    Ok(format!("IMAP login to {host}:{port} succeeded"))
 }
 
 // ── IMAP commands ───────────────────────────────────────────────

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -16,6 +16,7 @@
    */
 
   import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
 
   // ── Props ───────────────────────────────────────────────────
   // Called when account setup completes successfully
@@ -83,6 +84,18 @@
     saving = true
 
     try {
+      // Probe the IMAP server with the entered credentials *before*
+      // persisting anything. This turns "saved a bad account and
+      // everything breaks silently on first fetch" into a clear,
+      // immediate error the user can act on (wrong host, wrong port,
+      // TLS failure, bad password — all surface here).
+      await invoke('test_connection', {
+        host: imapHost.trim(),
+        port: imapPort,
+        username: email.trim(),
+        password,
+      })
+
       // Generate a simple unique ID for this account.
       // crypto.randomUUID() is available in all modern browsers
       // (and Tauri's webview).
@@ -108,7 +121,7 @@
       // Success! Tell the parent component to switch to inbox
       oncomplete()
     } catch (e: any) {
-      error = typeof e === 'string' ? e : e?.message ?? 'Failed to save account'
+      error = formatError(e) || 'Failed to save account'
     } finally {
       saving = false
     }


### PR DESCRIPTION
## Summary
- `test_connection` Tauri command is no longer a stub — it performs a real `ImapClient::connect` + `logout` using the entered host/port/email/password and returns a structured `NimbusError` on failure.
- `AccountSetup.svelte` calls `test_connection` right before `add_account`, so wrong hostnames, wrong ports, TLS failures, and bad passwords surface immediately instead of getting saved into a dead account that fails on first fetch.
- Wizard error surface now goes through `formatError`, so the variant (`Auth: …`, `Network: …`, `Protocol: …`) reaches the UI with context.

Closes the final acceptance criterion on #6 ("Invalid credentials show a clear error message"). Auto-discovery via DNS SRV/MX is explicitly deferred to a follow-up issue.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `svelte-check` clean
- [ ] Manual: add an account with a wrong password → see "Auth: IMAP login failed…" inline in the wizard, no account persisted
- [ ] Manual: add with an unreachable host → see "Network: Failed to connect…"
- [ ] Manual: add with valid creds → account persists and inbox loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)