### PR TITLE
Dynamic folder list in Sidebar (closes #5)

### DIFF
--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -180,6 +180,40 @@ impl Cache {
         Ok(())
     }
 
+    /// Read the cached folder list for an account.
+    ///
+    /// Returns folders in the order they were inserted — the server's
+    /// native order, which is usually alphabetical or provider-specific.
+    /// Attributes are stored as a JSON array string and parsed back into
+    /// a `Vec<String>` here so callers see the same shape as the live
+    /// `list_folders` response.
+    pub fn get_folders(&self, account_id: &str) -> Result<Vec<Folder>, CacheError> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT name, delimiter, attributes, unread_count
+             FROM folders
+             WHERE account_id = ?1
+             ORDER BY name",
+        )?;
+        let rows = stmt.query_map(params![account_id], |r| {
+            let attrs_json: String = r.get(2)?;
+            let attributes: Vec<String> =
+                serde_json::from_str(&attrs_json).unwrap_or_default();
+            let unread: Option<i64> = r.get(3)?;
+            Ok(Folder {
+                name: r.get(0)?,
+                delimiter: r.get(1)?,
+                attributes,
+                unread_count: unread.map(|v| v as u32),
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     // ── Envelopes ───────────────────────────────────────────────
 
     /// Upsert a batch of envelopes, tagging each with the given `account_id`.
@@ -627,6 +661,50 @@ mod tests {
 
         assert!(cache.get_envelopes("acc", "INBOX", 5).unwrap().is_empty());
         assert!(cache.get_message("acc", "INBOX", 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn folders_roundtrip() {
+        let cache = open_test_cache();
+        let folders = vec![
+            Folder {
+                name: "INBOX".into(),
+                delimiter: Some("/".into()),
+                attributes: vec!["\\HasNoChildren".into()],
+                unread_count: Some(3),
+            },
+            Folder {
+                name: "Sent".into(),
+                delimiter: Some("/".into()),
+                attributes: vec!["\\Sent".into(), "\\HasNoChildren".into()],
+                unread_count: None,
+            },
+        ];
+        cache.upsert_folders("acc", &folders).unwrap();
+
+        let got = cache.get_folders("acc").unwrap();
+        assert_eq!(got.len(), 2);
+        // Ordered alphabetically: INBOX, Sent.
+        assert_eq!(got[0].name, "INBOX");
+        assert_eq!(got[0].unread_count, Some(3));
+        assert_eq!(got[1].name, "Sent");
+        assert_eq!(got[1].attributes, vec!["\\Sent", "\\HasNoChildren"]);
+
+        // Replacing the list wipes the previous rows.
+        cache
+            .upsert_folders(
+                "acc",
+                &[Folder {
+                    name: "Archive".into(),
+                    delimiter: None,
+                    attributes: vec![],
+                    unread_count: None,
+                }],
+            )
+            .unwrap();
+        let got = cache.get_folders("acc").unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "Archive");
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use nimbus_core::NimbusError;
-use nimbus_core::models::{Account, Email, EmailEnvelope};
+use nimbus_core::models::{Account, Email, EmailEnvelope, Folder};
 use nimbus_imap::ImapClient;
 use nimbus_store::cache::SyncState;
 use nimbus_store::{Cache, account_store, credentials};
@@ -251,6 +251,37 @@ async fn fetch_message_inner(
     Ok(email)
 }
 
+// ── Folder commands ─────────────────────────────────────────────
+
+/// List the account's mailboxes live from the server and write-through
+/// into the cache. Called by the Sidebar's refresh path after the
+/// cache-first render.
+#[tauri::command]
+async fn fetch_folders(
+    account_id: String,
+    cache: State<'_, Cache>,
+) -> Result<Vec<Folder>, NimbusError> {
+    let account = load_account(&account_id)?;
+    let mut client = connect_imap(&account).await?;
+    let folders = client.list_folders().await?;
+    let _ = client.logout().await;
+
+    // Write-through — cache failures are non-fatal; the live list is
+    // still returned so the UI can render something useful.
+    if let Err(e) = cache.upsert_folders(&account_id, &folders) {
+        tracing::warn!("cache.upsert_folders failed: {e}");
+    }
+    Ok(folders)
+}
+
+#[tauri::command]
+fn get_cached_folders(
+    account_id: String,
+    cache: State<'_, Cache>,
+) -> Result<Vec<Folder>, NimbusError> {
+    cache.get_folders(&account_id).map_err(Into::into)
+}
+
 // ── Cache-first read commands ───────────────────────────────────
 //
 // These return whatever's in the local cache instantly so the UI has
@@ -305,8 +336,10 @@ fn main() {
             test_connection,
             fetch_envelopes,
             fetch_message,
+            fetch_folders,
             get_cached_envelopes,
             get_cached_message,
+            get_cached_folders,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Nimbus");

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -29,6 +29,9 @@
   // switching comes later) and the currently selected message UID.
   // Kept at the App level so MailList and MailView stay in sync.
   let activeAccountId = $state<string | null>(null)
+  // Default to INBOX — the Sidebar replaces this as soon as the user
+  // picks a folder, or could switch it automatically if INBOX is absent.
+  let selectedFolder = $state<string>('INBOX')
   let selectedUid = $state<number | null>(null)
 
   // ── Check for existing accounts on startup ──────────────────
@@ -77,6 +80,14 @@
   function selectMessage(uid: number) {
     selectedUid = uid
   }
+
+  // Changing the folder resets the open message — the UID that was
+  // selected doesn't exist in the new folder, so showing it would be
+  // stale at best.
+  function selectFolder(name: string) {
+    selectedFolder = name
+    selectedUid = null
+  }
 </script>
 
 <!-- Loading state: shown briefly while we check for accounts -->
@@ -96,13 +107,19 @@
 <!-- Main inbox: the 3-panel mail client layout -->
 {:else if activeAccountId}
   <div class="h-full flex">
-    <Sidebar onsettings={goToSettings} />
+    <Sidebar
+      accountId={activeAccountId}
+      selectedFolder={selectedFolder}
+      onselectfolder={selectFolder}
+      onsettings={goToSettings}
+    />
     <MailList
       accountId={activeAccountId}
+      folder={selectedFolder}
       selectedUid={selectedUid}
       onselect={selectMessage}
     />
-    <MailView accountId={activeAccountId} uid={selectedUid} />
+    <MailView accountId={activeAccountId} folder={selectedFolder} uid={selectedUid} />
   </div>
 {:else}
   <div class="h-full flex items-center justify-center bg-surface-50 dark:bg-surface-900">

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -1,26 +1,111 @@
 <script lang="ts">
-  // Props passed from App.svelte
+  /**
+   * Sidebar — account's folder list + integration shortcuts.
+   *
+   * Folders come from the IMAP server. We load the cached list first
+   * so the sidebar paints instantly on launch, then refresh from the
+   * network in parallel (same pattern as MailList / MailView).
+   *
+   * Clicking a folder calls `onselectfolder(name)` so App.svelte can
+   * point MailList at the new folder.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+
+  interface Folder {
+    name: string
+    delimiter: string | null
+    attributes: string[]
+    unread_count: number | null
+  }
+
   interface Props {
+    accountId: string
+    selectedFolder: string
+    onselectfolder: (name: string) => void
     onsettings: () => void
   }
-  let { onsettings }: Props = $props()
+  let { accountId, selectedFolder, onselectfolder, onsettings }: Props = $props()
 
-  const folders = [
-    { name: 'Inbox', icon: '📥', count: 12 },
-    { name: 'Sent', icon: '📤', count: 0 },
-    { name: 'Drafts', icon: '📝', count: 3 },
-    { name: 'Starred', icon: '⭐', count: 5 },
-    { name: 'Trash', icon: '🗑️', count: 0 },
-  ]
+  let folders = $state<Folder[]>([])
+  let loading = $state(true)
+  let refreshing = $state(false)
+  let error = $state('')
 
+  // Integrations are still hardcoded — those are planned features, not
+  // derived from the mail server.
   const integrations = [
-    { name: 'Calendar', icon: '📅' },
-    { name: 'Contacts', icon: '👤' },
-    { name: 'Nextcloud Talk', icon: '💬' },
-    { name: 'Nextcloud Files', icon: '📁' },
+    { name: 'Calendar', icon: '\u{1F4C5}' },      // 📅
+    { name: 'Contacts', icon: '\u{1F464}' },      // 👤
+    { name: 'Nextcloud Talk', icon: '\u{1F4AC}' }, // 💬
+    { name: 'Nextcloud Files', icon: '\u{1F4C1}' },// 📁
   ]
 
-  let activeFolder = $state('Inbox')
+  $effect(() => {
+    void load(accountId)
+  })
+
+  async function load(id: string) {
+    loading = true
+    refreshing = false
+    error = ''
+
+    try {
+      const cached = await invoke<Folder[]>('get_cached_folders', { accountId: id })
+      if (id === accountId) {
+        folders = cached
+        if (cached.length > 0) loading = false
+      }
+    } catch (e) {
+      console.warn('get_cached_folders failed:', e)
+    }
+
+    refreshing = folders.length > 0
+    try {
+      const fresh = await invoke<Folder[]>('fetch_folders', { accountId: id })
+      if (id === accountId) {
+        folders = fresh
+      }
+    } catch (e) {
+      if (folders.length === 0) {
+        error = formatError(e) || 'Failed to load folders'
+      } else {
+        console.warn('fetch_folders failed (showing cached):', e)
+      }
+    } finally {
+      loading = false
+      refreshing = false
+    }
+  }
+
+  // Map IMAP folder attributes (\Sent, \Drafts, \Trash, etc.) to an
+  // emoji. Falls back to a plain folder icon. Attribute names come from
+  // async-imap's Debug formatting, so they look like `Sent`, `Drafts`,
+  // etc. — we match case-insensitively.
+  function folderIcon(f: Folder): string {
+    const name = f.name.toLowerCase()
+    const attrs = f.attributes.map((a) => a.toLowerCase())
+
+    const has = (k: string) => attrs.some((a) => a.includes(k))
+    if (name === 'inbox' || has('inbox')) return '\u{1F4E5}' // 📥
+    if (has('sent')) return '\u{1F4E4}' // 📤
+    if (has('draft')) return '\u{1F4DD}' // 📝
+    if (has('trash') || has('deleted')) return '\u{1F5D1}' // 🗑️
+    if (has('junk') || has('spam')) return '\u{1F6AB}' // 🚫
+    if (has('flagged') || has('starred')) return '\u{2B50}' // ⭐
+    if (has('archive')) return '\u{1F5C3}' // 🗃️
+    return '\u{1F4C1}' // 📁
+  }
+
+  // Short display name: strip the hierarchy prefix so "INBOX/Work" shows
+  // as "Work". INBOX itself keeps its name but title-cased.
+  function displayName(f: Folder): string {
+    if (f.name.toUpperCase() === 'INBOX') return 'Inbox'
+    const delim = f.delimiter ?? '/'
+    const parts = f.name.split(delim)
+    return parts[parts.length - 1] || f.name
+  }
 </script>
 
 <aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col">
@@ -38,27 +123,41 @@
 
   <!-- Mail folders -->
   <nav class="flex-1 overflow-y-auto px-2">
-    <p class="px-2 py-1 text-xs font-semibold text-surface-500 uppercase tracking-wider">Folders</p>
-    {#each folders as folder}
-      <button
-        class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors
-          {activeFolder === folder.name
-            ? 'bg-primary-500/10 text-primary-500 font-medium'
-            : 'hover:bg-surface-200 dark:hover:bg-surface-700'}"
-        onclick={() => (activeFolder = folder.name)}
-      >
-        <span>{folder.icon}</span>
-        <span class="flex-1 text-left">{folder.name}</span>
-        {#if folder.count > 0}
-          <span class="badge preset-filled-primary-500 text-xs">{folder.count}</span>
-        {/if}
-      </button>
-    {/each}
+    <p class="px-2 py-1 text-xs font-semibold text-surface-500 uppercase tracking-wider flex items-center justify-between">
+      <span>Folders</span>
+      {#if refreshing}
+        <span class="text-[10px] font-normal normal-case tracking-normal text-surface-500">Refreshing…</span>
+      {/if}
+    </p>
+
+    {#if loading}
+      <p class="px-3 py-2 text-xs text-surface-500">Loading folders…</p>
+    {:else if error}
+      <p class="px-3 py-2 text-xs text-red-500">{error}</p>
+    {:else if folders.length === 0}
+      <p class="px-3 py-2 text-xs text-surface-500">No folders.</p>
+    {:else}
+      {#each folders as folder (folder.name)}
+        <button
+          class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors
+            {selectedFolder === folder.name
+              ? 'bg-primary-500/10 text-primary-500 font-medium'
+              : 'hover:bg-surface-200 dark:hover:bg-surface-700'}"
+          onclick={() => onselectfolder(folder.name)}
+        >
+          <span>{folderIcon(folder)}</span>
+          <span class="flex-1 text-left truncate">{displayName(folder)}</span>
+          {#if folder.unread_count && folder.unread_count > 0}
+            <span class="badge preset-filled-primary-500 text-xs">{folder.unread_count}</span>
+          {/if}
+        </button>
+      {/each}
+    {/if}
 
     <hr class="my-3 border-surface-200 dark:border-surface-700" />
 
     <p class="px-2 py-1 text-xs font-semibold text-surface-500 uppercase tracking-wider">Integrations</p>
-    {#each integrations as item}
+    {#each integrations as item (item.name)}
       <button
         class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm hover:bg-surface-200 dark:hover:bg-surface-700 transition-colors"
       >


### PR DESCRIPTION
## Summary
- New Tauri commands: `fetch_folders` (network + write-through) and `get_cached_folders` (instant cache read).
- `Cache::get_folders` reads the folders table (already populated by `upsert_folders`, no schema change needed).
- Sidebar no longer hardcodes the folder list — it loads from cache first, kicks off `fetch_folders` in parallel, and swaps in the fresh list when it lands. Subtle "Refreshing…" hint during refresh.
- Folder selection lives on `App.svelte` now, flowing down to Sidebar, MailList, and MailView. Switching folder clears the selected UID (it's meaningless in another folder).
- Icons are inferred from IMAP attributes (`\Sent`, `\Drafts`, `\Trash`, …) rather than English names, so non-English mailboxes still get the right glyph. Display names strip the hierarchy prefix (`INBOX/Work` → `Work`).

Closes #5 — "list folders" was the one outstanding task; every other checklist item was already satisfied by prior PRs.

## Test plan
- [x] `cargo test -p nimbus-store` — 11 tests pass (new `folders_roundtrip`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `svelte-check` clean
- [ ] Manual: launch against a live account, sidebar shows server folders (INBOX, Sent, Drafts, …) with unread counts
- [ ] Manual: relaunch offline, sidebar paints from cache instantly
- [ ] Manual: click a non-INBOX folder → MailList switches, selected message clears, icon/name reasonable for the folder type

🤖 Generated with [Claude Code](https://claude.com/claude-code)