### PR TITLE
Implement compose/send UI and read/refresh polish (#7, #8)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -91,7 +91,7 @@ pub struct OutgoingEmail {
     /// HTML body
     pub body_html: Option<String>,
     /// File attachments
-    #[serde(skip)]
+    #[serde(default)]
     pub attachments: Vec<Attachment>,
 }
 
@@ -99,7 +99,11 @@ pub struct OutgoingEmail {
 ///
 /// The raw bytes are held in memory. For large files, consider
 /// streaming from disk in the future.
-#[derive(Debug, Clone)]
+///
+/// `data` is serialised as a JSON array of bytes — the Svelte frontend
+/// reads the picked file with `FileReader.readAsArrayBuffer` and sends
+/// `Array.from(new Uint8Array(buffer))`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Attachment {
     /// Display filename (e.g. "report.pdf")
     pub filename: String,

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -231,9 +231,7 @@ impl ImapClient {
                     .map_err(|e| NimbusError::Protocol(format!("UID FETCH failed: {e}")))?
                     .try_collect()
                     .await
-                    .map_err(|e| {
-                        NimbusError::Protocol(format!("Failed to read UID FETCH: {e}"))
-                    })?
+                    .map_err(|e| NimbusError::Protocol(format!("Failed to read UID FETCH: {e}")))?
             }
             None => {
                 // Newest `limit` by sequence number. Higher seq = newer.
@@ -471,6 +469,36 @@ impl ImapClient {
             is_starred,
             has_attachments,
         })
+    }
+
+    /// Mark a message as read by setting the `\Seen` flag on the server.
+    ///
+    /// Uses `UID STORE <uid> +FLAGS (\Seen)` — idempotent, so calling it on
+    /// an already-read message is a no-op. We SELECT (not EXAMINE) here
+    /// because EXAMINE opens the folder read-only and rejects STORE.
+    pub async fn mark_as_read(&mut self, folder: &str, uid: u32) -> Result<(), NimbusError> {
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        // Read-write SELECT so the server accepts the STORE.
+        session.select(folder).await.map_err(|e| {
+            NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
+        })?;
+
+        // uid_store returns a stream of updated flag sets — we don't need them,
+        // just drain so the command completes.
+        let _updates: Vec<_> = session
+            .uid_store(uid.to_string(), "+FLAGS (\\Seen)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID STORE failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
+
+        info!("Marked UID {uid} as \\Seen in '{folder}'");
+        Ok(())
     }
 
     /// Log out from the IMAP server and close the connection cleanly.

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -151,11 +151,7 @@ impl Cache {
     /// so we wipe-and-reinsert inside a transaction rather than trying to
     /// diff. The folder list is small (dozens of rows at most) so this
     /// is effectively free.
-    pub fn upsert_folders(
-        &self,
-        account_id: &str,
-        folders: &[Folder],
-    ) -> Result<(), CacheError> {
+    pub fn upsert_folders(&self, account_id: &str, folders: &[Folder]) -> Result<(), CacheError> {
         let mut conn = self.pool.get()?;
         let tx = conn.transaction()?;
         tx.execute("DELETE FROM folders WHERE account_id = ?1", [account_id])?;
@@ -176,7 +172,10 @@ impl Cache {
             }
         }
         tx.commit()?;
-        debug!("Cached {} folders for account '{account_id}'", folders.len());
+        debug!(
+            "Cached {} folders for account '{account_id}'",
+            folders.len()
+        );
         Ok(())
     }
 
@@ -197,8 +196,7 @@ impl Cache {
         )?;
         let rows = stmt.query_map(params![account_id], |r| {
             let attrs_json: String = r.get(2)?;
-            let attributes: Vec<String> =
-                serde_json::from_str(&attrs_json).unwrap_or_default();
+            let attributes: Vec<String> = serde_json::from_str(&attrs_json).unwrap_or_default();
             let unread: Option<i64> = r.get(3)?;
             Ok(Folder {
                 name: r.get(0)?,
@@ -294,10 +292,7 @@ impl Cache {
         )?;
         let rows = stmt.query_map(params![account_id, folder, limit as i64], |r| {
             let ts: i64 = r.get(4)?;
-            let date = Utc
-                .timestamp_opt(ts, 0)
-                .single()
-                .unwrap_or_else(Utc::now);
+            let date = Utc.timestamp_opt(ts, 0).single().unwrap_or_else(Utc::now);
             Ok(EmailEnvelope {
                 uid: r.get::<_, i64>(0)? as u32,
                 folder: r.get(1)?,
@@ -314,6 +309,27 @@ impl Cache {
             out.push(row?);
         }
         Ok(out)
+    }
+
+    /// Mark a cached envelope as read (sets `is_read = 1`).
+    ///
+    /// Used by the "mark as read when opened" path: we flip the local
+    /// cache immediately so the UI reflects the change without waiting
+    /// for the network round-trip to the IMAP server. If the row isn't
+    /// cached yet (message was never listed), this is a no-op.
+    pub fn mark_envelope_read(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+    ) -> Result<(), CacheError> {
+        let conn = self.pool.get()?;
+        conn.execute(
+            "UPDATE messages SET is_read = 1
+             WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+            params![account_id, folder, uid as i64],
+        )?;
+        Ok(())
     }
 
     // ── Message bodies ──────────────────────────────────────────
@@ -362,10 +378,8 @@ impl Cache {
         // Addresses are stored as JSON arrays — see the v1 → v2 migration
         // note. `unwrap_or_else` fallbacks are defensive; serde_json on a
         // Vec<String> can only fail if allocation fails.
-        let to_json =
-            serde_json::to_string(&email.to).unwrap_or_else(|_| "[]".into());
-        let cc_json =
-            serde_json::to_string(&email.cc).unwrap_or_else(|_| "[]".into());
+        let to_json = serde_json::to_string(&email.to).unwrap_or_else(|_| "[]".into());
+        let cc_json = serde_json::to_string(&email.cc).unwrap_or_else(|_| "[]".into());
 
         tx.execute(
             "INSERT INTO message_bodies
@@ -431,10 +445,7 @@ impl Cache {
                 params![account_id, folder, uid as i64],
                 |r| {
                     let ts: i64 = r.get(2)?;
-                    let date = Utc
-                        .timestamp_opt(ts, 0)
-                        .single()
-                        .unwrap_or_else(Utc::now);
+                    let date = Utc.timestamp_opt(ts, 0).single().unwrap_or_else(Utc::now);
                     let to_json: String = r.get(8)?;
                     let cc_json: String = r.get(9)?;
                     Ok(Email {
@@ -479,8 +490,7 @@ impl Cache {
                     Ok(SyncState {
                         uidvalidity: uv.map(|v| v as u32),
                         highest_uid_seen: hi.map(|v| v as u32),
-                        last_synced_at: ts
-                            .and_then(|t| Utc.timestamp_opt(t, 0).single()),
+                        last_synced_at: ts.and_then(|t| Utc.timestamp_opt(t, 0).single()),
                     })
                 },
             )
@@ -756,9 +766,6 @@ mod tests {
         assert_eq!(got.uidvalidity, Some(1234));
         assert_eq!(got.highest_uid_seen, Some(99));
         // Timestamps round-trip to whole seconds.
-        assert_eq!(
-            got.last_synced_at.unwrap().timestamp(),
-            now.timestamp()
-        );
+        assert_eq!(got.last_synced_at.unwrap().timestamp(), now.timestamp());
     }
 }

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -164,9 +164,8 @@ pub fn run_migrations(conn: &mut Connection) -> Result<(), CacheError> {
             .transaction()
             .map_err(|e| CacheError::Migration(format!("begin tx: {e}")))?;
 
-        tx.execute_batch(sql).map_err(|e| {
-            CacheError::Migration(format!("migration v{} → v{}: {e}", i, i + 1))
-        })?;
+        tx.execute_batch(sql)
+            .map_err(|e| CacheError::Migration(format!("migration v{} → v{}: {e}", i, i + 1)))?;
 
         tx.execute(
             "UPDATE schema_version SET version = ?1 WHERE id = 1",

--- a/crates/nimbus-store/src/credentials.rs
+++ b/crates/nimbus-store/src/credentials.rs
@@ -34,9 +34,9 @@ pub fn store_imap_password(account_id: &str, password: &str) -> Result<(), Nimbu
 
 /// Retrieve the IMAP password for an account.
 pub fn get_imap_password(account_id: &str) -> Result<String, NimbusError> {
-    entry(account_id)?
-        .get_password()
-        .map_err(|e| NimbusError::Auth(format!("no password found for account '{account_id}': {e}")))
+    entry(account_id)?.get_password().map_err(|e| {
+        NimbusError::Auth(format!("no password found for account '{account_id}': {e}"))
+    })
 }
 
 /// Remove the IMAP password for an account. Silently succeeds if the entry

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,8 +7,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use nimbus_core::NimbusError;
-use nimbus_core::models::{Account, Email, EmailEnvelope, Folder};
+use nimbus_core::models::{Account, Email, EmailEnvelope, Folder, OutgoingEmail};
 use nimbus_imap::ImapClient;
+use nimbus_smtp::SmtpClient;
 use nimbus_store::cache::SyncState;
 use nimbus_store::{Cache, account_store, credentials};
 use tauri::State;
@@ -251,6 +252,55 @@ async fn fetch_message_inner(
     Ok(email)
 }
 
+/// Mark a message as read on the server and in the local cache.
+///
+/// Cache first so the UI sees the change immediately; then the network
+/// call propagates the `\Seen` flag to the IMAP server. If the server
+/// call fails, we surface the error — but the cache is already updated,
+/// which is an acceptable divergence (the next sync will reconcile it).
+#[tauri::command]
+async fn mark_as_read(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    // Optimistic cache update — instant UI feedback.
+    if let Err(e) = cache.mark_envelope_read(&account_id, &folder, uid) {
+        tracing::warn!("cache.mark_envelope_read failed: {e}");
+    }
+
+    let account = load_account(&account_id)?;
+    let mut client = connect_imap(&account).await?;
+    let result = client.mark_as_read(&folder, uid).await;
+    let _ = client.logout().await;
+    result
+}
+
+// ── SMTP commands ───────────────────────────────────────────────
+
+/// Send an email via the account's configured SMTP server.
+///
+/// The frontend builds an `OutgoingEmail` (recipients, subject, body,
+/// attachments) and sends it here. We look up the account to get the
+/// SMTP host/port, retrieve the password from the keychain, and connect.
+/// The `from` field on `email` is authoritative — the UI sets it from
+/// the active account so Compose-from-alias can be added later without
+/// backend changes.
+#[tauri::command]
+async fn send_email(account_id: String, email: OutgoingEmail) -> Result<(), NimbusError> {
+    let account = load_account(&account_id)?;
+    let password = credentials::get_imap_password(&account.id)?;
+    let client = SmtpClient::connect(
+        &account.smtp_host,
+        account.smtp_port,
+        &account.email,
+        &password,
+    )
+    .await?;
+    client.send(&email).await
+}
+
 // ── Folder commands ─────────────────────────────────────────────
 
 /// List the account's mailboxes live from the server and write-through
@@ -337,6 +387,8 @@ fn main() {
             fetch_envelopes,
             fetch_message,
             fetch_folders,
+            mark_as_read,
+            send_email,
             get_cached_envelopes,
             get_cached_message,
             get_cached_folders,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -17,6 +17,7 @@
   import MailView from './lib/MailView.svelte'
   import AccountSetup from './lib/AccountSetup.svelte'
   import AccountSettings from './lib/AccountSettings.svelte'
+  import Compose, { type ComposeInitial } from './lib/Compose.svelte'
 
   // ── View state ──────────────────────────────────────────────
   // Which view is currently shown. Starts as 'loading' until we
@@ -29,10 +30,16 @@
   // switching comes later) and the currently selected message UID.
   // Kept at the App level so MailList and MailView stay in sync.
   let activeAccountId = $state<string | null>(null)
+  let activeAccountEmail = $state<string>('')
+  // Compose modal: `null` = closed. When open, carries a (possibly empty)
+  // initial prefill for reply / reply-all / forward.
+  let composeInitial = $state<ComposeInitial | null>(null)
   // Default to INBOX — the Sidebar replaces this as soon as the user
   // picks a folder, or could switch it automatically if INBOX is absent.
   let selectedFolder = $state<string>('INBOX')
   let selectedUid = $state<number | null>(null)
+  // Bumped to force child lists to re-fetch (manual refresh, mark-as-read).
+  let refreshToken = $state(0)
 
   // ── Check for existing accounts on startup ──────────────────
   // This runs once when the component mounts. It calls get_accounts
@@ -43,9 +50,10 @@
 
   async function checkAccounts() {
     try {
-      const accounts = await invoke<Array<{ id: string }>>('get_accounts')
+      const accounts = await invoke<Array<{ id: string; email: string }>>('get_accounts')
       if (accounts.length > 0) {
         activeAccountId = accounts[0].id
+        activeAccountEmail = accounts[0].email
         currentView = 'inbox'
       } else {
         currentView = 'setup'
@@ -88,6 +96,81 @@
     selectedFolder = name
     selectedUid = null
   }
+
+  // Triggered by the sidebar's refresh button.
+  function refreshAll() {
+    refreshToken++
+  }
+
+  // MailView fires this after it successfully marks a message \Seen on
+  // the server. Bumping the token makes MailList + Sidebar re-fetch so
+  // the bold "unread" styling and the folder badge update immediately.
+  function onMessageRead(_uid: number) {
+    refreshToken++
+  }
+
+  // Open the Compose modal. Called with no arg for a blank new message,
+  // or with a prefill for reply/reply-all/forward.
+  function openCompose(initial: ComposeInitial = {}) {
+    composeInitial = initial
+  }
+
+  function closeCompose() {
+    composeInitial = null
+  }
+
+  // Build a quoted reply body — RFC 3676 style "> " prefix on each line.
+  function quoteBody(from: string, date: string, body: string | null): string {
+    const quoted = (body ?? '')
+      .split('\n')
+      .map((l) => `> ${l}`)
+      .join('\n')
+    return `\n\nOn ${new Date(date).toLocaleString()}, ${from} wrote:\n${quoted}`
+  }
+
+  function replySubject(s: string): string {
+    return /^re:/i.test(s) ? s : `Re: ${s}`
+  }
+
+  function forwardSubject(s: string): string {
+    return /^fwd?:/i.test(s) ? s : `Fwd: ${s}`
+  }
+
+  type OpenMail = {
+    from: string
+    to: string[]
+    cc: string[]
+    subject: string
+    body_text: string | null
+    date: string
+  }
+
+  function onReply(mail: OpenMail) {
+    openCompose({
+      to: mail.from,
+      subject: replySubject(mail.subject),
+      body: quoteBody(mail.from, mail.date, mail.body_text),
+    })
+  }
+
+  function onReplyAll(mail: OpenMail) {
+    const others = [...mail.to, ...mail.cc].filter(
+      (a) => a && a.toLowerCase() !== activeAccountEmail.toLowerCase(),
+    )
+    openCompose({
+      to: mail.from,
+      cc: others.join(', '),
+      subject: replySubject(mail.subject),
+      body: quoteBody(mail.from, mail.date, mail.body_text),
+    })
+  }
+
+  function onForward(mail: OpenMail) {
+    openCompose({
+      subject: forwardSubject(mail.subject),
+      body: `\n\n---------- Forwarded message ----------\nFrom: ${mail.from}\nDate: ${new Date(mail.date).toLocaleString()}\nSubject: ${mail.subject}\n\n${mail.body_text ?? ''}`,
+    })
+  }
 </script>
 
 <!-- Loading state: shown briefly while we check for accounts -->
@@ -110,16 +193,36 @@
     <Sidebar
       accountId={activeAccountId}
       selectedFolder={selectedFolder}
+      refreshToken={refreshToken}
       onselectfolder={selectFolder}
       onsettings={goToSettings}
+      onrefresh={refreshAll}
+      oncompose={() => openCompose()}
     />
     <MailList
       accountId={activeAccountId}
       folder={selectedFolder}
       selectedUid={selectedUid}
+      refreshToken={refreshToken}
       onselect={selectMessage}
     />
-    <MailView accountId={activeAccountId} folder={selectedFolder} uid={selectedUid} />
+    <MailView
+      accountId={activeAccountId}
+      folder={selectedFolder}
+      uid={selectedUid}
+      onread={onMessageRead}
+      onreply={onReply}
+      onreplyall={onReplyAll}
+      onforward={onForward}
+    />
+    {#if composeInitial !== null}
+      <Compose
+        accountId={activeAccountId}
+        fromAddress={activeAccountEmail}
+        initial={composeInitial}
+        onclose={closeCompose}
+      />
+    {/if}
   </div>
 {:else}
   <div class="h-full flex items-center justify-center bg-surface-50 dark:bg-surface-900">

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  /**
+   * Compose — a modal for writing and sending an email.
+   *
+   * Handles new messages, replies, reply-all, and forwards. The parent
+   * opens it with an optional `initial` prefill (used for reply / forward
+   * to carry over To/Subject/quoted body).
+   *
+   * Body is plain text for now — a rich-text/Markdown editor is a later
+   * enhancement. Attachments are read in the browser via FileReader so
+   * we don't need the Tauri dialog plugin; the raw bytes are shipped to
+   * the backend as a byte array.
+   *
+   * Drafts are saved to localStorage under a per-account key. That's
+   * intentionally minimal — proper "Save to Drafts folder via IMAP APPEND"
+   * is tracked separately.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+
+  interface Attachment {
+    filename: string
+    content_type: string
+    data: number[]
+  }
+
+  export interface ComposeInitial {
+    to?: string
+    cc?: string
+    bcc?: string
+    subject?: string
+    body?: string
+    in_reply_to?: number | null
+  }
+
+  interface Props {
+    accountId: string
+    fromAddress: string
+    initial?: ComposeInitial
+    onclose: () => void
+  }
+  let { accountId, fromAddress, initial, onclose }: Props = $props()
+
+  // svelte-ignore state_referenced_locally
+  const DRAFT_KEY = `nimbus-draft:${accountId}`
+
+  // ── Form state ──────────────────────────────────────────────
+  // If we got an explicit initial (reply/forward), use it. Otherwise
+  // try to rehydrate a locally saved draft so the user doesn't lose
+  // work when they accidentally close the window. Props are snapshotted
+  // at mount — the modal is remounted when the parent opens a new one.
+  // svelte-ignore state_referenced_locally
+  const saved = !initial ? loadDraft() : null
+  // svelte-ignore state_referenced_locally
+  let to = $state(initial?.to ?? saved?.to ?? '')
+  // svelte-ignore state_referenced_locally
+  let cc = $state(initial?.cc ?? saved?.cc ?? '')
+  // svelte-ignore state_referenced_locally
+  let bcc = $state(initial?.bcc ?? saved?.bcc ?? '')
+  // svelte-ignore state_referenced_locally
+  let subject = $state(initial?.subject ?? saved?.subject ?? '')
+  // svelte-ignore state_referenced_locally
+  let body = $state(initial?.body ?? saved?.body ?? '')
+  let attachments = $state<Attachment[]>([])
+  // svelte-ignore state_referenced_locally
+  let showCcBcc = $state(!!cc || !!bcc)
+
+  let sending = $state(false)
+  let error = $state('')
+  let savedHint = $state('')
+
+  // Autosave draft whenever the user edits a field.
+  $effect(() => {
+    const draft = { to, cc, bcc, subject, body }
+    try {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
+    } catch {
+      // localStorage full or disabled — silently ignore.
+    }
+  })
+
+  function loadDraft(): null | { to: string; cc: string; bcc: string; subject: string; body: string } {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY)
+      return raw ? JSON.parse(raw) : null
+    } catch {
+      return null
+    }
+  }
+
+  function clearDraft() {
+    try {
+      localStorage.removeItem(DRAFT_KEY)
+    } catch {
+      // ignore
+    }
+  }
+
+  function saveDraft() {
+    // The effect already wrote it — just give the user confirmation.
+    savedHint = 'Draft saved'
+    setTimeout(() => (savedHint = ''), 1500)
+  }
+
+  // Split a comma/semicolon-separated address list into trimmed addresses.
+  function splitAddrs(s: string): string[] {
+    return s
+      .split(/[,;]/)
+      .map((a) => a.trim())
+      .filter(Boolean)
+  }
+
+  async function onPickFiles(e: Event) {
+    const input = e.target as HTMLInputElement
+    if (!input.files) return
+    const picked: Attachment[] = []
+    for (const file of Array.from(input.files)) {
+      const buf = await file.arrayBuffer()
+      picked.push({
+        filename: file.name,
+        content_type: file.type || 'application/octet-stream',
+        data: Array.from(new Uint8Array(buf)),
+      })
+    }
+    attachments = [...attachments, ...picked]
+    input.value = ''
+  }
+
+  function removeAttachment(i: number) {
+    attachments = attachments.filter((_, idx) => idx !== i)
+  }
+
+  async function send() {
+    error = ''
+    const toList = splitAddrs(to)
+    if (toList.length === 0) {
+      error = 'At least one recipient is required.'
+      return
+    }
+    sending = true
+    try {
+      await invoke('send_email', {
+        accountId,
+        email: {
+          from: fromAddress,
+          to: toList,
+          cc: splitAddrs(cc),
+          bcc: splitAddrs(bcc),
+          reply_to: null,
+          subject,
+          body_text: body,
+          body_html: null,
+          attachments,
+        },
+      })
+      clearDraft()
+      onclose()
+    } catch (e: any) {
+      error = formatError(e) || 'Failed to send'
+    } finally {
+      sending = false
+    }
+  }
+
+  function cancel() {
+    // Draft is kept in localStorage so the user can resume later.
+    onclose()
+  }
+</script>
+
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+  <div class="w-[720px] max-h-[90vh] bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl flex flex-col">
+    <header class="px-5 py-3 border-b border-surface-200 dark:border-surface-700 flex items-center justify-between">
+      <h2 class="text-base font-semibold">New message</h2>
+      <button class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100" onclick={cancel} aria-label="Close">✕</button>
+    </header>
+
+    <div class="flex-1 overflow-y-auto p-5 space-y-3">
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-14 text-surface-500" for="compose-to">To</label>
+        <input id="compose-to" class="input flex-1 px-3 py-2 text-sm rounded-md" bind:value={to} placeholder="alice@example.com, bob@example.com" />
+        {#if !showCcBcc}
+          <button class="text-xs text-primary-500 hover:underline" onclick={() => (showCcBcc = true)}>Cc/Bcc</button>
+        {/if}
+      </div>
+
+      {#if showCcBcc}
+        <div class="flex items-center gap-2">
+          <label class="text-xs w-14 text-surface-500" for="compose-cc">Cc</label>
+          <input id="compose-cc" class="input flex-1 px-3 py-2 text-sm rounded-md" bind:value={cc} />
+        </div>
+        <div class="flex items-center gap-2">
+          <label class="text-xs w-14 text-surface-500" for="compose-bcc">Bcc</label>
+          <input id="compose-bcc" class="input flex-1 px-3 py-2 text-sm rounded-md" bind:value={bcc} />
+        </div>
+      {/if}
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-14 text-surface-500" for="compose-subject">Subject</label>
+        <input id="compose-subject" class="input flex-1 px-3 py-2 text-sm rounded-md" bind:value={subject} />
+      </div>
+
+      <textarea
+        class="input w-full px-3 py-2 text-sm rounded-md font-mono"
+        rows="14"
+        bind:value={body}
+        placeholder="Write your message…"
+      ></textarea>
+
+      {#if attachments.length > 0}
+        <div class="flex flex-wrap gap-2">
+          {#each attachments as att, i (i)}
+            <span class="inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface-200 dark:bg-surface-800 text-xs">
+              <span>📎 {att.filename}</span>
+              <button class="text-surface-500 hover:text-red-500" onclick={() => removeAttachment(i)} aria-label="Remove">✕</button>
+            </span>
+          {/each}
+        </div>
+      {/if}
+
+      {#if error}
+        <p class="text-sm text-red-500">{error}</p>
+      {/if}
+    </div>
+
+    <footer class="px-5 py-3 border-t border-surface-200 dark:border-surface-700 flex items-center gap-2">
+      <button class="btn preset-filled-primary-500" disabled={sending} onclick={send}>
+        {sending ? 'Sending…' : 'Send'}
+      </button>
+      <label class="btn preset-outlined-surface-500 cursor-pointer">
+        📎 Attach
+        <input type="file" multiple class="hidden" onchange={onPickFiles} />
+      </label>
+      <button class="btn preset-outlined-surface-500" onclick={saveDraft}>Save draft</button>
+      {#if savedHint}
+        <span class="text-xs text-surface-500">{savedHint}</span>
+      {/if}
+      <div class="flex-1"></div>
+      <button class="btn preset-outlined-surface-500" onclick={cancel}>Cancel</button>
+    </footer>
+  </div>
+</div>

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -29,9 +29,17 @@
     accountId: string
     folder?: string
     selectedUid: number | null
+    /** Bumped by the parent to force a network re-fetch (manual refresh). */
+    refreshToken?: number
     onselect: (uid: number) => void
   }
-  let { accountId, folder = 'INBOX', selectedUid, onselect }: Props = $props()
+  let {
+    accountId,
+    folder = 'INBOX',
+    selectedUid,
+    refreshToken = 0,
+    onselect,
+  }: Props = $props()
 
   // ── Fetch state ─────────────────────────────────────────────
   //
@@ -46,8 +54,10 @@
   let refreshing = $state(false)
   let error = $state('')
 
-  // Re-fetch whenever the account or folder changes.
+  // Re-fetch whenever the account, folder, or refreshToken changes.
   $effect(() => {
+    // Touch refreshToken so Svelte re-runs this effect when it's bumped.
+    refreshToken
     void load(accountId, folder)
   })
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -32,8 +32,20 @@
     accountId: string
     folder?: string
     uid: number | null
+    onread?: (uid: number) => void
+    onreply?: (mail: Email) => void
+    onreplyall?: (mail: Email) => void
+    onforward?: (mail: Email) => void
   }
-  let { accountId, folder = 'INBOX', uid }: Props = $props()
+  let {
+    accountId,
+    folder = 'INBOX',
+    uid,
+    onread,
+    onreply,
+    onreplyall,
+    onforward,
+  }: Props = $props()
 
   let email = $state<Email | null>(null)
   let loading = $state(false)
@@ -92,6 +104,19 @@
       loading = false
       refreshing = false
     }
+
+    // Mark as read — fire-and-forget. The MailList picked up an optimistic
+    // cache update from the backend, and onread() lets the parent refresh
+    // the envelope list so the unread styling clears immediately.
+    if (email && !email.is_read && id === accountId && f === folder && u === uid) {
+      try {
+        await invoke('mark_as_read', { accountId: id, folder: f, uid: u })
+        if (email) email.is_read = true
+        onread?.(u)
+      } catch (e: any) {
+        console.warn('mark_as_read failed:', e)
+      }
+    }
   }
 
   function formatFullDate(iso: string): string {
@@ -137,9 +162,9 @@
 
     <!-- Action bar -->
     <div class="flex items-center gap-2 px-6 py-2 border-b border-surface-200 dark:border-surface-700 text-sm">
-      <button class="btn btn-sm preset-outlined-surface-500">Reply</button>
-      <button class="btn btn-sm preset-outlined-surface-500">Reply All</button>
-      <button class="btn btn-sm preset-outlined-surface-500">Forward</button>
+      <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreply?.(email)}>Reply</button>
+      <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreplyall?.(email)}>Reply All</button>
+      <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onforward?.(email)}>Forward</button>
       <div class="flex-1"></div>
       <button class="btn btn-sm preset-outlined-surface-500">Archive</button>
       <button class="btn btn-sm preset-outlined-surface-500">Delete</button>

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -23,10 +23,22 @@
   interface Props {
     accountId: string
     selectedFolder: string
+    /** Bumped by the parent to force a network re-fetch (manual refresh). */
+    refreshToken?: number
     onselectfolder: (name: string) => void
     onsettings: () => void
+    onrefresh?: () => void
+    oncompose?: () => void
   }
-  let { accountId, selectedFolder, onselectfolder, onsettings }: Props = $props()
+  let {
+    accountId,
+    selectedFolder,
+    refreshToken = 0,
+    onselectfolder,
+    onsettings,
+    onrefresh,
+    oncompose,
+  }: Props = $props()
 
   let folders = $state<Folder[]>([])
   let loading = $state(true)
@@ -42,7 +54,10 @@
     { name: 'Nextcloud Files', icon: '\u{1F4C1}' },// 📁
   ]
 
+  // Re-fetch whenever accountId or refreshToken changes.
   $effect(() => {
+    // Touch refreshToken so Svelte re-runs this effect when it's bumped.
+    refreshToken
     void load(accountId)
   })
 
@@ -116,19 +131,30 @@
 
   <!-- Compose button -->
   <div class="p-3">
-    <button class="btn preset-filled-primary-500 w-full">
+    <button class="btn preset-filled-primary-500 w-full" onclick={() => oncompose?.()}>
       Compose
     </button>
   </div>
 
   <!-- Mail folders -->
   <nav class="flex-1 overflow-y-auto px-2">
-    <p class="px-2 py-1 text-xs font-semibold text-surface-500 uppercase tracking-wider flex items-center justify-between">
+    <div class="px-2 py-1 text-xs font-semibold text-surface-500 uppercase tracking-wider flex items-center justify-between">
       <span>Folders</span>
-      {#if refreshing}
-        <span class="text-[10px] font-normal normal-case tracking-normal text-surface-500">Refreshing…</span>
-      {/if}
-    </p>
+      <div class="flex items-center gap-2">
+        {#if refreshing}
+          <span class="text-[10px] font-normal normal-case tracking-normal text-surface-500">Refreshing…</span>
+        {/if}
+        <button
+          class="text-surface-500 hover:text-primary-500 disabled:opacity-50 normal-case tracking-normal"
+          title="Refresh"
+          aria-label="Refresh"
+          disabled={refreshing}
+          onclick={() => onrefresh?.()}
+        >
+          &#x21bb;
+        </button>
+      </div>
+    </div>
 
     {#if loading}
       <p class="px-3 py-2 text-xs text-surface-500">Loading folders…</p>


### PR DESCRIPTION
Issue #7 — Inbox view
- Auto-mark messages as read on open: new `mark_as_read` Tauri command with optimistic cache update, then IMAP `UID STORE +FLAGS (\Seen)`.
- Manual refresh button in the sidebar with a `refreshToken` prop propagated to Sidebar/MailList so both panes re-fetch in sync.
- MailView fires `onread` after marking, bumping the token so unread styling and folder badges update without a reload.

Issue #8 — Compose & send
- New `send_email` Tauri command connects via SMTP (STARTTLS/implicit TLS), authenticates with the keychain password, and sends the `OutgoingEmail` payload.
- `Attachment` is now `Serialize`/`Deserialize` so the frontend can ship picked file bytes across IPC (no tauri-plugin-dialog needed).
- New `Compose.svelte` modal: To/Cc/Bcc/Subject/body, multi-file attachments via `<input type=file>`, autosaved drafts in localStorage, send/cancel.
- Reply / Reply All / Forward buttons in MailView now open Compose with a prefilled subject (`Re:` / `Fwd:`), quoted body, and correct recipient set (Reply All excludes the current account's address).
- Sidebar Compose button opens a blank modal