### PR TITLE
Rich text editor for email compose (closes #8)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,24 @@
       "name": "ui",
       "version": "0.0.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
+        "@tauri-apps/api": "^2.10.1",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-color": "^3.22.3",
+        "@tiptap/extension-highlight": "^3.22.3",
+        "@tiptap/extension-horizontal-rule": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-link": "^3.22.3",
+        "@tiptap/extension-placeholder": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-table-cell": "^3.22.3",
+        "@tiptap/extension-table-header": "^3.22.3",
+        "@tiptap/extension-table-row": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extension-underline": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
+        "svelte-tiptap": "^3.0.1"
       },
       "devDependencies": {
         "@skeletonlabs/skeleton": "^4.15.1",
@@ -63,7 +80,6 @@
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
       "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
@@ -73,7 +89,6 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
@@ -84,7 +99,6 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@internationalized/date": {
@@ -101,7 +115,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -112,7 +125,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -123,7 +135,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -133,14 +144,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -175,6 +184,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -520,7 +535,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -863,6 +877,544 @@
         "url": "https://opencollective.com/tauri"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.3.tgz",
+      "integrity": "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.3.tgz",
+      "integrity": "sha512-IaUx3zh7yLHXzIXKL+fw/jzFhsIImdhJyw0lMhe8FfYrefFqXJFYW/sey6+L/e8B3AWvTksPA6VBwefzbH77JA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.3.tgz",
+      "integrity": "sha512-tysipHla2zCWr8XNIWRaW9O+7i7/SoEqnRqSRUUi2ailcJjlia+RBy3RykhkgyThrQDStu5KGBS/UvrXwA+O1A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.22.3.tgz",
+      "integrity": "sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.3.tgz",
+      "integrity": "sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.3.tgz",
+      "integrity": "sha512-wafWTDQOuMKtXpZEuk1PFQmzopabBciNLryL90MB9S03MNLaQQZYLnmYkDBlzAaLAbgF5QiC+2XZQEBQuTVjFQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.3.tgz",
+      "integrity": "sha512-RiQtEjDAPrHpdo6sw6b7fOw/PijqgFIsozKKkGcSeBgWHQuFg7q9OxJTj+l0e60rVwSu/5gmKEEobzM9bX+t2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-color": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.22.3.tgz",
+      "integrity": "sha512-eZtOc4Zp5jnlZh4+gvr3JmOa3kPlIU8IbTByDMgXEMdVGZ5cOk+H4TMIlhU0j7j1TMWm8+r1WYtrU9E9ooz9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.3.tgz",
+      "integrity": "sha512-MCSr1PFPtTd++lA3H1RNgqAczAE59XXJ5wUFIQf2F+/0DPY5q2SU4g5QsNJVxPPft5mrNT4C6ty8xBPrALFEdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.3.tgz",
+      "integrity": "sha512-taXq9Tl5aybdFbptJtFRHX9LFJzbXphAbPp4/vutFyTrBu5meXDxuS+B9pEmE+Or0XcolTlW2nDZB0Tqnr18JQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.22.3.tgz",
+      "integrity": "sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.3.tgz",
+      "integrity": "sha512-L/Px4UeQEVG/D9WIlcAOIej+4wyIBCMUSYicSR+hW68UsObe4rxVbUas1QgidQKm6DOhoT7U7D4KQHA/Gdg/7A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.3.tgz",
+      "integrity": "sha512-J0v8I99y9tbvVmgKYKzKP/JYNsWaZYS7avn4rzLft2OhnyTfwt3OoY8DtpHmmi6apSUaCtoWHWta/TmoEfK1nQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.3.tgz",
+      "integrity": "sha512-XBHuhiEV2EEhZHpOLcplLqAmBIhJciU3I6AtwmqeEqDC0P114uMEfAO7JGlbBZdCYotNer26PKnu44TBTeNtkw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-highlight": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-3.22.3.tgz",
+      "integrity": "sha512-iGDzQ3IuVQpfQcWsMEQ0B8q3R83bZZH6l6O2MuCmWbzm/p7mMi5vQwRCMLAbM9xFELq8KjDMHOWeER4fozp/Sg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.3.tgz",
+      "integrity": "sha512-wI2bFzScs+KgWeBH/BtypcVKeYelCyqV0RG8nxsZMWtPrBhqixzNd0Oi3gEKtjSjKUqMQ/kjJAIRuESr5UzlHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-image": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.22.3.tgz",
+      "integrity": "sha512-Qpp8c5LOQaNpHrzjqZtoxtIR+8sSqJ7k8v+8anmYw3nxjvt2kpfT28Vd7aWMX55ZS43LaxMx+MkZqbmgUmMP0w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.3.tgz",
+      "integrity": "sha512-LteA4cb4EGCiUtrK2JHvDF/Zg0/YqV4DUyHhAAho+oGEQDupZlsS6m0ia5wQcclkiTLzsoPrwcSNu6RDGQ16wQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.3.tgz",
+      "integrity": "sha512-S8/P2o9pv6B3kqLjH2TRWwSAximGbciNc6R8/QcN6HWLYxp0N0JoqN3rZHl9VWIBAGRWc4zkt80dhqrl2xmgfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.3.tgz",
+      "integrity": "sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.3.tgz",
+      "integrity": "sha512-80CNf4oO5y8+LdckT4CyMe1t01EyhpRrQC9H45JW20P7559Nrchp5my3vvMtIAJbpTPPZtcB7LwdzWGKsG5drg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.3.tgz",
+      "integrity": "sha512-pKuyj5llu35zd/s2u/H9aydKZjmPRAIK5P1q/YXULhhCNln2RnmuRfQ5NklAqTD3yGciQ2lxDwwf7J6iw3ergA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.3.tgz",
+      "integrity": "sha512-orAghtmd+K4Euu4BgI1hG+iZDXBYOyl5YTwiLBc2mQn+pqtZ9LqaH2us4ETwEwNP3/IWXGSAimUZ19nuL+eM2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.3.tgz",
+      "integrity": "sha512-oO7rhfyhEuwm+50s9K3GZPjYyEEEvFAvm1wXopvZnhbkBLydIWImBfrZoC5IQh4/sRDlTIjosV2C+ji5y0tUSg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.22.3.tgz",
+      "integrity": "sha512-7vbtlDVO00odqCnsMSmA4b6wjL5PFdfExFsdsDO0K0VemqHZ/doIRx/tosNUD1VYSOyKQd8U7efUjkFyVoIPlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.3.tgz",
+      "integrity": "sha512-jY2InoUlKkuk5KHoIDGdML1OCA2n6PRHAtxwHNkAmiYh0Khf0zaVPGFpx4dgQrN7W5Q1WE6oBZnjrvy6qb7w0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-table": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.22.3.tgz",
+      "integrity": "sha512-inbQSusJad7H0T++L1APg/anfL5d15cNGp2YG3vwo6TQr71nn2c9pepvmz3xuAIt8eygZDRba+4GT/COP1f9QA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-table-cell": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-3.22.3.tgz",
+      "integrity": "sha512-LgaUgNwjHe6J7dq66N7iflC9efjgygsYWkHJtfLzaSU82tXzk8HSwBrMRCaj0PU+AR967/jGixEZIxH9xfXswQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-table-header": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-3.22.3.tgz",
+      "integrity": "sha512-5wQ5rne9ccdbzeqC1AEDaUzlWjnpQNgBctgSPKEv+Da88lRRcGX21H+b/8jhL7fr4/sznr45toKGUg8NmRhboQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-table-row": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-3.22.3.tgz",
+      "integrity": "sha512-dkoHnbOZgb2iQLXsp2FUu0KejAh3LOqDLMixYYU/0lnUwhqGG8kgu6+0YkCiUhedbfMFqVvemdKnRddpTQ4sqg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.3.tgz",
+      "integrity": "sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-text-align": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.22.3.tgz",
+      "integrity": "sha512-dG1NHE0yGf7fYiOdabCJuecI2IJ1uogyY/QvZqvPNaxRjZDoXYuGlMtz9jEDiIdQSaPED2MSsS7KkuNFQIEMGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.22.3.tgz",
+      "integrity": "sha512-JKmWAogM/LX9ZJmXJQalpcR77wWVtVXdRFgvHGsFomW9WFhZqcnIEDWR2sbpZHWtu8dml6eBQGhdLppJmxeFfA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.3.tgz",
+      "integrity": "sha512-Ch6CBWRa5w90yYSPUW6x9Py9JdrXMqk3pZ9OIlMYD8A7BqyZGfiHerX7XDMYDS09KjyK3U9XH60/zxYOzXdDLA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.3.tgz",
+      "integrity": "sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.3.tgz",
+      "integrity": "sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.3.tgz",
+      "integrity": "sha512-vdW/Oo1fdwTL1VOQ5YYbTov00ANeHLquBVEZyL/EkV7Xv5io9rXQsCysJfTSHhiQlyr2MtWFB4+CPGuwXjQWOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-blockquote": "^3.22.3",
+        "@tiptap/extension-bold": "^3.22.3",
+        "@tiptap/extension-bullet-list": "^3.22.3",
+        "@tiptap/extension-code": "^3.22.3",
+        "@tiptap/extension-code-block": "^3.22.3",
+        "@tiptap/extension-document": "^3.22.3",
+        "@tiptap/extension-dropcursor": "^3.22.3",
+        "@tiptap/extension-gapcursor": "^3.22.3",
+        "@tiptap/extension-hard-break": "^3.22.3",
+        "@tiptap/extension-heading": "^3.22.3",
+        "@tiptap/extension-horizontal-rule": "^3.22.3",
+        "@tiptap/extension-italic": "^3.22.3",
+        "@tiptap/extension-link": "^3.22.3",
+        "@tiptap/extension-list": "^3.22.3",
+        "@tiptap/extension-list-item": "^3.22.3",
+        "@tiptap/extension-list-keymap": "^3.22.3",
+        "@tiptap/extension-ordered-list": "^3.22.3",
+        "@tiptap/extension-paragraph": "^3.22.3",
+        "@tiptap/extension-strike": "^3.22.3",
+        "@tiptap/extension-text": "^3.22.3",
+        "@tiptap/extension-underline": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tsconfig/svelte": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz",
@@ -885,7 +1437,28 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -902,7 +1475,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@zag-js/accordion": {
@@ -1520,7 +2092,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1529,11 +2100,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1543,7 +2119,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1569,11 +2144,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -1619,7 +2199,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -1636,18 +2215,40 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esrap": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
       "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -1705,7 +2306,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -1994,22 +2594,58 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -2049,6 +2685,12 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -2114,12 +2756,216 @@
         "node": ">=4"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.1.tgz",
+      "integrity": "sha512-2OSIKBFyLo2iqDpjQHEC7tKt3lluhY7L44pcRai8EpoU9R7cZDj/dklEsOOIubNKWUXab6dL7y4JtAWnrlR4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -2169,6 +3015,12 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -2196,7 +3048,6 @@
       "version": "5.55.3",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.3.tgz",
       "integrity": "sha512-dS1N+i3bA1v+c4UDb750MlN5vCO82G6vxh8HeTsPsTdJ1BLsN1zxSyDlIdBBqUjqZ/BxEwM8UrFf98aaoVnZFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -2242,6 +3093,26 @@
       "peerDependencies": {
         "svelte": "^4.0.0 || ^5.0.0-next.0",
         "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/svelte-tiptap": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-tiptap/-/svelte-tiptap-3.0.1.tgz",
+      "integrity": "sha512-Vi3kVGOd01f7mslOxGbJB7z2QavdvH+6WffhB+Y5fleTiZaW0YWqIboyO2u/uh4BQeosiINmmuRJ+Qwb7mYP+A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "^3.0.0",
+        "@tiptap/extension-bubble-menu": "^3.0.0",
+        "@tiptap/extension-floating-menu": "^3.0.0",
+        "@tiptap/pm": "^3.0.0",
+        "svelte": "^5.0.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -2302,6 +3173,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -2415,11 +3292,16 @@
         }
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     }
   }

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,23 @@
     "vite": "^8.0.4"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.10.1"
+    "@tauri-apps/api": "^2.10.1",
+    "@tiptap/core": "^3.22.3",
+    "@tiptap/extension-color": "^3.22.3",
+    "@tiptap/extension-highlight": "^3.22.3",
+    "@tiptap/extension-horizontal-rule": "^3.22.3",
+    "@tiptap/extension-image": "^3.22.3",
+    "@tiptap/extension-link": "^3.22.3",
+    "@tiptap/extension-placeholder": "^3.22.3",
+    "@tiptap/extension-table": "^3.22.3",
+    "@tiptap/extension-table-cell": "^3.22.3",
+    "@tiptap/extension-table-header": "^3.22.3",
+    "@tiptap/extension-table-row": "^3.22.3",
+    "@tiptap/extension-text-align": "^3.22.3",
+    "@tiptap/extension-text-style": "^3.22.3",
+    "@tiptap/extension-underline": "^3.22.3",
+    "@tiptap/pm": "^3.22.3",
+    "@tiptap/starter-kit": "^3.22.3",
+    "svelte-tiptap": "^3.0.1"
   }
 }

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -18,6 +18,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import RichTextEditor from './RichTextEditor.svelte'
 
   interface Attachment {
     filename: string
@@ -63,8 +64,33 @@
   // svelte-ignore state_referenced_locally
   let body = $state(initial?.body ?? saved?.body ?? '')
   let attachments = $state<Attachment[]>([])
+  // The editor content as HTML — kept in sync via the RichTextEditor's
+  // onchange callback. The initial body (from reply/forward/draft) is
+  // plain text, so we convert newlines to <br> for the WYSIWYG view.
+  // svelte-ignore state_referenced_locally
+  let bodyHtml = $state(textToHtml(body))
   // svelte-ignore state_referenced_locally
   let showCcBcc = $state(!!cc || !!bcc)
+
+  /** Naively convert plain text (with newlines) into minimal HTML. */
+  function textToHtml(text: string): string {
+    if (!text) return ''
+    // If it already looks like HTML (from a draft/forward), return as-is.
+    if (/<[a-z][\s\S]*>/i.test(text)) return text
+    // Escape & < > so they render literally, then convert line breaks.
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>')
+  }
+
+  /** Strip HTML tags to produce a plain-text fallback for `body_text`. */
+  function htmlToText(html: string): string {
+    const tmp = document.createElement('div')
+    tmp.innerHTML = html
+    return tmp.textContent ?? tmp.innerText ?? ''
+  }
 
   let sending = $state(false)
   let error = $state('')
@@ -72,7 +98,7 @@
 
   // Autosave draft whenever the user edits a field.
   $effect(() => {
-    const draft = { to, cc, bcc, subject, body }
+    const draft = { to, cc, bcc, subject, body: bodyHtml }
     try {
       localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
     } catch {
@@ -149,8 +175,8 @@
           bcc: splitAddrs(bcc),
           reply_to: null,
           subject,
-          body_text: body,
-          body_html: null,
+          body_text: htmlToText(bodyHtml),
+          body_html: bodyHtml || null,
           attachments,
         },
       })
@@ -201,12 +227,10 @@
         <input id="compose-subject" class="input flex-1 px-3 py-2 text-sm rounded-md" bind:value={subject} />
       </div>
 
-      <textarea
-        class="input w-full px-3 py-2 text-sm rounded-md font-mono"
-        rows="14"
-        bind:value={body}
-        placeholder="Write your message…"
-      ></textarea>
+      <RichTextEditor
+        content={bodyHtml}
+        onchange={(html) => { bodyHtml = html }}
+      />
 
       {#if attachments.length > 0}
         <div class="flex flex-wrap gap-2">

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1,0 +1,311 @@
+<script lang="ts">
+  /**
+   * RichTextEditor — Tiptap-based WYSIWYG editor for composing emails.
+   *
+   * Provides an Outlook-style toolbar with formatting controls: text
+   * styles (bold, italic, underline, strikethrough), headings, lists,
+   * alignment, links, tables, colors, horizontal rules, and images.
+   *
+   * The editor exposes its HTML content reactively via `onchange` so the
+   * parent (Compose) can read it at send time.
+   */
+
+  import { onDestroy } from 'svelte'
+  import createEditor from 'svelte-tiptap'
+  import EditorContent from 'svelte-tiptap/EditorContent.svelte'
+  import StarterKit from '@tiptap/starter-kit'
+  import Underline from '@tiptap/extension-underline'
+  import Link from '@tiptap/extension-link'
+  import Image from '@tiptap/extension-image'
+  import TextAlign from '@tiptap/extension-text-align'
+  import Placeholder from '@tiptap/extension-placeholder'
+  import TextStyle from '@tiptap/extension-text-style'
+  import Color from '@tiptap/extension-color'
+  import Highlight from '@tiptap/extension-highlight'
+  import Table from '@tiptap/extension-table'
+  import TableRow from '@tiptap/extension-table-row'
+  import TableCell from '@tiptap/extension-table-cell'
+  import TableHeader from '@tiptap/extension-table-header'
+
+  interface Props {
+    /** Initial HTML content (e.g. quoted reply body). */
+    content?: string
+    /** Placeholder text shown when the editor is empty. */
+    placeholder?: string
+    /** Fires on every content change with the current HTML. */
+    onchange?: (html: string) => void
+  }
+  let {
+    content = '',
+    placeholder = 'Write your message\u2026',
+    onchange,
+  }: Props = $props()
+
+  const editor = createEditor({
+    extensions: [
+      StarterKit.configure({
+        // Horizontal rule is from StarterKit already, but we keep the
+        // default config.
+        heading: { levels: [1, 2, 3] },
+      }),
+      Underline,
+      Link.configure({
+        openOnClick: false,
+        HTMLAttributes: { target: '_blank', rel: 'noopener noreferrer' },
+      }),
+      Image.configure({ inline: true }),
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      Placeholder.configure({ placeholder }),
+      TextStyle,
+      Color,
+      Highlight.configure({ multicolor: true }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableCell,
+      TableHeader,
+    ],
+    content,
+    onUpdate: ({ editor: e }) => {
+      onchange?.(e.getHTML())
+    },
+  })
+
+  onDestroy(() => {
+    $editor?.destroy()
+  })
+
+  // ── Toolbar helpers ─────────────────────────────────────────
+
+  /** Prompt for a URL and insert/update a link. */
+  function setLink() {
+    const prev = $editor?.getAttributes('link')?.href ?? ''
+    const url = window.prompt('URL', prev)
+    if (url === null) return
+    if (url === '') {
+      $editor?.chain().focus().extendMarkRange('link').unsetLink().run()
+    } else {
+      $editor
+        ?.chain()
+        .focus()
+        .extendMarkRange('link')
+        .setLink({ href: url })
+        .run()
+    }
+  }
+
+  /** Prompt for an image URL and insert it. */
+  function addImage() {
+    const url = window.prompt('Image URL')
+    if (url) {
+      $editor?.chain().focus().setImage({ src: url }).run()
+    }
+  }
+
+  /** Insert a 3x3 table. */
+  function insertTable() {
+    $editor
+      ?.chain()
+      .focus()
+      .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+      .run()
+  }
+
+  function setColor(e: Event) {
+    const color = (e.target as HTMLInputElement).value
+    $editor?.chain().focus().setColor(color).run()
+  }
+
+  function setHighlight(e: Event) {
+    const color = (e.target as HTMLInputElement).value
+    $editor?.chain().focus().toggleHighlight({ color }).run()
+  }
+
+  // Reactive "is active" helpers for styling toolbar buttons.
+  function active(name: string, attrs?: Record<string, unknown>): string {
+    return $editor?.isActive(name, attrs)
+      ? 'bg-surface-300 dark:bg-surface-600'
+      : ''
+  }
+</script>
+
+<style>
+  /* Toolbar buttons — small, consistent touch targets. */
+  .tb {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.1s;
+    position: relative;
+    border: none;
+    background: transparent;
+    color: inherit;
+  }
+  .tb:hover {
+    background: var(--color-surface-200);
+  }
+  :global(.dark) .tb:hover {
+    background: var(--color-surface-700);
+  }
+  /* Tiptap editor chrome — keep the editing area clean and consistent
+     with the rest of the app. */
+  :global(.tiptap) {
+    outline: none;
+    min-height: 200px;
+    padding: 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.625;
+  }
+  :global(.tiptap p.is-editor-empty:first-child::before) {
+    content: attr(data-placeholder);
+    float: left;
+    pointer-events: none;
+    height: 0;
+    color: #9ca3af;
+  }
+  /* Basic table styling so it's visible in the editor. */
+  :global(.tiptap table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0.5rem 0;
+  }
+  :global(.tiptap th),
+  :global(.tiptap td) {
+    border: 1px solid #d1d5db;
+    padding: 0.375rem 0.625rem;
+    text-align: left;
+    min-width: 80px;
+  }
+  :global(.tiptap th) {
+    background: #f3f4f6;
+    font-weight: 600;
+  }
+  :global(.tiptap img) {
+    max-width: 100%;
+    height: auto;
+  }
+  :global(.tiptap blockquote) {
+    border-left: 3px solid #d1d5db;
+    padding-left: 0.75rem;
+    margin: 0.5rem 0;
+    color: #6b7280;
+  }
+  :global(.tiptap hr) {
+    border: none;
+    border-top: 1px solid #d1d5db;
+    margin: 1rem 0;
+  }
+  :global(.tiptap ul),
+  :global(.tiptap ol) {
+    padding-left: 1.5rem;
+    margin: 0.25rem 0;
+  }
+  :global(.tiptap ul) { list-style-type: disc; }
+  :global(.tiptap ol) { list-style-type: decimal; }
+  :global(.tiptap a) { color: #3b82f6; text-decoration: underline; }
+</style>
+
+{#if $editor}
+  <!-- Toolbar -->
+  <div class="flex flex-wrap items-center gap-0.5 px-2 py-1.5 border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 text-sm">
+    <!-- Text style group -->
+    <button class="tb {active('bold')}" title="Bold" onclick={() => $editor?.chain().focus().toggleBold().run()}>
+      <strong>B</strong>
+    </button>
+    <button class="tb {active('italic')}" title="Italic" onclick={() => $editor?.chain().focus().toggleItalic().run()}>
+      <em>I</em>
+    </button>
+    <button class="tb {active('underline')}" title="Underline" onclick={() => $editor?.chain().focus().toggleUnderline().run()}>
+      <u>U</u>
+    </button>
+    <button class="tb {active('strike')}" title="Strikethrough" onclick={() => $editor?.chain().focus().toggleStrike().run()}>
+      <s>S</s>
+    </button>
+
+    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+    <!-- Headings -->
+    <button class="tb {active('heading', { level: 1 })}" title="Heading 1" onclick={() => $editor?.chain().focus().toggleHeading({ level: 1 }).run()}>
+      H1
+    </button>
+    <button class="tb {active('heading', { level: 2 })}" title="Heading 2" onclick={() => $editor?.chain().focus().toggleHeading({ level: 2 }).run()}>
+      H2
+    </button>
+    <button class="tb {active('heading', { level: 3 })}" title="Heading 3" onclick={() => $editor?.chain().focus().toggleHeading({ level: 3 }).run()}>
+      H3
+    </button>
+
+    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+    <!-- Lists -->
+    <button class="tb {active('bulletList')}" title="Bullet list" onclick={() => $editor?.chain().focus().toggleBulletList().run()}>
+      &#8226; List
+    </button>
+    <button class="tb {active('orderedList')}" title="Numbered list" onclick={() => $editor?.chain().focus().toggleOrderedList().run()}>
+      1. List
+    </button>
+
+    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+    <!-- Alignment -->
+    <button class="tb {active({ textAlign: 'left' })}" title="Align left" onclick={() => $editor?.chain().focus().setTextAlign('left').run()}>
+      &#x2261;L
+    </button>
+    <button class="tb {active({ textAlign: 'center' })}" title="Align center" onclick={() => $editor?.chain().focus().setTextAlign('center').run()}>
+      &#x2261;C
+    </button>
+    <button class="tb {active({ textAlign: 'right' })}" title="Align right" onclick={() => $editor?.chain().focus().setTextAlign('right').run()}>
+      &#x2261;R
+    </button>
+
+    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+    <!-- Colors -->
+    <label class="tb cursor-pointer" title="Text color">
+      A
+      <input type="color" class="w-0 h-0 opacity-0 absolute" onchange={setColor} />
+    </label>
+    <label class="tb cursor-pointer" title="Highlight color">
+      <span class="bg-yellow-200 px-0.5 rounded-sm">H</span>
+      <input type="color" value="#fde68a" class="w-0 h-0 opacity-0 absolute" onchange={setHighlight} />
+    </label>
+
+    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+    <!-- Insert group -->
+    <button class="tb {active('link')}" title="Insert link" onclick={setLink}>
+      Link
+    </button>
+    <button class="tb" title="Insert image" onclick={addImage}>
+      Image
+    </button>
+    <button class="tb" title="Insert table" onclick={insertTable}>
+      Table
+    </button>
+    <button class="tb" title="Horizontal rule" onclick={() => $editor?.chain().focus().setHorizontalRule().run()}>
+      &#x2015;
+    </button>
+    <button class="tb {active('blockquote')}" title="Blockquote" onclick={() => $editor?.chain().focus().toggleBlockquote().run()}>
+      &#x201C;
+    </button>
+
+    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+    <!-- Undo / Redo -->
+    <button class="tb" title="Undo" onclick={() => $editor?.chain().focus().undo().run()}>
+      &#x21A9;
+    </button>
+    <button class="tb" title="Redo" onclick={() => $editor?.chain().focus().redo().run()}>
+      &#x21AA;
+    </button>
+  </div>
+
+  <!-- Editor area -->
+  <div class="border border-surface-200 dark:border-surface-700 rounded-b-md bg-white dark:bg-surface-950 overflow-y-auto" style="max-height: 360px;">
+    <EditorContent editor={$editor} />
+  </div>
+{/if}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -11,18 +11,17 @@
    */
 
   import { onDestroy } from 'svelte'
-  import createEditor from 'svelte-tiptap'
-  import EditorContent from 'svelte-tiptap/EditorContent.svelte'
+  import { createEditor, EditorContent } from 'svelte-tiptap'
   import StarterKit from '@tiptap/starter-kit'
   import Underline from '@tiptap/extension-underline'
   import Link from '@tiptap/extension-link'
   import Image from '@tiptap/extension-image'
   import TextAlign from '@tiptap/extension-text-align'
   import Placeholder from '@tiptap/extension-placeholder'
-  import TextStyle from '@tiptap/extension-text-style'
+  import { TextStyle } from '@tiptap/extension-text-style'
   import Color from '@tiptap/extension-color'
   import Highlight from '@tiptap/extension-highlight'
-  import Table from '@tiptap/extension-table'
+  import { Table } from '@tiptap/extension-table'
   import TableRow from '@tiptap/extension-table-row'
   import TableCell from '@tiptap/extension-table-cell'
   import TableHeader from '@tiptap/extension-table-header'
@@ -41,11 +40,10 @@
     onchange,
   }: Props = $props()
 
+  // svelte-ignore state_referenced_locally
   const editor = createEditor({
     extensions: [
       StarterKit.configure({
-        // Horizontal rule is from StarterKit already, but we keep the
-        // default config.
         heading: { levels: [1, 2, 3] },
       }),
       Underline,
@@ -55,6 +53,7 @@
       }),
       Image.configure({ inline: true }),
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
+      // svelte-ignore state_referenced_locally
       Placeholder.configure({ placeholder }),
       TextStyle,
       Color,
@@ -64,6 +63,7 @@
       TableCell,
       TableHeader,
     ],
+    // svelte-ignore state_referenced_locally
     content,
     onUpdate: ({ editor: e }) => {
       onchange?.(e.getHTML())
@@ -121,10 +121,15 @@
   }
 
   // Reactive "is active" helpers for styling toolbar buttons.
+  const ACTIVE_CLS = 'bg-surface-300 dark:bg-surface-600'
+
   function active(name: string, attrs?: Record<string, unknown>): string {
-    return $editor?.isActive(name, attrs)
-      ? 'bg-surface-300 dark:bg-surface-600'
-      : ''
+    return $editor?.isActive(name, attrs) ? ACTIVE_CLS : ''
+  }
+
+  /** Check active state via an attribute map (e.g. `{ textAlign: 'left' }`). */
+  function activeAttrs(attrs: Record<string, unknown>): string {
+    return $editor?.isActive(attrs) ? ACTIVE_CLS : ''
   }
 </script>
 
@@ -252,13 +257,13 @@
     <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
 
     <!-- Alignment -->
-    <button class="tb {active({ textAlign: 'left' })}" title="Align left" onclick={() => $editor?.chain().focus().setTextAlign('left').run()}>
+    <button class="tb {activeAttrs({ textAlign: 'left' })}" title="Align left" onclick={() => $editor?.chain().focus().setTextAlign('left').run()}>
       &#x2261;L
     </button>
-    <button class="tb {active({ textAlign: 'center' })}" title="Align center" onclick={() => $editor?.chain().focus().setTextAlign('center').run()}>
+    <button class="tb {activeAttrs({ textAlign: 'center' })}" title="Align center" onclick={() => $editor?.chain().focus().setTextAlign('center').run()}>
       &#x2261;C
     </button>
-    <button class="tb {active({ textAlign: 'right' })}" title="Align right" onclick={() => $editor?.chain().focus().setTextAlign('right').run()}>
+    <button class="tb {activeAttrs({ textAlign: 'right' })}" title="Align right" onclick={() => $editor?.chain().focus().setTextAlign('right').run()}>
       &#x2261;R
     </button>
 

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -76,48 +76,77 @@
 
   // ── Toolbar helpers ─────────────────────────────────────────
 
-  /** Prompt for a URL and insert/update a link. */
+  // ── Toolbar helpers ─────────────────────────────────────────
+  // Each helper grabs the editor from the store at call time (not
+  // capture time) so it's always the live instance.
+
+  function cmd() {
+    return $editor!.chain().focus()
+  }
+
+  function toggleHeading(level: 1 | 2 | 3) {
+    cmd().toggleHeading({ level }).run()
+  }
+
+  function doUndo() { cmd().undo().run() }
+  function doRedo() { cmd().redo().run() }
+
   function setLink() {
     const prev = $editor?.getAttributes('link')?.href ?? ''
     const url = window.prompt('URL', prev)
     if (url === null) return
     if (url === '') {
-      $editor?.chain().focus().extendMarkRange('link').unsetLink().run()
+      cmd().extendMarkRange('link').unsetLink().run()
     } else {
-      $editor
-        ?.chain()
-        .focus()
-        .extendMarkRange('link')
-        .setLink({ href: url })
-        .run()
+      cmd().extendMarkRange('link').setLink({ href: url }).run()
     }
   }
 
-  /** Prompt for an image URL and insert it. */
-  function addImage() {
+  /** Insert an image from a local file (embedded as data URL). */
+  function addImageFromFile() {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/*'
+    input.onchange = () => {
+      const file = input.files?.[0]
+      if (!file) return
+      const reader = new FileReader()
+      reader.onload = () => {
+        const src = reader.result as string
+        cmd().setImage({ src }).run()
+      }
+      reader.readAsDataURL(file)
+    }
+    input.click()
+  }
+
+  /** Insert an image from a URL. */
+  function addImageFromUrl() {
     const url = window.prompt('Image URL')
     if (url) {
-      $editor?.chain().focus().setImage({ src: url }).run()
+      cmd().setImage({ src: url }).run()
     }
   }
 
-  /** Insert a 3x3 table. */
-  function insertTable() {
-    $editor
-      ?.chain()
-      .focus()
-      .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-      .run()
+  // ── Table grid picker state ────────────────────────────────
+  let showTablePicker = $state(false)
+  let tableHoverRows = $state(0)
+  let tableHoverCols = $state(0)
+  const TABLE_GRID = 8  // 8x8 picker like Outlook
+
+  function insertTable(rows: number, cols: number) {
+    cmd().insertTable({ rows, cols, withHeaderRow: true }).run()
+    showTablePicker = false
   }
 
   function setColor(e: Event) {
     const color = (e.target as HTMLInputElement).value
-    $editor?.chain().focus().setColor(color).run()
+    cmd().setColor(color).run()
   }
 
   function setHighlight(e: Event) {
     const color = (e.target as HTMLInputElement).value
-    $editor?.chain().focus().toggleHighlight({ color }).run()
+    cmd().toggleHighlight({ color }).run()
   }
 
   // Reactive "is active" helpers for styling toolbar buttons.
@@ -127,7 +156,6 @@
     return $editor?.isActive(name, attrs) ? ACTIVE_CLS : ''
   }
 
-  /** Check active state via an attribute map (e.g. `{ textAlign: 'left' }`). */
   function activeAttrs(attrs: Record<string, unknown>): string {
     return $editor?.isActive(attrs) ? ACTIVE_CLS : ''
   }
@@ -234,13 +262,13 @@
     <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
 
     <!-- Headings -->
-    <button class="tb {active('heading', { level: 1 })}" title="Heading 1" onclick={() => $editor?.chain().focus().toggleHeading({ level: 1 }).run()}>
+    <button class="tb {active('heading', { level: 1 })}" title="Heading 1" onclick={() => toggleHeading(1)}>
       H1
     </button>
-    <button class="tb {active('heading', { level: 2 })}" title="Heading 2" onclick={() => $editor?.chain().focus().toggleHeading({ level: 2 }).run()}>
+    <button class="tb {active('heading', { level: 2 })}" title="Heading 2" onclick={() => toggleHeading(2)}>
       H2
     </button>
-    <button class="tb {active('heading', { level: 3 })}" title="Heading 3" onclick={() => $editor?.chain().focus().toggleHeading({ level: 3 }).run()}>
+    <button class="tb {active('heading', { level: 3 })}" title="Heading 3" onclick={() => toggleHeading(3)}>
       H3
     </button>
 
@@ -285,26 +313,66 @@
     <button class="tb {active('link')}" title="Insert link" onclick={setLink}>
       Link
     </button>
-    <button class="tb" title="Insert image" onclick={addImage}>
-      Image
-    </button>
-    <button class="tb" title="Insert table" onclick={insertTable}>
-      Table
-    </button>
-    <button class="tb" title="Horizontal rule" onclick={() => $editor?.chain().focus().setHorizontalRule().run()}>
+
+    <!-- Image: dropdown with File / URL options -->
+    <div class="relative inline-block">
+      <button class="tb" title="Insert image" onclick={() => addImageFromFile()}>
+        Image
+      </button>
+      <button class="tb text-[10px]" title="Insert image from URL" onclick={() => addImageFromUrl()}>
+        URL
+      </button>
+    </div>
+
+    <!-- Table: Outlook-style grid picker -->
+    <div class="relative inline-block">
+      <button class="tb" title="Insert table" onclick={() => (showTablePicker = !showTablePicker)}>
+        Table
+      </button>
+      {#if showTablePicker}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="absolute left-0 top-full mt-1 z-50 p-2 bg-white dark:bg-surface-800 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg"
+          onmouseleave={() => { tableHoverRows = 0; tableHoverCols = 0 }}
+        >
+          <div class="text-xs text-surface-500 mb-1 text-center">
+            {tableHoverRows > 0 ? `${tableHoverRows} × ${tableHoverCols}` : 'Pick size'}
+          </div>
+          <div class="grid gap-0.5" style="grid-template-columns: repeat({TABLE_GRID}, 1fr)">
+            {#each { length: TABLE_GRID } as _, r}
+              {#each { length: TABLE_GRID } as _, c}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                  class="w-4 h-4 border rounded-sm cursor-pointer transition-colors
+                    {r < tableHoverRows && c < tableHoverCols
+                      ? 'bg-primary-500/40 border-primary-500'
+                      : 'bg-surface-100 dark:bg-surface-700 border-surface-300 dark:border-surface-600'}"
+                  onmouseenter={() => { tableHoverRows = r + 1; tableHoverCols = c + 1 }}
+                  onclick={() => insertTable(r + 1, c + 1)}
+                  role="button"
+                  tabindex="-1"
+                ></div>
+              {/each}
+            {/each}
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <button class="tb" title="Horizontal rule" onclick={() => cmd().setHorizontalRule().run()}>
       &#x2015;
     </button>
-    <button class="tb {active('blockquote')}" title="Blockquote" onclick={() => $editor?.chain().focus().toggleBlockquote().run()}>
+    <button class="tb {active('blockquote')}" title="Blockquote" onclick={() => cmd().toggleBlockquote().run()}>
       &#x201C;
     </button>
 
     <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
 
     <!-- Undo / Redo -->
-    <button class="tb" title="Undo" onclick={() => $editor?.chain().focus().undo().run()}>
+    <button class="tb" title="Undo (Ctrl+Z)" onclick={() => doUndo()}>
       &#x21A9;
     </button>
-    <button class="tb" title="Redo" onclick={() => $editor?.chain().focus().redo().run()}>
+    <button class="tb" title="Redo (Ctrl+Y)" onclick={() => doRedo()}>
       &#x21AA;
     </button>
   </div>


### PR DESCRIPTION
## Summary
- New `RichTextEditor.svelte` component built on Tiptap (ProseMirror) with a full formatting toolbar: bold/italic/underline/strike, headings (H1–H3), bullet & numbered lists, text alignment, font color, highlight, links, inline images, tables, blockquotes, horizontal rules, undo/redo.
- Replaces the plain `<textarea>` in `Compose.svelte`. The editor emits HTML that's sent as `body_html` alongside a stripped plaintext `body_text` — the SMTP client already builds `multipart/alternative` from both, so no backend changes needed.
- Drafts persist HTML so formatting survives close/reopen. Reply/forward quoted text is converted from plain text to minimal HTML for correct display in the WYSIWYG view.

Closes the last open task on #8 ("Rich text editor for the email body").

## Test plan
- [x] `svelte-check` clean
- [x] `cargo check` clean (no backend changes)
- [x] Manual: open Compose, apply formatting (bold, list, heading, table, link), send to self — verify formatting renders in received email
- [x] Manual: Reply to a message — quoted text appears in the editor with `>` formatting
- [x] Manual: close Compose without sending, reopen — draft restores with formatting intact
- [x] Manual: send with attachment + rich formatting — arrives with both

🤖 Generated with [Claude Code](https://claude.com/claude-code)