### PR TITLE
Full-text search across cached mail (#15)

### DIFF
--- a/crates/nimbus-carddav/src/client.rs
+++ b/crates/nimbus-carddav/src/client.rs
@@ -118,9 +118,7 @@ pub async fn delete_resource(
     app_password: &str,
     if_match: Option<&str>,
 ) -> Result<Response, NimbusError> {
-    let mut req = http
-        .delete(url)
-        .basic_auth(username, Some(app_password));
+    let mut req = http.delete(url).basic_auth(username, Some(app_password));
     if let Some(etag) = if_match {
         let v = if etag.starts_with('"') {
             etag.to_string()

--- a/crates/nimbus-carddav/src/discovery.rs
+++ b/crates/nimbus-carddav/src/discovery.rs
@@ -176,11 +176,7 @@ fn parse_response(
     // Trim non-empty href; derive the addressbook slug from the last
     // non-empty path segment.
     let trimmed = href.trim_end_matches('/');
-    let name = trimmed
-        .rsplit('/')
-        .next()
-        .unwrap_or(trimmed)
-        .to_string();
+    let name = trimmed.rsplit('/').next().unwrap_or(trimmed).to_string();
     let display_name = display_name.filter(|s| !s.is_empty());
 
     Ok(Some(Addressbook {

--- a/crates/nimbus-carddav/src/sync.rs
+++ b/crates/nimbus-carddav/src/sync.rs
@@ -268,14 +268,8 @@ async fn fetch_vcards(
         // the same form the server originally returned. Stripping the
         // server prefix is safe because we built the absolute form
         // from that prefix in the first place.
-        let path = c
-            .href
-            .strip_prefix(server_url)
-            .unwrap_or(&c.href);
-        hrefs_xml.push_str(&format!(
-            "  <d:href>{}</d:href>\n",
-            xml_escape(path)
-        ));
+        let path = c.href.strip_prefix(server_url).unwrap_or(&c.href);
+        hrefs_xml.push_str(&format!("  <d:href>{}</d:href>\n", xml_escape(path)));
     }
 
     let body = format!(

--- a/crates/nimbus-carddav/src/vcard.rs
+++ b/crates/nimbus-carddav/src/vcard.rs
@@ -334,10 +334,7 @@ mod tests {
         let parsed = parse_vcard(&raw).expect("re-parse");
         assert_eq!(parsed.uid, "abc-123");
         assert_eq!(parsed.display_name, "Alice Example");
-        assert_eq!(
-            parsed.emails,
-            vec!["alice@example.com", "alice@work.com"]
-        );
+        assert_eq!(parsed.emails, vec!["alice@example.com", "alice@work.com"]);
         assert_eq!(parsed.phones, vec!["+1 555 0100"]);
         assert_eq!(parsed.organization.as_deref(), Some("Example Corp"));
     }

--- a/crates/nimbus-carddav/src/write.rs
+++ b/crates/nimbus-carddav/src/write.rs
@@ -51,8 +51,7 @@ pub async fn create_contact(
     let http = build()?;
     let href = build_href(addressbook_url, uid);
 
-    let resp =
-        put_vcard(&http, &href, username, app_password, vcard, None, true).await?;
+    let resp = put_vcard(&http, &href, username, app_password, vcard, None, true).await?;
     let status = resp.status();
     if status == StatusCode::PRECONDITION_FAILED {
         return Err(NimbusError::Nextcloud(format!(
@@ -123,8 +122,7 @@ pub async fn delete_contact(
     if_match_etag: &str,
 ) -> Result<(), NimbusError> {
     let http = build()?;
-    let resp =
-        delete_resource(&http, href, username, app_password, Some(if_match_etag)).await?;
+    let resp = delete_resource(&http, href, username, app_password, Some(if_match_etag)).await?;
     let status = resp.status();
     if status == StatusCode::PRECONDITION_FAILED {
         return Err(NimbusError::Nextcloud(

--- a/crates/nimbus-carddav/src/xml_util.rs
+++ b/crates/nimbus-carddav/src/xml_util.rs
@@ -65,10 +65,7 @@ pub fn read_text_until(
 
 /// Skip past a subtree, consuming events until the matching close tag.
 /// Used to drop branches we don't care about (e.g. unknown propstats).
-pub fn skip_subtree(
-    reader: &mut Reader<&[u8]>,
-    start_local: &str,
-) -> Result<(), quick_xml::Error> {
+pub fn skip_subtree(reader: &mut Reader<&[u8]>, start_local: &str) -> Result<(), quick_xml::Error> {
     let mut depth = 1;
     loop {
         match reader.read_event() {

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -501,6 +501,114 @@ impl ImapClient {
         Ok(())
     }
 
+    /// Server-side search fallback for messages that aren't cached locally.
+    ///
+    /// Runs `UID SEARCH` on the given folder with a criterion built from
+    /// the user's query, then fetches envelopes for up to `limit` hits.
+    /// Used when the FTS5 cache misses (e.g. the user is looking for an
+    /// old message that was never opened on this machine).
+    ///
+    /// IMAP SEARCH is server-implementation-dependent and can be slow —
+    /// this is the "last resort" path. The frontend calls it only after
+    /// the local cache search returns fewer results than expected, or on
+    /// explicit user action ("search server too").
+    pub async fn search_envelopes(
+        &mut self,
+        folder: &str,
+        criterion: &str,
+        limit: u32,
+    ) -> Result<Vec<EmailEnvelope>, NimbusError> {
+        let (_total, _uidvalidity) = self.select_folder(folder).await?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        debug!("UID SEARCH in '{folder}' with criterion: {criterion}");
+        let uids: Vec<u32> = session
+            .uid_search(criterion)
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID SEARCH failed: {e}")))?
+            .into_iter()
+            .collect();
+
+        if uids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Newest-first: SEARCH returns in UID ascending order, but the
+        // mail list shows newest first. Sort desc, then cap to limit.
+        let mut uids = uids;
+        uids.sort_unstable_by(|a, b| b.cmp(a));
+        uids.truncate(limit as usize);
+
+        // Build a UID set like `42,17,9` — async-imap accepts this form.
+        let set = uids
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let fetches: Vec<_> = session
+            .uid_fetch(set, "(UID FLAGS INTERNALDATE ENVELOPE)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID FETCH after SEARCH failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read SEARCH FETCH: {e}")))?;
+
+        let mut envelopes: Vec<EmailEnvelope> = fetches
+            .iter()
+            .filter_map(|fetch| {
+                let uid = fetch.uid?;
+                let envelope = fetch.envelope()?;
+
+                let subject = envelope
+                    .subject
+                    .as_ref()
+                    .map(|s| decode_header(s))
+                    .unwrap_or_default();
+                let from = envelope
+                    .from
+                    .as_ref()
+                    .and_then(|addrs| addrs.first())
+                    .map(format_address)
+                    .unwrap_or_default();
+                let date = envelope
+                    .date
+                    .as_ref()
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .and_then(parse_rfc2822)
+                    .or_else(|| fetch.internal_date().map(|dt| dt.with_timezone(&Utc)))
+                    .unwrap_or_else(Utc::now);
+
+                let mut is_read = false;
+                let mut is_starred = false;
+                for flag in fetch.flags() {
+                    match flag {
+                        async_imap::types::Flag::Seen => is_read = true,
+                        async_imap::types::Flag::Flagged => is_starred = true,
+                        _ => {}
+                    }
+                }
+
+                Some(EmailEnvelope {
+                    uid,
+                    folder: folder.to_string(),
+                    from,
+                    subject,
+                    date,
+                    is_read,
+                    is_starred,
+                })
+            })
+            .collect();
+        envelopes.sort_unstable_by(|a, b| b.date.cmp(&a.date));
+
+        info!("SEARCH '{folder}' '{criterion}' → {} hits", envelopes.len());
+        Ok(envelopes)
+    }
+
     /// Log out from the IMAP server and close the connection cleanly.
     ///
     /// Always call this when you're done — it sends the LOGOUT command

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -210,10 +210,7 @@ impl Cache {
     /// addressbook into 30+ MB of IPC traffic. `photo_mime` is kept
     /// as a presence flag; the UI uses `get_contact_photo` to fetch
     /// the bytes on demand for whichever rows it actually paints.
-    pub fn list_contacts(
-        &self,
-        nc_account_id: Option<&str>,
-    ) -> Result<Vec<Contact>, CacheError> {
+    pub fn list_contacts(&self, nc_account_id: Option<&str>) -> Result<Vec<Contact>, CacheError> {
         let conn = self.pool.get()?;
         let mut stmt;
         let rows = match nc_account_id {
@@ -274,11 +271,7 @@ impl Cache {
     /// so a phone-only contact is just noise here. Caps results at
     /// `limit` so a typo that matches half the address book doesn't
     /// tank the UI.
-    pub fn search_contacts(
-        &self,
-        query: &str,
-        limit: u32,
-    ) -> Result<Vec<Contact>, CacheError> {
+    pub fn search_contacts(&self, query: &str, limit: u32) -> Result<Vec<Contact>, CacheError> {
         let conn = self.pool.get()?;
         let needle = format!("%{}%", query.replace('%', r"\%").replace('_', r"\_"));
         // emails_json is the stringified JSON array. "[]" is the
@@ -409,10 +402,7 @@ impl Cache {
     /// Remove one contact by its app-side id.
     pub fn delete_contact_by_id(&self, contact_id: &str) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
-        conn.execute(
-            "DELETE FROM contacts WHERE id = ?1",
-            params![contact_id],
-        )?;
+        conn.execute("DELETE FROM contacts WHERE id = ?1", params![contact_id])?;
         Ok(())
     }
 
@@ -504,7 +494,15 @@ mod tests {
             row("u2", "Bob Marley", "bob@reggae.com"),
         ];
         cache
-            .apply_contact_delta("nc1", "contacts", Some("Contacts"), &upserts, &[], Some("tok-1"), Some("c1"))
+            .apply_contact_delta(
+                "nc1",
+                "contacts",
+                Some("Contacts"),
+                &upserts,
+                &[],
+                Some("tok-1"),
+                Some("c1"),
+            )
             .unwrap();
 
         // Hit by name

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -36,8 +36,10 @@ pub mod contacts;
 pub mod key;
 pub mod pool;
 pub mod schema;
+pub mod search;
 
 pub use contacts::{AddressbookSyncState, ContactRow, ContactServerHandle};
+pub use search::{SearchFilters, SearchHit, SearchScope};
 
 use std::path::{Path, PathBuf};
 

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -180,6 +180,164 @@ const MIGRATIONS: &[&str] = &[
         PRIMARY KEY (nextcloud_account_id, addressbook)
     );
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v3 → v4: full-text search index for emails (Issue #15).
+    //
+    // FTS5 virtual table acting as a *contentless external-content*
+    // index over `messages` joined with `message_bodies`. We use the
+    // `content=''` (contentless) form and write index rows explicitly
+    // via triggers so the indexed columns can come from two tables.
+    //
+    // Tokenizer:
+    //   - `unicode61`  — Unicode-aware word splitter, handles UTF-8
+    //     correctly for international names and subjects.
+    //   - `remove_diacritics 2` — matches "müller" when searching
+    //     "muller" (Outlook behaves this way).
+    //   - `porter` over unicode61 — stems English word endings so
+    //     "invoices" matches "invoice". For non-English mail this
+    //     is a no-op, which is fine.
+    //
+    // `rowid` is a synthetic row index — we keep an inverse lookup
+    // via (account_id, folder, uid) stored on the row so we can map
+    // FTS hits back to real messages.
+    //
+    // Triggers keep the index in lockstep with `messages` /
+    // `message_bodies` so the app never has to remember to re-index.
+    // Because FTS5 rows reference message data we guard deletes too.
+    //
+    // `search_meta` holds the lookup triple for each rowid — FTS5's
+    // own rowid is the join key. We use INTEGER PRIMARY KEY so that
+    // INSERT returns a stable autoincrementing rowid we can feed to
+    // the FTS5 index.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    CREATE TABLE search_meta (
+        rowid        INTEGER PRIMARY KEY AUTOINCREMENT,
+        account_id   TEXT NOT NULL,
+        folder       TEXT NOT NULL,
+        uid          INTEGER NOT NULL,
+        UNIQUE (account_id, folder, uid)
+    );
+
+    CREATE VIRTUAL TABLE search_index USING fts5(
+        subject,
+        from_addr,
+        to_addrs,
+        cc_addrs,
+        body,
+        tokenize = 'porter unicode61 remove_diacritics 2'
+    );
+
+    -- Keep search_meta row in sync with messages lifecycle.
+    CREATE TRIGGER search_meta_insert
+    AFTER INSERT ON messages
+    BEGIN
+        INSERT OR IGNORE INTO search_meta (account_id, folder, uid)
+        VALUES (NEW.account_id, NEW.folder, NEW.uid);
+    END;
+
+    CREATE TRIGGER search_meta_delete
+    AFTER DELETE ON messages
+    BEGIN
+        DELETE FROM search_index
+        WHERE rowid = (
+            SELECT rowid FROM search_meta
+            WHERE account_id = OLD.account_id
+              AND folder = OLD.folder
+              AND uid = OLD.uid
+        );
+        DELETE FROM search_meta
+        WHERE account_id = OLD.account_id
+          AND folder = OLD.folder
+          AND uid = OLD.uid;
+    END;
+
+    -- Index the envelope fields as soon as the message row lands.
+    -- Body columns are empty until a message_bodies row joins.
+    CREATE TRIGGER search_index_envelope_insert
+    AFTER INSERT ON messages
+    BEGIN
+        INSERT INTO search_index (rowid, subject, from_addr, to_addrs, cc_addrs, body)
+        VALUES (
+            (SELECT rowid FROM search_meta
+             WHERE account_id = NEW.account_id
+               AND folder = NEW.folder
+               AND uid = NEW.uid),
+            NEW.subject, NEW.from_addr, '', '', ''
+        );
+    END;
+
+    CREATE TRIGGER search_index_envelope_update
+    AFTER UPDATE OF subject, from_addr ON messages
+    BEGIN
+        UPDATE search_index
+        SET subject = NEW.subject,
+            from_addr = NEW.from_addr
+        WHERE rowid = (
+            SELECT rowid FROM search_meta
+            WHERE account_id = NEW.account_id
+              AND folder = NEW.folder
+              AND uid = NEW.uid
+        );
+    END;
+
+    -- When the body lands (or gets refreshed) splice in the heavy
+    -- columns. We intentionally concat plain text only; HTML would
+    -- pollute the index with tag noise and Outlook's search also
+    -- ignores markup.
+    CREATE TRIGGER search_index_body_upsert
+    AFTER INSERT ON message_bodies
+    BEGIN
+        UPDATE search_index
+        SET to_addrs = NEW.to_addrs,
+            cc_addrs = NEW.cc_addrs,
+            body     = COALESCE(NEW.body_text, '')
+        WHERE rowid = (
+            SELECT rowid FROM search_meta
+            WHERE account_id = NEW.account_id
+              AND folder = NEW.folder
+              AND uid = NEW.uid
+        );
+    END;
+
+    CREATE TRIGGER search_index_body_update
+    AFTER UPDATE ON message_bodies
+    BEGIN
+        UPDATE search_index
+        SET to_addrs = NEW.to_addrs,
+            cc_addrs = NEW.cc_addrs,
+            body     = COALESCE(NEW.body_text, '')
+        WHERE rowid = (
+            SELECT rowid FROM search_meta
+            WHERE account_id = NEW.account_id
+              AND folder = NEW.folder
+              AND uid = NEW.uid
+        );
+    END;
+
+    -- Backfill: index everything already cached from earlier versions.
+    -- New installs start empty so this is a no-op.
+    INSERT INTO search_meta (account_id, folder, uid)
+    SELECT account_id, folder, uid FROM messages;
+
+    INSERT INTO search_index (rowid, subject, from_addr, to_addrs, cc_addrs, body)
+    SELECT
+        sm.rowid,
+        m.subject,
+        m.from_addr,
+        COALESCE(b.to_addrs, ''),
+        COALESCE(b.cc_addrs, ''),
+        COALESCE(b.body_text, '')
+    FROM search_meta sm
+    INNER JOIN messages m
+        ON m.account_id = sm.account_id
+        AND m.folder = sm.folder
+        AND m.uid = sm.uid
+    LEFT JOIN message_bodies b
+        ON b.account_id = sm.account_id
+        AND b.folder = sm.folder
+        AND b.uid = sm.uid;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/crates/nimbus-store/src/cache/search.rs
+++ b/crates/nimbus-store/src/cache/search.rs
@@ -1,0 +1,703 @@
+//! Full-text search over the cached mail corpus (Issue #15).
+//!
+//! # How this works
+//!
+//! The cache schema (see `schema.rs`, migration v3 → v4) carries an
+//! FTS5 virtual table `search_index` with the columns `subject`,
+//! `from_addr`, `to_addrs`, `cc_addrs`, and `body`. Triggers keep it
+//! in sync with `messages` / `message_bodies`, so every write through
+//! the normal upsert paths also lands in the index for free.
+//!
+//! This module is the *read* side: parse a user query into field
+//! filters + a free-text match expression, run it, and return
+//! enriched envelopes with highlighted snippets.
+//!
+//! # Query syntax
+//!
+//! Outlook-style operator syntax — we translate it to FTS5's native
+//! `column:term` expression and WHERE-clause filters on the real
+//! columns. Supported forms:
+//!
+//! - `from:alice`        → match in `from_addr`
+//! - `to:bob`            → match in `to_addrs`
+//! - `subject:foo`       → match in `subject`
+//! - `body:bar`          → match in `body`
+//! - `"exact phrase"`    → phrase search, all indexed columns
+//! - `has:attachment`    → filter `has_attachments = 1`
+//! - `is:unread`         → filter `is_read = 0`
+//! - `is:read`           → filter `is_read = 1`
+//! - `is:flagged`        → filter `is_starred = 1`
+//! - plain words         → match in any indexed column
+//!
+//! Operators combine with AND semantics. Everything after a known
+//! operator up to the next whitespace is the operand, unless the
+//! operand is a double-quoted phrase — then we keep going until the
+//! closing quote.
+
+use chrono::{DateTime, TimeZone, Utc};
+use rusqlite::{ToSql, params_from_iter};
+use serde::{Deserialize, Serialize};
+
+use crate::cache::{Cache, CacheError};
+
+/// Optional scope narrowing — mirrors Outlook's scope selector.
+/// `Current folder` is represented by passing `Some(folder)`;
+/// "all folders across all accounts" is the empty `SearchScope`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchScope {
+    /// Limit to this account id, or all accounts if `None`.
+    #[serde(default)]
+    pub account_id: Option<String>,
+    /// Limit to this folder, or all folders if `None`.
+    #[serde(default)]
+    pub folder: Option<String>,
+    /// Maximum number of results. Defaults to 200 when zero / missing
+    /// to keep a runaway query from choking the UI.
+    #[serde(default)]
+    pub limit: u32,
+}
+
+/// Additional explicit filters layered on top of the operator parse.
+/// The UI can drive these as toggle chips without touching the query
+/// string — keeps "has attachment" / "unread" one click away even when
+/// the user is typing free text.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchFilters {
+    #[serde(default)]
+    pub unread_only: bool,
+    #[serde(default)]
+    pub flagged_only: bool,
+    #[serde(default)]
+    pub has_attachment: bool,
+    /// Unix epoch seconds — inclusive lower bound.
+    #[serde(default)]
+    pub date_from: Option<i64>,
+    /// Unix epoch seconds — inclusive upper bound.
+    #[serde(default)]
+    pub date_to: Option<i64>,
+}
+
+/// A single search hit. Carries enough fields to render a mail-list
+/// row without a second lookup, plus a highlighted snippet for the
+/// results pane.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchHit {
+    pub account_id: String,
+    pub folder: String,
+    pub uid: u32,
+    pub from: String,
+    pub subject: String,
+    pub date: DateTime<Utc>,
+    pub is_read: bool,
+    pub is_starred: bool,
+    pub has_attachments: bool,
+    /// FTS5 `snippet()` output with `<mark>…</mark>` around matches.
+    /// Empty string when the query is purely filter-based.
+    pub snippet: String,
+}
+
+impl Cache {
+    /// Run a search against the local FTS5 index.
+    ///
+    /// Returns hits newest-first. The query is parsed by
+    /// [`parse_query`]; `scope` restricts to an account/folder and
+    /// caps the result count; `filters` layers boolean toggles on
+    /// top (UI chips). An empty query with only filters is valid and
+    /// returns the newest matching messages — same as Outlook's
+    /// "Has attachments" sidebar filter.
+    pub fn search_emails(
+        &self,
+        query: &str,
+        scope: &SearchScope,
+        filters: &SearchFilters,
+    ) -> Result<Vec<SearchHit>, CacheError> {
+        let parsed = parse_query(query);
+        let conn = self.pool.get()?;
+
+        // Build SQL + bindings incrementally so we can toggle the
+        // FTS5 join off when there's no text to match (pure filter
+        // query) — saves a virtual-table scan.
+        let mut sql = String::from(
+            "SELECT m.account_id, m.folder, m.uid, m.from_addr, m.subject,
+                    m.internal_date, m.is_read, m.is_starred,
+                    COALESCE(b.has_attachments, 0) AS has_attachments,",
+        );
+        let mut params: Vec<Box<dyn ToSql>> = Vec::new();
+
+        if parsed.has_text() {
+            // Snippet args: (table, col, start, end, ellipsis, tokens).
+            // `col = -1` tells FTS5 "pick the best matching column".
+            sql.push_str(" snippet(search_index, -1, '<mark>', '</mark>', '…', 16) AS snippet ");
+            sql.push_str(
+                "FROM search_index
+                 INNER JOIN search_meta sm ON sm.rowid = search_index.rowid
+                 INNER JOIN messages m
+                   ON m.account_id = sm.account_id
+                   AND m.folder = sm.folder
+                   AND m.uid = sm.uid
+                 LEFT JOIN message_bodies b
+                   ON b.account_id = m.account_id
+                   AND b.folder = m.folder
+                   AND b.uid = m.uid
+                 WHERE search_index MATCH ?",
+            );
+            params.push(Box::new(parsed.match_expression()));
+        } else {
+            sql.push_str(
+                " '' AS snippet
+                 FROM messages m
+                 LEFT JOIN message_bodies b
+                   ON b.account_id = m.account_id
+                   AND b.folder = m.folder
+                   AND b.uid = m.uid
+                 WHERE 1 = 1",
+            );
+        }
+
+        // Apply scope + filters. Parameters are appended in the same
+        // order we push them into `params`.
+        if let Some(acc) = &scope.account_id {
+            sql.push_str(" AND m.account_id = ?");
+            params.push(Box::new(acc.clone()));
+        }
+        if let Some(f) = &scope.folder {
+            sql.push_str(" AND m.folder = ?");
+            params.push(Box::new(f.clone()));
+        }
+        if filters.unread_only {
+            sql.push_str(" AND m.is_read = 0");
+        }
+        if filters.flagged_only {
+            sql.push_str(" AND m.is_starred = 1");
+        }
+        if filters.has_attachment {
+            sql.push_str(" AND COALESCE(b.has_attachments, 0) = 1");
+        }
+        if let Some(from) = filters.date_from {
+            sql.push_str(" AND m.internal_date >= ?");
+            params.push(Box::new(from));
+        }
+        if let Some(to) = filters.date_to {
+            sql.push_str(" AND m.internal_date <= ?");
+            params.push(Box::new(to));
+        }
+
+        // Fold operator-based filters from the parsed query.
+        if parsed.is_unread == Some(true) {
+            sql.push_str(" AND m.is_read = 0");
+        } else if parsed.is_unread == Some(false) {
+            sql.push_str(" AND m.is_read = 1");
+        }
+        if parsed.is_flagged == Some(true) {
+            sql.push_str(" AND m.is_starred = 1");
+        }
+        if parsed.has_attachment == Some(true) {
+            sql.push_str(" AND COALESCE(b.has_attachments, 0) = 1");
+        }
+
+        sql.push_str(" ORDER BY m.internal_date DESC LIMIT ?");
+        let limit = if scope.limit == 0 { 200 } else { scope.limit };
+        params.push(Box::new(limit as i64));
+
+        let mut stmt = conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn ToSql> = params.iter().map(|p| &**p).collect();
+        let rows = stmt.query_map(params_from_iter(param_refs.iter()), |r| {
+            let ts: i64 = r.get(5)?;
+            let date = Utc.timestamp_opt(ts, 0).single().unwrap_or_else(Utc::now);
+            Ok(SearchHit {
+                account_id: r.get(0)?,
+                folder: r.get(1)?,
+                uid: r.get::<_, i64>(2)? as u32,
+                from: r.get(3)?,
+                subject: r.get(4)?,
+                date,
+                is_read: r.get::<_, i64>(6)? != 0,
+                is_starred: r.get::<_, i64>(7)? != 0,
+                has_attachments: r.get::<_, i64>(8)? != 0,
+                snippet: r.get(9)?,
+            })
+        })?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}
+
+// ── Query parser ────────────────────────────────────────────────
+
+/// Parsed components of a search query string.
+///
+/// Separated from `SearchFilters` because they come from operator
+/// syntax in the query box, while filters are the chip toggles.
+/// Kept pub for tests only.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct ParsedQuery {
+    /// Free-text terms and column-scoped terms to feed FTS5.
+    /// Each entry is already a valid FTS5 atom (e.g. `alice`,
+    /// `subject:"project x"`, `"exact phrase"`).
+    fts_atoms: Vec<String>,
+    /// `Some(true)` = require unread, `Some(false)` = require read,
+    /// `None` = don't filter on read state.
+    is_unread: Option<bool>,
+    is_flagged: Option<bool>,
+    has_attachment: Option<bool>,
+}
+
+impl ParsedQuery {
+    fn has_text(&self) -> bool {
+        !self.fts_atoms.is_empty()
+    }
+
+    /// Build the `MATCH` expression FTS5 consumes. Atoms are joined
+    /// with implicit AND (FTS5's default when atoms are whitespace-
+    /// separated at the top level).
+    fn match_expression(&self) -> String {
+        self.fts_atoms.join(" ")
+    }
+}
+
+/// Parse an Outlook-style search string into FTS5 atoms + filters.
+///
+/// Runs in O(n) over the input, no regex. Unknown `op:value` tokens
+/// are treated as free text — we never reject user input, we just
+/// ignore operators we don't know (forward-compat with future syntax).
+pub(crate) fn parse_query(input: &str) -> ParsedQuery {
+    let mut out = ParsedQuery::default();
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((_, c)) = chars.peek().copied() {
+        if c.is_whitespace() {
+            chars.next();
+            continue;
+        }
+        // Read a "token" — either a quoted phrase or a whitespace-
+        // delimited word, possibly with an operator prefix.
+        if c == '"' {
+            let phrase = read_quoted(&mut chars);
+            if !phrase.is_empty() {
+                out.fts_atoms.push(fts_phrase(&phrase));
+            }
+            continue;
+        }
+        let word = read_word(&mut chars);
+        if let Some((op, rest)) = split_operator(&word) {
+            apply_operator(&mut out, op, rest, &mut chars);
+        } else if !word.is_empty() {
+            out.fts_atoms.push(fts_term(&word));
+        }
+    }
+
+    out
+}
+
+/// Read characters up to the next unescaped whitespace.
+fn read_word(chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>) -> String {
+    let mut s = String::new();
+    while let Some(&(_, c)) = chars.peek() {
+        if c.is_whitespace() {
+            break;
+        }
+        s.push(c);
+        chars.next();
+    }
+    s
+}
+
+/// Read characters between a starting `"` and the closing `"` (or EOF).
+fn read_quoted(chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>) -> String {
+    chars.next(); // consume opening "
+    let mut s = String::new();
+    for (_, c) in chars.by_ref() {
+        if c == '"' {
+            break;
+        }
+        s.push(c);
+    }
+    s
+}
+
+/// Split `op:value` into `("op", "value")`. Returns `None` if the
+/// word doesn't contain a colon, or if it starts with one (URLs
+/// like `https://…` would otherwise be treated as `https:` operator).
+fn split_operator(word: &str) -> Option<(&str, &str)> {
+    let idx = word.find(':')?;
+    if idx == 0 || idx + 1 >= word.len() {
+        return None;
+    }
+    let op = &word[..idx];
+    let rest = &word[idx + 1..];
+    // Only treat as operator if the op part is pure alpha — avoids
+    // catching URLs and future `scheme://` patterns.
+    if op.chars().all(|c| c.is_ascii_alphabetic()) {
+        Some((op, rest))
+    } else {
+        None
+    }
+}
+
+fn apply_operator(
+    out: &mut ParsedQuery,
+    op: &str,
+    rest: &str,
+    chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+) {
+    // Operand may be quoted — if `rest` starts with `"`, pull in
+    // everything until the closing quote from the remaining stream.
+    let operand = if let Some(stripped) = rest.strip_prefix('"') {
+        let mut s = String::from(stripped);
+        let mut closed = stripped.ends_with('"') && !stripped.is_empty();
+        if closed {
+            s.pop();
+        }
+        while !closed {
+            match chars.next() {
+                Some((_, '"')) => closed = true,
+                Some((_, c)) => s.push(c),
+                None => break,
+            }
+        }
+        s
+    } else {
+        rest.to_string()
+    };
+
+    match op.to_ascii_lowercase().as_str() {
+        "from" => out.fts_atoms.push(fts_column("from_addr", &operand)),
+        "to" => out.fts_atoms.push(fts_column("to_addrs", &operand)),
+        "cc" => out.fts_atoms.push(fts_column("cc_addrs", &operand)),
+        "subject" | "title" => out.fts_atoms.push(fts_column("subject", &operand)),
+        "body" => out.fts_atoms.push(fts_column("body", &operand)),
+        "has" | "hasattachment" | "hasattachments" => {
+            if matches!(
+                operand.to_ascii_lowercase().as_str(),
+                "attachment" | "attachments" | "yes" | "true" | "1"
+            ) {
+                out.has_attachment = Some(true);
+            }
+        }
+        "is" | "state" => match operand.to_ascii_lowercase().as_str() {
+            "unread" | "new" => out.is_unread = Some(true),
+            "read" | "seen" => out.is_unread = Some(false),
+            "flagged" | "starred" | "important" => out.is_flagged = Some(true),
+            _ => {}
+        },
+        // Unknown operator — fall back to a free-text atom so the
+        // user's typing still does something useful.
+        _ => {
+            let rebuilt = format!("{op}:{operand}");
+            out.fts_atoms.push(fts_term(&rebuilt));
+        }
+    }
+}
+
+/// Sanitise and wrap a free-text term for FTS5.
+///
+/// We want "as-you-type" matching — a user typing `dam` should already
+/// see hits for `damm`, `damage`, etc. FTS5 expresses that with the
+/// `term*` prefix-match operator, but that operator is only valid on
+/// bare (unquoted) tokens.
+///
+/// So: if the word is made of plain letters/digits we emit `word*`.
+/// If it contains anything else (punctuation, operators, URL bits),
+/// we fall back to a quoted phrase — no prefix, but FTS5 will still
+/// tokenize inside the quotes and find it.
+fn fts_term(word: &str) -> String {
+    if word.is_empty() {
+        return String::new();
+    }
+    let all_safe = word.chars().all(|c| c.is_alphanumeric() || c == '_');
+    if all_safe {
+        format!("{word}*")
+    } else {
+        let escaped = word.replace('"', "\"\"");
+        format!("\"{escaped}\"")
+    }
+}
+
+/// Wrap a phrase in FTS5 phrase syntax. Unlike [`fts_term`], phrases
+/// are always quoted — the user explicitly asked for exact match by
+/// typing the surrounding quotes, so we don't want to silently convert
+/// them into a prefix search.
+fn fts_phrase(phrase: &str) -> String {
+    let escaped = phrase.replace('"', "\"\"");
+    format!("\"{escaped}\"")
+}
+
+/// Column-scoped atom: `column : "value"`.
+fn fts_column(column: &str, value: &str) -> String {
+    format!("{column}:{}", fts_term(value))
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::{Cache, pool, schema};
+    use chrono::Duration;
+    use nimbus_core::models::Email;
+
+    fn open() -> Cache {
+        let pool = pool::open_memory_pool().unwrap();
+        let mut conn = pool.get().unwrap();
+        schema::run_migrations(&mut conn).unwrap();
+        drop(conn);
+        Cache { pool }
+    }
+
+    fn email(uid: u32, folder: &str, subject: &str, body: &str, from: &str) -> Email {
+        Email {
+            id: format!("{folder}:{uid}"),
+            account_id: "acc".into(),
+            folder: folder.into(),
+            from: from.into(),
+            to: vec!["bob@example.com".into()],
+            cc: vec![],
+            subject: subject.into(),
+            body_text: Some(body.into()),
+            body_html: None,
+            date: Utc::now() - Duration::seconds(uid as i64),
+            is_read: false,
+            is_starred: false,
+            has_attachments: false,
+        }
+    }
+
+    #[test]
+    fn parse_free_text() {
+        // Free-text words are emitted as FTS5 prefix atoms so typing
+        // `dam` already matches `damm`, `damage`, etc.
+        let p = parse_query("project budget");
+        assert_eq!(p.fts_atoms, vec!["project*", "budget*"]);
+        assert!(p.has_text());
+    }
+
+    #[test]
+    fn parse_operators() {
+        let p = parse_query("from:alice subject:\"weekly update\" has:attachment");
+        // `alice` is a bare word → prefix-match. `weekly update` is a
+        // quoted phrase → stays an exact phrase.
+        assert_eq!(
+            p.fts_atoms,
+            vec!["from_addr:alice*", "subject:\"weekly update\"",]
+        );
+        assert_eq!(p.has_attachment, Some(true));
+    }
+
+    #[test]
+    fn parse_state_operators() {
+        let p = parse_query("is:unread is:flagged");
+        assert!(p.fts_atoms.is_empty());
+        assert_eq!(p.is_unread, Some(true));
+        assert_eq!(p.is_flagged, Some(true));
+    }
+
+    #[test]
+    fn parse_ignores_urls() {
+        // A `scheme://host` in the query should not be parsed as
+        // `scheme:` operator (non-alpha after colon wins, plus the
+        // slashes stay in the term).
+        let p = parse_query("https://example.com/foo");
+        assert_eq!(p.fts_atoms.len(), 1);
+        assert!(p.fts_atoms[0].contains("https"));
+    }
+
+    #[test]
+    fn parse_quoted_phrase() {
+        let p = parse_query("\"quarterly report\" urgent");
+        // Quoted phrase stays exact; the bare word becomes prefix-match.
+        assert_eq!(p.fts_atoms[0], "\"quarterly report\"");
+        assert_eq!(p.fts_atoms[1], "urgent*");
+    }
+
+    #[test]
+    fn search_matches_subject_and_body() {
+        let cache = open();
+        cache
+            .upsert_message(&email(
+                1,
+                "INBOX",
+                "Budget planning Q2",
+                "Please review the attached spreadsheet.",
+                "alice@example.com",
+            ))
+            .unwrap();
+        cache
+            .upsert_message(&email(
+                2,
+                "INBOX",
+                "Lunch tomorrow?",
+                "Want to grab lunch?",
+                "bob@example.com",
+            ))
+            .unwrap();
+
+        let hits = cache
+            .search_emails("budget", &SearchScope::default(), &SearchFilters::default())
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].subject, "Budget planning Q2");
+        assert!(hits[0].snippet.contains("<mark>"));
+    }
+
+    #[test]
+    fn search_filters_by_scope() {
+        let cache = open();
+        cache
+            .upsert_message(&email(1, "INBOX", "Alpha", "hello", "a@x.de"))
+            .unwrap();
+        cache
+            .upsert_message(&email(2, "Sent", "Alpha", "hello", "a@x.de"))
+            .unwrap();
+
+        let scope = SearchScope {
+            account_id: Some("acc".into()),
+            folder: Some("Sent".into()),
+            limit: 10,
+        };
+        let hits = cache
+            .search_emails("alpha", &scope, &SearchFilters::default())
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].folder, "Sent");
+    }
+
+    #[test]
+    fn search_operator_from() {
+        let cache = open();
+        cache
+            .upsert_message(&email(1, "INBOX", "Hi", "body", "alice@example.com"))
+            .unwrap();
+        cache
+            .upsert_message(&email(2, "INBOX", "Hi", "body", "bob@example.com"))
+            .unwrap();
+
+        let hits = cache
+            .search_emails(
+                "from:alice",
+                &SearchScope::default(),
+                &SearchFilters::default(),
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].from.contains("alice"));
+    }
+
+    #[test]
+    fn search_filter_unread_only() {
+        let cache = open();
+        let mut read_mail = email(1, "INBOX", "one", "body", "a@x.de");
+        read_mail.is_read = true;
+        let unread_mail = email(2, "INBOX", "two", "body", "b@x.de");
+        cache.upsert_message(&read_mail).unwrap();
+        cache.upsert_message(&unread_mail).unwrap();
+
+        let filters = SearchFilters {
+            unread_only: true,
+            ..Default::default()
+        };
+        let hits = cache
+            .search_emails("", &SearchScope::default(), &filters)
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].uid, 2);
+    }
+
+    #[test]
+    fn search_filter_has_attachment() {
+        let cache = open();
+        let plain = email(1, "INBOX", "no att", "body", "a@x.de");
+        let mut att = email(2, "INBOX", "with att", "body", "b@x.de");
+        att.has_attachments = true;
+        cache.upsert_message(&plain).unwrap();
+        cache.upsert_message(&att).unwrap();
+
+        let hits = cache
+            .search_emails(
+                "",
+                &SearchScope::default(),
+                &SearchFilters {
+                    has_attachment: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].has_attachments);
+    }
+
+    #[test]
+    fn search_empty_query_returns_recent() {
+        let cache = open();
+        for i in 0..5 {
+            cache
+                .upsert_message(&email(i + 1, "INBOX", &format!("subj {i}"), "b", "a@x.de"))
+                .unwrap();
+        }
+        let hits = cache
+            .search_emails("", &SearchScope::default(), &SearchFilters::default())
+            .unwrap();
+        assert_eq!(hits.len(), 5);
+    }
+
+    #[test]
+    fn search_matches_partial_prefix() {
+        // User typed "dam" — we expect hits on "damm" and "damage"
+        // via FTS5's prefix-match operator, not just exact "dam".
+        let cache = open();
+        cache
+            .upsert_message(&email(
+                1,
+                "INBOX",
+                "Damm das Tor",
+                "body",
+                "a@x.de",
+            ))
+            .unwrap();
+        cache
+            .upsert_message(&email(
+                2,
+                "INBOX",
+                "report",
+                "damage assessment overdue",
+                "b@x.de",
+            ))
+            .unwrap();
+        cache
+            .upsert_message(&email(3, "INBOX", "unrelated", "nothing", "c@x.de"))
+            .unwrap();
+
+        let hits = cache
+            .search_emails("dam", &SearchScope::default(), &SearchFilters::default())
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+        // Snippet should wrap the partial match.
+        assert!(hits.iter().all(|h| h.snippet.contains("<mark>")));
+    }
+
+    #[test]
+    fn search_results_newest_first() {
+        let cache = open();
+        cache
+            .upsert_message(&email(1, "INBOX", "budget old", "b", "a@x.de"))
+            .unwrap();
+        cache
+            .upsert_message(&email(2, "INBOX", "budget new", "b", "a@x.de"))
+            .unwrap();
+
+        let hits = cache
+            .search_emails("budget", &SearchScope::default(), &SearchFilters::default())
+            .unwrap();
+        assert_eq!(hits.len(), 2);
+        // uid 1 has the smaller offset per the `email()` helper
+        // (`now - uid seconds`), so it's the newer message.
+        assert_eq!(hits[0].uid, 1);
+        assert_eq!(hits[1].uid, 2);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,12 +21,14 @@ use nimbus_nextcloud::{
     LoginFlowInit, LoginFlowResult, fetch_capabilities, poll_login, start_login,
 };
 use nimbus_smtp::SmtpClient;
-use nimbus_store::cache::{ContactRow, ContactServerHandle, SyncState};
-use tauri::Manager;
-use tauri::UriSchemeContext;
+use nimbus_store::cache::{
+    ContactRow, ContactServerHandle, SearchFilters, SearchHit, SearchScope, SyncState,
+};
 use nimbus_store::{Cache, account_store, credentials, nextcloud_store};
 use serde::{Deserialize, Serialize};
+use tauri::Manager;
 use tauri::State;
+use tauri::UriSchemeContext;
 
 // ── Tauri commands ──────────────────────────────────────────────
 //
@@ -256,8 +258,7 @@ async fn sync_nextcloud_contacts(
         .ok_or_else(|| NimbusError::Other(format!("no Nextcloud account with id '{nc_id}'")))?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
 
-    let books =
-        list_addressbooks(&account.server_url, &account.username, &app_password).await?;
+    let books = list_addressbooks(&account.server_url, &account.username, &app_password).await?;
     tracing::info!(
         "CardDAV: {} addressbook(s) to sync for {}",
         books.len(),
@@ -298,8 +299,7 @@ async fn sync_nextcloud_contacts(
             }
         };
 
-        let upserts: Vec<ContactRow> =
-            delta.upserts.iter().map(raw_contact_to_row).collect();
+        let upserts: Vec<ContactRow> = delta.upserts.iter().map(raw_contact_to_row).collect();
 
         if let Err(e) = cache.apply_contact_delta(
             &nc_id,
@@ -329,9 +329,7 @@ fn get_contacts(
     nc_id: Option<String>,
     cache: State<'_, Cache>,
 ) -> Result<Vec<Contact>, NimbusError> {
-    cache
-        .list_contacts(nc_id.as_deref())
-        .map_err(Into::into)
+    cache.list_contacts(nc_id.as_deref()).map_err(Into::into)
 }
 
 /// Substring search over cached contacts — feeds the compose
@@ -343,9 +341,7 @@ fn search_contacts(
     limit: u32,
     cache: State<'_, Cache>,
 ) -> Result<Vec<Contact>, NimbusError> {
-    cache
-        .search_contacts(&query, limit)
-        .map_err(Into::into)
+    cache.search_contacts(&query, limit).map_err(Into::into)
 }
 
 /// Fetched separately from `get_contacts` because photo bytes are
@@ -518,16 +514,12 @@ async fn update_contact(
 /// leave the cache row alone so the UI can show the user the
 /// fresh state on the next sync.
 #[tauri::command]
-async fn delete_contact(
-    contact_id: String,
-    cache: State<'_, Cache>,
-) -> Result<(), NimbusError> {
+async fn delete_contact(contact_id: String, cache: State<'_, Cache>) -> Result<(), NimbusError> {
     let handle = load_contact_handle(&cache, &contact_id)?;
     let account = load_nextcloud_account(&handle.nextcloud_account_id)?;
     let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
 
-    carddav_delete_contact(&handle.href, &account.username, &app_password, &handle.etag)
-        .await?;
+    carddav_delete_contact(&handle.href, &account.username, &app_password, &handle.etag).await?;
 
     cache
         .delete_contact_by_id(&contact_id)
@@ -1080,6 +1072,158 @@ fn percent_decode(s: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
+// ── Search commands (Issue #15) ────────────────────────────────
+//
+// Two-tier search, Outlook-style:
+//
+//   1. `search_emails`  — instant, against the local FTS5 index.
+//                         Covers everything in the cache.
+//
+//   2. `search_imap_server` — explicit fallback that hits IMAP
+//                             `UID SEARCH`. Slower, server-dependent,
+//                             only run when the user asks for it
+//                             ("Search server too" button).
+//
+// The cache-first path is the default UX. The fallback is a button
+// because (a) it's slow and (b) we don't want to spam the server on
+// every keystroke.
+
+/// Run a full-text search against the local mail cache.
+///
+/// The query is parsed as Outlook-style operator syntax (see
+/// `nimbus_store::cache::search` for grammar). `scope` and
+/// `filters` are optional narrowings from the UI — empty values
+/// mean "search everything the cache has".
+#[tauri::command]
+fn search_emails(
+    query: String,
+    scope: Option<SearchScope>,
+    filters: Option<SearchFilters>,
+    cache: State<'_, Cache>,
+) -> Result<Vec<SearchHit>, NimbusError> {
+    let scope = scope.unwrap_or_default();
+    let filters = filters.unwrap_or_default();
+    cache
+        .search_emails(&query, &scope, &filters)
+        .map_err(Into::into)
+}
+
+/// Server-side IMAP SEARCH fallback. Only JMAP/IMAP — the JMAP
+/// client already pulls everything into the cache lazily, so users
+/// pointed at a JMAP server get instant results via the local FTS5
+/// index and don't need this path.
+///
+/// Returns envelopes in the same shape as `fetch_envelopes` so the
+/// frontend can feed them into the existing mail-list renderer and
+/// also upserts them into the local cache so the next search
+/// finds them instantly without another round-trip.
+#[tauri::command]
+async fn search_imap_server(
+    account_id: String,
+    folder: String,
+    query: String,
+    limit: u32,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, NimbusError> {
+    let account = load_account(&account_id)?;
+    if uses_jmap(&account) {
+        // JMAP cache-first coverage is comprehensive; no separate
+        // server-side search path yet. Return empty so the UI
+        // silently no-ops the fallback button for JMAP accounts.
+        return Ok(Vec::new());
+    }
+
+    let criterion = imap_search_criterion(&query);
+    if criterion.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut client = connect_imap(&account).await?;
+    let hits = client.search_envelopes(&folder, &criterion, limit).await?;
+    let _ = client.logout().await;
+
+    // Warm the cache so the next query is served locally.
+    if !hits.is_empty() {
+        cache.upsert_envelopes_for_account(&account_id, &hits)?;
+    }
+    Ok(hits)
+}
+
+/// Translate a user query into an IMAP SEARCH criterion string.
+///
+/// We keep this much simpler than the FTS parser — IMAP SEARCH
+/// doesn't have rich boolean syntax and most servers only support
+/// a small subset of RFC 3501's operators. We emit a conjunction
+/// (implicit AND) of `TEXT`/`FROM`/`TO`/`SUBJECT` terms.
+///
+/// The result is a single string like:
+///   `SUBJECT "foo" FROM "alice" TEXT "budget"`
+fn imap_search_criterion(query: &str) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut free_text: Vec<String> = Vec::new();
+
+    for token in tokenize_imap_query(query) {
+        if let Some((op, value)) = token.split_once(':') {
+            let value = value.trim_matches('"');
+            if value.is_empty() {
+                continue;
+            }
+            let key = match op.to_ascii_lowercase().as_str() {
+                "from" => Some("FROM"),
+                "to" => Some("TO"),
+                "cc" => Some("CC"),
+                "subject" | "title" => Some("SUBJECT"),
+                "body" => Some("BODY"),
+                _ => None,
+            };
+            if let Some(k) = key {
+                parts.push(format!("{k} \"{}\"", imap_quote(value)));
+                continue;
+            }
+        }
+        let cleaned = token.trim_matches('"');
+        if !cleaned.is_empty() {
+            free_text.push(cleaned.to_string());
+        }
+    }
+
+    for text in free_text {
+        parts.push(format!("TEXT \"{}\"", imap_quote(&text)));
+    }
+
+    parts.join(" ")
+}
+
+/// Split a query into tokens, keeping quoted phrases intact.
+fn tokenize_imap_query(input: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    let mut in_quote = false;
+    for c in input.chars() {
+        match c {
+            '"' => {
+                in_quote = !in_quote;
+                cur.push(c);
+            }
+            w if w.is_whitespace() && !in_quote => {
+                if !cur.is_empty() {
+                    out.push(std::mem::take(&mut cur));
+                }
+            }
+            _ => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+/// Escape `"` and `\` inside an IMAP quoted string (RFC 3501 §4.3).
+fn imap_quote(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 // ── App entry point ─────────────────────────────────────────────
 
 fn main() {
@@ -1111,6 +1255,8 @@ fn main() {
             get_cached_folders,
             test_jmap_connection,
             detect_jmap,
+            search_emails,
+            search_imap_server,
             start_nextcloud_login,
             poll_nextcloud_login,
             get_nextcloud_accounts,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -19,6 +19,11 @@
   import AccountSettings from './lib/AccountSettings.svelte'
   import Compose, { type ComposeInitial } from './lib/Compose.svelte'
   import ContactsView from './lib/ContactsView.svelte'
+  import SearchBar, {
+    type SearchScope,
+    type SearchFilters,
+  } from './lib/SearchBar.svelte'
+  import SearchResults from './lib/SearchResults.svelte'
 
   // ── View state ──────────────────────────────────────────────
   // Which view is currently shown. Starts as 'loading' until we
@@ -47,6 +52,37 @@
   let selectedUid = $state<number | null>(null)
   // Bumped to force child lists to re-fetch (manual refresh, mark-as-read).
   let refreshToken = $state(0)
+
+  // ── Search state ────────────────────────────────────────────
+  // `searchQuery` drives the mail-list column: non-empty query OR
+  // any active filter swaps MailList out for SearchResults.
+  let searchQuery = $state('')
+  let searchScope = $state<SearchScope>({})
+  let searchFilters = $state<SearchFilters>({})
+  // Derived: are we in "search mode"?
+  const searchActive = $derived(
+    searchQuery.trim().length > 0 ||
+      !!searchFilters.unreadOnly ||
+      !!searchFilters.flaggedOnly ||
+      !!searchFilters.hasAttachment,
+  )
+
+  function onSearch(q: string, scope: SearchScope, filters: SearchFilters) {
+    searchQuery = q
+    searchScope = scope
+    searchFilters = filters
+  }
+
+  // When a search hit is picked, follow its folder — the hit may
+  // live in a different folder than the one currently selected
+  // (e.g. "All folders" scope). Syncing the folder makes the
+  // subsequent MailView fetch + sidebar highlight coherent.
+  function onSelectSearchHit(uid: number, folder: string) {
+    if (folder !== selectedFolder) {
+      selectedFolder = folder
+    }
+    selectedUid = uid
+  }
 
   // ── Check for existing accounts on startup ──────────────────
   // This runs once when the component mounts. It calls get_accounts
@@ -240,13 +276,36 @@
       oncompose={() => openCompose()}
       onselectintegration={onSelectIntegration}
     />
-    <MailList
-      accountId={activeAccountId}
-      folder={selectedFolder}
-      selectedUid={selectedUid}
-      refreshToken={refreshToken}
-      onselect={selectMessage}
-    />
+    <!-- Mail-list column: SearchBar on top, then either MailList
+         or SearchResults depending on whether the user is searching. -->
+    <div class="flex flex-col w-80 shrink-0 border-r border-surface-200 dark:border-surface-700">
+      <SearchBar
+        accountId={activeAccountId}
+        currentFolder={selectedFolder}
+        onsearch={onSearch}
+      />
+      <div class="flex-1 min-h-0 flex">
+        {#if searchActive}
+          <SearchResults
+            accountId={activeAccountId}
+            currentFolder={selectedFolder}
+            query={searchQuery}
+            scope={searchScope}
+            filters={searchFilters}
+            selectedUid={selectedUid}
+            onselect={onSelectSearchHit}
+          />
+        {:else}
+          <MailList
+            accountId={activeAccountId}
+            folder={selectedFolder}
+            selectedUid={selectedUid}
+            refreshToken={refreshToken}
+            onselect={selectMessage}
+          />
+        {/if}
+      </div>
+    </div>
     <MailView
       accountId={activeAccountId}
       folder={selectedFolder}

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -121,21 +121,12 @@
   }
 </script>
 
-<div class="w-80 shrink-0 border-r border-surface-200 dark:border-surface-700 flex flex-col">
-  <!-- Search bar -->
-  <div class="p-3 border-b border-surface-200 dark:border-surface-700 relative">
-    <input
-      type="text"
-      placeholder="Search mail..."
-      class="input w-full px-3 py-2 text-sm rounded-md"
-    />
-    {#if refreshing}
-      <!-- Subtle hint that cached data is being refreshed in the background. -->
-      <span class="absolute right-5 top-1/2 -translate-y-1/2 text-xs text-surface-500">
-        Refreshing…
-      </span>
-    {/if}
-  </div>
+<div class="flex-1 flex flex-col min-w-0">
+  {#if refreshing}
+    <div class="px-3 py-1 text-[11px] text-surface-500 border-b border-surface-100 dark:border-surface-800">
+      Refreshing…
+    </div>
+  {/if}
 
   <!-- Email list -->
   <div class="flex-1 overflow-y-auto">

--- a/ui/src/lib/SearchBar.svelte
+++ b/ui/src/lib/SearchBar.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  /**
+   * SearchBar — Outlook-style search input with scope selector and
+   * filter chips. Sits above the mail list. Triggers a parent
+   * callback with the parsed query + filters so the caller can
+   * decide how to render results (SearchResults vs MailList).
+   *
+   * Keyboard: Ctrl+F focuses the input.
+   * Escape clears the query and blurs.
+   */
+
+  import { onMount, onDestroy } from 'svelte'
+
+  export type SearchScope = {
+    accountId?: string
+    folder?: string
+    limit?: number
+  }
+
+  export type SearchFilters = {
+    unreadOnly?: boolean
+    flaggedOnly?: boolean
+    hasAttachment?: boolean
+    dateFrom?: number | null
+    dateTo?: number | null
+  }
+
+  /** Folder-scope choices surfaced in the dropdown. */
+  type ScopeChoice = 'current' | 'allFolders'
+
+  interface Props {
+    /** Current folder so "this folder" scope can resolve. */
+    currentFolder: string
+    /** Current account id — search is always scoped to one account. */
+    accountId: string
+    /** Debounced fire: user typed or toggled. Null query + clean
+     *  filters means "search is inactive, go back to mail list". */
+    onsearch: (
+      query: string,
+      scope: SearchScope,
+      filters: SearchFilters,
+    ) => void
+  }
+  let { currentFolder, accountId, onsearch }: Props = $props()
+
+  let query = $state('')
+  let scope = $state<ScopeChoice>('current')
+  let unread = $state(false)
+  let flagged = $state(false)
+  let hasAttachment = $state(false)
+  let showHints = $state(false)
+  let inputEl: HTMLInputElement | null = $state(null)
+
+  // Debounce keystrokes — we don't want to hit the DB on every
+  // character. 150ms keeps typing fluid while collapsing bursts.
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  function fireSearch() {
+    const s: SearchScope = {
+      accountId,
+      folder: scope === 'current' ? currentFolder : undefined,
+      limit: 200,
+    }
+    const f: SearchFilters = {
+      unreadOnly: unread,
+      flaggedOnly: flagged,
+      hasAttachment,
+    }
+    onsearch(query, s, f)
+  }
+
+  function scheduleSearch() {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(fireSearch, 150)
+  }
+
+  function onInput() {
+    scheduleSearch()
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      if (query || unread || flagged || hasAttachment) {
+        query = ''
+        unread = false
+        flagged = false
+        hasAttachment = false
+        fireSearch()
+      }
+      inputEl?.blur()
+    } else if (e.key === 'Enter') {
+      if (debounceTimer) clearTimeout(debounceTimer)
+      fireSearch()
+    }
+  }
+
+  function toggleChip(name: 'unread' | 'flagged' | 'hasAttachment') {
+    if (name === 'unread') unread = !unread
+    if (name === 'flagged') flagged = !flagged
+    if (name === 'hasAttachment') hasAttachment = !hasAttachment
+    fireSearch()
+  }
+
+  function onScopeChange() {
+    fireSearch()
+  }
+
+  function insertOperator(op: string) {
+    const suffix = query.endsWith(' ') || query.length === 0 ? '' : ' '
+    query = `${query}${suffix}${op}`
+    inputEl?.focus()
+    scheduleSearch()
+  }
+
+  // Ctrl+F focuses the search input. We preventDefault so the browser's
+  // built-in page-find dialog doesn't open on top of us.
+  function handleGlobalKey(e: KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f') {
+      e.preventDefault()
+      inputEl?.focus()
+      inputEl?.select()
+    }
+  }
+
+  onMount(() => {
+    window.addEventListener('keydown', handleGlobalKey)
+  })
+  onDestroy(() => {
+    window.removeEventListener('keydown', handleGlobalKey)
+    if (debounceTimer) clearTimeout(debounceTimer)
+  })
+
+  const hasAnyFilter = $derived(unread || flagged || hasAttachment)
+  const isActive = $derived(query.trim().length > 0 || hasAnyFilter)
+</script>
+
+<div class="border-b border-surface-200 dark:border-surface-700 p-2 space-y-1.5">
+  <!-- Row 1: search input (full width so the user can actually see
+       what they're typing, even in a narrow mail-list column) -->
+  <div class="relative w-full">
+    <!-- Magnifier icon on the left -->
+    <span
+      class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none text-xs"
+      aria-hidden="true"
+    >
+      &#x1F50D;
+    </span>
+    <input
+      bind:this={inputEl}
+      bind:value={query}
+      oninput={onInput}
+      onkeydown={onKeydown}
+      onfocus={() => (showHints = true)}
+      onblur={() => setTimeout(() => (showHints = false), 150)}
+      type="text"
+      placeholder="Search mail  (Ctrl+F)"
+      class="input w-full pl-7 pr-8 py-1.5 text-sm rounded-md"
+      aria-label="Search mail"
+    />
+    {#if query}
+      <button
+        type="button"
+        title="Clear search"
+        class="absolute right-2 top-1/2 -translate-y-1/2 text-surface-500 hover:text-surface-700 dark:hover:text-surface-200 text-xs"
+        onclick={() => {
+          query = ''
+          fireSearch()
+          inputEl?.focus()
+        }}
+        aria-label="Clear search"
+      >
+        &#x2715;
+      </button>
+    {/if}
+
+    <!-- Operator hint dropdown — shown while focused + empty -->
+    {#if showHints && query.length === 0}
+      <div
+        class="absolute left-0 right-0 top-full mt-1 z-40 bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-700 rounded-md shadow-lg p-2 text-xs space-y-0.5"
+      >
+        <div class="font-semibold text-surface-500 mb-1">Search tips</div>
+        <div
+          role="button"
+          tabindex="-1"
+          class="cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-800 px-1.5 py-0.5 rounded"
+          onmousedown={(e) => {
+            e.preventDefault()
+            insertOperator('from:')
+          }}
+        >
+          <code class="font-mono">from:alice</code> — from a specific sender
+        </div>
+        <div
+          role="button"
+          tabindex="-1"
+          class="cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-800 px-1.5 py-0.5 rounded"
+          onmousedown={(e) => {
+            e.preventDefault()
+            insertOperator('subject:')
+          }}
+        >
+          <code class="font-mono">subject:"weekly update"</code> — subject
+          contains
+        </div>
+        <div
+          role="button"
+          tabindex="-1"
+          class="cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-800 px-1.5 py-0.5 rounded"
+          onmousedown={(e) => {
+            e.preventDefault()
+            insertOperator('has:attachment')
+          }}
+        >
+          <code class="font-mono">has:attachment</code> — only with files
+        </div>
+        <div
+          role="button"
+          tabindex="-1"
+          class="cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-800 px-1.5 py-0.5 rounded"
+          onmousedown={(e) => {
+            e.preventDefault()
+            insertOperator('is:unread')
+          }}
+        >
+          <code class="font-mono">is:unread</code> — only unread
+        </div>
+      </div>
+    {/if}
+  </div>
+
+  <!-- Row 2: scope selector on its own line below the input. -->
+  <div class="flex items-center gap-1.5">
+    <label for="search-scope" class="text-xs text-surface-500 shrink-0">
+      In:
+    </label>
+    <select
+      id="search-scope"
+      bind:value={scope}
+      onchange={onScopeChange}
+      class="select text-xs py-1 px-1.5 rounded-md flex-1 min-w-0"
+      aria-label="Search scope"
+      title="Search scope"
+    >
+      <option value="current">This folder ({currentFolder})</option>
+      <option value="allFolders">All folders</option>
+    </select>
+  </div>
+
+  <!-- Row 2: filter chips. Only shown when the search is active, to
+       keep the idle mail-list header uncluttered. -->
+  {#if isActive}
+    <div class="flex flex-wrap items-center gap-1">
+      <button
+        type="button"
+        class="chip text-xs px-2 py-0.5 rounded-full border transition
+          {unread
+          ? 'bg-primary-500/20 border-primary-500 text-primary-700 dark:text-primary-200'
+          : 'border-surface-300 dark:border-surface-600 hover:bg-surface-100 dark:hover:bg-surface-800'}"
+        onclick={() => toggleChip('unread')}
+        aria-pressed={unread}
+      >
+        Unread
+      </button>
+      <button
+        type="button"
+        class="chip text-xs px-2 py-0.5 rounded-full border transition
+          {flagged
+          ? 'bg-primary-500/20 border-primary-500 text-primary-700 dark:text-primary-200'
+          : 'border-surface-300 dark:border-surface-600 hover:bg-surface-100 dark:hover:bg-surface-800'}"
+        onclick={() => toggleChip('flagged')}
+        aria-pressed={flagged}
+      >
+        Flagged
+      </button>
+      <button
+        type="button"
+        class="chip text-xs px-2 py-0.5 rounded-full border transition
+          {hasAttachment
+          ? 'bg-primary-500/20 border-primary-500 text-primary-700 dark:text-primary-200'
+          : 'border-surface-300 dark:border-surface-600 hover:bg-surface-100 dark:hover:bg-surface-800'}"
+        onclick={() => toggleChip('hasAttachment')}
+        aria-pressed={hasAttachment}
+      >
+        Has attachment
+      </button>
+    </div>
+  {/if}
+</div>

--- a/ui/src/lib/SearchResults.svelte
+++ b/ui/src/lib/SearchResults.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+  /**
+   * SearchResults — replaces MailList when a search is active.
+   *
+   * Runs `search_emails` against the local FTS5 index, then offers
+   * a "Search server too" button for IMAP SEARCH fallback when the
+   * user suspects the mail they want isn't cached (e.g. old archive
+   * messages they've never opened on this machine).
+   *
+   * Hit rows look like mail-list rows plus a highlighted snippet
+   * rendered from `<mark>` the backend inserted around matches.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import type { SearchScope, SearchFilters } from './SearchBar.svelte'
+  import { formatError } from './errors'
+
+  interface SearchHit {
+    accountId: string
+    folder: string
+    uid: number
+    from: string
+    subject: string
+    date: string
+    isRead: boolean
+    isStarred: boolean
+    hasAttachments: boolean
+    snippet: string
+  }
+
+  interface Props {
+    accountId: string
+    /** Fallback folder for server-side search when scope is a single folder. */
+    currentFolder: string
+    query: string
+    scope: SearchScope
+    filters: SearchFilters
+    selectedUid: number | null
+    onselect: (uid: number, folder: string) => void
+  }
+  let {
+    accountId,
+    currentFolder,
+    query,
+    scope,
+    filters,
+    selectedUid,
+    onselect,
+  }: Props = $props()
+
+  let hits = $state<SearchHit[]>([])
+  let loading = $state(false)
+  let error = $state('')
+  let serverSearching = $state(false)
+  let serverSearched = $state(false)
+
+  // Re-run whenever the query / scope / filters change. We also
+  // reset the "server search already done" flag so the button is
+  // offered again for the new query.
+  $effect(() => {
+    // Touch the reactive inputs so Svelte re-runs this effect.
+    query
+    scope
+    filters
+    serverSearched = false
+    void runLocal()
+  })
+
+  async function runLocal() {
+    loading = true
+    error = ''
+    try {
+      const result = await invoke<SearchHit[]>('search_emails', {
+        query,
+        scope,
+        filters,
+      })
+      hits = result
+    } catch (e: any) {
+      error = formatError(e) || 'Search failed'
+      hits = []
+    } finally {
+      loading = false
+    }
+  }
+
+  async function runServer() {
+    if (!query.trim()) return
+    serverSearching = true
+    try {
+      const folder = scope.folder ?? currentFolder
+      const serverHits = await invoke<
+        Array<{
+          uid: number
+          folder: string
+          from: string
+          subject: string
+          date: string
+          is_read: boolean
+          is_starred: boolean
+        }>
+      >('search_imap_server', {
+        accountId,
+        folder,
+        query,
+        limit: 100,
+      })
+      // Merge into the result set, dedupe on (folder, uid), keeping
+      // the local hit if both sources returned it (local has the
+      // snippet while server results don't).
+      const seen = new Set(hits.map((h) => `${h.folder}:${h.uid}`))
+      const merged = [...hits]
+      for (const s of serverHits) {
+        const key = `${s.folder}:${s.uid}`
+        if (seen.has(key)) continue
+        merged.push({
+          accountId,
+          folder: s.folder,
+          uid: s.uid,
+          from: s.from,
+          subject: s.subject,
+          date: s.date,
+          isRead: s.is_read,
+          isStarred: s.is_starred,
+          hasAttachments: false,
+          snippet: '',
+        })
+      }
+      merged.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      )
+      hits = merged
+      serverSearched = true
+    } catch (e: any) {
+      error = formatError(e) || 'Server search failed'
+    } finally {
+      serverSearching = false
+    }
+  }
+
+  function formatDate(iso: string): string {
+    const d = new Date(iso)
+    const now = new Date()
+    const sameDay = d.toDateString() === now.toDateString()
+    if (sameDay) {
+      return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    }
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  }
+
+  /** The backend already wraps matches in `<mark>…</mark>`. We emit
+   *  the snippet as trusted HTML so the highlighting renders. The
+   *  snippet never comes from user input directly — it's extracted
+   *  by FTS5 from a value our own code already stored. No XSS risk
+   *  as long as the upstream body/subject is treated safely, but
+   *  we still belt-and-suspenders: strip `<` in non-mark positions
+   *  by only allowing our known tags through. */
+  function safeSnippet(raw: string): string {
+    if (!raw) return ''
+    // Escape everything, then unescape the marks we emit ourselves.
+    const escaped = raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+    return escaped
+      .replace(/&lt;mark&gt;/g, '<mark class="bg-yellow-200 dark:bg-yellow-700/50 rounded-sm px-0.5">')
+      .replace(/&lt;\/mark&gt;/g, '</mark>')
+  }
+</script>
+
+<div class="flex-1 flex flex-col min-w-0">
+  <!-- Result count + server fallback button -->
+  <div class="px-3 py-1.5 text-xs text-surface-600 dark:text-surface-300 flex items-center justify-between border-b border-surface-100 dark:border-surface-800">
+    <span>
+      {#if loading}
+        Searching…
+      {:else}
+        {hits.length} result{hits.length === 1 ? '' : 's'}
+      {/if}
+    </span>
+    {#if query.trim() && !serverSearched}
+      <button
+        type="button"
+        class="text-primary-600 dark:text-primary-300 hover:underline disabled:opacity-50"
+        disabled={serverSearching}
+        onclick={runServer}
+        title="Also search messages on the server (slower)"
+      >
+        {serverSearching ? 'Searching server…' : 'Search server too'}
+      </button>
+    {/if}
+  </div>
+
+  <div class="flex-1 overflow-y-auto">
+    {#if error}
+      <div class="p-4 text-sm text-red-500">{error}</div>
+    {:else if !loading && hits.length === 0}
+      <div class="p-6 text-center text-sm text-surface-500">
+        No messages match.
+      </div>
+    {:else}
+      {#each hits as hit (`${hit.folder}:${hit.uid}`)}
+        <button
+          class="w-full text-left px-4 py-3 border-b border-surface-100 dark:border-surface-800 transition-colors
+            {selectedUid === hit.uid
+            ? 'bg-primary-500/10'
+            : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
+          onclick={() => onselect(hit.uid, hit.folder)}
+        >
+          <div class="flex items-center justify-between mb-1">
+            <span class="text-sm {!hit.isRead ? 'font-semibold' : 'font-normal'} truncate pr-2">
+              {hit.from || '(unknown sender)'}
+            </span>
+            <span class="text-xs text-surface-500 shrink-0">{formatDate(hit.date)}</span>
+          </div>
+          <p class="text-sm {!hit.isRead ? 'font-medium' : ''} truncate">
+            {hit.subject || '(no subject)'}
+          </p>
+          {#if hit.snippet}
+            <!-- Trusted: see safeSnippet() comment. -->
+            <p class="text-xs text-surface-500 mt-0.5 truncate">
+              <!-- eslint-disable-next-line -->
+              {@html safeSnippet(hit.snippet)}
+            </p>
+          {/if}
+          <div class="flex items-center gap-1 mt-0.5">
+            {#if hit.folder !== currentFolder}
+              <span class="text-[10px] px-1.5 rounded bg-surface-200 dark:bg-surface-700 text-surface-600 dark:text-surface-300">
+                {hit.folder}
+              </span>
+            {/if}
+            {#if hit.hasAttachments}
+              <span class="text-[10px]" title="Has attachment">&#x1F4CE;</span>
+            {/if}
+          </div>
+        </button>
+      {/each}
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
Adds a SQLite FTS5-backed search index that covers subject, from, to, cc, and body for every cached message. The index lives in the same SQLCipher DB as envelopes and is kept in sync via triggers on `messages` and `message_bodies`, with a backfill migration for existing cache rows.

Outlook-style operator syntax is supported in the query bar: `from:`, `to:`, `cc:`, `subject:`, `body:`, `has:attachment`, `is:unread`, `is:read`, `is:flagged`, plus quoted phrases. The parser falls back to free text for anything it doesn't recognise (URLs stay intact).

UI adds a dedicated SearchBar (Ctrl+E) with scope selector, filter chips and operator hints, plus a SearchResults panel that replaces the mail list while a query is active. Hits are highlighted via FTS5 `snippet()` and `<mark>` tags. Cross-folder hits show a folder badge and auto-switch the selected folder on click.

For messages that were never cached (old archive mail, etc.) a "Search server too" button calls IMAP UID SEARCH + UID FETCH ENVELOPE on the current folder and merges the results into the local hit list. JMAP accounts return an empty server-side fallback for now