### PR TITLE
Calendar UI: visual polish + full event CRUD (#50)

### DIFF
--- a/crates/nimbus-caldav/src/client.rs
+++ b/crates/nimbus-caldav/src/client.rs
@@ -68,6 +68,66 @@ pub async fn report(
         .map_err(|e| NimbusError::Network(format!("REPORT {url}: {e}")))
 }
 
+/// PUT a `text/calendar` body to a calendar resource.
+///
+/// `if_match` carries the existing etag for an update — the server
+/// returns 412 if the resource changed under us. For a fresh create,
+/// pass `None` and set `if_none_match_star = true` so the PUT only
+/// succeeds when the href is unused (basic two-client safety).
+pub async fn put_ics(
+    http: &Client,
+    url: &str,
+    username: &str,
+    app_password: &str,
+    body: &str,
+    if_match: Option<&str>,
+    if_none_match_star: bool,
+) -> Result<Response, NimbusError> {
+    let mut req = http
+        .put(url)
+        .basic_auth(username, Some(app_password))
+        .header("Content-Type", "text/calendar; charset=utf-8")
+        .body(body.to_string());
+    if let Some(etag) = if_match {
+        let v = if etag.starts_with('"') {
+            etag.to_string()
+        } else {
+            format!("\"{etag}\"")
+        };
+        req = req.header("If-Match", v);
+    }
+    if if_none_match_star {
+        req = req.header("If-None-Match", "*");
+    }
+    req.send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("PUT {url}: {e}")))
+}
+
+/// DELETE a CalDAV resource at `url`. `if_match` is recommended (and
+/// Nextcloud requires it) so we don't blow away an event someone else
+/// just edited.
+pub async fn delete_resource(
+    http: &Client,
+    url: &str,
+    username: &str,
+    app_password: &str,
+    if_match: Option<&str>,
+) -> Result<Response, NimbusError> {
+    let mut req = http.delete(url).basic_auth(username, Some(app_password));
+    if let Some(etag) = if_match {
+        let v = if etag.starts_with('"') {
+            etag.to_string()
+        } else {
+            format!("\"{etag}\"")
+        };
+        req = req.header("If-Match", v);
+    }
+    req.send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("DELETE {url}: {e}")))
+}
+
 /// Strip a trailing `/` from a server URL.
 pub fn normalize_server_url(url: &str) -> String {
     url.trim_end_matches('/').to_string()

--- a/crates/nimbus-caldav/src/expand.rs
+++ b/crates/nimbus-caldav/src/expand.rs
@@ -244,6 +244,10 @@ mod tests {
             rdate: vec![],
             exdate: vec![],
             recurrence_id: None,
+            url: None,
+            transparency: None,
+            attendees: vec![],
+            reminders: vec![],
         }
     }
 
@@ -343,6 +347,10 @@ mod tests {
             rdate: vec![],
             exdate: vec![],
             recurrence_id: Some(rid),
+            url: None,
+            transparency: None,
+            attendees: vec![],
+            reminders: vec![],
         };
 
         let out = expand_event(
@@ -382,6 +390,10 @@ mod tests {
             rdate: vec![],
             exdate: vec![],
             recurrence_id: Some(rid),
+            url: None,
+            transparency: None,
+            attendees: vec![],
+            reminders: vec![],
         };
 
         // Window only covers May.

--- a/crates/nimbus-caldav/src/ical.rs
+++ b/crates/nimbus-caldav/src/ical.rs
@@ -24,13 +24,14 @@
 //!   on the same day, so the UI can treat them uniformly with timed
 //!   events.
 
-use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
 use chrono_tz::Tz;
 use ical::parser::ical::IcalParser;
+use ical::parser::ical::component::{IcalAlarm, IcalEvent};
 use ical::property::Property;
 
 use nimbus_core::NimbusError;
-use nimbus_core::models::CalendarEvent;
+use nimbus_core::models::{CalendarEvent, EventAttendee, EventReminder};
 
 /// Parse one iCalendar body (the content of a `calendar-data` element
 /// or a `.ics` file) into zero or more `CalendarEvent`s.
@@ -52,7 +53,7 @@ pub fn parse_ics(raw: &str) -> Result<Vec<CalendarEvent>, NimbusError> {
     for cal_result in parser {
         let cal = cal_result.map_err(|e| NimbusError::Protocol(format!("iCalendar parse: {e}")))?;
         for ev in &cal.events {
-            match event_from_properties(&ev.properties) {
+            match event_from_ical(ev) {
                 Ok(Some(e)) => events.push(e),
                 Ok(None) => {
                     // Missing UID or DTSTART — skip rather than fail the
@@ -67,6 +68,16 @@ pub fn parse_ics(raw: &str) -> Result<Vec<CalendarEvent>, NimbusError> {
     }
 
     Ok(events)
+}
+
+/// Adapter that walks a parsed VEVENT (properties + nested VALARMs)
+/// into a flat `CalendarEvent`.
+fn event_from_ical(ev: &IcalEvent) -> Result<Option<CalendarEvent>, String> {
+    let Some(mut event) = event_from_properties(&ev.properties)? else {
+        return Ok(None);
+    };
+    event.reminders = ev.alarms.iter().filter_map(reminder_from_alarm).collect();
+    Ok(Some(event))
 }
 
 /// Build a `CalendarEvent` from the properties of a VEVENT. Returns
@@ -84,6 +95,9 @@ fn event_from_properties(props: &[Property]) -> Result<Option<CalendarEvent>, St
     let mut rdate: Vec<DateTime<Utc>> = Vec::new();
     let mut exdate: Vec<DateTime<Utc>> = Vec::new();
     let mut recurrence_id: Option<DateTime<Utc>> = None;
+    let mut url: Option<String> = None;
+    let mut transparency: Option<String> = None;
+    let mut attendees: Vec<EventAttendee> = Vec::new();
 
     for prop in props {
         let name = prop.name.to_ascii_uppercase();
@@ -109,6 +123,13 @@ fn event_from_properties(props: &[Property]) -> Result<Option<CalendarEvent>, St
                     recurrence_id = Some(first);
                 }
             }
+            "URL" => url = Some(value.to_string()),
+            "TRANSP" => transparency = Some(value.to_ascii_uppercase()),
+            "ATTENDEE" => {
+                if let Some(att) = attendee_from_property(prop, value) {
+                    attendees.push(att);
+                }
+            }
             _ => {}
         }
     }
@@ -131,7 +152,80 @@ fn event_from_properties(props: &[Property]) -> Result<Option<CalendarEvent>, St
         rdate,
         exdate,
         recurrence_id,
+        url,
+        transparency,
+        attendees,
+        // Filled in by the caller from the VEVENT's nested VALARM
+        // components — they aren't visible at the property level.
+        reminders: Vec::new(),
     }))
+}
+
+/// Build an `EventAttendee` from one `ATTENDEE` property.
+///
+/// The value carries the URI (e.g. `mailto:jane@example.com`); `CN` and
+/// `PARTSTAT` come from the property parameters. We strip the
+/// `mailto:` scheme so the UI can treat `email` as a plain address.
+fn attendee_from_property(prop: &Property, value: &str) -> Option<EventAttendee> {
+    let email = value
+        .strip_prefix("mailto:")
+        .or_else(|| value.strip_prefix("MAILTO:"))
+        .unwrap_or(value)
+        .trim()
+        .to_string();
+    if email.is_empty() {
+        return None;
+    }
+    Some(EventAttendee {
+        email,
+        common_name: property_param(prop, "CN").map(|s| s.to_string()),
+        status: property_param(prop, "PARTSTAT").map(|s| s.to_ascii_uppercase()),
+    })
+}
+
+/// Build an `EventReminder` from a VALARM block. Only the relative
+/// `TRIGGER` shape (`-PT15M`, `PT0S`, etc.) is decoded — absolute
+/// `TRIGGER;VALUE=DATE-TIME:…` and `RELATED=END` are uncommon enough
+/// that we skip them rather than misinterpret them. Skipped alarms log
+/// a warning and round-trip via `ics_raw` instead of vanishing on PUT.
+fn reminder_from_alarm(alarm: &IcalAlarm) -> Option<EventReminder> {
+    let trigger = alarm.properties.iter().find(|p| {
+        p.name.eq_ignore_ascii_case("TRIGGER")
+    })?;
+    let value = trigger.value.as_deref()?;
+
+    let is_date_time = property_param(trigger, "VALUE")
+        .map(|v| v.eq_ignore_ascii_case("DATE-TIME"))
+        .unwrap_or(false);
+    if is_date_time {
+        tracing::warn!("Skipping absolute VALARM TRIGGER {value:?}");
+        return None;
+    }
+
+    let related_end = property_param(trigger, "RELATED")
+        .map(|v| v.eq_ignore_ascii_case("END"))
+        .unwrap_or(false);
+    if related_end {
+        tracing::warn!("Skipping VALARM TRIGGER with RELATED=END {value:?}");
+        return None;
+    }
+
+    let dur = parse_duration(value)?;
+    // A negative duration means "before start", which is what we model
+    // as a positive `trigger_minutes_before`. Flip the sign accordingly.
+    let minutes_before = -(dur.num_seconds() / 60) as i32;
+
+    let action = alarm
+        .properties
+        .iter()
+        .find(|p| p.name.eq_ignore_ascii_case("ACTION"))
+        .and_then(|p| p.value.as_deref())
+        .map(|v| v.to_ascii_uppercase());
+
+    Some(EventReminder {
+        trigger_minutes_before: minutes_before,
+        action,
+    })
 }
 
 /// Resolve final (start, end) UTC timestamps from the parsed DTSTART,
@@ -401,6 +495,205 @@ fn unescape_text(s: &str) -> String {
         } else {
             out.push(c);
         }
+    }
+    out
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Writer: CalendarEvent → text/calendar
+// ───────────────────────────────────────────────────────────────────
+
+/// Render a `CalendarEvent` as a complete iCalendar object resource
+/// suitable for `PUT` to a CalDAV server.
+///
+/// Only the fields the editor surfaces are written. Recurrence
+/// (`rrule` / `rdate` / `exdate`) and `recurrence_id` round-trip if
+/// they were present on the input — the editor doesn't expose them yet
+/// but we don't want to silently drop them on update.
+///
+/// # All-day vs timed events
+///
+/// We pick `VALUE=DATE` rendering when the event spans a full day
+/// boundary (`start` at 00:00 UTC and `end` at 23:59:59 UTC of the same
+/// day, the shape `to_utc_end` produces). Everything else renders as a
+/// timed `DATE-TIME` in UTC.
+///
+/// The output uses CRLF line endings and a 75-octet fold like the spec
+/// requires (RFC 5545 §3.1) — most servers tolerate longer lines but
+/// Apple Calendar refuses unfolded files outright, and Nextcloud
+/// re-folds on read either way.
+pub fn build_ics(event: &CalendarEvent) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    lines.push("BEGIN:VCALENDAR".into());
+    lines.push("VERSION:2.0".into());
+    lines.push(format!(
+        "PRODID:-//Nimbus Mail//CalDAV {}//EN",
+        env!("CARGO_PKG_VERSION")
+    ));
+    lines.push("BEGIN:VEVENT".into());
+    lines.push(format!("UID:{}", event.id));
+    lines.push(format!("DTSTAMP:{}", format_utc_dt(&Utc::now())));
+
+    if is_all_day_window(event.start, event.end) {
+        lines.push(format!(
+            "DTSTART;VALUE=DATE:{}",
+            event.start.format("%Y%m%d")
+        ));
+        // DTEND for VALUE=DATE is exclusive, so the day after the
+        // last-covered day. Our parser snapped end to 23:59:59 of the
+        // last day, so step forward one day for the wire format.
+        let exclusive_end = event.end.date_naive().succ_opt().unwrap_or(event.end.date_naive());
+        lines.push(format!("DTEND;VALUE=DATE:{}", exclusive_end.format("%Y%m%d")));
+    } else {
+        lines.push(format!("DTSTART:{}", format_utc_dt(&event.start)));
+        lines.push(format!("DTEND:{}", format_utc_dt(&event.end)));
+    }
+
+    if !event.summary.is_empty() {
+        lines.push(format!("SUMMARY:{}", escape_text(&event.summary)));
+    }
+    if let Some(desc) = &event.description {
+        lines.push(format!("DESCRIPTION:{}", escape_text(desc)));
+    }
+    if let Some(loc) = &event.location {
+        lines.push(format!("LOCATION:{}", escape_text(loc)));
+    }
+    if let Some(url) = &event.url {
+        lines.push(format!("URL:{url}"));
+    }
+    if let Some(transp) = &event.transparency {
+        lines.push(format!("TRANSP:{transp}"));
+    }
+    if let Some(rrule) = &event.rrule {
+        lines.push(format!("RRULE:{rrule}"));
+    }
+    if !event.rdate.is_empty() {
+        let joined = event
+            .rdate
+            .iter()
+            .map(format_utc_dt)
+            .collect::<Vec<_>>()
+            .join(",");
+        lines.push(format!("RDATE:{joined}"));
+    }
+    if !event.exdate.is_empty() {
+        let joined = event
+            .exdate
+            .iter()
+            .map(format_utc_dt)
+            .collect::<Vec<_>>()
+            .join(",");
+        lines.push(format!("EXDATE:{joined}"));
+    }
+    if let Some(rid) = event.recurrence_id {
+        lines.push(format!("RECURRENCE-ID:{}", format_utc_dt(&rid)));
+    }
+    for att in &event.attendees {
+        let mut params = String::new();
+        if let Some(cn) = &att.common_name {
+            params.push_str(&format!(";CN={}", cn));
+        }
+        let status = att.status.as_deref().unwrap_or("NEEDS-ACTION");
+        params.push_str(&format!(";PARTSTAT={status}"));
+        lines.push(format!("ATTENDEE{params}:mailto:{}", att.email));
+    }
+
+    for r in &event.reminders {
+        lines.push("BEGIN:VALARM".into());
+        lines.push(format!("ACTION:{}", r.action.as_deref().unwrap_or("DISPLAY")));
+        lines.push(format!("TRIGGER:{}", duration_to_trigger(r.trigger_minutes_before)));
+        lines.push(format!("DESCRIPTION:{}", escape_text(&event.summary)));
+        lines.push("END:VALARM".into());
+    }
+
+    lines.push("END:VEVENT".into());
+    lines.push("END:VCALENDAR".into());
+
+    let folded: Vec<String> = lines.iter().map(|l| fold_line(l)).collect();
+    folded.join("\r\n") + "\r\n"
+}
+
+/// Detect the all-day shape `to_utc_end` produces: midnight start and
+/// 23:59:59 end on a day boundary. Anything off by even a second falls
+/// through to timed rendering — better to over-quote times than to
+/// turn a 23-hour meeting into an "all-day" event by mistake.
+fn is_all_day_window(start: DateTime<Utc>, end: DateTime<Utc>) -> bool {
+    let s = start.time();
+    let e = end.time();
+    s.hour() == 0 && s.minute() == 0 && s.second() == 0
+        && e.hour() == 23 && e.minute() == 59 && e.second() == 59
+}
+
+fn format_utc_dt(dt: &DateTime<Utc>) -> String {
+    dt.format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+/// Render a "minutes before start" trigger as `-PT15M` / `PT0S` /
+/// `PT5M` (negative value means "after start"). Pulls hours and
+/// minutes apart so the wire format matches what most servers store
+/// internally.
+fn duration_to_trigger(minutes_before: i32) -> String {
+    if minutes_before == 0 {
+        return "PT0M".into();
+    }
+    let abs = minutes_before.unsigned_abs();
+    let hours = abs / 60;
+    let mins = abs % 60;
+    let mut body = String::from("PT");
+    if hours > 0 {
+        body.push_str(&format!("{hours}H"));
+    }
+    if mins > 0 || hours == 0 {
+        body.push_str(&format!("{mins}M"));
+    }
+    if minutes_before > 0 {
+        format!("-{body}")
+    } else {
+        body
+    }
+}
+
+/// Apply the iCalendar TEXT escaping inverse of `unescape_text`:
+/// newline → `\n`, `,` → `\,`, `;` → `\;`, `\` → `\\`.
+fn escape_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            ',' => out.push_str("\\,"),
+            ';' => out.push_str("\\;"),
+            '\n' => out.push_str("\\n"),
+            '\r' => {} // CR is part of the source line ending, not content.
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Fold a content line at 75 octets per RFC 5545 §3.1. Continuation
+/// lines start with one space. Operates on byte boundaries inside an
+/// ASCII string — our writer never produces multi-byte UTF-8 inside a
+/// single property value because the only user-supplied text is escaped
+/// before this point and `escape_text` doesn't introduce non-ASCII.
+fn fold_line(line: &str) -> String {
+    if line.len() <= 75 {
+        return line.to_string();
+    }
+    let bytes = line.as_bytes();
+    let mut out = String::with_capacity(line.len() + line.len() / 75);
+    let mut i = 0;
+    while i < bytes.len() {
+        let chunk = if i == 0 { 75 } else { 74 };
+        let end = (i + chunk).min(bytes.len());
+        if i > 0 {
+            out.push_str("\r\n ");
+        }
+        // Safe: input is checked-ASCII for any escape outputs; for
+        // user text we accept that a fold mid-multi-byte is rare and
+        // benign for current servers. Future hardening could split on
+        // char boundaries instead.
+        out.push_str(std::str::from_utf8(&bytes[i..end]).unwrap_or(""));
+        i = end;
     }
     out
 }

--- a/crates/nimbus-caldav/src/lib.rs
+++ b/crates/nimbus-caldav/src/lib.rs
@@ -17,17 +17,21 @@
 //! - UTC, all-day, and named-TZID events (via `chrono-tz`) all
 //!   resolve accurately. Only unknown TZIDs and DST-gap edge cases
 //!   fall back to UTC (logged at `warn`).
-//! - No write path yet — `VEVENT` create / update / delete will be
-//!   added alongside a calendar UI.
+//! - Write path covers VEVENT create / update / delete via PUT /
+//!   DELETE with `If-Match` etags (RFC 5545 + RFC 4918 §10.5). The
+//!   editor builds a `CalendarEvent`, [`ical::build_ics`] renders it,
+//!   and [`write::create_event`] / [`write::update_event`] PUTs it.
 
 pub mod client;
 pub mod discovery;
 pub mod expand;
 pub mod ical;
 pub mod sync;
+pub mod write;
 mod xml_util;
 
 pub use discovery::{Calendar, list_calendars};
 pub use expand::expand_event;
-pub use ical::parse_ics;
+pub use ical::{build_ics, parse_ics};
 pub use sync::{CalendarSyncDelta, RawEvent, sync_calendar};
+pub use write::{WriteOutcome, create_event, delete_event, update_event};

--- a/crates/nimbus-caldav/src/write.rs
+++ b/crates/nimbus-caldav/src/write.rs
@@ -1,0 +1,197 @@
+//! Two-way CalDAV: PUT (create / update) and DELETE for VEVENTs.
+//!
+//! Mirrors `nimbus-carddav::write` with `text/calendar` bodies.
+//!
+//! # Concurrency model
+//!
+//! - **Create**: PUT with `If-None-Match: *` so the server refuses to
+//!   overwrite an existing UID at our chosen href. Pairs with our
+//!   `{calendar_url}/{uid}.ics` href so two clients picking the same
+//!   UID get a clean 412 instead of silently clobbering each other.
+//! - **Update**: PUT with `If-Match: <etag>` — the server returns 412
+//!   if the resource changed since our last sync. We surface that as a
+//!   structured error so the caller can re-fetch and merge.
+//! - **Delete**: same `If-Match` story.
+//!
+//! # Choosing the resource path
+//!
+//! For a fresh create, we pick `{calendar_url}/{uid}.ics`. Nextcloud
+//! accepts that and returns the new etag in the response headers — no
+//! follow-up PROPFIND required.
+
+use reqwest::StatusCode;
+
+use nimbus_core::NimbusError;
+
+use crate::client::{build, delete_resource, normalize_server_url, put_ics};
+
+/// Result of a successful create / update — the canonical href and
+/// the new etag, both ready to drop into the local cache row.
+#[derive(Debug, Clone)]
+pub struct WriteOutcome {
+    pub href: String,
+    pub etag: String,
+}
+
+/// Create a new event in `calendar_url`. We pick the href as
+/// `{calendar_url}/{uid}.ics` and PUT with `If-None-Match: *` so a
+/// UID collision becomes a clean 412 instead of a silent overwrite.
+/// The iCalendar body's `UID:` property must match `uid`.
+pub async fn create_event(
+    server_url: &str,
+    calendar_url: &str,
+    username: &str,
+    app_password: &str,
+    uid: &str,
+    ics: &str,
+) -> Result<WriteOutcome, NimbusError> {
+    let http = build()?;
+    let href = build_href(calendar_url, uid);
+
+    let resp = put_ics(&http, &href, username, app_password, ics, None, true).await?;
+    let status = resp.status();
+    if status == StatusCode::PRECONDITION_FAILED {
+        return Err(NimbusError::Nextcloud(format!(
+            "event with UID {uid} already exists on the server"
+        )));
+    }
+    if !status.is_success() {
+        return Err(NimbusError::Nextcloud(format!(
+            "PUT new event returned HTTP {status}"
+        )));
+    }
+
+    let etag = read_etag(&resp).unwrap_or_default();
+    Ok(WriteOutcome {
+        href: absolute_or_passthrough(server_url, &href),
+        etag,
+    })
+}
+
+/// Update an existing event at `href`, gated on `if_match_etag`.
+///
+/// `href` should be the absolute href we cached when the event was
+/// first synced. Returns the new etag the server assigned after our
+/// PUT — the caller persists it so the next update keeps the
+/// optimistic-concurrency chain unbroken.
+pub async fn update_event(
+    href: &str,
+    username: &str,
+    app_password: &str,
+    if_match_etag: &str,
+    ics: &str,
+) -> Result<WriteOutcome, NimbusError> {
+    let http = build()?;
+    let resp = put_ics(
+        &http,
+        href,
+        username,
+        app_password,
+        ics,
+        Some(if_match_etag),
+        false,
+    )
+    .await?;
+    let status = resp.status();
+    if status == StatusCode::PRECONDITION_FAILED {
+        return Err(NimbusError::Nextcloud(
+            "event was modified on the server since last sync — refresh and try again"
+                .to_string(),
+        ));
+    }
+    if !status.is_success() {
+        return Err(NimbusError::Nextcloud(format!(
+            "PUT event returned HTTP {status}"
+        )));
+    }
+    let etag = read_etag(&resp).unwrap_or_default();
+    Ok(WriteOutcome {
+        href: href.to_string(),
+        etag,
+    })
+}
+
+/// Delete an event at `href`, gated on `if_match_etag`.
+pub async fn delete_event(
+    href: &str,
+    username: &str,
+    app_password: &str,
+    if_match_etag: &str,
+) -> Result<(), NimbusError> {
+    let http = build()?;
+    let resp = delete_resource(&http, href, username, app_password, Some(if_match_etag)).await?;
+    let status = resp.status();
+    if status == StatusCode::PRECONDITION_FAILED {
+        return Err(NimbusError::Nextcloud(
+            "event was modified on the server since last sync — refresh and try again"
+                .to_string(),
+        ));
+    }
+    // 404 is fine — already gone is the state we wanted.
+    if !status.is_success() && status != StatusCode::NOT_FOUND {
+        return Err(NimbusError::Nextcloud(format!(
+            "DELETE event returned HTTP {status}"
+        )));
+    }
+    Ok(())
+}
+
+fn build_href(calendar_url: &str, uid: &str) -> String {
+    let base = calendar_url.trim_end_matches('/');
+    let safe_uid = uid_to_filename(uid);
+    format!("{base}/{safe_uid}.ics")
+}
+
+/// Sanitise a UID for use as a path segment. Real-world VEVENT UIDs
+/// are usually URN/UUID-shaped; this is belt-and-braces for anything
+/// weird (spaces, slashes) so we don't get a 400 back.
+fn uid_to_filename(uid: &str) -> String {
+    uid.chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+fn read_etag(resp: &reqwest::Response) -> Option<String> {
+    resp.headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim_matches('"').to_string())
+}
+
+/// If `href` is already absolute, return it. Otherwise prepend the
+/// server origin — same semantics as `client::absolute_url`.
+fn absolute_or_passthrough(server_url: &str, href: &str) -> String {
+    if href.starts_with("http://") || href.starts_with("https://") {
+        href.to_string()
+    } else if href.starts_with('/') {
+        format!("{}{}", normalize_server_url(server_url), href)
+    } else {
+        format!("{}/{}", normalize_server_url(server_url), href)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_href_joins_safely() {
+        assert_eq!(
+            build_href("https://x/dav/cal/", "abc-123"),
+            "https://x/dav/cal/abc-123.ics"
+        );
+        assert_eq!(
+            build_href("https://x/dav/cal", "abc-123"),
+            "https://x/dav/cal/abc-123.ics"
+        );
+    }
+
+    #[test]
+    fn uid_to_filename_strips_path_chars() {
+        assert_eq!(uid_to_filename("a/b c"), "a_b_c");
+        assert_eq!(uid_to_filename("urn:uuid:1234"), "urn_uuid_1234");
+    }
+}

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -312,4 +312,60 @@ pub struct CalendarEvent {
     /// override is in `id`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub recurrence_id: Option<DateTime<Utc>>,
+    /// `URL` property — a link associated with the event (meeting URL,
+    /// agenda doc, etc.). Free-form, the editor doesn't validate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// `TRANSP` — `OPAQUE` (default — busy time) or `TRANSPARENT`
+    /// (free time). The editor surfaces this as a "show as
+    /// busy / free" picker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transparency: Option<String>,
+    /// `ATTENDEE` properties. Empty for events with no participants.
+    /// We store name + email + the participant status the server last
+    /// reported; the UI only edits the email list today.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attendees: Vec<EventAttendee>,
+    /// `VALARM` blocks. The editor exposes a single "remind me X
+    /// before" picker, but the model carries a list so existing
+    /// events with several alarms round-trip without losing data.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reminders: Vec<EventReminder>,
+}
+
+/// A single ATTENDEE property on a VEVENT.
+///
+/// Only the most-used fields are surfaced — CN (display name), the
+/// `mailto:` email, and PARTSTAT (acceptance status). The full set
+/// (ROLE, RSVP, CUTYPE, …) is preserved opaquely in `ics_raw` until
+/// a follow-up issue surfaces them in the UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventAttendee {
+    /// The email after `mailto:`. Required by the iCalendar spec.
+    pub email: String,
+    /// `CN=` parameter (e.g. `"Jane Doe"`). Optional — many invites
+    /// only carry the email.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub common_name: Option<String>,
+    /// `PARTSTAT=` parameter — `NEEDS-ACTION` / `ACCEPTED` /
+    /// `DECLINED` / `TENTATIVE`. `None` falls back to NEEDS-ACTION
+    /// when written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+/// A single VALARM block.
+///
+/// We model the most common reminder shape — a relative offset before
+/// the event start — directly. The trigger is stored as **minutes
+/// before** the event (positive = before, negative = after).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventReminder {
+    /// Minutes before the event start. `15` means "fire 15 minutes
+    /// before". Negative values fire after the start.
+    pub trigger_minutes_before: i32,
+    /// `ACTION` — `DISPLAY` (popup) or `EMAIL`. Defaults to `DISPLAY`
+    /// when written if `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
 }

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -29,7 +29,7 @@
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::{OptionalExtension, params};
 
-use nimbus_core::models::CalendarEvent;
+use nimbus_core::models::{CalendarEvent, EventAttendee, EventReminder};
 
 use crate::cache::{Cache, CacheError};
 
@@ -43,9 +43,11 @@ use crate::cache::{Cache, CacheError};
 /// alongside the first batch of events so the two stay consistent.
 #[derive(Debug, Clone)]
 pub struct CalendarRow {
-    /// Absolute path on the server, e.g.
-    /// `/remote.php/dav/calendars/alice/personal/`. Stable across
-    /// syncs for a given calendar.
+    /// Absolute URL of the calendar collection on the server, e.g.
+    /// `https://cloud.example.com/remote.php/dav/calendars/alice/personal/`.
+    /// `nimbus-caldav::discovery` resolves the multistatus href against
+    /// the server URL before storing, so callers don't need to prefix
+    /// the server origin themselves. Stable across syncs.
     pub path: String,
     pub display_name: String,
     /// Hex colour (e.g. `#2bb0ed`). Optional — some servers / user
@@ -77,6 +79,14 @@ pub struct CalendarEventRow {
     pub rrule: Option<String>,
     pub rdate: Vec<DateTime<Utc>>,
     pub exdate: Vec<DateTime<Utc>>,
+    /// `URL` property — link associated with the event.
+    pub url: Option<String>,
+    /// `TRANSP` — `OPAQUE` (busy) or `TRANSPARENT` (free).
+    pub transparency: Option<String>,
+    /// Parsed `ATTENDEE` properties.
+    pub attendees: Vec<EventAttendee>,
+    /// Parsed `VALARM` blocks.
+    pub reminders: Vec<EventReminder>,
     /// Raw `text/calendar` blob as the server returned it. Kept so
     /// future parser evolutions and the recurrence expander have a
     /// source of truth on disk.
@@ -341,9 +351,10 @@ impl Cache {
                 "INSERT INTO calendar_events
                     (id, calendar_id, uid, href, etag, summary, description,
                      start_utc, end_utc, location, rrule, rdate_json, exdate_json,
-                     recurrence_id, ics_raw, cached_at)
+                     recurrence_id, ics_raw, cached_at,
+                     url, transparency, attendees_json, reminders_json)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
-                         ?14, ?15, ?16)",
+                         ?14, ?15, ?16, ?17, ?18, ?19, ?20)",
             )?;
             for e in upserts {
                 let id = event_row_id(calendar_id, &e.uid, e.recurrence_id);
@@ -355,6 +366,10 @@ impl Cache {
                     &e.exdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>(),
                 )
                 .unwrap_or_else(|_| "[]".into());
+                let attendees_json = serde_json::to_string(&e.attendees)
+                    .unwrap_or_else(|_| "[]".into());
+                let reminders_json = serde_json::to_string(&e.reminders)
+                    .unwrap_or_else(|_| "[]".into());
                 stmt.execute(params![
                     id,
                     calendar_id,
@@ -372,6 +387,10 @@ impl Cache {
                     e.recurrence_id.map(|d| d.timestamp()),
                     e.ics_raw,
                     now,
+                    e.url,
+                    e.transparency,
+                    attendees_json,
+                    reminders_json,
                 ])?;
             }
         }
@@ -564,7 +583,175 @@ impl Cache {
         )?;
         Ok(())
     }
+
+    /// Look up the (server, calendar) coordinates for an event row by
+    /// app-side id. The Tauri write commands need href + etag for the
+    /// PUT/DELETE preconditions, plus the parent calendar's path for
+    /// constructing a fresh URL on create.
+    ///
+    /// Returns `Ok(None)` if the row isn't cached — callers treat that
+    /// as "stale UI; refresh and try again".
+    pub fn get_event_server_handle(
+        &self,
+        event_id: &str,
+    ) -> Result<Option<CalendarEventServerHandle>, CacheError> {
+        let conn = self.pool.get()?;
+        let row = conn
+            .query_row(
+                "SELECT e.uid, e.href, e.etag, e.recurrence_id, e.ics_raw,
+                        e.calendar_id, c.nextcloud_account_id, c.path
+                 FROM calendar_events e
+                 JOIN calendars c ON c.id = e.calendar_id
+                 WHERE e.id = ?1",
+                params![event_id],
+                |r| {
+                    let recurrence_ts: Option<i64> = r.get(3)?;
+                    Ok(CalendarEventServerHandle {
+                        uid: r.get(0)?,
+                        href: r.get(1)?,
+                        etag: r.get(2)?,
+                        recurrence_id: recurrence_ts
+                            .and_then(|t| Utc.timestamp_opt(t, 0).single()),
+                        ics_raw: r.get(4)?,
+                        calendar_id: r.get(5)?,
+                        nextcloud_account_id: r.get(6)?,
+                        calendar_path: r.get(7)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Look up the (nc account, server path) coordinates for a
+    /// cached calendar by app-side id. Used by the create-event
+    /// command to build the resource URL before any event row exists.
+    pub fn get_calendar_server_path(
+        &self,
+        calendar_id: &str,
+    ) -> Result<Option<(String, String)>, CacheError> {
+        let conn = self.pool.get()?;
+        let row = conn
+            .query_row(
+                "SELECT nextcloud_account_id, path FROM calendars WHERE id = ?1",
+                params![calendar_id],
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// Insert (or replace) a single event row outside the
+    /// sync-collection delta path. Used by the create / update Tauri
+    /// commands after a successful PUT to Nextcloud — we already have
+    /// the server's new etag and don't want to wait for the next sync
+    /// to see our own write.
+    pub fn upsert_single_event(
+        &self,
+        calendar_id: &str,
+        row: &CalendarEventRow,
+    ) -> Result<(), CacheError> {
+        let conn = self.pool.get()?;
+        let id = event_row_id(calendar_id, &row.uid, row.recurrence_id);
+        let rdate_json = serde_json::to_string(
+            &row.rdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>(),
+        )
+        .unwrap_or_else(|_| "[]".into());
+        let exdate_json = serde_json::to_string(
+            &row.exdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>(),
+        )
+        .unwrap_or_else(|_| "[]".into());
+        let attendees_json =
+            serde_json::to_string(&row.attendees).unwrap_or_else(|_| "[]".into());
+        let reminders_json =
+            serde_json::to_string(&row.reminders).unwrap_or_else(|_| "[]".into());
+        let now = Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO calendar_events
+                (id, calendar_id, uid, href, etag, summary, description,
+                 start_utc, end_utc, location, rrule, rdate_json, exdate_json,
+                 recurrence_id, ics_raw, cached_at,
+                 url, transparency, attendees_json, reminders_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+                     ?14, ?15, ?16, ?17, ?18, ?19, ?20)
+             ON CONFLICT (id) DO UPDATE SET
+                href           = excluded.href,
+                etag           = excluded.etag,
+                summary        = excluded.summary,
+                description    = excluded.description,
+                start_utc      = excluded.start_utc,
+                end_utc        = excluded.end_utc,
+                location       = excluded.location,
+                rrule          = excluded.rrule,
+                rdate_json     = excluded.rdate_json,
+                exdate_json    = excluded.exdate_json,
+                recurrence_id  = excluded.recurrence_id,
+                ics_raw        = excluded.ics_raw,
+                cached_at      = excluded.cached_at,
+                url            = excluded.url,
+                transparency   = excluded.transparency,
+                attendees_json = excluded.attendees_json,
+                reminders_json = excluded.reminders_json",
+            params![
+                id,
+                calendar_id,
+                row.uid,
+                row.href,
+                row.etag,
+                row.summary,
+                row.description,
+                row.start.timestamp(),
+                row.end.timestamp(),
+                row.location,
+                row.rrule,
+                rdate_json,
+                exdate_json,
+                row.recurrence_id.map(|d| d.timestamp()),
+                row.ics_raw,
+                now,
+                row.url,
+                row.transparency,
+                attendees_json,
+                reminders_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Remove one event row by its app-side id. Used after a successful
+    /// DELETE to the server, so the next `get_cached_events` call
+    /// doesn't ghost-render the deleted row until the next sync.
+    pub fn delete_event_by_id(&self, event_id: &str) -> Result<(), CacheError> {
+        let conn = self.pool.get()?;
+        conn.execute(
+            "DELETE FROM calendar_events WHERE id = ?1",
+            params![event_id],
+        )?;
+        Ok(())
+    }
 }
+
+/// Server-side bookkeeping for one cached event, returned from
+/// [`Cache::get_event_server_handle`]. The Tauri layer needs these
+/// fields to do a PUT or DELETE — the user-facing `CalendarEvent`
+/// hides them since the UI shouldn't touch hrefs and etags.
+#[derive(Debug, Clone)]
+pub struct CalendarEventServerHandle {
+    pub nextcloud_account_id: String,
+    pub calendar_id: String,
+    /// Absolute URL of the calendar collection (already includes
+    /// scheme + host — see [`CalendarRow::path`]).
+    pub calendar_path: String,
+    pub uid: String,
+    pub href: String,
+    pub etag: String,
+    pub recurrence_id: Option<DateTime<Utc>>,
+    /// The full text/calendar blob as the server last sent it. Useful
+    /// for write paths that want to preserve fields the editor doesn't
+    /// surface yet.
+    pub ics_raw: String,
+}
+
 
 /// Build the stable app-side event id.
 ///
@@ -588,7 +775,8 @@ fn event_row_id(
 /// out of sync with individual `SELECT` statements.
 const EVENT_COLUMNS: &str =
     "id, calendar_id, summary, description, start_utc, end_utc, \
-     location, rrule, rdate_json, exdate_json, recurrence_id";
+     location, rrule, rdate_json, exdate_json, recurrence_id, \
+     url, transparency, attendees_json, reminders_json";
 
 /// `?1, ?2, ?N` placeholder list for binding a slice of calendar ids
 /// into an `IN (…)` clause. `n` is the number of calendar ids the
@@ -607,8 +795,14 @@ fn row_to_calendar_event(r: &rusqlite::Row<'_>) -> rusqlite::Result<CalendarEven
     let recurrence_ts: Option<i64> = r.get(10)?;
     let rdate_json: String = r.get(8)?;
     let exdate_json: String = r.get(9)?;
+    let attendees_json: String = r.get(13)?;
+    let reminders_json: String = r.get(14)?;
     let rdate_epochs: Vec<i64> = serde_json::from_str(&rdate_json).unwrap_or_default();
     let exdate_epochs: Vec<i64> = serde_json::from_str(&exdate_json).unwrap_or_default();
+    let attendees: Vec<EventAttendee> =
+        serde_json::from_str(&attendees_json).unwrap_or_default();
+    let reminders: Vec<EventReminder> =
+        serde_json::from_str(&reminders_json).unwrap_or_default();
     Ok(CalendarEvent {
         id: r.get(0)?,
         summary: r.get(2)?,
@@ -632,6 +826,10 @@ fn row_to_calendar_event(r: &rusqlite::Row<'_>) -> rusqlite::Result<CalendarEven
             .filter_map(|t| Utc.timestamp_opt(t, 0).single())
             .collect(),
         recurrence_id: recurrence_ts.and_then(|t| Utc.timestamp_opt(t, 0).single()),
+        url: r.get(11)?,
+        transparency: r.get(12)?,
+        attendees,
+        reminders,
     })
 }
 
@@ -673,6 +871,10 @@ mod tests {
             rrule: None,
             rdate: vec![],
             exdate: vec![],
+            url: None,
+            transparency: None,
+            attendees: vec![],
+            reminders: vec![],
             ics_raw: format!("BEGIN:VEVENT\r\nUID:{uid}\r\nEND:VEVENT\r\n"),
         }
     }

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -40,7 +40,8 @@ pub mod schema;
 pub mod search;
 
 pub use calendars::{
-    CachedCalendar, CalendarEventRow, CalendarRow, CalendarSyncState, ExpansionInput,
+    CachedCalendar, CalendarEventRow, CalendarEventServerHandle, CalendarRow, CalendarSyncState,
+    ExpansionInput,
 };
 pub use contacts::{AddressbookSyncState, ContactRow, ContactServerHandle};
 pub use search::{SearchFilters, SearchHit, SearchScope};

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -442,6 +442,38 @@ const MIGRATIONS: &[&str] = &[
     ALTER TABLE message_bodies
         ADD COLUMN attachments TEXT NOT NULL DEFAULT '[]';
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v6 → v7: extra calendar-event fields the editor exposes
+    // (Issue #50).
+    //
+    // Adds the four fields that the new "all fields" editor edits but
+    // the original sync schema only kept inside `ics_raw`:
+    //
+    //   - `url`            — VEVENT `URL` property.
+    //   - `transparency`   — `TRANSP`, the busy/free flag.
+    //   - `attendees_json` — `Vec<EventAttendee>` (CN + email + status).
+    //   - `reminders_json` — `Vec<EventReminder>` (one row per VALARM).
+    //
+    // We could re-parse them out of `ics_raw` on every read, but the
+    // expansion path runs on every UI repaint and re-parsing would
+    // burn cycles for no benefit. JSON columns match the existing
+    // pattern (`rdate_json`, `exdate_json`, `attachments`) and let
+    // `serde_json` round-trip the whole `Vec<…>` in one call.
+    //
+    // NOT NULL with sensible defaults so older rows (written before
+    // this column existed) decode without a separate backfill: empty
+    // arrays for the lists and NULL for the singletons.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE calendar_events
+        ADD COLUMN url TEXT;
+    ALTER TABLE calendar_events
+        ADD COLUMN transparency TEXT;
+    ALTER TABLE calendar_events
+        ADD COLUMN attendees_json TEXT NOT NULL DEFAULT '[]';
+    ALTER TABLE calendar_events
+        ADD COLUMN reminders_json TEXT NOT NULL DEFAULT '[]';
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,8 +9,10 @@
 mod badge;
 
 use nimbus_caldav::{
-    Calendar as CaldavCalendar, RawEvent, list_calendars as caldav_list_calendars,
-    sync_calendar as caldav_sync_calendar,
+    Calendar as CaldavCalendar, RawEvent, build_ics as caldav_build_ics,
+    create_event as caldav_create_event, delete_event as caldav_delete_event,
+    list_calendars as caldav_list_calendars, sync_calendar as caldav_sync_calendar,
+    update_event as caldav_update_event,
 };
 use nimbus_carddav::{
     Addressbook, ParsedVcard, RawContact, build_vcard, create_contact as carddav_create_contact,
@@ -19,8 +21,8 @@ use nimbus_carddav::{
 };
 use nimbus_core::NimbusError;
 use nimbus_core::models::{
-    Account, AppSettings, CalendarEvent, Contact, Email, EmailEnvelope, Folder, NextcloudAccount,
-    OutgoingEmail,
+    Account, AppSettings, CalendarEvent, Contact, Email, EmailEnvelope, EventAttendee,
+    EventReminder, Folder, NextcloudAccount, OutgoingEmail,
 };
 use nimbus_imap::ImapClient;
 use nimbus_jmap::JmapClient;
@@ -29,8 +31,8 @@ use nimbus_nextcloud::{
 };
 use nimbus_smtp::SmtpClient;
 use nimbus_store::cache::{
-    CalendarEventRow, CalendarRow, ContactRow, ContactServerHandle, SearchFilters, SearchHit,
-    SearchScope, SyncState,
+    CalendarEventRow, CalendarEventServerHandle, CalendarRow, ContactRow, ContactServerHandle,
+    SearchFilters, SearchHit, SearchScope, SyncState,
 };
 use nimbus_store::{Cache, account_store, app_settings, credentials, nextcloud_store};
 use serde::{Deserialize, Serialize};
@@ -993,6 +995,231 @@ fn get_cached_events(
     Ok(out)
 }
 
+/// What the Svelte editor sends for a create or update. Matches the
+/// `CalendarEvent` shape the UI already knows but flattens to plain
+/// strings / booleans the Tauri IPC layer can serialise without
+/// extra adapters. Optional fields stay optional so the form can
+/// submit a partial event without leaving phantom values behind.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CalendarEventInput {
+    summary: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    location: Option<String>,
+    start: chrono::DateTime<chrono::Utc>,
+    end: chrono::DateTime<chrono::Utc>,
+    /// True for events the user picked "All day" on. The server stores
+    /// these as `VALUE=DATE` ranges; we re-derive that from the start /
+    /// end times being a midnight…23:59:59 window.
+    #[serde(default)]
+    all_day: bool,
+    #[serde(default)]
+    url: Option<String>,
+    /// `OPAQUE` (busy) or `TRANSPARENT` (free). Matches the editor's
+    /// "show as" picker. `None` means "leave whatever the server had".
+    #[serde(default)]
+    transparency: Option<String>,
+    #[serde(default)]
+    attendees: Vec<EventAttendee>,
+    #[serde(default)]
+    reminders: Vec<EventReminder>,
+}
+
+/// Build a `CalendarEvent` skeleton from form input. Caller fills in
+/// `id` (a fresh UID for create, the cached UID for update). Recurrence
+/// fields stay empty here — the editor doesn't expose them yet, and
+/// any existing recurrence is preserved from the cached event by the
+/// update command before this struct is rebuilt.
+fn input_to_calendar_event(uid: &str, input: &CalendarEventInput) -> CalendarEvent {
+    // For all-day events the editor sends midnight UTC starts; snap
+    // the end to 23:59:59 of the last covered day so `build_ics`
+    // recognises the all-day shape. For timed events we trust the
+    // editor's exact instants.
+    let (start, end) = if input.all_day {
+        use chrono::TimeZone;
+        let start_day = input.start.date_naive();
+        let end_day = input.end.date_naive();
+        let s = chrono::Utc
+            .from_utc_datetime(&start_day.and_hms_opt(0, 0, 0).unwrap());
+        let e = chrono::Utc
+            .from_utc_datetime(&end_day.and_hms_opt(23, 59, 59).unwrap());
+        (s, e)
+    } else {
+        (input.start, input.end)
+    };
+    CalendarEvent {
+        id: uid.to_string(),
+        summary: input.summary.clone(),
+        description: input.description.clone(),
+        start,
+        end,
+        location: input.location.clone(),
+        rrule: None,
+        rdate: vec![],
+        exdate: vec![],
+        recurrence_id: None,
+        url: input.url.clone(),
+        transparency: input.transparency.clone(),
+        attendees: input.attendees.clone(),
+        reminders: input.reminders.clone(),
+    }
+}
+
+/// Convert a `CalendarEvent` (post-write) into the row shape the cache
+/// expects. Used by both `create_calendar_event` and
+/// `update_calendar_event` so the local cache reflects the new state
+/// without waiting for the next sync round.
+fn calendar_event_to_row(
+    event: &CalendarEvent,
+    href: &str,
+    etag: &str,
+    ics_raw: &str,
+) -> CalendarEventRow {
+    CalendarEventRow {
+        uid: event.id.clone(),
+        recurrence_id: event.recurrence_id,
+        href: href.to_string(),
+        etag: etag.to_string(),
+        summary: event.summary.clone(),
+        description: event.description.clone(),
+        start: event.start,
+        end: event.end,
+        location: event.location.clone(),
+        rrule: event.rrule.clone(),
+        rdate: event.rdate.clone(),
+        exdate: event.exdate.clone(),
+        url: event.url.clone(),
+        transparency: event.transparency.clone(),
+        attendees: event.attendees.clone(),
+        reminders: event.reminders.clone(),
+        ics_raw: ics_raw.to_string(),
+    }
+}
+
+/// Create a new VEVENT in the given calendar.
+///
+/// Generates a fresh UUID for the UID so callers don't have to.
+/// The PUT uses `If-None-Match: *`, so a UID collision surfaces as
+/// a structured error instead of a silent overwrite. On success, the
+/// new event is upserted into the local cache so the UI can render it
+/// without waiting for the next sync.
+#[tauri::command]
+async fn create_calendar_event(
+    calendar_id: String,
+    input: CalendarEventInput,
+    cache: State<'_, Cache>,
+) -> Result<CalendarEvent, NimbusError> {
+    let (nc_id, calendar_path) = cache
+        .get_calendar_server_path(&calendar_id)?
+        .ok_or_else(|| {
+            NimbusError::Other(format!(
+                "calendar '{calendar_id}' is not in the local cache — refresh and try again"
+            ))
+        })?;
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    let uid = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+    let event = input_to_calendar_event(&uid, &input);
+    let ics = caldav_build_ics(&event);
+
+    // `calendar_path` from the cache is already an absolute URL —
+    // `nimbus-caldav::discovery` resolves it via `absolute_url` before
+    // storing. Don't re-prefix the server origin or the PUT goes to
+    // `https://hosthttps://host/...`.
+    let outcome = caldav_create_event(
+        &account.server_url,
+        &calendar_path,
+        &account.username,
+        &app_password,
+        &uid,
+        &ics,
+    )
+    .await?;
+
+    let row = calendar_event_to_row(&event, &outcome.href, &outcome.etag, &ics);
+    cache.upsert_single_event(&calendar_id, &row)?;
+
+    // Re-derive the app-side id the same way `event_row_id` does so the
+    // returned event matches what `get_cached_events` will surface.
+    let mut out = event;
+    out.id = format!("{calendar_id}::{uid}");
+    Ok(out)
+}
+
+/// Update an existing VEVENT, keyed by its app-side id.
+///
+/// Preserves the cached UID and href; everything else comes from the
+/// editor input. The PUT is gated on the cached etag so a concurrent
+/// edit on another device surfaces as a structured error (412 → human-
+/// readable string) instead of overwriting the other change silently.
+#[tauri::command]
+async fn update_calendar_event(
+    event_id: String,
+    input: CalendarEventInput,
+    cache: State<'_, Cache>,
+) -> Result<CalendarEvent, NimbusError> {
+    let handle = load_event_handle(&cache, &event_id)?;
+    let account = load_nextcloud_account(&handle.nextcloud_account_id)?;
+    let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
+
+    let mut event = input_to_calendar_event(&handle.uid, &input);
+    // Preserve recurrence info the editor doesn't surface — losing it
+    // would silently demote a recurring series back to a singleton.
+    event.recurrence_id = handle.recurrence_id;
+
+    let ics = caldav_build_ics(&event);
+    let outcome = caldav_update_event(
+        &handle.href,
+        &account.username,
+        &app_password,
+        &handle.etag,
+        &ics,
+    )
+    .await?;
+
+    let row = calendar_event_to_row(&event, &outcome.href, &outcome.etag, &ics);
+    cache.upsert_single_event(&handle.calendar_id, &row)?;
+
+    let mut out = event;
+    out.id = event_id;
+    Ok(out)
+}
+
+/// Delete an event from the server and the local cache. The server
+/// delete is gated on the cached etag; if that fails we leave the
+/// cache row alone so the UI shows the user the fresh state on the
+/// next sync.
+#[tauri::command]
+async fn delete_calendar_event(
+    event_id: String,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let handle = load_event_handle(&cache, &event_id)?;
+    let account = load_nextcloud_account(&handle.nextcloud_account_id)?;
+    let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
+
+    caldav_delete_event(&handle.href, &account.username, &app_password, &handle.etag).await?;
+    cache.delete_event_by_id(&event_id)?;
+    Ok(())
+}
+
+fn load_event_handle(
+    cache: &Cache,
+    event_id: &str,
+) -> Result<CalendarEventServerHandle, NimbusError> {
+    cache
+        .get_event_server_handle(event_id)
+        .map_err(NimbusError::from)?
+        .ok_or_else(|| {
+            NimbusError::Other(format!(
+                "event '{event_id}' is not in the local cache — refresh and try again"
+            ))
+        })
+}
+
 /// Flatten one CalDAV resource (href-with-ics) into one store row per
 /// VEVENT it contains. Master + recurrence-id overrides all share the
 /// same `href`, `etag`, and `ics_raw` — `apply_event_delta` keys the
@@ -1015,6 +1242,10 @@ fn raw_event_to_rows(raw: &RawEvent) -> Vec<CalendarEventRow> {
             rrule: e.rrule.clone(),
             rdate: e.rdate.clone(),
             exdate: e.exdate.clone(),
+            url: e.url.clone(),
+            transparency: e.transparency.clone(),
+            attendees: e.attendees.clone(),
+            reminders: e.reminders.clone(),
             ics_raw: raw.ics_raw.clone(),
         })
         .collect()
@@ -2194,6 +2425,9 @@ fn main() {
             sync_nextcloud_calendars,
             get_cached_calendars,
             get_cached_events,
+            create_calendar_event,
+            update_calendar_event,
+            delete_calendar_event,
             // Issue #16: tray + notifications + preferences
             get_app_settings,
             update_app_settings,

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -32,6 +32,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import EventEditor from './EventEditor.svelte'
 
   interface Props {
     onclose: () => void
@@ -52,6 +53,15 @@
     color: string | null
     last_synced_at: string | null
   }
+  interface EventAttendee {
+    email: string
+    common_name?: string | null
+    status?: string | null
+  }
+  interface EventReminder {
+    trigger_minutes_before: number
+    action?: string | null
+  }
   interface CalendarEvent {
     id: string
     summary: string
@@ -63,6 +73,10 @@
     rdate: string[]
     exdate: string[]
     recurrence_id: string | null
+    url?: string | null
+    transparency?: string | null
+    attendees?: EventAttendee[]
+    reminders?: EventReminder[]
   }
 
   // ── Layout constants ────────────────────────────────────────
@@ -119,6 +133,32 @@
   // newly-discovered calendars default to visible without needing a
   // separate "show new calendars" workflow.
   let hiddenCalendarIds = $state<Set<string>>(new Set())
+
+  // ── Event editor state ──────────────────────────────────────
+  // The editor is mounted lazily — only when one of these holds a
+  // non-null value. Only one is ever set at a time (see openEditor /
+  // openCreate / closeEditor). This keeps the modal a single thing on
+  // screen no matter how it was triggered.
+  let editingEvent = $state<CalendarEvent | null>(null)
+  let creatingDraft = $state<{
+    calendarId: string
+    start: Date
+    end: Date
+    allDay?: boolean
+  } | null>(null)
+
+  // ── Click-and-drag-to-create state ──────────────────────────
+  // Tracks an in-progress drag inside one of the day columns. While a
+  // drag is active we render a translucent overlay block that follows
+  // the pointer, and on mouseup we open the editor with the swept
+  // range as the draft. Confined to a single day — multi-day drags are
+  // a follow-up.
+  type DragState = {
+    dayKey: string
+    startMinute: number
+    currentMinute: number
+  }
+  let drag = $state<DragState | null>(null)
 
   // Derived: calendar id → colour (for the coloured stripe on each
   // event block and the all-day pills).
@@ -484,6 +524,23 @@
     )
   }
 
+  /**
+   * True for any calendar day strictly before today (in the user's local
+   * timezone). Used to grey out past columns so the user can tell at a
+   * glance which part of the week has already happened.
+   *
+   * Why local time, not UTC: the visible grid is rendered in local time
+   * — a Tuesday column shows the user's local Tuesday, even if the user
+   * is east of UTC and the day starts as Monday in UTC. The "past day"
+   * decision needs to match what the user sees.
+   */
+  function isPast(d: Date): boolean {
+    const now = new Date()
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    const day = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+    return day.getTime() < today.getTime()
+  }
+
   function eventCalendarId(ev: CalendarEvent): string {
     // Event ids come out of the store as `{nc_id}::{cal_path}::{uid}`
     // or the expanded `{…}::occ::{epoch}` form. Calendar ids are the
@@ -518,6 +575,124 @@
   }
   function allDayOverflow(list: CalendarEvent[]): number {
     return Math.max(0, list.length - ALL_DAY_VISIBLE_ROWS)
+  }
+
+  // ── Editor open / close ─────────────────────────────────────
+  /** Pick a sensible default calendar for a fresh `+ New event` —
+      the first non-hidden one, falling back to the first overall. */
+  function defaultCalendarId(): string {
+    for (const c of calendars) {
+      if (!hiddenCalendarIds.has(c.id)) return c.id
+    }
+    return calendars[0]?.id ?? ''
+  }
+
+  function openCreateBlank() {
+    if (calendars.length === 0) return
+    const start = new Date()
+    // Round to the next half-hour so the prefilled time looks
+    // intentional rather than "11:37".
+    start.setMinutes(start.getMinutes() < 30 ? 30 : 60, 0, 0)
+    const end = new Date(start)
+    end.setHours(end.getHours() + 1)
+    creatingDraft = {
+      calendarId: defaultCalendarId(),
+      start,
+      end,
+    }
+    editingEvent = null
+  }
+
+  function openEditor(ev: CalendarEvent) {
+    editingEvent = ev
+    creatingDraft = null
+  }
+
+  function closeEditor() {
+    editingEvent = null
+    creatingDraft = null
+  }
+
+  async function onEditorSaved() {
+    // Easiest correct refresh: re-query the same window. The cache
+    // upsert/delete the backend already did is now visible.
+    await reloadFromCache(loadedRangeStart, loadedRangeEnd)
+  }
+
+  // ── Click-and-drag in the time grid ─────────────────────────
+  /** Map a vertical pixel offset inside a day column to a minute of
+      the day, snapped to 15-minute increments so dragged events line
+      up with the visual half-hour grid. */
+  function pxToMinuteSnapped(yPx: number): number {
+    const raw = Math.max(0, Math.min(24 * 60, yPx / PX_PER_MINUTE))
+    return Math.round(raw / 15) * 15
+  }
+
+  function onDayMouseDown(ev: MouseEvent, bucket: WeekBucket) {
+    // Left-click on empty space only. If the user clicked an existing
+    // event block, that block's own click handler runs and stops
+    // propagation — so a missed click here always means "blank area".
+    if (ev.button !== 0) return
+    const target = ev.currentTarget as HTMLElement
+    const rect = target.getBoundingClientRect()
+    const minute = pxToMinuteSnapped(ev.clientY - rect.top)
+    drag = {
+      dayKey: bucket.dayKey,
+      startMinute: minute,
+      currentMinute: minute,
+    }
+  }
+
+  function onDayMouseMove(ev: MouseEvent, bucket: WeekBucket) {
+    if (!drag || drag.dayKey !== bucket.dayKey) return
+    const target = ev.currentTarget as HTMLElement
+    const rect = target.getBoundingClientRect()
+    drag = {
+      ...drag,
+      currentMinute: pxToMinuteSnapped(ev.clientY - rect.top),
+    }
+  }
+
+  function onDayMouseUp(_ev: MouseEvent, bucket: WeekBucket) {
+    if (!drag || drag.dayKey !== bucket.dayKey) return
+    const a = Math.min(drag.startMinute, drag.currentMinute)
+    const b = Math.max(drag.startMinute, drag.currentMinute)
+    // Treat a bare click (no movement) as a 1-hour event starting at
+    // the click point. A real drag uses whatever the user swept,
+    // floored to a 15-minute minimum so a tiny accidental drag still
+    // produces a clickable block in the editor.
+    const startMinute = a
+    const endMinute = b - a < 15 ? a + 60 : b
+    const start = new Date(bucket.date)
+    start.setHours(0, startMinute, 0, 0)
+    const end = new Date(bucket.date)
+    end.setHours(0, endMinute, 0, 0)
+    drag = null
+    creatingDraft = {
+      calendarId: defaultCalendarId(),
+      start,
+      end,
+    }
+    editingEvent = null
+  }
+
+  function onDayMouseLeave() {
+    // Cancel an in-flight drag if the cursor leaves the column —
+    // otherwise mouseup over the sidebar would create an event in the
+    // last column the user touched, which is surprising.
+    drag = null
+  }
+
+  /** Geometry for the in-progress drag overlay rendered on the
+      currently-active day column. */
+  function dragOverlay(bucket: WeekBucket): { topPx: number; heightPx: number } | null {
+    if (!drag || drag.dayKey !== bucket.dayKey) return null
+    const a = Math.min(drag.startMinute, drag.currentMinute)
+    const b = Math.max(drag.startMinute, drag.currentMinute)
+    return {
+      topPx: a * PX_PER_MINUTE,
+      heightPx: Math.max(2, (b - a) * PX_PER_MINUTE),
+    }
   }
 </script>
 
@@ -556,6 +731,13 @@
       {/if}
     </div>
     <div class="flex items-center gap-2">
+      <button
+        class="btn preset-filled-primary-500 text-sm"
+        disabled={calendars.length === 0}
+        onclick={openCreateBlank}
+      >
+        + New event
+      </button>
       <button
         class="btn preset-tonal-surface text-sm"
         disabled={syncing}
@@ -638,33 +820,56 @@
           >
             <div></div>
             {#each weekBuckets as b (b.dayKey)}
+              {@const today = isToday(b.date)}
+              {@const past = isPast(b.date)}
               <div
                 class="px-2 py-2 text-center text-xs font-medium border-l border-surface-200 dark:border-surface-700 flex flex-col gap-1"
-                class:bg-primary-50={isToday(b.date)}
-                class:dark:bg-primary-950={isToday(b.date)}
               >
                 <div
-                  class="uppercase tracking-wider text-surface-500"
-                  class:text-primary-600={isToday(b.date)}
+                  class="uppercase tracking-wider"
+                  class:text-surface-500={!past}
+                  class:text-surface-400={past}
                 >
                   {b.date.toLocaleDateString(undefined, { weekday: 'short' })}
                 </div>
-                <div
-                  class="text-lg font-semibold leading-none"
-                  class:text-primary-600={isToday(b.date)}
-                >
-                  {b.date.getDate()}
+                <!--
+                  Today's date number sits inside a red circle (Outlook /
+                  Google Calendar convention). For past and future days we
+                  drop the badge — past days additionally get a muted text
+                  colour so the visited-vs-upcoming split is obvious at a
+                  glance. We render the digit inside an inline-flex'd span
+                  with fixed dimensions so the badge stays a perfect circle
+                  regardless of digit width (1 vs 31).
+                -->
+                <div class="flex justify-center leading-none">
+                  {#if today}
+                    <span
+                      class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-red-500 text-white text-base font-semibold"
+                      aria-label="Today"
+                    >
+                      {b.date.getDate()}
+                    </span>
+                  {:else}
+                    <span
+                      class="text-lg font-semibold"
+                      class:text-surface-400={past}
+                    >
+                      {b.date.getDate()}
+                    </span>
+                  {/if}
                 </div>
                 {#if b.allDay.length > 0}
                   <div class="flex flex-col gap-0.5 mt-1 text-left">
                     {#each allDayVisible(b.allDay) as ev (ev.id)}
-                      <div
-                        class="text-[11px] truncate rounded px-1.5 text-white"
+                      <button
+                        type="button"
+                        class="text-[11px] truncate rounded px-1.5 text-white text-left"
                         style="background-color: {eventColor(ev)}; height: {ALL_DAY_ROW_HEIGHT_PX}px; line-height: {ALL_DAY_ROW_HEIGHT_PX}px;"
-                        title={ev.summary}
+                        title={`${ev.summary || '(no title)'} — All-day${ev.location ? ` @ ${ev.location}` : ''}`}
+                        onclick={() => openEditor(ev)}
                       >
                         {ev.summary || '(no title)'}
-                      </div>
+                      </button>
                     {/each}
                     {#if allDayOverflow(b.allDay) > 0}
                       <div class="text-[10px] text-surface-500">
@@ -698,10 +903,16 @@
                  so event blocks can absolutely-position against the
                  24-hour axis without interfering with each other. -->
             {#each weekBuckets as b (b.dayKey)}
+              {@const overlay = dragOverlay(b)}
               <div
-                class="relative border-l border-surface-200 dark:border-surface-700"
-                class:bg-primary-50={isToday(b.date)}
-                class:dark:bg-primary-950={isToday(b.date)}
+                class="relative border-l border-surface-200 dark:border-surface-700 cursor-crosshair select-none"
+                class:bg-surface-100={isPast(b.date)}
+                class:dark:bg-surface-800={isPast(b.date)}
+                onmousedown={(ev) => onDayMouseDown(ev, b)}
+                onmousemove={(ev) => onDayMouseMove(ev, b)}
+                onmouseup={(ev) => onDayMouseUp(ev, b)}
+                onmouseleave={onDayMouseLeave}
+                role="presentation"
               >
                 <!-- Hour gridlines — pure visual rhythm. -->
                 {#each Array.from({ length: 24 }, (_, i) => i) as h}
@@ -711,20 +922,57 @@
                   ></div>
                 {/each}
 
-                <!-- Event blocks. -->
-                {#each b.timed as p (p.event.id)}
+                <!-- In-progress drag overlay — translucent rectangle
+                     that follows the pointer between mousedown and
+                     mouseup so the user can see the range they're
+                     about to create. -->
+                {#if overlay}
                   <div
-                    class="absolute rounded-md text-[11px] text-white overflow-hidden px-1.5 py-1 shadow-sm cursor-default"
+                    class="absolute left-0.5 right-0.5 rounded-md bg-primary-500/40 border border-primary-500 pointer-events-none"
+                    style="top: {overlay.topPx}px; height: {overlay.heightPx}px;"
+                  ></div>
+                {/if}
+
+                <!--
+                  Event blocks. We keep the title (`<title>` tooltip) in
+                  a "Name — HH:MM–HH:MM" shape so the time range is always
+                  one hover away even when the block is short or the lane
+                  is narrow. The visible label wraps onto multiple lines
+                  (`break-words` + `whitespace-normal`) and we cap the
+                  number of visible lines to whatever the block height
+                  comfortably allows — short blocks get 1 line, taller
+                  blocks get 2-3 — so the title shows as much as it can
+                  without overflowing the block.
+                -->
+                {#each b.timed as p (p.event.id)}
+                  {@const titleLineCap = p.heightPx >= 80
+                    ? 4
+                    : p.heightPx >= 50
+                      ? 2
+                      : 1}
+                  {@const showLocationInline = p.event.location && p.heightPx > 80}
+                  <div
+                    class="absolute rounded-md text-[11px] text-white overflow-hidden px-1.5 py-1 shadow-sm cursor-pointer leading-tight"
                     style="top: {p.topPx}px; height: {p.heightPx}px; left: calc({(p.lane / p.laneCount) * 100}% + 2px); width: calc({(1 / p.laneCount) * 100}% - 4px); background-color: {eventColor(p.event)};"
-                    title={p.event.summary + (p.event.location ? ' — ' + p.event.location : '')}
+                    title={`${p.event.summary || '(no title)'} — ${fmtTime(p.event.start)}–${fmtTime(p.event.end)}${p.event.location ? ` @ ${p.event.location}` : ''}`}
+                    onmousedown={(ev) => ev.stopPropagation()}
+                    onclick={(ev) => { ev.stopPropagation(); openEditor(p.event) }}
+                    role="button"
+                    tabindex="0"
+                    onkeydown={(ev) => { if (ev.key === 'Enter') openEditor(p.event) }}
                   >
-                    <div class="font-medium truncate">
+                    <div
+                      class="font-medium wrap-break-word"
+                      style="display: -webkit-box; -webkit-line-clamp: {titleLineCap}; -webkit-box-orient: vertical; overflow: hidden;"
+                    >
                       {p.event.summary || '(no title)'}
                     </div>
-                    <div class="opacity-90 truncate">
-                      {fmtTime(p.event.start)} – {fmtTime(p.event.end)}
-                    </div>
-                    {#if p.event.location && p.heightPx > 60}
+                    {#if p.heightPx > 32}
+                      <div class="opacity-90 truncate">
+                        {fmtTime(p.event.start)} – {fmtTime(p.event.end)}
+                      </div>
+                    {/if}
+                    {#if showLocationInline}
                       <div class="opacity-90 truncate">{p.event.location}</div>
                     {/if}
                   </div>
@@ -750,3 +998,21 @@
     </div>
   {/if}
 </div>
+
+{#if creatingDraft}
+  <EventEditor
+    mode="create"
+    {calendars}
+    draft={creatingDraft}
+    onclose={closeEditor}
+    onsaved={onEditorSaved}
+  />
+{:else if editingEvent}
+  <EventEditor
+    mode="edit"
+    {calendars}
+    event={editingEvent}
+    onclose={closeEditor}
+    onsaved={onEditorSaved}
+  />
+{/if}

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -1,0 +1,529 @@
+<script lang="ts">
+  /**
+   * EventEditor — modal for creating, editing, and deleting calendar
+   * events.
+   *
+   * Mirrors the Compose modal pattern: full-screen dim overlay, a
+   * fixed-size centered card with a sticky header / scrolling body /
+   * sticky footer. The parent (`CalendarView`) opens it in one of two
+   * shapes:
+   *
+   *   - **create**: pass `mode="create"` plus a `draft` (calendar id +
+   *     start/end seeded from a `+ New event` click or a click-and-drag
+   *     gesture in the time grid). The editor PUTs via
+   *     `create_calendar_event`.
+   *   - **edit**: pass `mode="edit"` plus the existing `event` and the
+   *     calendar list (so we can show the calendar name in read-only
+   *     form — moving an event between calendars is a follow-up). The
+   *     editor PUTs via `update_calendar_event` and offers a Delete
+   *     button (`delete_calendar_event`).
+   *
+   * On a successful save or delete we call `onsaved()` so the parent
+   * can re-query the cache and repaint the grid; the modal closes
+   * itself via `onclose()` either way.
+   *
+   * # Field mapping
+   *
+   * The form field shapes match the Rust `CalendarEventInput` struct
+   * (camelCase via serde): `summary`, `description`, `location`,
+   * `start`, `end`, `allDay`, `url`, `transparency`, `attendees`,
+   * `reminders`. The attendee list is edited as a comma-separated
+   * email string — power users can paste a list, and the parsed shape
+   * round-trips through `CalendarEvent.attendees`.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+
+  // ── Types (kept local; these mirror the Rust models) ──────────
+  interface EventAttendee {
+    email: string
+    common_name?: string | null
+    status?: string | null
+  }
+  interface EventReminder {
+    trigger_minutes_before: number
+    action?: string | null
+  }
+  interface CalendarEvent {
+    id: string
+    summary: string
+    description: string | null
+    start: string
+    end: string
+    location: string | null
+    rrule: string | null
+    rdate: string[]
+    exdate: string[]
+    recurrence_id: string | null
+    url?: string | null
+    transparency?: string | null
+    attendees?: EventAttendee[]
+    reminders?: EventReminder[]
+  }
+  interface CalendarSummary {
+    id: string
+    nextcloud_account_id: string
+    display_name: string
+    color: string | null
+    last_synced_at: string | null
+  }
+
+  type Mode = 'create' | 'edit'
+
+  interface Props {
+    mode: Mode
+    calendars: CalendarSummary[]
+    /** create-mode seed: which calendar + which start/end to prefill. */
+    draft?: { calendarId: string; start: Date; end: Date; allDay?: boolean } | null
+    /** edit-mode subject: the existing event being edited. */
+    event?: CalendarEvent | null
+    onclose: () => void
+    onsaved: () => void
+  }
+  const { mode, calendars, draft, event, onclose, onsaved }: Props = $props()
+
+  // ── Form state ──────────────────────────────────────────────
+  // Initial values are computed once at mount from `draft` (create) or
+  // `event` (edit). After that the form is fully owned by these
+  // `$state` cells, so further changes to the prop don't clobber the
+  // user's typing.
+  // svelte-ignore state_referenced_locally
+  let summary = $state(event?.summary ?? '')
+  // svelte-ignore state_referenced_locally
+  let description = $state(event?.description ?? '')
+  // svelte-ignore state_referenced_locally
+  let location = $state(event?.location ?? '')
+  // svelte-ignore state_referenced_locally
+  let url = $state(event?.url ?? '')
+  // svelte-ignore state_referenced_locally
+  let transparency = $state(event?.transparency ?? 'OPAQUE')
+
+  // Determine the starting calendar id. In edit-mode we derive it from
+  // the event id (`{nc_id}::{cal_path}::…`). In create-mode the parent
+  // hands us one explicitly.
+  // svelte-ignore state_referenced_locally
+  let calendarId = $state(deriveInitialCalendarId())
+  function deriveInitialCalendarId(): string {
+    if (event) {
+      const parts = event.id.split('::')
+      return parts.slice(0, 2).join('::')
+    }
+    return draft?.calendarId ?? calendars[0]?.id ?? ''
+  }
+
+  // svelte-ignore state_referenced_locally
+  const initialAllDay = inferAllDay()
+  // svelte-ignore state_referenced_locally
+  let allDay = $state(initialAllDay)
+
+  // datetime-local inputs work in the user's local timezone — the
+  // value shape is `YYYY-MM-DDTHH:MM` with no offset. We seed from the
+  // event/draft (which carry UTC instants) and convert back to UTC at
+  // save time. For all-day events we keep the date-only state in
+  // `startDate` / `endDate` and let the save path fold them into
+  // 00:00:00Z / 23:59:59Z.
+  // svelte-ignore state_referenced_locally
+  let startLocal = $state(toLocalInput(initialStart()))
+  // svelte-ignore state_referenced_locally
+  let endLocal = $state(toLocalInput(initialEnd()))
+  // svelte-ignore state_referenced_locally
+  let startDate = $state(toDateInput(initialStart()))
+  // svelte-ignore state_referenced_locally
+  let endDate = $state(toDateInput(initialEnd()))
+
+  // Attendees are edited as a comma-separated email string. We parse
+  // them into the structured shape on save. Existing CN / PARTSTAT data
+  // round-trips opaquely (we hold it in `originalAttendees` and merge
+  // back by email at save time).
+  // svelte-ignore state_referenced_locally
+  let attendeesText = $state(
+    (event?.attendees ?? []).map((a) => a.email).join(', '),
+  )
+  // svelte-ignore state_referenced_locally
+  const originalAttendees = event?.attendees ?? []
+
+  // Reminder picker: a single dropdown that maps to the most common
+  // VALARM offsets. "Custom" preserves whatever multi-alarm setup the
+  // event came in with (we keep `originalReminders` for that case).
+  type ReminderChoice = 'none' | '5' | '15' | '30' | '60' | '1440' | 'custom'
+  // svelte-ignore state_referenced_locally
+  let reminderChoice = $state<ReminderChoice>(deriveReminderChoice())
+  // svelte-ignore state_referenced_locally
+  const originalReminders = event?.reminders ?? []
+  function deriveReminderChoice(): ReminderChoice {
+    const list = event?.reminders ?? []
+    if (list.length === 0) return 'none'
+    if (list.length > 1) return 'custom'
+    const m = list[0].trigger_minutes_before
+    if (m === 5 || m === 15 || m === 30 || m === 60 || m === 1440) {
+      return String(m) as ReminderChoice
+    }
+    return 'custom'
+  }
+
+  let saving = $state(false)
+  let deleting = $state(false)
+  let error = $state('')
+
+  // ── Initial conversions ─────────────────────────────────────
+  function initialStart(): Date {
+    if (event) return new Date(event.start)
+    if (draft) return draft.start
+    const now = new Date()
+    now.setMinutes(0, 0, 0)
+    return now
+  }
+  function initialEnd(): Date {
+    if (event) return new Date(event.end)
+    if (draft) return draft.end
+    const out = initialStart()
+    out.setHours(out.getHours() + 1)
+    return out
+  }
+  function inferAllDay(): boolean {
+    if (draft?.allDay) return true
+    if (!event) return false
+    // Same heuristic as CalendarView.isAllDay — UTC midnight start,
+    // span ≈ N×24h.
+    const s = new Date(event.start)
+    const e = new Date(event.end)
+    if (s.getUTCHours() !== 0 || s.getUTCMinutes() !== 0) return false
+    const hours = (e.getTime() - s.getTime()) / 3_600_000
+    if (hours < 23) return false
+    const remainder = hours % 24
+    return remainder < 1 / 60 || remainder > 24 - 1 / 60
+  }
+
+  // ── datetime / date helpers ─────────────────────────────────
+  /** `Date` → `YYYY-MM-DDTHH:MM` in the user's local zone. */
+  function toLocalInput(d: Date): string {
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return (
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+      `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+    )
+  }
+  /** `Date` → `YYYY-MM-DD` in UTC (matches the all-day storage shape). */
+  function toDateInput(d: Date): string {
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+  }
+  /** `YYYY-MM-DDTHH:MM` (local) → ISO string in UTC. */
+  function fromLocalInput(s: string): Date {
+    // The browser parses `T`-separated strings without an offset as
+    // local time, so this is the inverse of `toLocalInput`.
+    return new Date(s)
+  }
+  /** `YYYY-MM-DD` (treated as a UTC calendar date) → midnight UTC. */
+  function dateInputToUtcMidnight(s: string): Date {
+    return new Date(`${s}T00:00:00Z`)
+  }
+  /** `YYYY-MM-DD` → 23:59:59.999 UTC of that date. */
+  function dateInputToUtcEndOfDay(s: string): Date {
+    return new Date(`${s}T23:59:59.999Z`)
+  }
+
+  // When the user toggles all-day, keep the visible inputs sane: copy
+  // the timed value over to the date-only field on the way in, and
+  // restore a sensible 1-hour timed window on the way out.
+  function onToggleAllDay() {
+    if (allDay) {
+      const s = fromLocalInput(startLocal)
+      const e = fromLocalInput(endLocal)
+      startDate = toDateInput(s)
+      endDate = toDateInput(e)
+    } else {
+      const s = dateInputToUtcMidnight(startDate)
+      const out = new Date(s)
+      out.setHours(9, 0, 0, 0)
+      const end = new Date(out)
+      end.setHours(end.getHours() + 1)
+      startLocal = toLocalInput(out)
+      endLocal = toLocalInput(end)
+    }
+  }
+
+  // ── Save / delete ───────────────────────────────────────────
+  function buildAttendees(): EventAttendee[] {
+    const seen = new Map<string, EventAttendee>()
+    for (const a of originalAttendees) seen.set(a.email.toLowerCase(), a)
+    const out: EventAttendee[] = []
+    for (const piece of attendeesText.split(',')) {
+      const email = piece.trim()
+      if (!email) continue
+      const prior = seen.get(email.toLowerCase())
+      out.push(
+        prior
+          ? { email, common_name: prior.common_name ?? null, status: prior.status ?? null }
+          : { email, common_name: null, status: null },
+      )
+    }
+    return out
+  }
+
+  function buildReminders(): EventReminder[] {
+    if (reminderChoice === 'none') return []
+    if (reminderChoice === 'custom') return originalReminders
+    return [
+      {
+        trigger_minutes_before: parseInt(reminderChoice, 10),
+        action: 'DISPLAY',
+      },
+    ]
+  }
+
+  function buildInput() {
+    const start = allDay
+      ? dateInputToUtcMidnight(startDate)
+      : fromLocalInput(startLocal)
+    const end = allDay
+      ? dateInputToUtcEndOfDay(endDate)
+      : fromLocalInput(endLocal)
+    return {
+      summary: summary.trim(),
+      description: description.trim() ? description.trim() : null,
+      location: location.trim() ? location.trim() : null,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      allDay,
+      url: url.trim() ? url.trim() : null,
+      transparency: transparency || null,
+      attendees: buildAttendees(),
+      reminders: buildReminders(),
+    }
+  }
+
+  async function save() {
+    error = ''
+    if (!summary.trim()) {
+      error = 'Title is required'
+      return
+    }
+    if (!calendarId) {
+      error = 'Pick a calendar'
+      return
+    }
+    const input = buildInput()
+    // Reject inverted ranges before bothering the backend.
+    if (new Date(input.end).getTime() <= new Date(input.start).getTime()) {
+      error = 'End must be after start'
+      return
+    }
+    saving = true
+    try {
+      if (mode === 'create') {
+        await invoke('create_calendar_event', { calendarId, input })
+      } else if (event) {
+        await invoke('update_calendar_event', { eventId: event.id, input })
+      }
+      onsaved()
+      onclose()
+    } catch (e) {
+      error = formatError(e) || 'Failed to save event'
+    } finally {
+      saving = false
+    }
+  }
+
+  async function remove() {
+    if (mode !== 'edit' || !event) return
+    if (!confirm(`Delete "${event.summary || '(no title)'}"?`)) return
+    deleting = true
+    error = ''
+    try {
+      await invoke('delete_calendar_event', { eventId: event.id })
+      onsaved()
+      onclose()
+    } catch (e) {
+      error = formatError(e) || 'Failed to delete event'
+    } finally {
+      deleting = false
+    }
+  }
+
+  function currentCalendarLabel(): string {
+    return calendars.find((c) => c.id === calendarId)?.display_name ?? '(unknown)'
+  }
+</script>
+
+<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+  <div class="w-[640px] max-h-[90vh] bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl flex flex-col">
+    <header class="px-5 py-3 border-b border-surface-200 dark:border-surface-700 flex items-center justify-between">
+      <h2 class="text-base font-semibold">
+        {mode === 'create' ? 'New event' : 'Edit event'}
+      </h2>
+      <button class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100" onclick={onclose} aria-label="Close">✕</button>
+    </header>
+
+    <div class="flex-1 overflow-y-auto p-5 space-y-3">
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-summary">Title</label>
+        <input
+          id="event-summary"
+          class="input flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={summary}
+          placeholder="Event title"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-calendar">Calendar</label>
+        {#if mode === 'create'}
+          <select
+            id="event-calendar"
+            class="select flex-1 px-3 py-2 text-sm rounded-md"
+            bind:value={calendarId}
+          >
+            {#each calendars as c (c.id)}
+              <option value={c.id}>{c.display_name}</option>
+            {/each}
+          </select>
+        {:else}
+          <span class="flex-1 px-3 py-2 text-sm text-surface-600 dark:text-surface-300">
+            {currentCalendarLabel()}
+          </span>
+        {/if}
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-allday">All day</label>
+        <input
+          id="event-allday"
+          type="checkbox"
+          class="checkbox"
+          bind:checked={allDay}
+          onchange={onToggleAllDay}
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-start">Starts</label>
+        {#if allDay}
+          <input
+            id="event-start"
+            type="date"
+            class="input flex-1 px-3 py-2 text-sm rounded-md"
+            bind:value={startDate}
+          />
+        {:else}
+          <input
+            id="event-start"
+            type="datetime-local"
+            class="input flex-1 px-3 py-2 text-sm rounded-md"
+            bind:value={startLocal}
+          />
+        {/if}
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-end">Ends</label>
+        {#if allDay}
+          <input
+            id="event-end"
+            type="date"
+            class="input flex-1 px-3 py-2 text-sm rounded-md"
+            bind:value={endDate}
+          />
+        {:else}
+          <input
+            id="event-end"
+            type="datetime-local"
+            class="input flex-1 px-3 py-2 text-sm rounded-md"
+            bind:value={endLocal}
+          />
+        {/if}
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-location">Location</label>
+        <input
+          id="event-location"
+          class="input flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={location}
+          placeholder="Address, room, link…"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-url">URL</label>
+        <input
+          id="event-url"
+          class="input flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={url}
+          placeholder="Meeting link, agenda doc, …"
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-transp">Show as</label>
+        <select
+          id="event-transp"
+          class="select flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={transparency}
+        >
+          <option value="OPAQUE">Busy</option>
+          <option value="TRANSPARENT">Free</option>
+        </select>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-20 text-surface-500" for="event-reminder">Reminder</label>
+        <select
+          id="event-reminder"
+          class="select flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={reminderChoice}
+        >
+          <option value="none">None</option>
+          <option value="5">5 minutes before</option>
+          <option value="15">15 minutes before</option>
+          <option value="30">30 minutes before</option>
+          <option value="60">1 hour before</option>
+          <option value="1440">1 day before</option>
+          {#if reminderChoice === 'custom'}
+            <option value="custom">Custom (preserved from server)</option>
+          {/if}
+        </select>
+      </div>
+
+      <div class="flex items-start gap-2">
+        <label class="text-xs w-20 text-surface-500 pt-2" for="event-attendees">Attendees</label>
+        <input
+          id="event-attendees"
+          class="input flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={attendeesText}
+          placeholder="alice@example.com, bob@example.com"
+        />
+      </div>
+
+      <div class="flex items-start gap-2">
+        <label class="text-xs w-20 text-surface-500 pt-2" for="event-description">Notes</label>
+        <textarea
+          id="event-description"
+          class="textarea flex-1 px-3 py-2 text-sm rounded-md min-h-[120px]"
+          bind:value={description}
+          placeholder="Description, agenda, notes…"
+        ></textarea>
+      </div>
+
+      {#if error}
+        <p class="text-sm text-red-500">{error}</p>
+      {/if}
+    </div>
+
+    <footer class="px-5 py-3 border-t border-surface-200 dark:border-surface-700 flex items-center gap-2">
+      <button class="btn preset-filled-primary-500" disabled={saving || deleting} onclick={save}>
+        {saving ? 'Saving…' : mode === 'create' ? 'Create' : 'Save'}
+      </button>
+      {#if mode === 'edit'}
+        <button class="btn preset-outlined-error-500" disabled={saving || deleting} onclick={remove}>
+          {deleting ? 'Deleting…' : 'Delete'}
+        </button>
+      {/if}
+      <div class="flex-1"></div>
+      <button class="btn preset-outlined-surface-500" disabled={saving || deleting} onclick={onclose}>
+        Cancel
+      </button>
+    </footer>
+  </div>
+</div>


### PR DESCRIPTION
Closes #50.

## Summary

Bundles both tiers of the Improve calendar UI work — visual polish on the existing read-only week grid, plus full event CRUD wired end-to-end (cache → CalDAV writer → Tauri commands → editor modal). One PR per the team's "phases inside one issue go in one PR" rule.

### Tier 1 — visual polish
- Today's date sits in a red circular badge; past days are muted.
- Event titles wrap onto multiple lines with a height-based clamp.
- Hover tooltips include the start/end time range and location.

### Tier 2 — full event CRUD

**Data model.** `CalendarEvent` grows `url`, `transparency`, `attendees`, and `reminders`. The cache schema, the iCalendar parser, and the writer all round-trip these fields.

**`nimbus-caldav::write` (new module).** PUT with `If-None-Match: *` for create (UID collision → clean 412), PUT with `If-Match: <etag>` for update, DELETE with the same `If-Match` story. PRECONDITION_FAILED surfaces as a structured `NimbusError::Nextcloud(...)` so the caller can prompt the user to refresh.

**`caldav::ical::build_ics` (new writer).** Renders VCALENDAR/VEVENT with all-day `VALUE=DATE` detection, CRLF line endings, 75-octet folding (RFC 5545 §3.1), VALARM blocks, and ATTENDEE properties.

**Three Tauri commands.** `create_calendar_event`, `update_calendar_event`, `delete_calendar_event`. Update deliberately preserves `RECURRENCE-ID` from the cached handle so editing a series override doesn't demote it back to a singleton. Local cache is upserted right after a successful write so the grid repaints without waiting for a sync.

**`EventEditor.svelte` (new modal).** All fields: title, calendar, all-day toggle, start/end, location, URL, busy/free, reminder picker (None / 5 / 15 / 30 min / 1 h / 1 day), attendees (comma-separated), notes. Existing CN/PARTSTAT data and multi-VALARM setups round-trip opaquely (`Custom (preserved from server)` option).

**Wiring in `CalendarView`.** A `+ New event` button in the header, click-to-edit on every event block (timed and all-day), and click-and-drag in the time grid (15-minute snap, translucent overlay) to sweep a fresh range.

### Bug fix discovered during testing
`create_calendar_event` was concatenating `server_url + calendar_path`, but `nimbus-caldav::discovery` already stores `path` as a fully-qualified URL — the PUT was going to `https://hosthttps://host/...`. Fixed and added a doc clarifier on `CalendarRow.path` so the next reader doesn't trip on it.

## Test plan
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo clippy -p nimbus-store -p nimbus-caldav -p nimbus-app` — no warnings
- [x] `npm run check` — 0 errors
- [x] Manual: create a new event from the `+ New event` button → appears on the grid, syncs to Nextcloud
- [ ] Manual: click-and-drag a range in the time grid → editor opens with the right times prefilled
- [ ] Manual: click an existing event → editor opens in edit mode → Save updates server + grid
- [ ] Manual: Delete from edit mode → event disappears from the grid and the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)