### PR TITLE
Nextcloud Files: sidebar-routed view with bulk mail actions (#53)

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -26,6 +26,7 @@
   import Compose, { type ComposeInitial } from './lib/Compose.svelte'
   import ContactsView from './lib/ContactsView.svelte'
   import CalendarView from './lib/CalendarView.svelte'
+  import FilesView from './lib/FilesView.svelte'
   import SearchBar, {
     type SearchScope,
     type SearchFilters,
@@ -42,6 +43,7 @@
     | 'settings'
     | 'contacts'
     | 'calendar'
+    | 'files'
   let currentView = $state<View>('loading')
 
   // Which integration tab is active in the sidebar. Lives next to
@@ -267,6 +269,9 @@
     } else if (name === 'Calendar') {
       activeIntegration = name
       currentView = 'calendar'
+    } else if (name === 'Nextcloud Files') {
+      activeIntegration = name
+      currentView = 'files'
     }
   }
 
@@ -422,6 +427,40 @@
     <div class="flex-1">
       <CalendarView onclose={goToInbox} />
     </div>
+  </div>
+
+<!-- Nextcloud Files view: same shape as Calendar / Contacts. The
+     "New mail with link" / "New mail with attachment" buttons inside
+     `FilesView` route through the same `openCompose` everything else
+     uses, so the resulting draft sits on top of whichever view the
+     user came from. -->
+{:else if currentView === 'files' && activeAccountId}
+  <div class="h-full flex">
+    <Sidebar
+      accountId={activeAccountId}
+      selectedFolder={selectedFolder}
+      refreshToken={refreshToken}
+      activeIntegration={activeIntegration}
+      onselectfolder={(f) => {
+        selectFolder(f)
+        goToInbox()
+      }}
+      onsettings={goToSettings}
+      onrefresh={refreshAll}
+      oncompose={() => openCompose()}
+      onselectintegration={onSelectIntegration}
+    />
+    <div class="flex-1">
+      <FilesView onclose={goToInbox} oncompose={openCompose} />
+    </div>
+    {#if composeInitial !== null}
+      <Compose
+        accountId={activeAccountId}
+        fromAddress={activeAccountEmail}
+        initial={composeInitial}
+        onclose={closeCompose}
+      />
+    {/if}
   </div>
 
 <!-- Main inbox: the 3-panel mail client layout -->

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -35,6 +35,15 @@
     subject?: string
     body?: string
     in_reply_to?: number | null
+    /** Files to pre-attach. Used by `FilesView`'s "New mail with
+        attachment" action so the user can pick files in the Files
+        view and land in Compose with them already attached. */
+    attachments?: Attachment[]
+    /** Public Nextcloud share URLs to render into the body as a
+        "Shared via Nextcloud" block. Used by `FilesView`'s "New mail
+        with link" action — the same shape the in-Compose picker
+        produces via `appendHtml`. */
+    nextcloudLinks?: { filename: string; url: string }[]
   }
 
   interface Props {
@@ -65,7 +74,8 @@
   let subject = $state(initial?.subject ?? saved?.subject ?? '')
   // svelte-ignore state_referenced_locally
   let body = $state(initial?.body ?? saved?.body ?? '')
-  let attachments = $state<Attachment[]>([])
+  // svelte-ignore state_referenced_locally
+  let attachments = $state<Attachment[]>(initial?.attachments ?? [])
   // Whether the Nextcloud file picker modal is mounted. Picker is lazy
   // so we don't hit `get_nextcloud_accounts` / PROPFIND until the user
   // actually clicks "Attach from Nextcloud".
@@ -78,7 +88,24 @@
   // onchange callback. The initial body (from reply/forward/draft) is
   // plain text, so we convert newlines to <br> for the WYSIWYG view.
   // svelte-ignore state_referenced_locally
-  let bodyHtml = $state(textToHtml(body))
+  let bodyHtml = $state(initialBodyHtml())
+
+  /** Build the editor's starting HTML — the body (plain text or
+      already-HTML draft) with any pre-rendered Nextcloud share-link
+      block appended. Same shape as the in-Compose picker emits when
+      its `onlinks` callback fires. */
+  function initialBodyHtml(): string {
+    let html = textToHtml(body)
+    if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
+      const esc = (s: string) =>
+        s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      const items = initial.nextcloudLinks
+        .map((l) => `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`)
+        .join('')
+      html += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
+    }
+    return html
+  }
   // svelte-ignore state_referenced_locally
   let showCcBcc = $state(!!cc || !!bcc)
 

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -34,6 +34,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import AddressAutocomplete from './AddressAutocomplete.svelte'
 
   // ── Types (kept local; these mirror the Rust models) ──────────
   interface EventAttendee {
@@ -132,16 +133,43 @@
   // svelte-ignore state_referenced_locally
   let endDate = $state(toDateInput(initialEnd()))
 
-  // Attendees are edited as a comma-separated email string. We parse
-  // them into the structured shape on save. Existing CN / PARTSTAT data
-  // round-trips opaquely (we hold it in `originalAttendees` and merge
-  // back by email at save time).
+  // Attendees are edited as a comma-separated address list. We seed
+  // each existing attendee in RFC `"Common Name" <addr>` form so the
+  // shape matches what `<AddressAutocomplete>` emits when the user
+  // picks a contact — that way edits round-trip cleanly. Existing CN /
+  // PARTSTAT data is held in `originalAttendees` and merged back by
+  // email at save time.
   // svelte-ignore state_referenced_locally
   let attendeesText = $state(
-    (event?.attendees ?? []).map((a) => a.email).join(', '),
+    (event?.attendees ?? []).map(formatAddressForInput).join(', '),
   )
   // svelte-ignore state_referenced_locally
   const originalAttendees = event?.attendees ?? []
+
+  /** Render an existing attendee back into the address-input format. */
+  function formatAddressForInput(a: EventAttendee): string {
+    if (a.common_name && a.common_name !== a.email) {
+      const safe = a.common_name.replace(/"/g, '\\"')
+      return `"${safe}" <${a.email}>`
+    }
+    return a.email
+  }
+
+  /**
+   * Parse a single comma-separated piece into `{ email, name }`.
+   * Accepts `"Name" <addr>`, `Name <addr>`, or a bare `addr`.
+   * Returns null for empty / malformed pieces.
+   */
+  function parseAddress(piece: string): { email: string; name: string | null } | null {
+    const trimmed = piece.trim()
+    if (!trimmed) return null
+    const m = trimmed.match(/^\s*(?:"([^"]*)"|([^<]*?))\s*<([^>]+)>\s*$/)
+    if (m) {
+      const name = (m[1] ?? m[2] ?? '').trim().replace(/\\"/g, '"')
+      return { email: m[3].trim(), name: name || null }
+    }
+    return { email: trimmed, name: null }
+  }
 
   // Reminder picker: a single dropdown that maps to the most common
   // VALARM offsets. "Custom" preserves whatever multi-alarm setup the
@@ -249,15 +277,18 @@
     const seen = new Map<string, EventAttendee>()
     for (const a of originalAttendees) seen.set(a.email.toLowerCase(), a)
     const out: EventAttendee[] = []
-    for (const piece of attendeesText.split(',')) {
-      const email = piece.trim()
-      if (!email) continue
-      const prior = seen.get(email.toLowerCase())
-      out.push(
-        prior
-          ? { email, common_name: prior.common_name ?? null, status: prior.status ?? null }
-          : { email, common_name: null, status: null },
-      )
+    for (const piece of attendeesText.split(/[,;]/)) {
+      const parsed = parseAddress(piece)
+      if (!parsed) continue
+      const prior = seen.get(parsed.email.toLowerCase())
+      // Prefer the freshly typed/picked name when present (the user may
+      // have updated it), and fall back to the server's prior CN.
+      const common_name = parsed.name ?? prior?.common_name ?? null
+      out.push({
+        email: parsed.email,
+        common_name,
+        status: prior?.status ?? null,
+      })
     }
     return out
   }
@@ -488,9 +519,8 @@
 
       <div class="flex items-start gap-2">
         <label class="text-xs w-20 text-surface-500 pt-2" for="event-attendees">Attendees</label>
-        <input
+        <AddressAutocomplete
           id="event-attendees"
-          class="input flex-1 px-3 py-2 text-sm rounded-md"
           bind:value={attendeesText}
           placeholder="alice@example.com, bob@example.com"
         />

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  /**
+   * FilesView — sidebar-routed full-pane Nextcloud file browser.
+   *
+   * The complement to `NextcloudFilePicker` (which only opens from
+   * inside Compose). This view is what the user lands on when they
+   * click "Nextcloud Files" in the sidebar's Integrations list.
+   *
+   * # Per-issue actions
+   *
+   * The two "browser-context" actions issue #53 calls for:
+   *   - **Send as link in mail** — works for files *and* folders. We
+   *     call `create_nextcloud_share` for each selection and then
+   *     open Compose with the resulting URLs pre-rendered into the
+   *     body (Compose's existing share-link block).
+   *   - **Send as attachment in mail** — files only (Nextcloud has
+   *     no zip-folder endpoint). We download each file's bytes and
+   *     hand them to Compose as pre-filled `attachments`.
+   *
+   * Both actions accept a multi-select (the footer counts feed the
+   * button labels) so the user can build "one mail, three files"
+   * without juggling separate Compose windows.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+  import NextcloudFileBrowser, {
+    type FileEntry,
+    type NextcloudAccount,
+  } from './NextcloudFileBrowser.svelte'
+  import type { ComposeInitial } from './Compose.svelte'
+
+  interface Attachment {
+    filename: string
+    content_type: string
+    data: number[]
+  }
+
+  interface Props {
+    onclose: () => void
+    /** Open Compose with the given prefill (attachments / share links).
+        Wired by App.svelte to the same handler that drives every other
+        Compose entry point. */
+    oncompose: (initial: ComposeInitial) => void
+  }
+  let { onclose, oncompose }: Props = $props()
+
+  // Bound from the inner browser. The view's own footer reads these
+  // to label/disable buttons and to drive the action commands.
+  let accountId = $state('')
+  let currentPath = $state('/')
+  let selected = $state<Set<string>>(new Set())
+  let entries = $state<FileEntry[]>([])
+  let accounts = $state<NextcloudAccount[]>([])
+  let error = $state('')
+
+  let attaching = $state(false)
+  let sharing = $state(false)
+
+  let selectedFileCount = $derived.by(() => {
+    let n = 0
+    for (const e of entries) if (!e.is_dir && selected.has(e.path)) n++
+    return n
+  })
+  let selectedFolderCount = $derived(selected.size - selectedFileCount)
+
+  function basename(path: string): string {
+    return path.split('/').filter(Boolean).pop() ?? path
+  }
+
+  /** Download every selected file (folders are skipped — Nextcloud has
+      no zip-folder endpoint) and open Compose with them pre-attached. */
+  async function sendAsAttachment() {
+    const filePaths = entries
+      .filter((e) => !e.is_dir && selected.has(e.path))
+      .map((e) => e.path)
+    if (filePaths.length === 0) return
+    attaching = true
+    error = ''
+    try {
+      // Same parallelisation rationale as the picker: each invoke is
+      // an independent task, so this scales with file count rather
+      // than serialising.
+      const attachments = await Promise.all(
+        filePaths.map(async (p) => {
+          const bytes = await invoke<number[]>('download_nextcloud_file', {
+            ncId: accountId,
+            path: p,
+          })
+          const ct =
+            entries.find((e) => e.path === p)?.content_type ??
+            'application/octet-stream'
+          return {
+            filename: basename(p),
+            content_type: ct,
+            data: bytes,
+          } satisfies Attachment
+        }),
+      )
+      oncompose({ attachments })
+    } catch (e) {
+      error = formatError(e) || 'Failed to download file(s)'
+    } finally {
+      attaching = false
+    }
+  }
+
+  /** Mint a public link for every selection (files *and* folders) and
+      open Compose with them rendered into the body as a "Shared via
+      Nextcloud" block — same shape Compose already produces when the
+      share button inside the picker is used. */
+  async function sendAsLink() {
+    if (selected.size === 0) return
+    sharing = true
+    error = ''
+    try {
+      const paths = Array.from(selected)
+      const links = await Promise.all(
+        paths.map(async (p) => {
+          const url = await invoke<string>('create_nextcloud_share', {
+            ncId: accountId,
+            path: p,
+          })
+          return { filename: basename(p), url }
+        }),
+      )
+      oncompose({ nextcloudLinks: links })
+    } catch (e) {
+      error = formatError(e) || 'Failed to create share link(s)'
+    } finally {
+      sharing = false
+    }
+  }
+</script>
+
+<div class="h-full flex flex-col bg-surface-50 dark:bg-surface-900">
+  <!-- Header — same shape as the Calendar / Contacts views so the
+       sidebar-routed integrations all feel like one app, not three. -->
+  <div
+    class="flex items-center justify-between px-6 py-3 border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800"
+  >
+    <div class="flex items-center gap-3">
+      <h2 class="text-xl font-semibold">Nextcloud Files</h2>
+      {#if currentPath !== '/'}
+        <span class="text-sm text-surface-500 font-mono">{currentPath}</span>
+      {/if}
+    </div>
+    <div class="flex items-center gap-2">
+      <button class="btn preset-tonal-surface text-sm" onclick={onclose}>
+        Close
+      </button>
+    </div>
+  </div>
+
+  <!-- The shared browser fills the rest. The browser itself owns
+       account picking, breadcrumbs, listing, and "+ New folder" — we
+       only consume its bound state for the action footer. -->
+  <div class="flex-1 min-h-0 flex flex-col">
+    <NextcloudFileBrowser
+      bind:accountId
+      bind:currentPath
+      bind:selected
+      bind:entries
+      bind:accounts
+      bind:error
+    />
+
+    {#if error}
+      <p class="px-5 py-2 text-sm text-red-500 border-t border-surface-200 dark:border-surface-700">
+        {error}
+      </p>
+    {/if}
+
+    <!-- Action footer. Both buttons are bulk-aware: select N items and
+         the resulting Compose window carries all N attachments / links
+         in a single new message. -->
+    {#if accounts.length > 0 && accountId}
+      <footer class="px-5 py-3 border-t border-surface-200 dark:border-surface-700 flex items-center gap-2">
+        <span class="text-xs text-surface-500">
+          {#if selected.size === 0}
+            Tick a file or folder to share via mail
+          {:else if selectedFolderCount === 0}
+            {selectedFileCount} file{selectedFileCount === 1 ? '' : 's'} selected
+          {:else if selectedFileCount === 0}
+            {selectedFolderCount} folder{selectedFolderCount === 1 ? '' : 's'} selected
+          {:else}
+            {selectedFileCount} file{selectedFileCount === 1 ? '' : 's'},
+            {selectedFolderCount} folder{selectedFolderCount === 1 ? '' : 's'} selected
+          {/if}
+        </span>
+        <div class="flex-1"></div>
+        <button
+          class="btn preset-outlined-primary-500"
+          disabled={selected.size === 0 || sharing || attaching}
+          onclick={sendAsLink}
+          title="Open a new mail with public download links inserted into the body"
+        >
+          {sharing ? 'Sharing…' : '🔗 New mail with link'}
+        </button>
+        <button
+          class="btn preset-filled-primary-500"
+          disabled={selectedFileCount === 0 || attaching || sharing}
+          onclick={sendAsAttachment}
+          title={selectedFileCount === 0 && selectedFolderCount > 0
+            ? 'Folders can be shared as a link, but not attached as bytes'
+            : 'Open a new mail with the selected files attached'}
+        >
+          {attaching ? 'Downloading…' : '📎 New mail with attachment'}
+        </button>
+      </footer>
+    {/if}
+  </div>
+</div>

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -1,0 +1,366 @@
+<script lang="ts">
+  /**
+   * NextcloudFileBrowser — the inner "browse Nextcloud" UI shared by
+   * the modal picker (`NextcloudFilePicker`) and the sidebar-routed
+   * full-pane view (`FilesView`).
+   *
+   * Owns the *browse* concerns and nothing else:
+   *   - account loading + selection (only shown when N > 1)
+   *   - folder navigation + breadcrumbs
+   *   - listing + sort (folders first, natural sort within each group)
+   *   - multi-select (unless `pickFolderMode` hides the checkboxes)
+   *   - inline "+ New folder" with validation
+   *
+   * Action buttons (Attach / Share / Send via mail / …) are rendered
+   * by the parent — the parent is the only one that knows what should
+   * happen when the user commits a selection. We expose enough state
+   * via `bind:`-able props for that footer to be smart.
+   *
+   * # Bindable state
+   *
+   *   bind:accountId    — currently active account id ('' = none)
+   *   bind:currentPath  — folder we're currently looking at ('/' = root)
+   *   bind:selected     — Set of paths the user has ticked
+   *   bind:entries      — current folder's children (for content_type lookup)
+   *   bind:accounts     — list of NC accounts (so the parent can detect
+   *                       "no accounts connected" without re-fetching)
+   *   bind:error        — last error string ('' = none) — parent renders
+   *                       it wherever it wants
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+
+  interface NextcloudCapabilities {
+    version?: string | null
+    talk: boolean
+    files: boolean
+    caldav: boolean
+    carddav: boolean
+  }
+  export interface NextcloudAccount {
+    id: string
+    server_url: string
+    username: string
+    display_name?: string | null
+    capabilities?: NextcloudCapabilities | null
+  }
+  export interface FileEntry {
+    name: string
+    path: string
+    is_dir: boolean
+    size: number | null
+    content_type: string | null
+    modified: string | null
+  }
+
+  interface Props {
+    /** Hide checkboxes — used by the picker's "save here" mode where
+        the user is choosing a destination folder, not files. */
+    pickFolderMode?: boolean
+    accountId?: string
+    currentPath?: string
+    selected?: Set<string>
+    entries?: FileEntry[]
+    accounts?: NextcloudAccount[]
+    error?: string
+  }
+  let {
+    pickFolderMode = false,
+    accountId = $bindable(''),
+    currentPath = $bindable('/'),
+    selected = $bindable(new Set<string>()),
+    entries = $bindable<FileEntry[]>([]),
+    accounts = $bindable<NextcloudAccount[]>([]),
+    error = $bindable(''),
+  }: Props = $props()
+
+  let loading = $state(false)
+  // "+ New folder" inline input — hidden until the user clicks the
+  // button. Driven by component state so we can validate and show
+  // errors inline rather than via a blocking `prompt()`.
+  let creatingFolder = $state(false)
+  let newFolderName = $state('')
+  let creatingFolderInFlight = $state(false)
+  let newFolderInput = $state<HTMLInputElement | null>(null)
+  $effect(() => {
+    if (creatingFolder && newFolderInput) {
+      newFolderInput.focus()
+    }
+  })
+
+  $effect(() => {
+    loadAccounts()
+  })
+
+  async function loadAccounts() {
+    try {
+      const list = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
+      accounts = list
+      if (list.length === 1 && !accountId) {
+        accountId = list[0].id
+        await loadFolder('/')
+      }
+    } catch (e) {
+      error = formatError(e) || 'Failed to load Nextcloud accounts'
+    }
+  }
+
+  async function selectAccount(id: string) {
+    accountId = id
+    selected = new Set()
+    await loadFolder('/')
+  }
+
+  async function loadFolder(path: string) {
+    if (!accountId) return
+    loading = true
+    error = ''
+    try {
+      const list = await invoke<FileEntry[]>('list_nextcloud_files', {
+        ncId: accountId,
+        path,
+      })
+      // Folders first, then files. Within each group, natural sort so
+      // numbered names (1, 2, 9, 10, 11) come out the way humans expect
+      // — `numeric: true` reads runs of digits as whole numbers, and
+      // `sensitivity: 'base'` makes it case-insensitive. Matches the
+      // Nextcloud web UI ordering.
+      list.sort((a, b) => {
+        if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1
+        return a.name.localeCompare(b.name, undefined, {
+          numeric: true,
+          sensitivity: 'base',
+        })
+      })
+      entries = list
+      currentPath = path
+    } catch (e) {
+      error = formatError(e) || 'Failed to list folder'
+    } finally {
+      loading = false
+    }
+  }
+
+  // Breadcrumb segments — each one is a clickable jump back up the
+  // tree.
+  let breadcrumbs = $derived.by(() => {
+    const segs = currentPath.split('/').filter(Boolean)
+    const out = [{ label: 'Home', path: '/' }]
+    let acc = ''
+    for (const s of segs) {
+      acc += '/' + s
+      out.push({ label: s, path: acc })
+    }
+    return out
+  })
+
+  function onEntryClick(entry: FileEntry) {
+    if (entry.is_dir) {
+      loadFolder(entry.path)
+    } else if (!pickFolderMode) {
+      // In folder-pick mode files aren't selectable — they're shown
+      // only as a preview of what's already in the destination folder.
+      toggleSelected(entry.path)
+    }
+  }
+
+  function toggleSelected(path: string) {
+    // Svelte 5 Sets need reassignment to trigger reactivity.
+    const next = new Set(selected)
+    if (next.has(path)) next.delete(path)
+    else next.add(path)
+    selected = next
+  }
+
+  function formatSize(bytes: number | null): string {
+    if (bytes == null) return ''
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+    return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`
+  }
+
+  function iconFor(entry: FileEntry): string {
+    if (entry.is_dir) return '📁'
+    const ct = entry.content_type ?? ''
+    if (ct.startsWith('image/')) return '🖼️'
+    if (ct.startsWith('video/')) return '🎞️'
+    if (ct.startsWith('audio/')) return '🎵'
+    if (ct.includes('pdf')) return '📄'
+    if (ct.includes('zip') || ct.includes('compressed')) return '🗜️'
+    if (ct.startsWith('text/')) return '📝'
+    return '📎'
+  }
+
+  function navigateTo(path: string) {
+    loadFolder(path)
+  }
+
+  function startCreateFolder() {
+    newFolderName = ''
+    error = ''
+    creatingFolder = true
+  }
+
+  function cancelCreateFolder() {
+    creatingFolder = false
+    newFolderName = ''
+  }
+
+  /**
+   * Create the folder named in `newFolderName` inside `currentPath`,
+   * refresh the listing, and pre-select the new folder so the parent's
+   * "Share as link" / "Send via mail" footer button immediately
+   * targets it.
+   */
+  async function confirmCreateFolder() {
+    const trimmed = newFolderName.trim()
+    if (!trimmed) {
+      error = 'Folder name is required.'
+      return
+    }
+    // Names with path separators would silently change which folder
+    // the create lands in — block here rather than let the server
+    // return a confusing 409.
+    if (trimmed.includes('/') || trimmed.includes('\\')) {
+      error = "Folder name can't contain '/' or '\\'."
+      return
+    }
+    creatingFolderInFlight = true
+    error = ''
+    try {
+      const base = currentPath.endsWith('/') ? currentPath : `${currentPath}/`
+      const fullPath = `${base}${trimmed}`
+      await invoke('create_nextcloud_directory', {
+        ncId: accountId,
+        path: fullPath,
+      })
+      creatingFolder = false
+      newFolderName = ''
+      await loadFolder(currentPath)
+      const folderPath = `${fullPath}/`
+      const next = new Set(selected)
+      next.add(folderPath)
+      selected = next
+    } catch (e) {
+      error = formatError(e) || 'Failed to create folder'
+    } finally {
+      creatingFolderInFlight = false
+    }
+  }
+</script>
+
+{#if accounts.length === 0}
+  <div class="p-6 text-sm text-surface-500">
+    No Nextcloud account connected. Add one under
+    <strong>Settings → Nextcloud</strong> first.
+  </div>
+{:else}
+  {#if accounts.length > 1}
+    <div class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
+      <label for="nc-files-account" class="text-xs text-surface-500">Account</label>
+      <select
+        id="nc-files-account"
+        class="select text-sm"
+        value={accountId}
+        onchange={(e) => selectAccount((e.target as HTMLSelectElement).value)}
+      >
+        <option value="" disabled>Choose an account</option>
+        {#each accounts as acc (acc.id)}
+          <option value={acc.id}>{acc.display_name ?? acc.username} ({acc.server_url})</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
+  {#if accountId}
+    <nav class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-1 text-xs overflow-x-auto">
+      {#each breadcrumbs as crumb, i (crumb.path)}
+        {#if i > 0}<span class="text-surface-400">/</span>{/if}
+        <button
+          class="hover:underline {i === breadcrumbs.length - 1 ? 'font-semibold' : 'text-primary-500'}"
+          onclick={() => navigateTo(crumb.path)}
+          disabled={i === breadcrumbs.length - 1}
+        >{crumb.label}</button>
+      {/each}
+      <div class="flex-1"></div>
+      {#if !creatingFolder}
+        <button
+          class="text-primary-500 hover:underline"
+          onclick={startCreateFolder}
+          title="Create a new folder in this directory"
+        >+ New folder</button>
+      {/if}
+    </nav>
+
+    {#if creatingFolder}
+      <!--
+        Inline name input rendered as its own row so a long folder name
+        doesn't squeeze the breadcrumbs off-screen on narrow widths.
+      -->
+      <div class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
+        <label for="nc-new-folder" class="text-xs text-surface-500">New folder name</label>
+        <input
+          id="nc-new-folder"
+          class="input flex-1 px-3 py-1.5 text-sm rounded-md"
+          bind:this={newFolderInput}
+          bind:value={newFolderName}
+          placeholder="My folder"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') confirmCreateFolder()
+            else if (e.key === 'Escape') cancelCreateFolder()
+          }}
+        />
+        <button
+          class="btn preset-filled-primary-500 text-xs"
+          disabled={creatingFolderInFlight || !newFolderName.trim()}
+          onclick={confirmCreateFolder}
+        >{creatingFolderInFlight ? 'Creating…' : 'Create'}</button>
+        <button
+          class="btn preset-outlined-surface-500 text-xs"
+          disabled={creatingFolderInFlight}
+          onclick={cancelCreateFolder}
+        >Cancel</button>
+      </div>
+    {/if}
+
+    <div class="flex-1 overflow-y-auto">
+      {#if loading}
+        <div class="p-6 text-sm text-surface-500">Loading…</div>
+      {:else if entries.length === 0}
+        <div class="p-6 text-sm text-surface-500">This folder is empty.</div>
+      {:else}
+        <ul class="divide-y divide-surface-200 dark:divide-surface-800">
+          {#each entries as entry (entry.path)}
+            <li>
+              <button
+                class="w-full flex items-center gap-3 px-5 py-2 text-left hover:bg-surface-100 dark:hover:bg-surface-800"
+                onclick={() => onEntryClick(entry)}
+              >
+                <!--
+                  Folders also get a checkbox so the user can select a
+                  folder to share as a public link. Click stops
+                  propagation so the row's onclick (navigate-into) doesn't
+                  also fire.
+                -->
+                {#if !pickFolderMode}
+                  <input
+                    type="checkbox"
+                    class="checkbox"
+                    checked={selected.has(entry.path)}
+                    onclick={(e) => e.stopPropagation()}
+                    onchange={() => toggleSelected(entry.path)}
+                  />
+                {/if}
+                <span class="text-lg">{iconFor(entry)}</span>
+                <span class="flex-1 truncate text-sm">{entry.name}</span>
+                <span class="text-xs text-surface-500">{formatSize(entry.size)}</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {/if}
+{/if}

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -1,49 +1,29 @@
 <script lang="ts">
   /**
-   * NextcloudFilePicker — modal that lets the user browse their Nextcloud
-   * and pick files to attach to an outgoing email.
+   * NextcloudFilePicker — modal wrapper around `NextcloudFileBrowser`.
    *
-   * Flow:
-   * 1. On mount, load the list of Nextcloud accounts. If there's exactly
-   *    one, select it automatically. If none, show an "add one in
-   *    settings" message and close-only.
-   * 2. On account selection, load the root folder via `list_nextcloud_files`.
-   * 3. Clicking a folder navigates into it (loads children). Clicking a
-   *    file toggles its selection (multi-select via checkbox).
-   * 4. "Attach" downloads each selected file via `download_nextcloud_file`,
-   *    shapes it into the `{filename, content_type, data}` triple Compose
-   *    expects, and calls `onpicked(attachments)`. Downloads run in
-   *    parallel — one slow file doesn't block the rest.
+   * Two callers today, both via Compose:
+   *   - **Attach mode** (default): the user picks files; we download
+   *     each one and hand the bytes back via `onpicked`.
+   *   - **Share-as-link mode** (when `onlinks` is set): the user picks
+   *     files or folders; we ask the server to mint public share URLs
+   *     and return them via `onlinks`.
+   *   - **Folder-pick mode** (when `onpickfolder` is set): the user
+   *     navigates the tree and picks the *current* folder as a target
+   *     (used by "Save attachment to Nextcloud").
    *
-   * We keep the full path (`/Documents/Work/report.pdf`) as the canonical
-   * identifier; the UI shows the last segment as a label.
+   * The browse UI itself lives in `NextcloudFileBrowser` so the
+   * sidebar-routed `FilesView` can reuse it without dragging in modal
+   * chrome or attach-specific actions.
    */
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import NextcloudFileBrowser, {
+    type FileEntry,
+    type NextcloudAccount,
+  } from './NextcloudFileBrowser.svelte'
 
-  interface NextcloudCapabilities {
-    version?: string | null
-    talk: boolean
-    files: boolean
-    caldav: boolean
-    carddav: boolean
-  }
-  interface NextcloudAccount {
-    id: string
-    server_url: string
-    username: string
-    display_name?: string | null
-    capabilities?: NextcloudCapabilities | null
-  }
-  interface FileEntry {
-    name: string
-    path: string
-    is_dir: boolean
-    size: number | null
-    content_type: string | null
-    modified: string | null
-  }
   interface Attachment {
     filename: string
     content_type: string
@@ -65,125 +45,34 @@
      */
     onlinks?: (links: ShareLink[]) => void
     /**
-     * If set, the picker switches to **folder-pick mode**. The user
-     * navigates the tree as usual but instead of selecting files, they
-     * pick the *current folder* as a destination — this is what the
-     * "Save to Nextcloud" flow needs (pick a folder, the caller then
-     * uploads bytes into it). When this is set, the per-file checkboxes
-     * and Attach/Share buttons are hidden and a "Save here" button
-     * appears in the footer.
+     * If set, the picker switches to **folder-pick mode**: the user
+     * navigates the tree and picks the *current folder* as a
+     * destination (the per-file checkboxes and Attach/Share buttons
+     * are hidden, and a "Save here" button appears in the footer).
      */
     onpickfolder?: (accountId: string, folderPath: string) => void
     onclose: () => void
   }
   let { onpicked, onlinks, onpickfolder, onclose }: Props = $props()
 
-  // True when the picker is being used to choose a destination folder
-  // rather than to attach/share existing files.
   let pickFolderMode = $derived(onpickfolder != null)
 
-  let accounts = $state<NextcloudAccount[]>([])
-  let accountId = $state<string>('')
-  let currentPath = $state<string>('/')
-  let entries = $state<FileEntry[]>([])
+  // Bound from the inner browser — we read these to drive the footer
+  // buttons and the download/share actions.
+  let accountId = $state('')
+  let currentPath = $state('/')
   let selected = $state<Set<string>>(new Set())
-  let loading = $state(false)
+  let entries = $state<FileEntry[]>([])
+  let accounts = $state<NextcloudAccount[]>([])
+  let error = $state('')
+
   let downloading = $state(false)
   let sharing = $state(false)
-  let error = $state('')
-  // "New folder" inline input — hidden until the user clicks the button.
-  // We keep the name in component state rather than driving it via a
-  // prompt() so we can validate, show errors inline, and select the new
-  // folder on success.
-  let creatingFolder = $state(false)
-  let newFolderName = $state('')
-  let creatingFolderInFlight = $state(false)
-  // Bound to the inline input so we can focus it the moment the user
-  // clicks "+ New folder". Using `autofocus` directly would trip the
-  // svelte a11y rule (autofocus surprises screen-reader users); a
-  // post-click programmatic focus is the recommended replacement.
-  let newFolderInput = $state<HTMLInputElement | null>(null)
-  $effect(() => {
-    if (creatingFolder && newFolderInput) {
-      newFolderInput.focus()
-    }
-  })
 
-  $effect(() => {
-    loadAccounts()
-  })
-
-  async function loadAccounts() {
-    try {
-      const list = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
-      accounts = list
-      if (list.length === 1) {
-        accountId = list[0].id
-        await loadFolder('/')
-      }
-    } catch (e) {
-      error = formatError(e) || 'Failed to load Nextcloud accounts'
-    }
-  }
-
-  async function selectAccount(id: string) {
-    accountId = id
-    selected = new Set()
-    await loadFolder('/')
-  }
-
-  async function loadFolder(path: string) {
-    if (!accountId) return
-    loading = true
-    error = ''
-    try {
-      const list = await invoke<FileEntry[]>('list_nextcloud_files', {
-        ncId: accountId,
-        path,
-      })
-      // Folders first, then files. Within each group we use "natural"
-      // ordering so numbered names sort as a human expects:
-      //   1, 2, 9, 10, 11   (not 1, 10, 11, 2, 9).
-      // `numeric: true` on localeCompare reads runs of digits as whole
-      // numbers instead of character-by-character. `sensitivity: 'base'`
-      // makes the sort case-insensitive so "apple" doesn't land after
-      // "Banana" — matches what the Nextcloud web UI does.
-      list.sort((a, b) => {
-        if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1
-        return a.name.localeCompare(b.name, undefined, {
-          numeric: true,
-          sensitivity: 'base',
-        })
-      })
-      entries = list
-      currentPath = path
-    } catch (e) {
-      error = formatError(e) || 'Failed to list folder'
-    } finally {
-      loading = false
-    }
-  }
-
-  // Build breadcrumb segments from the current path — each becomes a
-  // clickable step back up the tree.
-  let breadcrumbs = $derived.by(() => {
-    const segs = currentPath.split('/').filter(Boolean)
-    const out = [{ label: 'Home', path: '/' }]
-    let acc = ''
-    for (const s of segs) {
-      acc += '/' + s
-      out.push({ label: s, path: acc })
-    }
-    return out
-  })
-
-  /**
-   * Selection split by entry type. Folders can be shared as public
-   * links but not attached as bytes (there's nothing meaningful to
-   * pull down — Nextcloud has no zip-folder endpoint). Files can be
-   * either. We compute counts so the footer can label buttons
-   * correctly and disable Attach when the selection is folders-only.
-   */
+  // Selection split by entry type. Folders can be shared as public
+  // links but not attached as bytes (Nextcloud has no zip-folder
+  // endpoint, so there's nothing meaningful to download). The footer
+  // uses these counts to label and disable buttons appropriately.
   let selectedFileCount = $derived.by(() => {
     let n = 0
     for (const e of entries) if (!e.is_dir && selected.has(e.path)) n++
@@ -191,53 +80,11 @@
   })
   let selectedFolderCount = $derived(selected.size - selectedFileCount)
 
-  function onEntryClick(entry: FileEntry) {
-    if (entry.is_dir) {
-      loadFolder(entry.path)
-    } else if (!pickFolderMode) {
-      // In folder-pick mode files aren't selectable — they're shown
-      // only as a preview of what's already in the destination folder.
-      toggleSelected(entry.path)
-    }
-  }
-
-  function toggleSelected(path: string) {
-    // Svelte 5 Sets: reassign to trigger reactivity.
-    const next = new Set(selected)
-    if (next.has(path)) next.delete(path)
-    else next.add(path)
-    selected = next
-  }
-
-  function formatSize(bytes: number | null): string {
-    if (bytes == null) return ''
-    if (bytes < 1024) return `${bytes} B`
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-    if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
-    return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`
-  }
-
-  function iconFor(entry: FileEntry): string {
-    if (entry.is_dir) return '📁'
-    const ct = entry.content_type ?? ''
-    if (ct.startsWith('image/')) return '🖼️'
-    if (ct.startsWith('video/')) return '🎞️'
-    if (ct.startsWith('audio/')) return '🎵'
-    if (ct.includes('pdf')) return '📄'
-    if (ct.includes('zip') || ct.includes('compressed')) return '🗜️'
-    if (ct.startsWith('text/')) return '📝'
-    return '📎'
-  }
-
-  /** Last-segment of a `/foo/bar/baz.ext` path — the human filename. */
   function basename(path: string): string {
     return path.split('/').filter(Boolean).pop() ?? path
   }
 
   async function attachSelected() {
-    // Folders in the selection are silently skipped — the footer
-    // disables this button when the selection is folders-only, so
-    // reaching here means at least one file is selected.
     const filePaths = entries
       .filter((e) => !e.is_dir && selected.has(e.path))
       .map((e) => e.path)
@@ -245,8 +92,8 @@
     downloading = true
     error = ''
     try {
-      // Run all downloads concurrently. Tauri bridges each invoke to a
-      // separate async task so this genuinely parallelises.
+      // Run all downloads in parallel — Tauri bridges each invoke to
+      // its own async task so this genuinely parallelises.
       const results = await Promise.all(
         filePaths.map(async (p) => {
           const bytes = await invoke<number[]>('download_nextcloud_file', {
@@ -278,8 +125,6 @@
     error = ''
     try {
       const paths = Array.from(selected)
-      // Same parallelisation rationale as downloads. Each invoke is
-      // an independent OCS POST against Nextcloud.
       const results = await Promise.all(
         paths.map(async (p) => {
           const url = await invoke<string>('create_nextcloud_share', {
@@ -295,66 +140,6 @@
       error = formatError(e) || 'Failed to create share link(s)'
     } finally {
       sharing = false
-    }
-  }
-
-  function navigateTo(path: string) {
-    loadFolder(path)
-  }
-
-  function startCreateFolder() {
-    newFolderName = ''
-    error = ''
-    creatingFolder = true
-  }
-
-  function cancelCreateFolder() {
-    creatingFolder = false
-    newFolderName = ''
-  }
-
-  /**
-   * Create the folder named in `newFolderName` inside `currentPath`,
-   * then refresh the listing and pre-select the new folder so the user
-   * can immediately hit "Share as link".
-   */
-  async function confirmCreateFolder() {
-    const trimmed = newFolderName.trim()
-    if (!trimmed) {
-      error = 'Folder name is required.'
-      return
-    }
-    // Filenames containing path separators would silently change which
-    // folder we created in. Block them here rather than letting the
-    // server return a confusing 409.
-    if (trimmed.includes('/') || trimmed.includes('\\')) {
-      error = "Folder name can't contain '/' or '\\'."
-      return
-    }
-    creatingFolderInFlight = true
-    error = ''
-    try {
-      // Join currentPath + name without doubling slashes. currentPath is
-      // always either '/' or '/foo/bar' (no trailing slash except root).
-      const base = currentPath.endsWith('/') ? currentPath : `${currentPath}/`
-      const fullPath = `${base}${trimmed}`
-      await invoke('create_nextcloud_directory', {
-        ncId: accountId,
-        path: fullPath,
-      })
-      creatingFolder = false
-      newFolderName = ''
-      // Re-list so the new folder appears, then pre-select it (with the
-      // trailing slash the parser uses on folder paths).
-      await loadFolder(currentPath)
-      const folderPath = `${fullPath}/`
-      const next = new Set(selected)
-      next.add(folderPath)
-      selected = next
-    } catch (e) {
-      error = formatError(e) || 'Failed to create folder'
-    } finally {
-      creatingFolderInFlight = false
     }
   }
 </script>
@@ -376,120 +161,15 @@
       >✕</button>
     </header>
 
-    {#if accounts.length === 0}
-      <div class="p-6 text-sm text-surface-500">
-        No Nextcloud account connected. Add one under
-        <strong>Settings → Nextcloud</strong> first.
-      </div>
-    {:else}
-      {#if accounts.length > 1}
-        <div class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
-          <label for="nc-files-account" class="text-xs text-surface-500">Account</label>
-          <select
-            id="nc-files-account"
-            class="select text-sm"
-            value={accountId}
-            onchange={(e) => selectAccount((e.target as HTMLSelectElement).value)}
-          >
-            <option value="" disabled>Choose an account</option>
-            {#each accounts as acc (acc.id)}
-              <option value={acc.id}>{acc.display_name ?? acc.username} ({acc.server_url})</option>
-            {/each}
-          </select>
-        </div>
-      {/if}
-
-      {#if accountId}
-        <nav class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-1 text-xs overflow-x-auto">
-          {#each breadcrumbs as crumb, i (crumb.path)}
-            {#if i > 0}<span class="text-surface-400">/</span>{/if}
-            <button
-              class="hover:underline {i === breadcrumbs.length - 1 ? 'font-semibold' : 'text-primary-500'}"
-              onclick={() => navigateTo(crumb.path)}
-              disabled={i === breadcrumbs.length - 1}
-            >{crumb.label}</button>
-          {/each}
-          <div class="flex-1"></div>
-          {#if !creatingFolder}
-            <button
-              class="text-primary-500 hover:underline"
-              onclick={startCreateFolder}
-              title="Create a new folder in this directory"
-            >+ New folder</button>
-          {/if}
-        </nav>
-
-        {#if creatingFolder}
-          <!--
-            Inline name input. We render it as its own row (rather than
-            inside the breadcrumb bar) so a long folder name doesn't
-            squeeze the breadcrumbs off-screen on narrow widths.
-          -->
-          <div class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
-            <label for="nc-new-folder" class="text-xs text-surface-500">New folder name</label>
-            <input
-              id="nc-new-folder"
-              class="input flex-1 px-3 py-1.5 text-sm rounded-md"
-              bind:this={newFolderInput}
-              bind:value={newFolderName}
-              placeholder="My folder"
-              onkeydown={(e) => {
-                if (e.key === 'Enter') confirmCreateFolder()
-                else if (e.key === 'Escape') cancelCreateFolder()
-              }}
-            />
-            <button
-              class="btn preset-filled-primary-500 text-xs"
-              disabled={creatingFolderInFlight || !newFolderName.trim()}
-              onclick={confirmCreateFolder}
-            >{creatingFolderInFlight ? 'Creating…' : 'Create'}</button>
-            <button
-              class="btn preset-outlined-surface-500 text-xs"
-              disabled={creatingFolderInFlight}
-              onclick={cancelCreateFolder}
-            >Cancel</button>
-          </div>
-        {/if}
-
-        <div class="flex-1 overflow-y-auto">
-          {#if loading}
-            <div class="p-6 text-sm text-surface-500">Loading…</div>
-          {:else if entries.length === 0}
-            <div class="p-6 text-sm text-surface-500">This folder is empty.</div>
-          {:else}
-            <ul class="divide-y divide-surface-200 dark:divide-surface-800">
-              {#each entries as entry (entry.path)}
-                <li>
-                  <button
-                    class="w-full flex items-center gap-3 px-5 py-2 text-left hover:bg-surface-100 dark:hover:bg-surface-800"
-                    onclick={() => onEntryClick(entry)}
-                  >
-                    <!--
-                      Folders also get a checkbox so the user can select
-                      a folder to share as a public link. Clicking the
-                      checkbox toggles selection without bubbling to the
-                      row's onclick (which would navigate into the folder).
-                    -->
-                    {#if !pickFolderMode}
-                      <input
-                        type="checkbox"
-                        class="checkbox"
-                        checked={selected.has(entry.path)}
-                        onclick={(e) => e.stopPropagation()}
-                        onchange={() => toggleSelected(entry.path)}
-                      />
-                    {/if}
-                    <span class="text-lg">{iconFor(entry)}</span>
-                    <span class="flex-1 truncate text-sm">{entry.name}</span>
-                    <span class="text-xs text-surface-500">{formatSize(entry.size)}</span>
-                  </button>
-                </li>
-              {/each}
-            </ul>
-          {/if}
-        </div>
-      {/if}
-    {/if}
+    <NextcloudFileBrowser
+      {pickFolderMode}
+      bind:accountId
+      bind:currentPath
+      bind:selected
+      bind:entries
+      bind:accounts
+      bind:error
+    />
 
     {#if error}
       <p class="px-5 py-2 text-sm text-red-500 border-t border-surface-200 dark:border-surface-700">


### PR DESCRIPTION
Closes #53.

## Summary

- New **Nextcloud Files** sidebar entry opens a full-pane file browser. Tick files/folders, then "🔗 New mail with link" or "📎 New mail with attachment" — both bulk-aware, both pop a Compose drawer with the selection pre-filled.
- Refactored the browse UI out of `NextcloudFilePicker` into a shared `NextcloudFileBrowser` component (account picking, breadcrumbs, listing, sort, multi-select, "+ New folder"). The Compose picker still works the same — it's just a thin modal wrapper around the shared browser now.
- `ComposeInitial` gains `attachments` and `nextcloudLinks` so any caller can prefill a draft. The "Shared via Nextcloud" link block is rendered identically whether the share comes from inside Compose or from FilesView.

**Bundled in (off-issue, by request):** EventEditor's attendees field now uses `AddressAutocomplete` — same contact-suggestion dropdown as Compose's To/Cc/Bcc. Existing attendees seed in RFC `"Name" <addr>` form so edits round-trip; PARTSTAT round-trips opaquely.

## Test plan

- [ ] Click **Nextcloud Files** in the sidebar — full-pane browser opens, accounts list, breadcrumbs work.
- [ ] Tick a file → "📎 New mail with attachment" → Compose opens with the file attached.
- [ ] Tick a folder → "📎 New mail with attachment" is disabled (folders can't be attached).
- [ ] Tick a folder → "🔗 New mail with link" → Compose opens with a public-share link in the body.
- [ ] Tick multiple items → both buttons act on the whole selection.
- [ ] Inside Compose, "☁️ From Nextcloud" still attaches and shares as before (no regression).
- [ ] EventEditor: open an existing event with attendees → names render as `"Alice" <alice@x>`. Type `ali` → contact dropdown opens. Pick → field gets `"Alice Example" <alice@x>, `. Save → backend gets `{ email, common_name }` correctly.
- [ ] EventEditor: bare addresses (`alice@x`) and `;`-separated lists also parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)