### PR TITLE
Nextcloud Talk integration (#13)

### DIFF
--- a/crates/nimbus-caldav/src/ical.rs
+++ b/crates/nimbus-caldav/src/ical.rs
@@ -522,7 +522,21 @@ fn unescape_text(s: &str) -> String {
 /// requires (RFC 5545 §3.1) — most servers tolerate longer lines but
 /// Apple Calendar refuses unfolded files outright, and Nextcloud
 /// re-folds on read either way.
-pub fn build_ics(event: &CalendarEvent) -> String {
+/// Render `event` as a CRLF-folded VCALENDAR/VEVENT body suitable for
+/// PUTing to a CalDAV server.
+///
+/// `organizer_email` / `organizer_name` populate the VEVENT's
+/// `ORGANIZER` property. RFC 5545 §3.6.1 makes ORGANIZER **required**
+/// whenever any `ATTENDEE` is present, and Nextcloud's CalDAV layer
+/// (Sabre/DAV) enforces this strictly — a PUT with attendees but no
+/// organizer is rejected with `403 Forbidden`. Callers that don't have
+/// an account context can pass `None`/`None`; the line is then only
+/// omitted when there are no attendees.
+pub fn build_ics(
+    event: &CalendarEvent,
+    organizer_email: Option<&str>,
+    organizer_name: Option<&str>,
+) -> String {
     let mut lines: Vec<String> = Vec::new();
     lines.push("BEGIN:VCALENDAR".into());
     lines.push("VERSION:2.0".into());
@@ -587,6 +601,15 @@ pub fn build_ics(event: &CalendarEvent) -> String {
     }
     if let Some(rid) = event.recurrence_id {
         lines.push(format!("RECURRENCE-ID:{}", format_utc_dt(&rid)));
+    }
+    if !event.attendees.is_empty() {
+        if let Some(email) = organizer_email {
+            let mut params = String::new();
+            if let Some(cn) = organizer_name {
+                params.push_str(&format!(";CN={cn}"));
+            }
+            lines.push(format!("ORGANIZER{params}:mailto:{email}"));
+        }
     }
     for att in &event.attendees {
         let mut params = String::new();

--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -9,7 +9,10 @@
 //! - **Capability detection** (`capabilities`) — asks the server which
 //!   apps (Talk, Files, CalDAV, CardDAV) are installed so the UI can
 //!   show or hide features accordingly.
-//! - **Talk / Files** (stubs for now) — filled in as their own issues.
+//! - **Files** (`files`) — WebDAV browse / download for "attach from
+//!   Nextcloud". Public shares (`shares`) for "send as link".
+//! - **Talk** (`talk`) — list, create, and add participants to Talk
+//!   rooms. The "create Talk room from email thread" flow lives here.
 
 pub mod auth;
 pub mod capabilities;
@@ -22,3 +25,4 @@ pub use auth::{LoginFlowInit, LoginFlowResult, poll_login, start_login};
 pub use capabilities::fetch_capabilities;
 pub use files::{FileEntry, create_directory, download_file, list_directory, upload_file};
 pub use shares::{PublicShare, create_public_share};
+pub use talk::{ParticipantSource, RoomType, TalkRoom, add_participant, create_room, list_rooms};

--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -25,4 +25,6 @@ pub use auth::{LoginFlowInit, LoginFlowResult, poll_login, start_login};
 pub use capabilities::fetch_capabilities;
 pub use files::{FileEntry, create_directory, download_file, list_directory, upload_file};
 pub use shares::{PublicShare, create_public_share};
-pub use talk::{ParticipantSource, RoomType, TalkRoom, add_participant, create_room, list_rooms};
+pub use talk::{
+    ParticipantSource, RoomType, TalkRoom, add_participant, create_room, list_rooms, rename_room,
+};

--- a/crates/nimbus-nextcloud/src/talk.rs
+++ b/crates/nimbus-nextcloud/src/talk.rs
@@ -1,1 +1,469 @@
-//! Nextcloud Talk integration — create and manage Talk rooms from within Nimbus.
+//! Nextcloud Talk (spreed) integration — list and create Talk rooms,
+//! and add participants to existing rooms.
+//!
+//! # Endpoint shape
+//!
+//! Talk lives under the OCS API at `/ocs/v2.php/apps/spreed/api/v4/`.
+//! All calls share the same OCS etiquette as `shares.rs`:
+//! `OCS-APIRequest: true` + `Accept: application/json`, Basic auth
+//! with the app password, and an envelope of the form
+//!
+//! ```json
+//! { "ocs": { "meta": { ... }, "data": { ... } } }
+//! ```
+//!
+//! On success `data` is the payload object (or array, for `list_rooms`).
+//! On failure `data` is typically `[]` and the failure code lives in
+//! `meta.statuscode` *even though HTTP itself returned 200* — same
+//! pattern shares.rs has to handle.
+//!
+//! # MVP scope (issue #13)
+//!
+//! Three operations, enough to power "create a Talk room from an email
+//! thread", "list rooms in the sidebar", and "share the room link":
+//!
+//! - [`list_rooms`] — every room the user is a participant of.
+//! - [`create_room`] — create a group room with an arbitrary set of
+//!   participants (Nextcloud users *and* email-only invitees).
+//! - [`add_participant`] — used internally by `create_room`, but
+//!   exposed so callers can also extend an existing room.
+//!
+//! Editing room settings (rename / set password / promote moderator)
+//! is left to a future issue — the existing Talk web UI handles those
+//! and Nimbus opens rooms in the browser anyway.
+
+use serde::{Deserialize, Serialize};
+
+use nimbus_core::NimbusError;
+
+use crate::client;
+
+// ── Talk's wire-level room-type enum ───────────────────────────
+//
+// Spreed encodes room type as a small integer. We keep the numbers
+// for the POST payload but expose a readable enum to the rest of the
+// app — the UI shouldn't have to remember that "2 = group".
+const ROOM_TYPE_GROUP: u8 = 2;
+
+/// Kind of Talk room. We only ever *create* groups, but we list and
+/// display all four standard types — `Other` is a forwards-compat
+/// catch-all for any future spreed addition (e.g. notes-to-self rooms).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoomType {
+    OneToOne,
+    Group,
+    Public,
+    Changelog,
+    Other,
+}
+
+impl RoomType {
+    fn from_wire(n: u8) -> RoomType {
+        match n {
+            1 => RoomType::OneToOne,
+            2 => RoomType::Group,
+            3 => RoomType::Public,
+            4 => RoomType::Changelog,
+            _ => RoomType::Other,
+        }
+    }
+}
+
+/// One Talk room as the UI cares about it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TalkRoom {
+    /// Stable room token; used in URLs and follow-up API calls.
+    pub token: String,
+    /// What the user sees in lists. The server falls back to a
+    /// participant-list summary if no explicit name was set, so this
+    /// is always non-empty.
+    pub display_name: String,
+    /// Room type (1:1, group, public, changelog, other).
+    pub room_type: RoomType,
+    /// Number of unread messages for the current user. Drives the
+    /// sidebar badge.
+    pub unread_messages: u32,
+    /// Whether the unread set contains a mention (@user). The sidebar
+    /// uses this for a stronger "ping" badge style.
+    pub unread_mention: bool,
+    /// Unix timestamp (seconds) of the last activity in the room.
+    /// Sortable so the sidebar lists the most recent first.
+    pub last_activity: i64,
+    /// Browser URL — `{server}/call/{token}`. Cached here so the UI
+    /// doesn't have to reconstruct it on every render and so the
+    /// "Share link in email" action has a single value to drop.
+    pub web_url: String,
+}
+
+/// Source of a new participant. Talk distinguishes between adding a
+/// known Nextcloud user (by user id) and inviting a guest by email
+/// address — the API uses different `source` values for each.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind", content = "value")]
+pub enum ParticipantSource {
+    /// Nextcloud user id on this server (e.g. `"alice"`).
+    User(String),
+    /// Email address — Talk emails the recipient an invite link.
+    Email(String),
+}
+
+// ── Wire format ────────────────────────────────────────────────
+//
+// Same two-phase pattern as `shares.rs`: meta first (always an object),
+// then `data` parsed into the concrete shape only after we've confirmed
+// the server didn't reply with `data: []` on failure.
+
+#[derive(Debug, Deserialize)]
+struct OcsRaw {
+    ocs: OcsBodyRaw,
+}
+
+#[derive(Debug, Deserialize)]
+struct OcsBodyRaw {
+    meta: OcsMeta,
+    #[serde(default)]
+    data: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct OcsMeta {
+    status: String,
+    statuscode: u16,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+/// Spreed's room object as it appears on the wire — only the fields
+/// we surface to the UI. The real object has 30+ fields (callFlags,
+/// guestList, lobbyState, …); the rest are dropped via the implicit
+/// serde tolerance for unknown fields.
+#[derive(Debug, Deserialize)]
+struct WireRoom {
+    token: String,
+    #[serde(rename = "type")]
+    room_type: u8,
+    #[serde(rename = "displayName", default)]
+    display_name: String,
+    #[serde(rename = "unreadMessages", default)]
+    unread_messages: u32,
+    #[serde(rename = "unreadMention", default)]
+    unread_mention: bool,
+    #[serde(rename = "lastActivity", default)]
+    last_activity: i64,
+}
+
+impl WireRoom {
+    fn into_room(self, server: &str) -> TalkRoom {
+        TalkRoom {
+            // `/call/{token}` is the canonical user-facing URL on every
+            // standard Nextcloud install. Subpath installs expose the
+            // same route; index.php prefixes are auto-handled by NC's
+            // URL rewriter.
+            web_url: format!("{server}/call/{}", self.token),
+            token: self.token,
+            display_name: self.display_name,
+            room_type: RoomType::from_wire(self.room_type),
+            unread_messages: self.unread_messages,
+            unread_mention: self.unread_mention,
+            last_activity: self.last_activity,
+        }
+    }
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/// List every Talk room the current user is a participant of.
+///
+/// Returns an empty list (not an error) on a freshly installed Talk
+/// where the user hasn't joined any rooms yet — the UI renders the
+/// "Create your first room" empty state in that case.
+pub async fn list_rooms(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+) -> Result<Vec<TalkRoom>, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}/ocs/v2.php/apps/spreed/api/v4/room?format=json");
+
+    tracing::debug!("GET {url}");
+    let http = client::build()?;
+    let resp = http
+        .get(&url)
+        .header("OCS-APIRequest", "true")
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("talk list request failed: {e}")))?;
+
+    let body = ocs_text(resp, "talk list rooms").await?;
+    let rooms: Vec<WireRoom> = parse_ocs_data(&body, "talk list rooms")?;
+    Ok(rooms.into_iter().map(|r| r.into_room(&server)).collect())
+}
+
+/// Create a new group Talk room and add `participants` to it.
+///
+/// Talk's create endpoint can take a single `invite` value to seed one
+/// participant in one round-trip, but we always create empty and add
+/// participants via [`add_participant`] afterwards — that lets us
+/// support email-source participants uniformly, which is the
+/// "create from email thread" path's main use case.
+///
+/// On a partial failure (room created, but adding the *n*th participant
+/// failed) we surface the participant error and rely on the user to
+/// finish the join in the browser. The room itself is preserved on the
+/// server — leaving an empty room dangling is better than rolling back
+/// and silently dropping a working room the user can still use.
+pub async fn create_room(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    room_name: &str,
+    participants: &[ParticipantSource],
+) -> Result<TalkRoom, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}/ocs/v2.php/apps/spreed/api/v4/room?format=json");
+
+    tracing::debug!("POST {url} (room_name={room_name:?})");
+    let http = client::build()?;
+    let resp = http
+        .post(&url)
+        .header("OCS-APIRequest", "true")
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .form(&[
+            ("roomType", ROOM_TYPE_GROUP.to_string().as_str()),
+            ("roomName", room_name),
+        ])
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("talk create request failed: {e}")))?;
+
+    let body = ocs_text(resp, "talk create room").await?;
+    let wire: WireRoom = parse_ocs_data(&body, "talk create room")?;
+    let room = wire.into_room(&server);
+
+    // Add participants serially. Talk rooms are typically small (single
+    // digits of participants) so wall-clock cost is negligible, and a
+    // serial loop keeps the error path simple — first failure wins,
+    // already-added participants stay added.
+    for p in participants {
+        add_participant(server_url, username, app_password, &room.token, p).await?;
+    }
+
+    Ok(room)
+}
+
+/// Add a single participant to an existing Talk room. Used by
+/// [`create_room`] to fill out the participant list, and exposed
+/// publicly so a future "Add participant" action can reuse it.
+pub async fn add_participant(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    room_token: &str,
+    participant: &ParticipantSource,
+) -> Result<(), NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!(
+        "{server}/ocs/v2.php/apps/spreed/api/v4/room/{room_token}/participants?format=json"
+    );
+
+    let (new_participant, source) = match participant {
+        ParticipantSource::User(id) => (id.as_str(), "users"),
+        ParticipantSource::Email(addr) => (addr.as_str(), "emails"),
+    };
+
+    tracing::debug!("POST {url} (source={source})");
+    let http = client::build()?;
+    let resp = http
+        .post(&url)
+        .header("OCS-APIRequest", "true")
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .form(&[("newParticipant", new_participant), ("source", source)])
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("talk add-participant request failed: {e}")))?;
+
+    let body = ocs_text(resp, "talk add participant").await?;
+    // Discard the participant payload — we just need the meta-level
+    // success signal to know the add stuck.
+    let _: serde_json::Value = parse_ocs_data(&body, "talk add participant")?;
+    Ok(())
+}
+
+// ── HTTP / parsing helpers ─────────────────────────────────────
+
+/// Centralise the auth-failure / non-2xx handling so the three call
+/// sites above stay focused on their request shape.
+async fn ocs_text(resp: reqwest::Response, ctx: &str) -> Result<String, NimbusError> {
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(NimbusError::Auth(
+            "Nextcloud rejected app password (revoked or expired)".into(),
+        ));
+    }
+    if !status.is_success() {
+        return Err(NimbusError::Nextcloud(format!(
+            "{ctx} returned HTTP {status}"
+        )));
+    }
+    resp.text()
+        .await
+        .map_err(|e| NimbusError::Network(format!("{ctx} body read failed: {e}")))
+}
+
+/// Parse the OCS envelope and surface either the typed payload or a
+/// meaningful error. Mirrors `shares::parse_share_response` — meta is
+/// inspected first because on OCS-level failures `data` may be `[]`,
+/// which would never deserialize into a payload struct.
+fn parse_ocs_data<T: serde::de::DeserializeOwned>(
+    body: &str,
+    ctx: &str,
+) -> Result<T, NimbusError> {
+    let raw: OcsRaw = serde_json::from_str(body)
+        .map_err(|e| NimbusError::Protocol(format!("{ctx} bad JSON: {e}")))?;
+
+    if raw.ocs.meta.status != "ok" || raw.ocs.meta.statuscode >= 400 {
+        let msg = raw
+            .ocs
+            .meta
+            .message
+            .unwrap_or_else(|| "rejected by server".to_string());
+        return Err(NimbusError::Nextcloud(format!(
+            "{ctx} failed (OCS {}): {}",
+            raw.ocs.meta.statuscode, msg
+        )));
+    }
+
+    serde_json::from_value(raw.ocs.data)
+        .map_err(|e| NimbusError::Protocol(format!("{ctx} data bad shape: {e}")))
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real-shape (trimmed) Nextcloud 28 list-rooms response. The actual
+    /// per-room object has 30+ fields; we only assert on the ones we
+    /// surface to the UI.
+    const LIST_OK: &str = r#"{
+      "ocs": {
+        "meta": { "status": "ok", "statuscode": 200, "message": "OK" },
+        "data": [
+          {
+            "token": "abc123",
+            "type": 2,
+            "displayName": "Project sync",
+            "unreadMessages": 4,
+            "unreadMention": true,
+            "lastActivity": 1745251200
+          },
+          {
+            "token": "def456",
+            "type": 1,
+            "displayName": "alice",
+            "unreadMessages": 0,
+            "unreadMention": false,
+            "lastActivity": 1745164800
+          }
+        ]
+      }
+    }"#;
+
+    #[test]
+    fn parses_list_rooms() {
+        let rooms: Vec<WireRoom> = parse_ocs_data(LIST_OK, "test").unwrap();
+        assert_eq!(rooms.len(), 2);
+
+        let r0 = &rooms[0];
+        assert_eq!(r0.token, "abc123");
+        assert_eq!(r0.room_type, 2);
+        assert_eq!(r0.display_name, "Project sync");
+        assert_eq!(r0.unread_messages, 4);
+        assert!(r0.unread_mention);
+
+        let mapped = rooms[0].clone_for_test().into_room("https://cloud.example.com");
+        assert_eq!(mapped.web_url, "https://cloud.example.com/call/abc123");
+        assert_eq!(mapped.room_type, RoomType::Group);
+    }
+
+    #[test]
+    fn parses_create_room() {
+        let body = r#"{
+          "ocs": {
+            "meta": { "status": "ok", "statuscode": 200, "message": "OK" },
+            "data": {
+              "token": "newtok",
+              "type": 2,
+              "displayName": "Standup",
+              "unreadMessages": 0,
+              "unreadMention": false,
+              "lastActivity": 0
+            }
+          }
+        }"#;
+        let wire: WireRoom = parse_ocs_data(body, "test").unwrap();
+        let room = wire.into_room("https://cloud.example.com");
+        assert_eq!(room.token, "newtok");
+        assert_eq!(room.web_url, "https://cloud.example.com/call/newtok");
+        assert_eq!(room.room_type, RoomType::Group);
+    }
+
+    /// Talk denied the create (e.g. user lacks the `talk:create` right):
+    /// HTTP 200 but `statuscode: 403` and `data: []`. Surface as a
+    /// Nextcloud error with the server's message.
+    #[test]
+    fn surfaces_ocs_failure() {
+        let body = r#"{
+          "ocs": {
+            "meta": {
+              "status": "failure",
+              "statuscode": 403,
+              "message": "Permission denied"
+            },
+            "data": []
+          }
+        }"#;
+        let err = parse_ocs_data::<WireRoom>(body, "test create").unwrap_err();
+        match err {
+            NimbusError::Nextcloud(msg) => {
+                assert!(msg.contains("403"), "expected status 403 in error: {msg}");
+                assert!(msg.contains("Permission denied"), "expected server msg: {msg}");
+            }
+            other => panic!("expected Nextcloud error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn surfaces_bad_json_as_protocol_error() {
+        let err = parse_ocs_data::<WireRoom>("not json", "test").unwrap_err();
+        assert!(matches!(err, NimbusError::Protocol(_)));
+    }
+
+    #[test]
+    fn unknown_room_type_falls_back_to_other() {
+        assert_eq!(RoomType::from_wire(99), RoomType::Other);
+        assert_eq!(RoomType::from_wire(1), RoomType::OneToOne);
+        assert_eq!(RoomType::from_wire(4), RoomType::Changelog);
+    }
+
+    // Helper because WireRoom doesn't derive Clone in the production
+    // code — we don't need it outside tests.
+    impl WireRoom {
+        fn clone_for_test(&self) -> WireRoom {
+            WireRoom {
+                token: self.token.clone(),
+                room_type: self.room_type,
+                display_name: self.display_name.clone(),
+                unread_messages: self.unread_messages,
+                unread_mention: self.unread_mention,
+                last_activity: self.last_activity,
+            }
+        }
+    }
+}

--- a/crates/nimbus-nextcloud/src/talk.rs
+++ b/crates/nimbus-nextcloud/src/talk.rs
@@ -27,10 +27,14 @@
 //!   participants (Nextcloud users *and* email-only invitees).
 //! - [`add_participant`] — used internally by `create_room`, but
 //!   exposed so callers can also extend an existing room.
+//! - [`rename_room`] — used by the Compose "Add Event" flow so the
+//!   Talk room created up-front (with the email subject as a
+//!   placeholder name) can be renamed to match the final event title
+//!   the user typed in the editor.
 //!
-//! Editing room settings (rename / set password / promote moderator)
-//! is left to a future issue — the existing Talk web UI handles those
-//! and Nimbus opens rooms in the browser anyway.
+//! Editing the rest of room settings (set password / promote
+//! moderator) is left to a future issue — the Talk web UI handles
+//! those and Nimbus opens rooms in the browser anyway.
 
 use serde::{Deserialize, Serialize};
 
@@ -291,6 +295,41 @@ pub async fn add_participant(
     // Discard the participant payload — we just need the meta-level
     // success signal to know the add stuck.
     let _: serde_json::Value = parse_ocs_data(&body, "talk add participant")?;
+    Ok(())
+}
+
+/// Rename an existing Talk room. Used by the Compose "Add Event"
+/// flow: we create the room up-front (so its URL can prefill the
+/// event editor's URL field) using the email subject as a placeholder
+/// name, then rename the room to the final event title once the user
+/// saves the event. The endpoint is the same `PUT /room/{token}` the
+/// Talk web UI hits when editing the room name.
+pub async fn rename_room(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    room_token: &str,
+    new_name: &str,
+) -> Result<(), NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}/ocs/v2.php/apps/spreed/api/v4/room/{room_token}?format=json");
+
+    tracing::debug!("PUT {url} (new_name={new_name:?})");
+    let http = client::build()?;
+    let resp = http
+        .put(&url)
+        .header("OCS-APIRequest", "true")
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .form(&[("roomName", new_name)])
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("talk rename request failed: {e}")))?;
+
+    let body = ocs_text(resp, "talk rename room").await?;
+    // Discard the updated-room payload — we already track the room
+    // locally and a rename doesn't change anything else we care about.
+    let _: serde_json::Value = parse_ocs_data(&body, "talk rename room")?;
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -457,6 +457,27 @@ async fn add_talk_participant(
     .await
 }
 
+/// Rename an existing Talk room. Used by the Compose "Add Event"
+/// flow to keep the auto-created Talk room's name in sync with the
+/// final event title once the user saves the event.
+#[tauri::command]
+async fn rename_talk_room(
+    nc_id: String,
+    room_token: String,
+    new_name: String,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::rename_room(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &room_token,
+        &new_name,
+    )
+    .await
+}
+
 // ── CardDAV contacts ────────────────────────────────────────────
 //
 // Contact sync is driven from a single entry point: the UI calls
@@ -2519,6 +2540,7 @@ fn main() {
             list_talk_rooms,
             create_talk_room,
             add_talk_participant,
+            rename_talk_room,
             upload_to_nextcloud,
             save_bytes_to_path,
             sync_nextcloud_contacts,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1164,6 +1164,35 @@ fn calendar_event_to_row(
     }
 }
 
+/// Derive the (email, display name) we surface as `ORGANIZER` on
+/// outbound VEVENTs. Nextcloud's CalDAV plugin (Sabre/DAV) returns
+/// `403 Forbidden` on a PUT that has any `ATTENDEE` but no
+/// `ORGANIZER`, so we always need *something* to put on that line
+/// when attendees are present.
+///
+/// The Nextcloud account model only carries `username` (which often
+/// is — but isn't required to be — an email). We use it directly
+/// when it parses as one, and otherwise synthesise `username@host`
+/// from the server URL. The synthetic value is opaque to the CalDAV
+/// validator (it just needs a syntactically valid `mailto:`), and
+/// for the user's own calendar it doesn't trigger iTIP delivery.
+fn organizer_for(account: &NextcloudAccount) -> (String, Option<String>) {
+    let email = if account.username.contains('@') {
+        account.username.clone()
+    } else {
+        let host = account
+            .server_url
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches('/')
+            .split('/')
+            .next()
+            .unwrap_or("nextcloud.local");
+        format!("{}@{}", account.username, host)
+    };
+    (email, account.display_name.clone())
+}
+
 /// Create a new VEVENT in the given calendar.
 ///
 /// Generates a fresh UUID for the UID so callers don't have to.
@@ -1189,7 +1218,12 @@ async fn create_calendar_event(
 
     let uid = format!("urn:uuid:{}", uuid::Uuid::new_v4());
     let event = input_to_calendar_event(&uid, &input);
-    let ics = caldav_build_ics(&event);
+    let (organizer_email, organizer_name) = organizer_for(&account);
+    let ics = caldav_build_ics(
+        &event,
+        Some(&organizer_email),
+        organizer_name.as_deref(),
+    );
 
     // `calendar_path` from the cache is already an absolute URL —
     // `nimbus-caldav::discovery` resolves it via `absolute_url` before
@@ -1236,7 +1270,12 @@ async fn update_calendar_event(
     // would silently demote a recurring series back to a singleton.
     event.recurrence_id = handle.recurrence_id;
 
-    let ics = caldav_build_ics(&event);
+    let (organizer_email, organizer_name) = organizer_for(&account);
+    let ics = caldav_build_ics(
+        &event,
+        Some(&organizer_email),
+        organizer_name.as_deref(),
+    );
     let outcome = caldav_update_event(
         &handle.href,
         &account.username,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -391,6 +391,72 @@ async fn create_nextcloud_directory(
     .await
 }
 
+// ── Nextcloud Talk ──────────────────────────────────────────────
+//
+// Three commands, mirroring the file/share pattern: each call loads
+// the account + app password from local state and forwards to the
+// matching `nimbus_nextcloud::talk::*` function. We don't cache the
+// room list — Talk's `/room` is cheap and unread counts go stale the
+// moment a colleague sends a message anyway. The sidebar polls on a
+// timer instead.
+
+/// List every Talk room the connected Nextcloud user is a participant
+/// of. Drives the sidebar's "Talk Rooms" group.
+#[tauri::command]
+async fn list_talk_rooms(nc_id: String) -> Result<Vec<nimbus_nextcloud::TalkRoom>, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::list_rooms(&account.server_url, &account.username, &app_password).await
+}
+
+/// Create a new group Talk room and invite `participants` to it.
+///
+/// `participants` carries a tagged enum (`{kind: "user"|"email", value: ...}`)
+/// per invitee — `kind=email` triggers Talk's guest-invite flow so
+/// recipients without a Nextcloud account get an emailed link. The
+/// frontend builds this list from the email's To/Cc by treating
+/// addresses matching the connected NC server's user list as `user`
+/// and the rest as `email`. (For the MVP we always send `email` and
+/// let Talk match users on the server side.)
+#[tauri::command]
+async fn create_talk_room(
+    nc_id: String,
+    room_name: String,
+    participants: Vec<nimbus_nextcloud::ParticipantSource>,
+) -> Result<nimbus_nextcloud::TalkRoom, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::create_room(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &room_name,
+        &participants,
+    )
+    .await
+}
+
+/// Add a single participant to an existing Talk room. Exposed so the
+/// UI can grow an "Add participant" affordance later without a
+/// backend round-trip.
+#[tauri::command]
+async fn add_talk_participant(
+    nc_id: String,
+    room_token: String,
+    participant: nimbus_nextcloud::ParticipantSource,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::add_participant(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &room_token,
+        &participant,
+    )
+    .await
+}
+
 // ── CardDAV contacts ────────────────────────────────────────────
 //
 // Contact sync is driven from a single entry point: the UI calls
@@ -2411,6 +2477,9 @@ fn main() {
             download_nextcloud_file,
             create_nextcloud_share,
             create_nextcloud_directory,
+            list_talk_rooms,
+            create_talk_room,
+            add_talk_participant,
             upload_to_nextcloud,
             save_bytes_to_path,
             sync_nextcloud_contacts,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -27,6 +27,8 @@
   import ContactsView from './lib/ContactsView.svelte'
   import CalendarView from './lib/CalendarView.svelte'
   import FilesView from './lib/FilesView.svelte'
+  import TalkView from './lib/TalkView.svelte'
+  import CreateTalkRoomModal, { type TalkRoom } from './lib/CreateTalkRoomModal.svelte'
   import SearchBar, {
     type SearchScope,
     type SearchFilters,
@@ -44,6 +46,7 @@
     | 'contacts'
     | 'calendar'
     | 'files'
+    | 'talk'
   let currentView = $state<View>('loading')
 
   // Which integration tab is active in the sidebar. Lives next to
@@ -272,6 +275,9 @@
     } else if (name === 'Nextcloud Files') {
       activeIntegration = name
       currentView = 'files'
+    } else if (name === 'Nextcloud Talk') {
+      activeIntegration = name
+      currentView = 'talk'
     }
   }
 
@@ -366,6 +372,89 @@
     openCompose({
       subject: forwardSubject(mail.subject),
       body: `\n\n---------- Forwarded message ----------\nFrom: ${mail.from}\nDate: ${new Date(mail.date).toLocaleString()}\nSubject: ${mail.subject}\n\n${mail.body_text ?? ''}`,
+    })
+  }
+
+  // ── "Create Talk room from this thread" flow ────────────────
+  // Triggered from MailView's 💬 Talk button. Opens a modal seeded
+  // with the email's subject and the thread's participants; on
+  // create, chains into Compose with the room link in the body and
+  // the same recipients in the To field, satisfying issue #13's
+  // "create a Talk room from an email thread" task in one user
+  // gesture.
+  let talkRoomDraft = $state<{
+    ncId: string
+    initialName: string
+    initialParticipants: string[]
+    /** Pre-fills Compose's `To` after the room is created — kept on
+        the draft so we don't have to re-derive it from the email. */
+    composeTo: string
+  } | null>(null)
+
+  /** Strip an `"Name" <addr>` wrapper down to the bare email. */
+  function bareEmail(s: string): string | null {
+    const t = s.trim()
+    if (!t) return null
+    const m = t.match(/^\s*(?:"[^"]*"|[^<]*?)\s*<([^>]+)>\s*$/)
+    return m ? m[1].trim() : t
+  }
+
+  async function onCreateTalkFromMail(mail: OpenMail) {
+    // For the MVP we use the first connected Nextcloud account. A
+    // multi-account picker can land later — most users have one NC.
+    let ncId = ''
+    try {
+      const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      if (list.length === 0) {
+        alert('Connect a Nextcloud account first (Settings → Nextcloud).')
+        return
+      }
+      ncId = list[0].id
+    } catch (e) {
+      alert(`Failed to load Nextcloud accounts: ${e}`)
+      return
+    }
+
+    // Build the participant set: From + To + Cc, deduped, minus the
+    // current user (who's already in the room as the creator).
+    const seen = new Set<string>()
+    const participants: string[] = []
+    for (const piece of [mail.from, ...mail.to, ...mail.cc]) {
+      const addr = bareEmail(piece)
+      if (!addr) continue
+      const key = addr.toLowerCase()
+      if (key === activeAccountEmail.toLowerCase()) continue
+      if (seen.has(key)) continue
+      seen.add(key)
+      participants.push(addr)
+    }
+
+    // The Compose `To` field happily accepts the original
+    // `"Name" <addr>` strings, so display names round-trip into the
+    // sent invite without us having to re-format.
+    const composeTo = [mail.from, ...mail.to, ...mail.cc]
+      .filter((a) => {
+        const e = bareEmail(a)
+        return e && e.toLowerCase() !== activeAccountEmail.toLowerCase()
+      })
+      .join(', ')
+
+    talkRoomDraft = {
+      ncId,
+      initialName: mail.subject || 'Talk',
+      initialParticipants: participants,
+      composeTo,
+    }
+  }
+
+  function onTalkRoomCreatedFromMail(room: TalkRoom) {
+    const draft = talkRoomDraft
+    talkRoomDraft = null
+    if (!draft) return
+    openCompose({
+      to: draft.composeTo,
+      subject: `Join Talk: ${room.display_name}`,
+      talkLink: { name: room.display_name, url: room.web_url },
     })
   }
 </script>
@@ -463,6 +552,38 @@
     {/if}
   </div>
 
+<!-- Nextcloud Talk view: same shape as Files. The "Share link"
+     button inside `TalkView` opens Compose with the room URL pre-
+     rendered into the body. -->
+{:else if currentView === 'talk' && activeAccountId}
+  <div class="h-full flex">
+    <Sidebar
+      accountId={activeAccountId}
+      selectedFolder={selectedFolder}
+      refreshToken={refreshToken}
+      activeIntegration={activeIntegration}
+      onselectfolder={(f) => {
+        selectFolder(f)
+        goToInbox()
+      }}
+      onsettings={goToSettings}
+      onrefresh={refreshAll}
+      oncompose={() => openCompose()}
+      onselectintegration={onSelectIntegration}
+    />
+    <div class="flex-1">
+      <TalkView onclose={goToInbox} oncompose={openCompose} />
+    </div>
+    {#if composeInitial !== null}
+      <Compose
+        accountId={activeAccountId}
+        fromAddress={activeAccountEmail}
+        initial={composeInitial}
+        onclose={closeCompose}
+      />
+    {/if}
+  </div>
+
 <!-- Main inbox: the 3-panel mail client layout -->
 {:else if activeAccountId}
   <div class="h-full flex">
@@ -515,6 +636,7 @@
       onreply={onReply}
       onreplyall={onReplyAll}
       onforward={onForward}
+      oncreatetalk={onCreateTalkFromMail}
     />
     {#if composeInitial !== null}
       <Compose
@@ -529,4 +651,18 @@
   <div class="h-full flex items-center justify-center bg-surface-50 dark:bg-surface-900">
     <p class="text-surface-500">No account selected.</p>
   </div>
+{/if}
+
+<!-- Talk-room creation modal — mounted at the app level so it can
+     overlay any view. Driven entirely by `talkRoomDraft`: setting it
+     opens the modal pre-filled, clearing it (or `oncreated`)
+     dismisses. -->
+{#if talkRoomDraft}
+  <CreateTalkRoomModal
+    ncId={talkRoomDraft.ncId}
+    initialName={talkRoomDraft.initialName}
+    initialParticipants={talkRoomDraft.initialParticipants}
+    onclose={() => (talkRoomDraft = null)}
+    oncreated={onTalkRoomCreatedFromMail}
+  />
 {/if}

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -179,6 +179,18 @@
       to seed the "URL" field of the Calendar event so the meeting
       invite carries the join link. */
   let createdTalkLink = $state<{ name: string; url: string } | null>(null)
+  /** Token of the room behind `createdTalkLink` — needed by
+      `add_talk_participant` when we sync event attendees back into
+      the room after the event is saved. */
+  let talkRoomToken: string | null = null
+  /** Lower-cased bare addresses we've already POSTed to Talk's
+      participant endpoint, so the post-save sync skips them. Includes
+      the participants we passed at room-creation time. */
+  const talkRoomParticipants = new Set<string>()
+  /** Whether the "Join the Talk room" body block has been appended
+      yet. The Talk button injects immediately; the Add-Event auto-
+      create defers injection until the event is saved. */
+  let talkLinkInjected = false
   let openingEvent = $state(false)
 
   /** Resolve a Nextcloud account id (cached for the rest of the
@@ -211,21 +223,71 @@
     return [...splitAddrs(to), ...splitAddrs(cc)]
   }
 
-  function onTalkRoomCreated(room: TalkRoom, participants: string[]) {
-    createdTalkLink = { name: room.display_name, url: room.web_url }
-    // Keep the mail recipients in sync with the Talk invite: any
-    // address the user typed into the modal that wasn't already on
-    // To/Cc/Bcc gets added to To.
-    mergeIntoRecipients(participants)
-    // Same "Join the Talk room" block shape that `initialBodyHtml`
-    // and `TalkView`'s share-link path produce — keeps the rendered
-    // mail consistent across every entry point.
+  /** Append the "Join the Talk room" body block once. Used by both
+      the immediate-injection path (Talk button) and the deferred path
+      (Add-Event auto-create → injected on event save). The flag keeps
+      callers from accidentally duplicating the block. */
+  function injectTalkBlock(link: { name: string; url: string }) {
+    if (talkLinkInjected) return
     const esc = (s: string) =>
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     const block =
       `<p><strong>Join the Talk room:</strong></p>` +
-      `<p>💬 <a href="${room.web_url}">${esc(room.display_name)}</a></p>`
+      `<p>💬 <a href="${link.url}">${esc(link.name)}</a></p>`
     editorApi?.appendHtml(block)
+    talkLinkInjected = true
+  }
+
+  function onTalkRoomCreated(room: TalkRoom, participants: string[]) {
+    createdTalkLink = { name: room.display_name, url: room.web_url }
+    talkRoomToken = room.token
+    for (const p of participants) {
+      const k = bareAddr(p).toLowerCase()
+      if (k) talkRoomParticipants.add(k)
+    }
+    // Keep the mail recipients in sync with the Talk invite: any
+    // address the user typed into the modal that wasn't already on
+    // To/Cc/Bcc gets added to To.
+    mergeIntoRecipients(participants)
+    // The Talk button is itself a "share this room now" gesture, so
+    // inject the body block immediately. The Add-Event auto-create
+    // path deliberately bypasses this callback (it uses
+    // `createTalkRoomSilently`) so its block can be deferred.
+    injectTalkBlock(createdTalkLink)
+  }
+
+  /**
+   * Create a Talk room without going through CreateTalkRoomModal —
+   * used by the Add-Event path so the auto-created room's URL is
+   * available to prefill the event's URL field. The body block is
+   * **not** injected here; that happens after the event is saved
+   * (per the user-facing "after the event is saved, add the talk
+   * link to the mail body" semantics).
+   */
+  async function createTalkRoomSilently() {
+    const id = ncAccountId
+    if (!id) return
+    const seen = new Set<string>()
+    const dedupd: { kind: 'email'; value: string }[] = []
+    for (const r of recipients()) {
+      const addr = bareAddr(r)
+      if (!addr) continue
+      const k = addr.toLowerCase()
+      if (seen.has(k)) continue
+      seen.add(k)
+      dedupd.push({ kind: 'email', value: addr })
+    }
+    const room = await invoke<TalkRoom>('create_talk_room', {
+      ncId: id,
+      // Talk requires a non-empty name. Fall back to a generic label
+      // when the user hasn't set a subject yet — they can rename in
+      // Nextcloud later.
+      roomName: subject.trim() || '(meeting)',
+      participants: dedupd,
+    })
+    createdTalkLink = { name: room.display_name, url: room.web_url }
+    talkRoomToken = room.token
+    for (const p of dedupd) talkRoomParticipants.add(p.value.toLowerCase())
   }
 
   async function openEventEditor() {
@@ -240,6 +302,7 @@
         error = 'Connect a Nextcloud account first (Settings → Nextcloud).'
         return
       }
+      if (!ncAccountId) ncAccountId = accounts[0].id
       const all: CalendarSummary[] = []
       for (const acc of accounts) {
         try {
@@ -253,6 +316,19 @@
       if (all.length === 0) {
         error = 'No calendars cached yet. Open the Calendar tab once to sync.'
         return
+      }
+      // Auto-create a Talk room so the event's URL field carries the
+      // join link from the start. We skip this if the user already
+      // created one via the Talk button (or via an earlier click of
+      // Add Event in the same Compose session). Failure is non-fatal:
+      // surface the error and still open the editor — the user can
+      // create the event without a link or paste one in by hand.
+      if (!createdTalkLink) {
+        try {
+          await createTalkRoomSilently()
+        } catch (e) {
+          error = formatError(e) || 'Failed to create Talk room for event'
+        }
       }
       showEventEditor = true
     } finally {
@@ -284,13 +360,24 @@
     }
   }
 
-  /** After the EventEditor saves, append a short "📅 Meeting" block
-      (title, when, and the event URL — typically the Talk room link)
-      and sync any newly added attendees back into the mail's To field
-      so the invite and the email line up in both directions. */
-  function onEventSaved(saved?: SavedEvent) {
+  /** After the EventEditor saves, do the post-save bookkeeping:
+   *
+   *   1. Add any new event attendees to the email's To field so the
+   *      mail recipients track the invite list.
+   *   2. Inject the deferred "Join the Talk room" body block (the
+   *      auto-create path skips immediate injection so the link
+   *      lands in the body once the meeting is actually scheduled).
+   *   3. Append the "📅 Meeting" block with title / when / link.
+   *   4. Best-effort: POST any new event attendees to the Talk room
+   *      so the room's participant list stays aligned with the
+   *      event's. EventEditor doesn't await this callback so the
+   *      sync happens in the background; per-address failures
+   *      (already-added, invalid email) are logged and skipped.
+   */
+  async function onEventSaved(saved?: SavedEvent) {
     if (!saved) return
     mergeIntoRecipients(saved.attendees)
+    if (createdTalkLink) injectTalkBlock(createdTalkLink)
     const esc = (s: string) =>
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     const start = new Date(saved.start)
@@ -325,6 +412,23 @@
       `<p>When: ${esc(when)}</p>` +
       linkLine
     editorApi?.appendHtml(block)
+
+    if (talkRoomToken && ncAccountId) {
+      for (const addr of saved.attendees) {
+        const key = addr.toLowerCase()
+        if (!key || talkRoomParticipants.has(key)) continue
+        try {
+          await invoke('add_talk_participant', {
+            ncId: ncAccountId,
+            roomToken: talkRoomToken,
+            participant: { kind: 'email', value: addr },
+          })
+          talkRoomParticipants.add(key)
+        } catch (e) {
+          console.warn('Failed to add Talk participant', addr, ':', e)
+        }
+      }
+    }
   }
 
   // Autosave draft whenever the user edits a field.
@@ -545,9 +649,13 @@
         type="button"
         class="btn preset-outlined-surface-500"
         disabled={openingEvent}
-        title="Create a calendar event with the current recipients as attendees{createdTalkLink ? ' (Talk link prefilled)' : ''}"
+        title={
+          createdTalkLink
+            ? 'Create a calendar event with the current recipients as attendees (existing Talk link prefilled)'
+            : 'Create a Talk room and a calendar event with the current recipients — the Talk link is added to the event URL and the email body'
+        }
         onclick={openEventEditor}
-      >{openingEvent ? 'Loading…' : '📅 Add event'}</button>
+      >{openingEvent ? (createdTalkLink ? 'Loading…' : 'Creating Talk room…') : '📅 Add event'}</button>
       <button class="btn preset-outlined-surface-500" onclick={saveDraft}>Save draft</button>
       {#if savedHint}
         <span class="text-xs text-surface-500">{savedHint}</span>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -211,8 +211,12 @@
     return [...splitAddrs(to), ...splitAddrs(cc)]
   }
 
-  function onTalkRoomCreated(room: TalkRoom) {
+  function onTalkRoomCreated(room: TalkRoom, participants: string[]) {
     createdTalkLink = { name: room.display_name, url: room.web_url }
+    // Keep the mail recipients in sync with the Talk invite: any
+    // address the user typed into the modal that wasn't already on
+    // To/Cc/Bcc gets added to To.
+    mergeIntoRecipients(participants)
     // Same "Join the Talk room" block shape that `initialBodyHtml`
     // and `TalkView`'s share-link path produce — keeps the rendered
     // mail consistent across every entry point.
@@ -281,11 +285,12 @@
   }
 
   /** After the EventEditor saves, append a short "📅 Meeting" block
-      so the recipients see the date/time in the email body. The Talk
-      link block (if any) was already injected when the room was
-      created, so we don't repeat it here. */
+      (title, when, and the event URL — typically the Talk room link)
+      and sync any newly added attendees back into the mail's To field
+      so the invite and the email line up in both directions. */
   function onEventSaved(saved?: SavedEvent) {
     if (!saved) return
+    mergeIntoRecipients(saved.attendees)
     const esc = (s: string) =>
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     const start = new Date(saved.start)
@@ -305,9 +310,20 @@
       ? `${dateStr}, ${start.toLocaleTimeString(undefined, timeFmt)}–${end.toLocaleTimeString(undefined, timeFmt)}`
       : `${start.toLocaleString(undefined, { ...timeFmt, dateStyle: 'medium' } as Intl.DateTimeFormatOptions)} – ${end.toLocaleString(undefined, { ...timeFmt, dateStyle: 'medium' } as Intl.DateTimeFormatOptions)}`
     const title = esc(saved.summary || '(untitled)')
+    // Label the link as "Talk room" when the URL matches the one we
+    // just created from the Talk button, otherwise call it "Meeting
+    // link" so a user who just types a URL by hand doesn't get a
+    // misleading "Talk room" label.
+    const isTalkLink =
+      !!saved.url && createdTalkLink?.url === saved.url
+    const linkLabel = isTalkLink ? 'Talk room' : 'Meeting link'
+    const linkLine = saved.url
+      ? `<p>${linkLabel}: <a href="${saved.url}">${esc(saved.url)}</a></p>`
+      : ''
     const block =
       `<p><strong>📅 Meeting:</strong> ${title}</p>` +
-      `<p>When: ${esc(when)}</p>`
+      `<p>When: ${esc(when)}</p>` +
+      linkLine
     editorApi?.appendHtml(block)
   }
 
@@ -350,6 +366,44 @@
       .split(/[,;]/)
       .map((a) => a.trim())
       .filter(Boolean)
+  }
+
+  /** Strip an `"Name" <addr>` wrapper down to the bare address. Same
+      parser shape the EventEditor / CreateTalkRoomModal use. */
+  function bareAddr(piece: string): string {
+    const trimmed = piece.trim()
+    if (!trimmed) return ''
+    const m = trimmed.match(/^\s*(?:"[^"]*"|[^<]*?)\s*<([^>]+)>\s*$/)
+    return m ? m[1].trim() : trimmed
+  }
+
+  /**
+   * Merge newly invited addresses back into the email's To field.
+   * Used by both the Talk-room-created and calendar-event-saved
+   * callbacks so adding someone in either modal also adds them to
+   * the mail recipients — keeping the invite and the email aligned.
+   * Deduplication is case-insensitive on the bare address, and we
+   * skip addresses that are already on To/Cc/Bcc so the user never
+   * gets surprised by a recipient jumping from Cc back to To.
+   */
+  function mergeIntoRecipients(addresses: string[]) {
+    const have = new Set<string>()
+    for (const field of [to, cc, bcc]) {
+      for (const a of splitAddrs(field)) {
+        const bare = bareAddr(a).toLowerCase()
+        if (bare) have.add(bare)
+      }
+    }
+    const additions: string[] = []
+    for (const a of addresses) {
+      const bare = bareAddr(a).toLowerCase()
+      if (!bare || have.has(bare)) continue
+      have.add(bare)
+      additions.push(a)
+    }
+    if (additions.length === 0) return
+    const current = splitAddrs(to)
+    to = [...current, ...additions].join(', ')
   }
 
   async function onPickFiles(e: Event) {

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -21,6 +21,24 @@
   import RichTextEditor, { type EditorApi } from './RichTextEditor.svelte'
   import AddressAutocomplete from './AddressAutocomplete.svelte'
   import NextcloudFilePicker from './NextcloudFilePicker.svelte'
+  import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
+  import EventEditor, { type SavedEvent } from './EventEditor.svelte'
+
+  /** Slim Nextcloud account row — same shape `TalkView` / `Sidebar` use.
+      We only need the id to pass to the Talk + Calendar commands. */
+  interface NextcloudAccount {
+    id: string
+  }
+  /** Slim calendar summary — matches the Rust `CalendarSummary` Tauri
+      return shape. We pass the full list to `EventEditor` so the user
+      can pick which calendar the event lands in. */
+  interface CalendarSummary {
+    id: string
+    nextcloud_account_id: string
+    display_name: string
+    color: string | null
+    last_synced_at: string | null
+  }
 
   interface Attachment {
     filename: string
@@ -146,6 +164,152 @@
   let sending = $state(false)
   let error = $state('')
   let savedHint = $state('')
+
+  // ── Talk room + Calendar event creation from Compose ────────
+  // Both flows piggyback on the existing modals (`CreateTalkRoomModal`,
+  // `EventEditor`) so the UX matches what the user already sees in
+  // TalkView / CalendarView. We lazy-load the Nextcloud account list
+  // and calendar list — neither is needed unless the user opens one
+  // of these flows.
+  let showTalkModal = $state(false)
+  let showEventEditor = $state(false)
+  let ncAccountId = $state('')
+  let calendars = $state<CalendarSummary[]>([])
+  /** The Talk room created during this compose session (if any). Used
+      to seed the "URL" field of the Calendar event so the meeting
+      invite carries the join link. */
+  let createdTalkLink = $state<{ name: string; url: string } | null>(null)
+  let openingEvent = $state(false)
+
+  /** Resolve a Nextcloud account id (cached for the rest of the
+      session). Sets `error` and returns null if none configured. */
+  async function ensureNextcloudAccount(): Promise<string | null> {
+    if (ncAccountId) return ncAccountId
+    try {
+      const accounts = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
+      if (accounts.length === 0) {
+        error = 'Connect a Nextcloud account first (Settings → Nextcloud).'
+        return null
+      }
+      ncAccountId = accounts[0].id
+      return ncAccountId
+    } catch (e) {
+      error = formatError(e) || 'Failed to load Nextcloud accounts'
+      return null
+    }
+  }
+
+  async function openTalkModal() {
+    error = ''
+    const id = await ensureNextcloudAccount()
+    if (id) showTalkModal = true
+  }
+
+  /** Combined To + Cc list as bare/RFC-formatted address strings,
+      ready to seed CreateTalkRoomModal / EventEditor's attendee inputs. */
+  function recipients(): string[] {
+    return [...splitAddrs(to), ...splitAddrs(cc)]
+  }
+
+  function onTalkRoomCreated(room: TalkRoom) {
+    createdTalkLink = { name: room.display_name, url: room.web_url }
+    // Same "Join the Talk room" block shape that `initialBodyHtml`
+    // and `TalkView`'s share-link path produce — keeps the rendered
+    // mail consistent across every entry point.
+    const esc = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    const block =
+      `<p><strong>Join the Talk room:</strong></p>` +
+      `<p>💬 <a href="${room.web_url}">${esc(room.display_name)}</a></p>`
+    editorApi?.appendHtml(block)
+  }
+
+  async function openEventEditor() {
+    error = ''
+    openingEvent = true
+    try {
+      // Calendars come from every connected Nextcloud account so the
+      // user can drop the event into any of their calendars — same
+      // aggregation CalendarView does on its own load.
+      const accounts = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
+      if (accounts.length === 0) {
+        error = 'Connect a Nextcloud account first (Settings → Nextcloud).'
+        return
+      }
+      const all: CalendarSummary[] = []
+      for (const acc of accounts) {
+        try {
+          const cs = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId: acc.id })
+          all.push(...cs)
+        } catch (e) {
+          console.warn('get_cached_calendars failed:', e)
+        }
+      }
+      calendars = all
+      if (all.length === 0) {
+        error = 'No calendars cached yet. Open the Calendar tab once to sync.'
+        return
+      }
+      showEventEditor = true
+    } finally {
+      openingEvent = false
+    }
+  }
+
+  /** Build the create-mode draft passed to EventEditor. Default time
+      window is the next half-hour for one hour — same behaviour the
+      grid's "+ New event" button uses. Subject, attendees, and the
+      Talk URL (if a room was just created) seed the editor so the
+      user only has to confirm the time. */
+  function eventDraft() {
+    const start = new Date()
+    // Round up to the next 30-minute mark so the prefilled slot is
+    // visually clean (no "10:13" oddities).
+    const minute = start.getMinutes()
+    const bump = (30 - (minute % 30)) % 30 || 30
+    start.setMinutes(minute + bump, 0, 0)
+    const end = new Date(start)
+    end.setHours(end.getHours() + 1)
+    return {
+      calendarId: calendars[0]?.id ?? '',
+      start,
+      end,
+      summary: subject,
+      attendees: recipients(),
+      url: createdTalkLink?.url ?? '',
+    }
+  }
+
+  /** After the EventEditor saves, append a short "📅 Meeting" block
+      so the recipients see the date/time in the email body. The Talk
+      link block (if any) was already injected when the room was
+      created, so we don't repeat it here. */
+  function onEventSaved(saved?: SavedEvent) {
+    if (!saved) return
+    const esc = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    const start = new Date(saved.start)
+    const end = new Date(saved.end)
+    const sameDay =
+      start.getFullYear() === end.getFullYear() &&
+      start.getMonth() === end.getMonth() &&
+      start.getDate() === end.getDate()
+    const dateStr = start.toLocaleDateString(undefined, {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+    const timeFmt: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' }
+    const when = sameDay
+      ? `${dateStr}, ${start.toLocaleTimeString(undefined, timeFmt)}–${end.toLocaleTimeString(undefined, timeFmt)}`
+      : `${start.toLocaleString(undefined, { ...timeFmt, dateStyle: 'medium' } as Intl.DateTimeFormatOptions)} – ${end.toLocaleString(undefined, { ...timeFmt, dateStyle: 'medium' } as Intl.DateTimeFormatOptions)}`
+    const title = esc(saved.summary || '(untitled)')
+    const block =
+      `<p><strong>📅 Meeting:</strong> ${title}</p>` +
+      `<p>When: ${esc(when)}</p>`
+    editorApi?.appendHtml(block)
+  }
 
   // Autosave draft whenever the user edits a field.
   $effect(() => {
@@ -317,6 +481,19 @@
         class="btn preset-outlined-surface-500"
         onclick={() => (showNcPicker = true)}
       >☁️ From Nextcloud</button>
+      <button
+        type="button"
+        class="btn preset-outlined-surface-500"
+        title="Create a Nextcloud Talk room with the current recipients and add the join link to this email"
+        onclick={openTalkModal}
+      >💬 Talk room</button>
+      <button
+        type="button"
+        class="btn preset-outlined-surface-500"
+        disabled={openingEvent}
+        title="Create a calendar event with the current recipients as attendees{createdTalkLink ? ' (Talk link prefilled)' : ''}"
+        onclick={openEventEditor}
+      >{openingEvent ? 'Loading…' : '📅 Add event'}</button>
       <button class="btn preset-outlined-surface-500" onclick={saveDraft}>Save draft</button>
       {#if savedHint}
         <span class="text-xs text-surface-500">{savedHint}</span>
@@ -347,5 +524,25 @@
       editorApi?.appendHtml(block)
     }}
     onclose={() => (showNcPicker = false)}
+  />
+{/if}
+
+{#if showTalkModal && ncAccountId}
+  <CreateTalkRoomModal
+    ncId={ncAccountId}
+    initialName={subject}
+    initialParticipants={recipients()}
+    onclose={() => (showTalkModal = false)}
+    oncreated={onTalkRoomCreated}
+  />
+{/if}
+
+{#if showEventEditor}
+  <EventEditor
+    mode="create"
+    {calendars}
+    draft={eventDraft()}
+    onclose={() => (showEventEditor = false)}
+    onsaved={onEventSaved}
   />
 {/if}

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -44,6 +44,12 @@
         with link" action — the same shape the in-Compose picker
         produces via `appendHtml`. */
     nextcloudLinks?: { filename: string; url: string }[]
+    /** Nextcloud Talk room link to render into the body as a
+        "Join the Talk room" block. Used by `TalkView`'s "Share link"
+        action and by `MailView`'s "Create Talk room from this thread"
+        action — the latter creates the room first and then opens
+        Compose to invite the participants. */
+    talkLink?: { name: string; url: string }
   }
 
   interface Props {
@@ -96,13 +102,21 @@
       its `onlinks` callback fires. */
   function initialBodyHtml(): string {
     let html = textToHtml(body)
+    const esc = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
-      const esc = (s: string) =>
-        s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
       const items = initial.nextcloudLinks
         .map((l) => `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`)
         .join('')
       html += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
+    }
+    if (initial?.talkLink) {
+      // Same block shape as the share-link block — keeps the rendered
+      // mail consistent across "Share file" and "Share Talk room"
+      // entry points.
+      html +=
+        `<p><strong>Join the Talk room:</strong></p>` +
+        `<p>💬 <a href="${initial.talkLink.url}">${esc(initial.talkLink.name)}</a></p>`
     }
     return html
   }

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -413,6 +413,31 @@
       linkLine
     editorApi?.appendHtml(block)
 
+    // Rename the auto-created Talk room to match the final event
+    // title. The room was created up-front (see `createTalkRoomSilently`)
+    // with the email subject as a placeholder name so we could prefill
+    // its URL into the event editor; once the user has typed an actual
+    // event title we rename the room so the Talk web UI shows
+    // something sensible.
+    if (
+      talkRoomToken &&
+      ncAccountId &&
+      createdTalkLink &&
+      saved.summary &&
+      saved.summary !== createdTalkLink.name
+    ) {
+      try {
+        await invoke('rename_talk_room', {
+          ncId: ncAccountId,
+          roomToken: talkRoomToken,
+          newName: saved.summary,
+        })
+        createdTalkLink = { ...createdTalkLink, name: saved.summary }
+      } catch (e) {
+        console.warn('Failed to rename Talk room:', e)
+      }
+    }
+
     if (talkRoomToken && ncAccountId) {
       for (const addr of saved.attendees) {
         const key = addr.toLowerCase()

--- a/ui/src/lib/CreateTalkRoomModal.svelte
+++ b/ui/src/lib/CreateTalkRoomModal.svelte
@@ -1,0 +1,178 @@
+<script lang="ts">
+  /**
+   * CreateTalkRoomModal — modal for creating a new Nextcloud Talk room.
+   *
+   * Two callers today:
+   *   - **TalkView's "+ New room"** — opens with empty fields.
+   *   - **MailView's "Talk" action** — opens with the email's subject as
+   *     the room name and the thread's participants (From + To + Cc)
+   *     pre-filled, satisfying issue #13's "create a Talk room from an
+   *     email thread" task.
+   *
+   * Participants are entered via the same `AddressAutocomplete` the
+   * Compose form uses, so picking from contacts works the same way.
+   * Each comma-separated address is sent to the backend as a Talk
+   * `email`-source participant — Talk emails them an invite link if
+   * the address doesn't match a Nextcloud account on the server, and
+   * promotes them to a full participant if it does. We don't need to
+   * pre-resolve which is which on the client.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+  import AddressAutocomplete from './AddressAutocomplete.svelte'
+
+  /** Mirrors the Rust `TalkRoom` Tauri-command return type. */
+  export interface TalkRoom {
+    token: string
+    display_name: string
+    room_type: 'one_to_one' | 'group' | 'public' | 'changelog' | 'other'
+    unread_messages: number
+    unread_mention: boolean
+    last_activity: number
+    web_url: string
+  }
+
+  interface Props {
+    /** Nextcloud account id to create the room under. */
+    ncId: string
+    /** Pre-fill the room name (e.g. an email subject). */
+    initialName?: string
+    /**
+     * Pre-fill participants. Each entry is a bare email address or an
+     * RFC `"Name" <addr>` string — both shapes are accepted by the
+     * same parser the EventEditor / Compose use. The backend only
+     * sees the bare address.
+     */
+    initialParticipants?: string[]
+    onclose: () => void
+    /**
+     * Fires once the room is created. Carries the freshly minted room
+     * so the caller can refresh its list and/or open Compose with
+     * the room link pre-filled.
+     */
+    oncreated: (room: TalkRoom) => void
+  }
+  const { ncId, initialName = '', initialParticipants = [], onclose, oncreated }: Props = $props()
+
+  // svelte-ignore state_referenced_locally
+  let roomName = $state(initialName)
+  // svelte-ignore state_referenced_locally
+  let participantsText = $state(initialParticipants.join(', '))
+  let creating = $state(false)
+  let error = $state('')
+
+  /**
+   * Strip an `"Name" <addr>` wrapper down to the bare address. Same
+   * shape parser as `EventEditor.parseAddress`, kept inline so this
+   * modal doesn't pull in the editor's helpers.
+   */
+  function bareEmail(piece: string): string | null {
+    const trimmed = piece.trim()
+    if (!trimmed) return null
+    const m = trimmed.match(/^\s*(?:"[^"]*"|[^<]*?)\s*<([^>]+)>\s*$/)
+    if (m) return m[1].trim()
+    return trimmed
+  }
+
+  function buildParticipants() {
+    const out: { kind: 'email'; value: string }[] = []
+    const seen = new Set<string>()
+    for (const piece of participantsText.split(/[,;]/)) {
+      const addr = bareEmail(piece)
+      if (!addr) continue
+      const key = addr.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      // Talk's `emails` source covers both NC users and external
+      // invitees: the server matches by email and promotes to a full
+      // participant if a Nextcloud user owns that address.
+      out.push({ kind: 'email', value: addr })
+    }
+    return out
+  }
+
+  async function create() {
+    error = ''
+    const name = roomName.trim()
+    if (!name) {
+      error = 'Room name is required.'
+      return
+    }
+    creating = true
+    try {
+      const room = await invoke<TalkRoom>('create_talk_room', {
+        ncId,
+        roomName: name,
+        participants: buildParticipants(),
+      })
+      oncreated(room)
+      onclose()
+    } catch (e) {
+      error = formatError(e) || 'Failed to create Talk room'
+    } finally {
+      creating = false
+    }
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
+  role="dialog"
+  aria-modal="true"
+>
+  <div class="w-[520px] max-h-[90vh] bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl flex flex-col">
+    <header class="px-5 py-3 border-b border-surface-200 dark:border-surface-700 flex items-center justify-between">
+      <h2 class="text-base font-semibold">New Talk room</h2>
+      <button
+        class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100"
+        onclick={onclose}
+        aria-label="Close"
+      >✕</button>
+    </header>
+
+    <div class="flex-1 overflow-y-auto p-5 space-y-3">
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-24 text-surface-500" for="talk-room-name">Room name</label>
+        <input
+          id="talk-room-name"
+          class="input flex-1 px-3 py-2 text-sm rounded-md"
+          bind:value={roomName}
+          placeholder="Project sync"
+          autocomplete="off"
+        />
+      </div>
+
+      <div class="flex items-start gap-2">
+        <label class="text-xs w-24 text-surface-500 pt-2" for="talk-room-participants">Invite</label>
+        <AddressAutocomplete
+          id="talk-room-participants"
+          bind:value={participantsText}
+          placeholder="alice@example.com, bob@example.com"
+        />
+      </div>
+
+      <p class="text-xs text-surface-500 pl-26">
+        Each address gets a Talk invite. Recipients with a Nextcloud account on this server join directly; others get an invite link by email.
+      </p>
+
+      {#if error}
+        <p class="text-sm text-red-500">{error}</p>
+      {/if}
+    </div>
+
+    <footer class="px-5 py-3 border-t border-surface-200 dark:border-surface-700 flex items-center gap-2">
+      <button
+        class="btn preset-filled-primary-500"
+        disabled={creating || !roomName.trim()}
+        onclick={create}
+      >
+        {creating ? 'Creating…' : 'Create room'}
+      </button>
+      <div class="flex-1"></div>
+      <button class="btn preset-outlined-surface-500" disabled={creating} onclick={onclose}>
+        Cancel
+      </button>
+    </footer>
+  </div>
+</div>

--- a/ui/src/lib/CreateTalkRoomModal.svelte
+++ b/ui/src/lib/CreateTalkRoomModal.svelte
@@ -48,10 +48,12 @@
     onclose: () => void
     /**
      * Fires once the room is created. Carries the freshly minted room
-     * so the caller can refresh its list and/or open Compose with
-     * the room link pre-filled.
+     * plus the final bare-address list of participants the user asked
+     * Talk to invite. Compose uses the participant list to copy any
+     * new addresses back into the email's To field so the invite and
+     * the room stay in sync both ways.
      */
-    oncreated: (room: TalkRoom) => void
+    oncreated: (room: TalkRoom, participantEmails: string[]) => void
   }
   const { ncId, initialName = '', initialParticipants = [], onclose, oncreated }: Props = $props()
 
@@ -101,12 +103,13 @@
     }
     creating = true
     try {
+      const participants = buildParticipants()
       const room = await invoke<TalkRoom>('create_talk_room', {
         ncId,
         roomName: name,
-        participants: buildParticipants(),
+        participants,
       })
-      oncreated(room)
+      oncreated(room, participants.map((p) => p.value))
       onclose()
     } catch (e) {
       error = formatError(e) || 'Failed to create Talk room'

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -72,15 +72,47 @@
 
   type Mode = 'create' | 'edit'
 
+  /** Payload `onsaved` carries back after a successful create. Edit /
+      delete still fire `onsaved()` with no argument — callers that
+      don't care about the payload (e.g. CalendarView) keep their
+      `() => void` handler unchanged. Compose uses this to append a
+      "📅 Meeting" block to the email body. */
+  export interface SavedEvent {
+    summary: string
+    start: string
+    end: string
+    url: string | null
+  }
+
   interface Props {
     mode: Mode
     calendars: CalendarSummary[]
-    /** create-mode seed: which calendar + which start/end to prefill. */
-    draft?: { calendarId: string; start: Date; end: Date; allDay?: boolean } | null
+    /**
+     * create-mode seed. Always carries the calendar id + start/end
+     * (from a `+ New event` click or a click-and-drag on the grid).
+     * The remaining content fields are optional prefills used by
+     * callers that want to open the editor with more than just a
+     * time slot — e.g. Compose's "Add event" action seeds summary
+     * (from the email subject), attendees (from To/Cc), and url
+     * (from a freshly created Talk room).
+     */
+    draft?: {
+      calendarId: string
+      start: Date
+      end: Date
+      allDay?: boolean
+      summary?: string
+      description?: string
+      location?: string
+      url?: string
+      /** Each entry is a bare address or `"Name" <addr>` — same
+          shape `parseAddress` accepts everywhere else. */
+      attendees?: string[]
+    } | null
     /** edit-mode subject: the existing event being edited. */
     event?: CalendarEvent | null
     onclose: () => void
-    onsaved: () => void
+    onsaved: (saved?: SavedEvent) => void
   }
   const { mode, calendars, draft, event, onclose, onsaved }: Props = $props()
 
@@ -90,13 +122,13 @@
   // `$state` cells, so further changes to the prop don't clobber the
   // user's typing.
   // svelte-ignore state_referenced_locally
-  let summary = $state(event?.summary ?? '')
+  let summary = $state(event?.summary ?? draft?.summary ?? '')
   // svelte-ignore state_referenced_locally
-  let description = $state(event?.description ?? '')
+  let description = $state(event?.description ?? draft?.description ?? '')
   // svelte-ignore state_referenced_locally
-  let location = $state(event?.location ?? '')
+  let location = $state(event?.location ?? draft?.location ?? '')
   // svelte-ignore state_referenced_locally
-  let url = $state(event?.url ?? '')
+  let url = $state(event?.url ?? draft?.url ?? '')
   // svelte-ignore state_referenced_locally
   let transparency = $state(event?.transparency ?? 'OPAQUE')
 
@@ -141,7 +173,9 @@
   // email at save time.
   // svelte-ignore state_referenced_locally
   let attendeesText = $state(
-    (event?.attendees ?? []).map(formatAddressForInput).join(', '),
+    event
+      ? (event.attendees ?? []).map(formatAddressForInput).join(', ')
+      : (draft?.attendees ?? []).join(', '),
   )
   // svelte-ignore state_referenced_locally
   const originalAttendees = event?.attendees ?? []
@@ -345,10 +379,16 @@
     try {
       if (mode === 'create') {
         await invoke('create_calendar_event', { calendarId, input })
+        onsaved({
+          summary: input.summary,
+          start: input.start,
+          end: input.end,
+          url: input.url,
+        })
       } else if (event) {
         await invoke('update_calendar_event', { eventId: event.id, input })
+        onsaved()
       }
-      onsaved()
       onclose()
     } catch (e) {
       error = formatError(e) || 'Failed to save event'

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -82,6 +82,10 @@
     start: string
     end: string
     url: string | null
+    /** Bare-address list of everyone invited to the event — Compose
+        uses this to merge any newly added addresses back into the
+        email's To field so the invite and the mail stay in sync. */
+    attendees: string[]
   }
 
   interface Props {
@@ -384,6 +388,7 @@
           start: input.start,
           end: input.end,
           url: input.url,
+          attendees: input.attendees.map((a) => a.email),
         })
       } else if (event) {
         await invoke('update_calendar_event', { eventId: event.id, input })

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -51,6 +51,10 @@
     onreply?: (mail: Email) => void
     onreplyall?: (mail: Email) => void
     onforward?: (mail: Email) => void
+    /** Open the "Create Talk room" flow seeded from this email's
+        subject + thread participants. Wired from `App.svelte` so the
+        resulting Compose window stacks on top of the inbox view. */
+    oncreatetalk?: (mail: Email) => void
   }
   let {
     accountId,
@@ -60,6 +64,7 @@
     onreply,
     onreplyall,
     onforward,
+    oncreatetalk,
   }: Props = $props()
 
   let email = $state<Email | null>(null)
@@ -358,6 +363,13 @@
       <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreply?.(email)}>Reply</button>
       <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreplyall?.(email)}>Reply All</button>
       <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onforward?.(email)}>Forward</button>
+      {#if oncreatetalk}
+        <button
+          class="btn btn-sm preset-outlined-primary-500"
+          onclick={() => email && oncreatetalk?.(email)}
+          title="Create a Nextcloud Talk room with the participants of this thread"
+        >💬 Talk</button>
+      {/if}
       <div class="flex-1"></div>
       <button class="btn btn-sm preset-outlined-surface-500">Archive</button>
       <button class="btn btn-sm preset-outlined-surface-500">Delete</button>

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -11,6 +11,7 @@
    */
 
   import { invoke } from '@tauri-apps/api/core'
+  import { onDestroy } from 'svelte'
   import { formatError } from './errors'
 
   interface Folder {
@@ -18,6 +19,14 @@
     delimiter: string | null
     attributes: string[]
     unread_count: number | null
+  }
+
+  /** Slim shape of a Talk room — only the fields we need for the
+      aggregate unread badge. Avoids importing TalkView's type so the
+      sidebar stays decoupled from the Talk view. */
+  interface TalkRoomSummary {
+    unread_messages: number
+    unread_mention: boolean
   }
 
   interface Props {
@@ -50,6 +59,16 @@
   let refreshing = $state(false)
   let error = $state('')
 
+  // Aggregate unread state across all Talk rooms on the user's first
+  // Nextcloud account. Drives the badge on the "Nextcloud Talk"
+  // integration entry — no count means no badge, mention means the
+  // badge gets the louder error tint. Polled on a 30s timer so the
+  // user gets a relatively prompt nudge when something new arrives.
+  let talkUnreadTotal = $state(0)
+  let talkUnreadHasMention = $state(false)
+  const TALK_POLL_MS = 30_000
+  let talkPollTimer: number | null = null
+
   // Integrations are still hardcoded — those are planned features, not
   // derived from the mail server.
   const integrations = [
@@ -65,6 +84,52 @@
     refreshToken
     void load(accountId)
   })
+
+  // Talk-unread polling lives in its own lifecycle: started once on
+  // mount and torn down on destroy. We don't tie it to `accountId`
+  // because the Talk badge follows the *Nextcloud* account, not the
+  // mail account — those can change independently.
+  $effect(() => {
+    void refreshTalkBadge()
+    talkPollTimer = window.setInterval(refreshTalkBadge, TALK_POLL_MS)
+    return () => {
+      if (talkPollTimer !== null) window.clearInterval(talkPollTimer)
+      talkPollTimer = null
+    }
+  })
+
+  onDestroy(() => {
+    if (talkPollTimer !== null) window.clearInterval(talkPollTimer)
+  })
+
+  /**
+   * Pull the latest Talk room list from the first connected Nextcloud
+   * account and aggregate the unread counts. Errors are swallowed —
+   * a flaky badge shouldn't block the rest of the sidebar from working.
+   */
+  async function refreshTalkBadge() {
+    try {
+      const accounts = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      if (accounts.length === 0) {
+        talkUnreadTotal = 0
+        talkUnreadHasMention = false
+        return
+      }
+      const rooms = await invoke<TalkRoomSummary[]>('list_talk_rooms', {
+        ncId: accounts[0].id,
+      })
+      let total = 0
+      let mention = false
+      for (const r of rooms) {
+        total += r.unread_messages
+        if (r.unread_mention && r.unread_messages > 0) mention = true
+      }
+      talkUnreadTotal = total
+      talkUnreadHasMention = mention
+    } catch (e) {
+      console.warn('Talk unread poll failed:', e)
+    }
+  }
 
   async function load(id: string) {
     loading = true
@@ -198,6 +263,13 @@
       >
         <span>{item.icon}</span>
         <span class="flex-1 text-left">{item.name}</span>
+        {#if item.name === 'Nextcloud Talk' && talkUnreadTotal > 0}
+          <span
+            class="badge text-xs
+                   {talkUnreadHasMention ? 'preset-filled-error-500' : 'preset-filled-primary-500'}"
+            title={talkUnreadHasMention ? 'You were mentioned' : 'Unread Talk messages'}
+          >{talkUnreadTotal}</span>
+        {/if}
       </button>
     {/each}
   </nav>

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+  /**
+   * TalkView — sidebar-routed full-pane Nextcloud Talk room list.
+   *
+   * Mirrors `FilesView`'s shape (header + scrollable body + footer)
+   * so the integration views feel like one app. Three actions per
+   * room: open in browser, share link in email, and (at the top)
+   * "+ New room" to create a fresh one.
+   *
+   * # Why we don't cache rooms
+   *
+   * Talk's `/room` endpoint is cheap (few KB) and unread counts go
+   * stale the second a colleague sends a message. We refetch on a
+   * 30s timer plus on focus, and on demand via the refresh button.
+   * No SQLite layer — the room list is purely a UI cache.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { onDestroy, onMount } from 'svelte'
+  import { formatError } from './errors'
+  import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
+  import type { ComposeInitial } from './Compose.svelte'
+
+  interface NextcloudAccount {
+    id: string
+    server_url: string
+    username: string
+    display_name?: string | null
+  }
+
+  interface Props {
+    onclose: () => void
+    /** Open Compose with the given prefill (used for "Share link"). */
+    oncompose: (initial: ComposeInitial) => void
+  }
+  const { onclose, oncompose }: Props = $props()
+
+  let accounts = $state<NextcloudAccount[]>([])
+  let accountId = $state('')
+  let rooms = $state<TalkRoom[]>([])
+  let loading = $state(false)
+  let error = $state('')
+  let showCreate = $state(false)
+
+  // Periodic refresh — 30s is the same cadence the Nextcloud web UI
+  // polls at. Long enough to be cheap, short enough that the unread
+  // counts don't lie for more than half a minute.
+  const REFRESH_INTERVAL_MS = 30_000
+  let pollTimer: number | null = null
+
+  onMount(async () => {
+    await loadAccounts()
+  })
+
+  onDestroy(() => {
+    if (pollTimer !== null) window.clearInterval(pollTimer)
+  })
+
+  async function loadAccounts() {
+    try {
+      const list = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
+      accounts = list
+      if (list.length === 1 && !accountId) {
+        accountId = list[0].id
+        await refresh()
+        startPolling()
+      }
+    } catch (e) {
+      error = formatError(e) || 'Failed to load Nextcloud accounts'
+    }
+  }
+
+  async function selectAccount(id: string) {
+    accountId = id
+    rooms = []
+    await refresh()
+    startPolling()
+  }
+
+  function startPolling() {
+    if (pollTimer !== null) window.clearInterval(pollTimer)
+    pollTimer = window.setInterval(() => {
+      // Silent refresh — don't flash the loading indicator on the
+      // periodic ticks. Errors stay quiet too; the next tick retries.
+      void refresh({ silent: true })
+    }, REFRESH_INTERVAL_MS)
+  }
+
+  async function refresh(opts: { silent?: boolean } = {}) {
+    if (!accountId) return
+    if (!opts.silent) loading = true
+    if (!opts.silent) error = ''
+    try {
+      const list = await invoke<TalkRoom[]>('list_talk_rooms', { ncId: accountId })
+      // Sort by last activity desc so the freshest conversation is on
+      // top. Rooms with zero last_activity (newly created, no messages
+      // yet) sink to the bottom.
+      list.sort((a, b) => b.last_activity - a.last_activity)
+      rooms = list
+    } catch (e) {
+      if (!opts.silent) error = formatError(e) || 'Failed to load Talk rooms'
+    } finally {
+      if (!opts.silent) loading = false
+    }
+  }
+
+  function openRoom(room: TalkRoom) {
+    void invoke('open_url', { url: room.web_url })
+  }
+
+  /**
+   * Open Compose with a "Join the Talk room: <link>" block in the
+   * body. Reuses the same `ComposeInitial.talkLink` field that the
+   * MailView "Talk" action populates — the rendered HTML lives in
+   * Compose's `initialBodyHtml` so the format stays consistent.
+   */
+  function shareRoom(room: TalkRoom) {
+    oncompose({
+      subject: `Join Talk: ${room.display_name}`,
+      talkLink: { name: room.display_name, url: room.web_url },
+    })
+  }
+
+  function onRoomCreated(room: TalkRoom) {
+    // Optimistically prepend the new room — the next periodic refresh
+    // (or the user's manual refresh) will reconcile any drift.
+    rooms = [room, ...rooms.filter((r) => r.token !== room.token)]
+  }
+
+  function formatRelative(unix: number): string {
+    if (!unix) return ''
+    const now = Date.now() / 1000
+    const delta = now - unix
+    if (delta < 60) return 'just now'
+    if (delta < 3600) return `${Math.floor(delta / 60)}m ago`
+    if (delta < 86400) return `${Math.floor(delta / 3600)}h ago`
+    if (delta < 7 * 86400) return `${Math.floor(delta / 86400)}d ago`
+    return new Date(unix * 1000).toLocaleDateString()
+  }
+
+  function roomTypeIcon(t: TalkRoom['room_type']): string {
+    if (t === 'one_to_one') return '\u{1F464}' // 👤
+    if (t === 'public') return '\u{1F310}' // 🌐
+    if (t === 'changelog') return '\u{1F4DC}' // 📜
+    return '\u{1F465}' // 👥
+  }
+</script>
+
+<div class="h-full flex flex-col bg-surface-50 dark:bg-surface-900">
+  <div
+    class="flex items-center justify-between px-6 py-3 border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800"
+  >
+    <h2 class="text-xl font-semibold">Talk Rooms</h2>
+    <div class="flex items-center gap-2">
+      <button
+        class="btn preset-filled-primary-500 text-sm"
+        disabled={!accountId}
+        onclick={() => (showCreate = true)}
+      >+ New room</button>
+      <button
+        class="btn preset-tonal-surface text-sm"
+        disabled={!accountId || loading}
+        onclick={() => refresh()}
+        title="Refresh room list"
+      >{loading ? 'Refreshing…' : '↻ Refresh'}</button>
+      <button class="btn preset-tonal-surface text-sm" onclick={onclose}>Close</button>
+    </div>
+  </div>
+
+  {#if accounts.length === 0}
+    <div class="p-6 text-sm text-surface-500">
+      No Nextcloud account connected. Add one under
+      <strong>Settings → Nextcloud</strong> first.
+    </div>
+  {:else}
+    {#if accounts.length > 1}
+      <div class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
+        <label for="talk-account" class="text-xs text-surface-500">Account</label>
+        <select
+          id="talk-account"
+          class="select text-sm"
+          value={accountId}
+          onchange={(e) => selectAccount((e.target as HTMLSelectElement).value)}
+        >
+          <option value="" disabled>Choose an account</option>
+          {#each accounts as acc (acc.id)}
+            <option value={acc.id}>{acc.display_name ?? acc.username} ({acc.server_url})</option>
+          {/each}
+        </select>
+      </div>
+    {/if}
+
+    {#if error}
+      <p class="px-5 py-2 text-sm text-red-500">{error}</p>
+    {/if}
+
+    {#if !accountId}
+      <p class="p-6 text-sm text-surface-500">Pick an account to view its Talk rooms.</p>
+    {:else if loading && rooms.length === 0}
+      <p class="p-6 text-sm text-surface-500">Loading rooms…</p>
+    {:else if rooms.length === 0}
+      <div class="p-6 text-sm text-surface-500">
+        No Talk rooms yet. Click <strong>+ New room</strong> to start your first conversation.
+      </div>
+    {:else}
+      <ul class="flex-1 overflow-y-auto divide-y divide-surface-200 dark:divide-surface-800">
+        {#each rooms as room (room.token)}
+          <li class="px-5 py-3 flex items-center gap-3 hover:bg-surface-100 dark:hover:bg-surface-800">
+            <span class="text-xl flex-shrink-0">{roomTypeIcon(room.room_type)}</span>
+
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="font-medium truncate">{room.display_name}</span>
+                {#if room.unread_messages > 0}
+                  <span
+                    class="badge text-xs flex-shrink-0
+                           {room.unread_mention ? 'preset-filled-error-500' : 'preset-filled-primary-500'}"
+                    title={room.unread_mention ? 'You were mentioned' : 'Unread messages'}
+                  >{room.unread_messages}</span>
+                {/if}
+              </div>
+              <p class="text-xs text-surface-500 truncate">
+                {formatRelative(room.last_activity)}
+              </p>
+            </div>
+
+            <button
+              class="btn preset-outlined-surface-500 text-xs"
+              onclick={() => shareRoom(room)}
+              title="Open a new mail with this room's join link"
+            >🔗 Share link</button>
+            <button
+              class="btn preset-filled-primary-500 text-xs"
+              onclick={() => openRoom(room)}
+              title="Open this Talk room in your browser"
+            >Open ↗</button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {/if}
+</div>
+
+{#if showCreate && accountId}
+  <CreateTalkRoomModal
+    ncId={accountId}
+    onclose={() => (showCreate = false)}
+    oncreated={onRoomCreated}
+  />
+{/if}


### PR DESCRIPTION
## Summary
- Closes #13 — full Nextcloud Talk integration (the flagship differentiator).
- Backend: `nimbus-nextcloud::talk` REST client (`list_rooms`, `create_room`, `add_participant`) over `/ocs/v2.php/apps/spreed/api/v4/`, with OCS-envelope error surfacing modelled on `shares.rs`. Tauri commands wire it up.
- Frontend: full-pane `TalkView` with 30s polling, account picker, unread badges, and share/open actions; reusable `CreateTalkRoomModal`; "Talk" action in `MailView` prefills participants from the email's recipients; Compose `talkLink` prefill renders a "Join the Talk room" block; Sidebar shows aggregate Talk unread badge on the integration entry.

## Test plan
- [x] `cargo build --workspace` clean
- [x] `npm run check` clean (1 pre-existing a11y warning in `RichTextEditor.svelte`)
- [x] 5 new unit tests in `talk.rs` cover happy path, OCS failures, bad JSON, and unknown room types
- [ ] Manual: open Talk view from sidebar, create a new room, send share link via Compose, open existing room in browser
- [ ] Manual: trigger "💬 Talk" from a reading-pane message — verify modal pre-populates participants from To/Cc and post-create Compose has the room link
- [ ] Manual: confirm sidebar badge appears (and turns red on mention) within 30s of a new unread message

🤖 Generated with [Claude Code](https://claude.com/claude-code)