### PR TITLE
Multi-account: finish wiring (switcher, unified inbox, from-picker, s…

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -57,6 +57,11 @@ pub struct Account {
     /// during account setup if the server supports `.well-known/jmap`.
     #[serde(default)]
     pub jmap_url: Option<String>,
+    /// Optional plain-text signature appended below new messages
+    /// composed from this account. Empty/None = no signature. The
+    /// frontend renders the standard `-- ` separator before it.
+    #[serde(default)]
+    pub signature: Option<String>,
 }
 
 /// Lightweight email metadata for list views.
@@ -76,6 +81,16 @@ pub struct EmailEnvelope {
     pub date: DateTime<Utc>,
     pub is_read: bool,
     pub is_starred: bool,
+    /// Owning account id. Populated when envelopes are read out of the
+    /// cache (where `account_id` is a column on every row) so the UI
+    /// can render an account label in unified-inbox mode and route the
+    /// "open message" click to the right account. IMAP/JMAP clients
+    /// don't know their own account id, so they leave this empty —
+    /// the cache write-through stamps it from the call site, and the
+    /// cache read paths fill it back in. `#[serde(default)]` keeps
+    /// older cached payloads parsing cleanly.
+    #[serde(default)]
+    pub account_id: String,
 }
 
 /// Represents an email message.

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -305,6 +305,11 @@ impl ImapClient {
                     date,
                     is_read,
                     is_starred,
+                    // The IMAP client doesn't carry the account id; the
+                    // caller stamps it into the cache via
+                    // `upsert_envelopes_for_account`, and cache reads
+                    // populate the field on the way back out.
+                    account_id: String::new(),
                 })
             })
             .collect();
@@ -717,6 +722,7 @@ impl ImapClient {
                     date,
                     is_read,
                     is_starred,
+                    account_id: String::new(),
                 })
             })
             .collect();

--- a/crates/nimbus-jmap/src/client.rs
+++ b/crates/nimbus-jmap/src/client.rs
@@ -343,6 +343,9 @@ impl JmapClient {
                     date,
                     is_read,
                     is_starred,
+                    // Stamped into the cache by the caller; left empty
+                    // here for the same reason as the IMAP path.
+                    account_id: String::new(),
                 }
             })
             .collect();

--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -143,6 +143,7 @@ mod tests {
             smtp_port: 587,
             use_jmap: false,
             jmap_url: None,
+            signature: None,
         }
     }
 

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -337,6 +337,46 @@ impl Cache {
                 date,
                 is_read: r.get::<_, i64>(5)? != 0,
                 is_starred: r.get::<_, i64>(6)? != 0,
+                account_id: account_id.to_string(),
+            })
+        })?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Return the newest `limit` envelopes in `folder` across **all**
+    /// accounts. Powers the unified-inbox view: each row carries its
+    /// owning `account_id` so the UI can render an account label and
+    /// route the "open message" click to the right account.
+    pub fn get_unified_envelopes(
+        &self,
+        folder: &str,
+        limit: u32,
+    ) -> Result<Vec<EmailEnvelope>, CacheError> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT account_id, uid, folder, from_addr, subject, internal_date, is_read, is_starred
+             FROM messages
+             WHERE folder = ?1
+             ORDER BY internal_date DESC
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![folder, limit as i64], |r| {
+            let ts: i64 = r.get(5)?;
+            let date = Utc.timestamp_opt(ts, 0).single().unwrap_or_else(Utc::now);
+            Ok(EmailEnvelope {
+                account_id: r.get(0)?,
+                uid: r.get::<_, i64>(1)? as u32,
+                folder: r.get(2)?,
+                from: r.get(3)?,
+                subject: r.get(4)?,
+                date,
+                is_read: r.get::<_, i64>(6)? != 0,
+                is_starred: r.get::<_, i64>(7)? != 0,
             })
         })?;
 
@@ -658,6 +698,7 @@ mod tests {
             date: Utc::now() - Duration::minutes(offset_min),
             is_read: false,
             is_starred: false,
+            account_id: String::new(),
         }
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1517,6 +1517,26 @@ async fn fetch_envelopes_inner(
         .map_err(Into::into)
 }
 
+/// Unified-inbox version of `fetch_envelopes`: polls every configured
+/// account's `folder` (sequentially — keeps the SMTP/IMAP server load
+/// predictable) and then returns the merged newest-`limit` view from
+/// the cache. A poll failure on one account is logged and skipped so a
+/// single broken account doesn't blank the unified list.
+#[tauri::command]
+async fn fetch_unified_envelopes(
+    folder: String,
+    limit: u32,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, NimbusError> {
+    let accounts = account_store::load_accounts().unwrap_or_default();
+    for account in &accounts {
+        if let Err(e) = poll_folder(account, &folder, limit, &cache).await {
+            tracing::warn!("unified poll failed for '{}': {e}", account.id);
+        }
+    }
+    cache.get_unified_envelopes(&folder, limit).map_err(Into::into)
+}
+
 /// Outcome of polling a single folder — used by both the user-facing
 /// `fetch_envelopes` command and the background sync loop.
 ///
@@ -1853,6 +1873,18 @@ fn get_cached_envelopes(
     cache
         .get_envelopes(&account_id, &folder, limit)
         .map_err(Into::into)
+}
+
+/// Cache-only sibling of `fetch_unified_envelopes` — returns the merged
+/// newest-`limit` envelopes across all accounts without hitting the
+/// network. Powers the instant first-paint of the unified inbox.
+#[tauri::command]
+fn get_unified_cached_envelopes(
+    folder: String,
+    limit: u32,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, NimbusError> {
+    cache.get_unified_envelopes(&folder, limit).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -2516,12 +2548,14 @@ fn main() {
             update_account,
             test_connection,
             fetch_envelopes,
+            fetch_unified_envelopes,
             fetch_message,
             download_email_attachment,
             fetch_folders,
             mark_as_read,
             send_email,
             get_cached_envelopes,
+            get_unified_cached_envelopes,
             get_cached_message,
             get_cached_folders,
             test_jmap_connection,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -56,11 +56,32 @@
   let activeIntegration = $state<string | null>(null)
 
   // ── Inbox state ─────────────────────────────────────────────
-  // The active account (first configured one for now — multi-account
-  // switching comes later) and the currently selected message UID.
-  // Kept at the App level so MailList and MailView stay in sync.
+  // All configured mail accounts and which one the user is currently
+  // looking at. Kept at the App level so Sidebar / MailList / MailView
+  // stay in sync when the user switches accounts. `activeAccountEmail`
+  // is derived from the list so it stays consistent if an account's
+  // email is edited in settings.
+  interface Account {
+    id: string
+    display_name: string
+    email: string
+  }
+  let accounts = $state<Account[]>([])
   let activeAccountId = $state<string | null>(null)
-  let activeAccountEmail = $state<string>('')
+  const activeAccountEmail = $derived(
+    accounts.find((a) => a.id === activeAccountId)?.email ?? '',
+  )
+  // Unified-inbox mode: when on, MailList aggregates INBOX across all
+  // accounts. `activeAccountId` stays pointed at a real account so the
+  // sidebar's folder tree, integrations, and default Compose-from
+  // continue to have a sensible "current account" — the unified view
+  // is an overlay on top, not a replacement for the active account.
+  let unifiedMode = $state(false)
+  // The account a clicked message belongs to. In single-account mode
+  // this just shadows `activeAccountId`; in unified mode it's set from
+  // the row's `account_id` so MailView opens the right message even
+  // though the folder picker isn't pointing at that account.
+  let selectedMessageAccountId = $state<string | null>(null)
   // Compose modal: `null` = closed. When open, carries a (possibly empty)
   // initial prefill for reply / reply-all / forward.
   let composeInitial = $state<ComposeInitial | null>(null)
@@ -233,17 +254,26 @@
 
   async function checkAccounts() {
     try {
-      const accounts = await invoke<Array<{ id: string; email: string }>>('get_accounts')
-      if (accounts.length > 0) {
-        activeAccountId = accounts[0].id
-        activeAccountEmail = accounts[0].email
+      const list = await invoke<Account[]>('get_accounts')
+      accounts = list
+      if (list.length > 0) {
+        // Keep the current selection if it still exists (e.g. after
+        // adding another account); otherwise fall back to the first.
+        // This also handles the "active account was just removed"
+        // case from AccountSettings.
+        if (!activeAccountId || !list.some((a) => a.id === activeAccountId)) {
+          activeAccountId = list[0].id
+        }
         currentView = 'inbox'
       } else {
+        activeAccountId = null
         currentView = 'setup'
       }
     } catch {
       // If we can't load accounts (e.g. first launch, file doesn't exist),
       // show the setup wizard
+      accounts = []
+      activeAccountId = null
       currentView = 'setup'
     }
   }
@@ -252,6 +282,49 @@
   function goToInbox() {
     currentView = 'inbox'
     activeIntegration = null
+    // The user may have added / removed accounts in settings; re-read
+    // the list so the sidebar switcher and the active selection reflect
+    // the current state.
+    void checkAccounts()
+  }
+
+  /**
+   * Switch the app to a different mail account. Called by the Sidebar
+   * account picker. IMAP UIDs are per-account so keeping `selectedUid`
+   * would point at a message that doesn't exist in the new account;
+   * resetting folder → INBOX keeps the landing experience predictable.
+   * Also clears search state because the query was scoped to the old
+   * account.
+   *
+   * The sentinel `"__all__"` toggles `unifiedMode` instead of changing
+   * the active account — `activeAccountId` stays pointed at whatever
+   * the user had before so the sidebar folder tree and integrations
+   * still have a sensible default. Pinging back into a real account
+   * id automatically turns unified mode off.
+   */
+  function selectAccount(id: string) {
+    if (id === '__all__') {
+      if (unifiedMode) return
+      unifiedMode = true
+      selectedFolder = 'INBOX'
+      selectedUid = null
+      selectedMessageAccountId = null
+      searchQuery = ''
+      searchScope = {}
+      searchFilters = {}
+      refreshToken++
+      return
+    }
+    if (!unifiedMode && id === activeAccountId) return
+    unifiedMode = false
+    activeAccountId = id
+    selectedFolder = 'INBOX'
+    selectedUid = null
+    selectedMessageAccountId = null
+    searchQuery = ''
+    searchScope = {}
+    searchFilters = {}
+    refreshToken++
   }
 
   function goToSetup() {
@@ -288,8 +361,12 @@
     currentView = 'inbox'
   }
 
-  function selectMessage(uid: number) {
+  function selectMessage(uid: number, accountId?: string) {
     selectedUid = uid
+    // Unified mode: each row carries its owning account id so MailView
+    // can fetch from the right account. Outside unified mode, the
+    // active account is implicit.
+    selectedMessageAccountId = accountId ?? null
   }
 
   // Changing the folder resets the open message — the UID that was
@@ -477,10 +554,12 @@
 {:else if currentView === 'contacts' && activeAccountId}
   <div class="h-full flex">
     <Sidebar
+      accounts={accounts}
       accountId={activeAccountId}
       selectedFolder={selectedFolder}
       refreshToken={refreshToken}
       activeIntegration={activeIntegration}
+      onselectaccount={selectAccount}
       onselectfolder={(f) => {
         selectFolder(f)
         goToInbox()
@@ -500,10 +579,12 @@
 {:else if currentView === 'calendar' && activeAccountId}
   <div class="h-full flex">
     <Sidebar
+      accounts={accounts}
       accountId={activeAccountId}
       selectedFolder={selectedFolder}
       refreshToken={refreshToken}
       activeIntegration={activeIntegration}
+      onselectaccount={selectAccount}
       onselectfolder={(f) => {
         selectFolder(f)
         goToInbox()
@@ -526,10 +607,12 @@
 {:else if currentView === 'files' && activeAccountId}
   <div class="h-full flex">
     <Sidebar
+      accounts={accounts}
       accountId={activeAccountId}
       selectedFolder={selectedFolder}
       refreshToken={refreshToken}
       activeIntegration={activeIntegration}
+      onselectaccount={selectAccount}
       onselectfolder={(f) => {
         selectFolder(f)
         goToInbox()
@@ -544,8 +627,8 @@
     </div>
     {#if composeInitial !== null}
       <Compose
+        accounts={accounts}
         accountId={activeAccountId}
-        fromAddress={activeAccountEmail}
         initial={composeInitial}
         onclose={closeCompose}
       />
@@ -558,10 +641,12 @@
 {:else if currentView === 'talk' && activeAccountId}
   <div class="h-full flex">
     <Sidebar
+      accounts={accounts}
       accountId={activeAccountId}
       selectedFolder={selectedFolder}
       refreshToken={refreshToken}
       activeIntegration={activeIntegration}
+      onselectaccount={selectAccount}
       onselectfolder={(f) => {
         selectFolder(f)
         goToInbox()
@@ -576,8 +661,8 @@
     </div>
     {#if composeInitial !== null}
       <Compose
+        accounts={accounts}
         accountId={activeAccountId}
-        fromAddress={activeAccountEmail}
         initial={composeInitial}
         onclose={closeCompose}
       />
@@ -588,10 +673,13 @@
 {:else if activeAccountId}
   <div class="h-full flex">
     <Sidebar
+      accounts={accounts}
       accountId={activeAccountId}
       selectedFolder={selectedFolder}
       refreshToken={refreshToken}
       activeIntegration={activeIntegration}
+      unified={unifiedMode}
+      onselectaccount={selectAccount}
       onselectfolder={selectFolder}
       onsettings={goToSettings}
       onrefresh={refreshAll}
@@ -599,7 +687,10 @@
       onselectintegration={onSelectIntegration}
     />
     <!-- Mail-list column: SearchBar on top, then either MailList
-         or SearchResults depending on whether the user is searching. -->
+         or SearchResults depending on whether the user is searching.
+         Search isn't wired for unified mode yet — searching while
+         unified is enabled scopes back to the active account, which
+         is the safer default than silently returning nothing. -->
     <div class="flex flex-col w-80 shrink-0 border-r border-surface-200 dark:border-surface-700">
       <SearchBar
         accountId={activeAccountId}
@@ -619,8 +710,10 @@
           />
         {:else}
           <MailList
+            accounts={accounts}
             accountId={activeAccountId}
             folder={selectedFolder}
+            unified={unifiedMode}
             selectedUid={selectedUid}
             refreshToken={refreshToken}
             onselect={selectMessage}
@@ -629,7 +722,7 @@
       </div>
     </div>
     <MailView
-      accountId={activeAccountId}
+      accountId={selectedMessageAccountId ?? activeAccountId}
       folder={selectedFolder}
       uid={selectedUid}
       onread={onMessageRead}
@@ -640,8 +733,8 @@
     />
     {#if composeInitial !== null}
       <Compose
+        accounts={accounts}
         accountId={activeAccountId}
-        fromAddress={activeAccountEmail}
         initial={composeInitial}
         onclose={closeCompose}
       />

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -21,6 +21,8 @@
     smtp_host: string
     smtp_port: number
     use_jmap: boolean
+    jmap_url?: string | null
+    signature?: string | null
   }
 
   // ── Props ───────────────────────────────────────────────────
@@ -128,6 +130,40 @@
     } catch (e: any) {
       error = typeof e === 'string' ? e : e?.message ?? 'Failed to remove account'
     }
+  }
+
+  // ── Signature editing ───────────────────────────────────────
+  // The signature lives directly on the `Account` row. Edits are
+  // debounced like the app preferences so dragging through a long
+  // textarea doesn't write to disk on every keystroke.
+  const sigSaveTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const sigSaveStatus = $state<Record<string, '' | 'saving' | 'saved' | 'error'>>({})
+
+  function onSignatureChange(account: Account, next: string) {
+    account.signature = next
+    sigSaveStatus[account.id] = 'saving'
+    const existing = sigSaveTimers.get(account.id)
+    if (existing) clearTimeout(existing)
+    sigSaveTimers.set(
+      account.id,
+      setTimeout(async () => {
+        try {
+          // The Rust `update_account` takes the full Account record;
+          // sending the in-place edited copy is fine because we never
+          // mutate fields the user can't edit here (host/port/etc).
+          await invoke('update_account', {
+            account: { ...account, signature: next.trim() || null },
+          })
+          sigSaveStatus[account.id] = 'saved'
+          setTimeout(() => {
+            if (sigSaveStatus[account.id] === 'saved') sigSaveStatus[account.id] = ''
+          }, 1500)
+        } catch (e) {
+          console.warn('failed to save signature', e)
+          sigSaveStatus[account.id] = 'error'
+        }
+      }, 400),
+    )
   }
 </script>
 
@@ -242,25 +278,48 @@
     {:else}
       <!-- Account list -->
       <div class="space-y-4">
-        {#each accounts as account}
-          <div class="card p-4 bg-surface-100 dark:bg-surface-800 rounded-lg flex items-start justify-between">
-            <div>
-              <p class="font-semibold">{account.display_name}</p>
-              <p class="text-sm text-surface-500">{account.email}</p>
-              <div class="text-xs text-surface-400 mt-2 space-y-0.5">
-                <p>IMAP: {account.imap_host}:{account.imap_port}</p>
-                <p>SMTP: {account.smtp_host}:{account.smtp_port}</p>
-                {#if account.use_jmap}
-                  <p class="text-primary-500">JMAP enabled</p>
+        {#each accounts as account (account.id)}
+          <div class="card p-4 bg-surface-100 dark:bg-surface-800 rounded-lg">
+            <div class="flex items-start justify-between">
+              <div>
+                <p class="font-semibold">{account.display_name}</p>
+                <p class="text-sm text-surface-500">{account.email}</p>
+                <div class="text-xs text-surface-400 mt-2 space-y-0.5">
+                  <p>IMAP: {account.imap_host}:{account.imap_port}</p>
+                  <p>SMTP: {account.smtp_host}:{account.smtp_port}</p>
+                  {#if account.use_jmap}
+                    <p class="text-primary-500">JMAP enabled</p>
+                  {/if}
+                </div>
+              </div>
+              <button
+                class="btn btn-sm preset-outlined-error-500"
+                onclick={() => removeAccount(account.id, account.email)}
+              >
+                Remove
+              </button>
+            </div>
+
+            <div class="mt-4 pt-4 border-t border-surface-200 dark:border-surface-700">
+              <div class="flex items-center justify-between mb-1">
+                <label class="text-sm font-medium" for="sig-{account.id}">Signature</label>
+                {#if sigSaveStatus[account.id] === 'saving'}
+                  <span class="text-xs text-surface-400">Saving…</span>
+                {:else if sigSaveStatus[account.id] === 'saved'}
+                  <span class="text-xs text-success-500">Saved</span>
+                {:else if sigSaveStatus[account.id] === 'error'}
+                  <span class="text-xs text-error-500">Save failed</span>
                 {/if}
               </div>
+              <textarea
+                id="sig-{account.id}"
+                rows="4"
+                value={account.signature ?? ''}
+                oninput={(e) => onSignatureChange(account, (e.currentTarget as HTMLTextAreaElement).value)}
+                placeholder="Appended to new messages sent from this account."
+                class="input w-full px-3 py-2 rounded-md font-mono text-sm"
+              ></textarea>
             </div>
-            <button
-              class="btn btn-sm preset-outlined-error-500"
-              onclick={() => removeAccount(account.id, account.email)}
-            >
-              Remove
-            </button>
           </div>
         {/each}
       </div>

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -40,6 +40,10 @@
   let smtpHost = $state('')
   let smtpPort = $state(587)    // 587 = standard SMTP submission port
   let useJmap = $state(false)
+  // Optional plain-text signature appended below new messages from
+  // this account. Empty string = no signature; the backend stores it
+  // as Option<String>.
+  let signature = $state('')
 
   // ── Step navigation ─────────────────────────────────────────
   const totalSteps = 3
@@ -114,6 +118,7 @@
           smtp_host: smtpHost.trim(),
           smtp_port: smtpPort,
           use_jmap: useJmap,
+          signature: signature.trim() || null,
         },
         password,
       })
@@ -250,6 +255,19 @@
             <input type="checkbox" bind:checked={useJmap} class="checkbox" />
             <span class="text-sm text-surface-700 dark:text-surface-300">
               Use JMAP instead of IMAP (if supported by your provider)
+            </span>
+          </label>
+
+          <label class="block mb-4">
+            <span class="text-sm font-medium text-surface-700 dark:text-surface-300">Signature (optional)</span>
+            <textarea
+              bind:value={signature}
+              rows="4"
+              placeholder={`Jane Doe\nProduct Manager · Example Corp\n+1 555 0100`}
+              class="input w-full mt-1 px-3 py-2 rounded-md font-mono text-sm"
+            ></textarea>
+            <span class="block text-xs text-surface-500 mt-1">
+              Appended to new messages sent from this account. You can change it later in Settings.
             </span>
           </label>
         </div>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -29,6 +29,14 @@
   interface NextcloudAccount {
     id: string
   }
+  /** Mail account row for the From: picker. Mirrors the public fields
+      of the Rust `Account` we actually consume here. */
+  interface MailAccount {
+    id: string
+    display_name: string
+    email: string
+    signature?: string | null
+  }
   /** Slim calendar summary — matches the Rust `CalendarSummary` Tauri
       return shape. We pass the full list to `EventEditor` so the user
       can pick which calendar the event lands in. */
@@ -71,13 +79,35 @@
   }
 
   interface Props {
+    /** Every configured mail account. Drives the From: picker; with
+        a single account the picker collapses to a static label. */
+    accounts: MailAccount[]
+    /** The account this draft starts in — usually the active inbox
+        account, or the receiving account for replies. The user can
+        switch via the From: picker before sending. */
     accountId: string
-    fromAddress: string
     initial?: ComposeInitial
     onclose: () => void
   }
-  let { accountId, fromAddress, initial, onclose }: Props = $props()
+  let { accounts, accountId, initial, onclose }: Props = $props()
 
+  // ── From: picker state ──────────────────────────────────────
+  // The id is the canonical handle (used for `send_email`); the rest
+  // of the form pulls the display name / email / signature from the
+  // selected account. We re-resolve through `accounts` so that an
+  // edit in settings (renamed account, updated signature) propagates
+  // without remounting the modal.
+  // svelte-ignore state_referenced_locally
+  let fromAccountId = $state(accountId)
+  const fromAccount = $derived(
+    accounts.find((a) => a.id === fromAccountId) ?? accounts[0],
+  )
+  const fromAddress = $derived(fromAccount?.email ?? '')
+
+  // Drafts are namespaced by the *initial* account so a reply draft
+  // doesn't collide with the new-mail draft sitting on a different
+  // account. Switching accounts mid-compose keeps using the same
+  // draft key — the saved draft was started from this account.
   // svelte-ignore state_referenced_locally
   const DRAFT_KEY = `nimbus-draft:${accountId}`
 
@@ -117,7 +147,10 @@
   /** Build the editor's starting HTML — the body (plain text or
       already-HTML draft) with any pre-rendered Nextcloud share-link
       block appended. Same shape as the in-Compose picker emits when
-      its `onlinks` callback fires. */
+      its `onlinks` callback fires. The signature is appended only for
+      brand-new messages (no `initial`, no rehydrated draft) — replies
+      and forwards already carry the user's intended body, and a draft
+      already includes whatever signature was present when it was saved. */
   function initialBodyHtml(): string {
     let html = textToHtml(body)
     const esc = (s: string) =>
@@ -136,7 +169,25 @@
         `<p><strong>Join the Talk room:</strong></p>` +
         `<p>💬 <a href="${initial.talkLink.url}">${esc(initial.talkLink.name)}</a></p>`
     }
+    if (!initial && !saved) {
+      const sig = signatureBlock(fromAccount?.signature)
+      if (sig) html += sig
+    }
     return html
+  }
+
+  /** Render a per-account signature as the standard `-- ` separator
+      followed by the user's lines. Returns `''` when there's no
+      signature configured so callers can append unconditionally. */
+  function signatureBlock(sig: string | null | undefined): string {
+    const text = (sig ?? '').trim()
+    if (!text) return ''
+    const esc = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    const lines = text.split('\n').map(esc).join('<br>')
+    // The "-- " (with trailing space) prefix is the RFC 3676 signature
+    // delimiter — well-behaved mail clients hide it from quoted replies.
+    return `<p>-- <br>${lines}</p>`
   }
   // svelte-ignore state_referenced_locally
   let showCcBcc = $state(!!cc || !!bcc)
@@ -565,7 +616,7 @@
     sending = true
     try {
       await invoke('send_email', {
-        accountId,
+        accountId: fromAccountId,
         email: {
           from: fromAddress,
           to: toList,
@@ -601,6 +652,28 @@
     </header>
 
     <div class="flex-1 overflow-y-auto p-5 space-y-3">
+      <!-- From: picker. Shown as a real <select> when the user has
+           more than one account, otherwise collapsed to a static label
+           so single-account users see no extra chrome. -->
+      <div class="flex items-center gap-2">
+        <label class="text-xs w-14 text-surface-500" for="compose-from">From</label>
+        {#if accounts.length > 1}
+          <select
+            id="compose-from"
+            class="select flex-1 px-3 py-2 text-sm rounded-md"
+            bind:value={fromAccountId}
+          >
+            {#each accounts as a (a.id)}
+              <option value={a.id}>{a.display_name || a.email} &lt;{a.email}&gt;</option>
+            {/each}
+          </select>
+        {:else}
+          <span id="compose-from" class="text-sm text-surface-700 dark:text-surface-300">
+            {fromAccount?.display_name || ''} &lt;{fromAddress}&gt;
+          </span>
+        {/if}
+      </div>
+
       <div class="flex items-center gap-2">
         <label class="text-xs w-14 text-surface-500" for="compose-to">To</label>
         <AddressAutocomplete

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -23,23 +23,57 @@
     date: string      // RFC 3339 string (serde serialises DateTime<Utc> this way)
     is_read: boolean
     is_starred: boolean
+    /** Owning account id. Always populated for envelopes read out of
+        the cache; left empty for envelopes coming straight from the
+        IMAP/JMAP clients (those paths don't surface to the UI). */
+    account_id: string
+  }
+
+  /** Slim account row used to render the account label on each row in
+      unified mode. We only need the id + display info. */
+  interface Account {
+    id: string
+    display_name: string
+    email: string
   }
 
   interface Props {
+    /** Required when `unified` is true; otherwise unused. The list
+        looks up each row's `account_id` here to render a short label. */
+    accounts?: Account[]
     accountId: string
     folder?: string
+    /** Aggregate INBOX across every account instead of fetching for a
+        single account. The list shows an extra account label per row
+        and reports the row's `account_id` back through `onselect`. */
+    unified?: boolean
     selectedUid: number | null
     /** Bumped by the parent to force a network re-fetch (manual refresh). */
     refreshToken?: number
-    onselect: (uid: number) => void
+    /** `accountId` is passed back when in unified mode so the parent
+        can route the open-message action to the right account. In
+        single-account mode it's omitted (the active account is implicit). */
+    onselect: (uid: number, accountId?: string) => void
   }
   let {
+    accounts = [],
     accountId,
     folder = 'INBOX',
+    unified = false,
     selectedUid,
     refreshToken = 0,
     onselect,
   }: Props = $props()
+
+  /** Short label for the per-row account chip in unified mode. We
+      prefer the display name and fall back to the email's local part
+      so the chip stays compact even with long names. */
+  function accountLabel(id: string): string {
+    const a = accounts.find((x) => x.id === id)
+    if (!a) return ''
+    if (a.display_name) return a.display_name
+    return a.email.split('@')[0] ?? a.email
+  }
 
   // ── Fetch state ─────────────────────────────────────────────
   //
@@ -54,28 +88,33 @@
   let refreshing = $state(false)
   let error = $state('')
 
-  // Re-fetch whenever the account, folder, or refreshToken changes.
+  // Re-fetch whenever the account, folder, unified flag, or
+  // refreshToken changes.
   $effect(() => {
-    // Touch refreshToken so Svelte re-runs this effect when it's bumped.
     refreshToken
-    void load(accountId, folder)
+    void load(accountId, folder, unified)
   })
 
-  async function load(id: string, f: string) {
+  async function load(id: string, f: string, isUnified: boolean) {
     loading = true
     refreshing = false
     error = ''
 
+    // Stale-response guard helper — `id`, `f`, and `isUnified` close
+    // over the call's arguments while `accountId`/`folder`/`unified`
+    // refer to whatever the parent currently has.
+    const stillCurrent = () =>
+      isUnified === unified && (isUnified || (id === accountId && f === folder))
+
     // Cache first — usually instant, may return [] on cold start.
     try {
-      const cached = await invoke<EmailEnvelope[]>('get_cached_envelopes', {
-        accountId: id,
-        folder: f,
-        limit: 50,
-      })
-      // Guard against a stale response landing after the user already
-      // navigated to a different folder/account.
-      if (id === accountId && f === folder) {
+      const cached = await invoke<EmailEnvelope[]>(
+        isUnified ? 'get_unified_cached_envelopes' : 'get_cached_envelopes',
+        isUnified
+          ? { folder: f, limit: 50 }
+          : { accountId: id, folder: f, limit: 50 },
+      )
+      if (stillCurrent()) {
         envelopes = cached
         if (cached.length > 0) loading = false
       }
@@ -88,16 +127,16 @@
     // see new mail as soon as the server responds.
     refreshing = envelopes.length > 0
     try {
-      const fresh = await invoke<EmailEnvelope[]>('fetch_envelopes', {
-        accountId: id,
-        folder: f,
-        limit: 50,
-      })
-      if (id === accountId && f === folder) {
+      const fresh = await invoke<EmailEnvelope[]>(
+        isUnified ? 'fetch_unified_envelopes' : 'fetch_envelopes',
+        isUnified
+          ? { folder: f, limit: 50 }
+          : { accountId: id, folder: f, limit: 50 },
+      )
+      if (stillCurrent()) {
         envelopes = fresh
       }
     } catch (e: any) {
-      // Only surface the network error when we have nothing to show.
       if (envelopes.length === 0) {
         error = formatError(e) || 'Failed to load mail'
       } else {
@@ -137,13 +176,13 @@
     {:else if envelopes.length === 0}
       <div class="p-6 text-center text-sm text-surface-500">No messages in {folder}.</div>
     {:else}
-      {#each envelopes as env (env.uid)}
+      {#each envelopes as env (`${env.account_id}:${env.uid}`)}
         <button
           class="w-full text-left px-4 py-3 border-b border-surface-100 dark:border-surface-800 transition-colors
-            {selectedUid === env.uid
+            {selectedUid === env.uid && (!unified || selectedUid === env.uid)
               ? 'bg-primary-500/10'
               : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
-          onclick={() => onselect(env.uid)}
+          onclick={() => onselect(env.uid, unified ? env.account_id : undefined)}
         >
           <div class="flex items-center justify-between mb-1">
             <span class="text-sm {!env.is_read ? 'font-semibold' : 'font-normal'} truncate pr-2">
@@ -154,6 +193,11 @@
           <p class="text-sm {!env.is_read ? 'font-medium' : ''} truncate">
             {env.subject || '(no subject)'}
           </p>
+          {#if unified && env.account_id}
+            <p class="text-[11px] text-surface-500 mt-1 truncate">
+              {accountLabel(env.account_id)}
+            </p>
+          {/if}
         </button>
       {/each}
     {/if}

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -21,6 +21,14 @@
     unread_count: number | null
   }
 
+  /** Slim account row for the picker — matches the Rust `Account`
+      struct's public fields that the switcher needs. */
+  interface Account {
+    id: string
+    display_name: string
+    email: string
+  }
+
   /** Slim shape of a Talk room — only the fields we need for the
       aggregate unread badge. Avoids importing TalkView's type so the
       sidebar stays decoupled from the Talk view. */
@@ -30,12 +38,23 @@
   }
 
   interface Props {
+    /** All configured mail accounts. Drives the account picker at the
+        top of the sidebar; the picker is hidden when the list has
+        fewer than two entries. */
+    accounts?: Account[]
     accountId: string
     selectedFolder: string
     /** Bumped by the parent to force a network re-fetch (manual refresh). */
     refreshToken?: number
     /** Which integration tab (if any) is currently active. */
     activeIntegration?: string | null
+    /** Whether the unified inbox is currently active. When true, the
+        per-account folder list is hidden and a single "All Inboxes"
+        entry takes its place. */
+    unified?: boolean
+    /** Called with a real account id to switch to that account, or with
+        the sentinel `"__all__"` to enable unified-inbox mode. */
+    onselectaccount?: (id: string) => void
     onselectfolder: (name: string) => void
     onsettings: () => void
     onrefresh?: () => void
@@ -43,10 +62,13 @@
     onselectintegration?: (name: string) => void
   }
   let {
+    accounts = [],
     accountId,
     selectedFolder,
     refreshToken = 0,
     activeIntegration = null,
+    unified = false,
+    onselectaccount,
     onselectfolder,
     onsettings,
     onrefresh,
@@ -58,6 +80,37 @@
   let loading = $state(true)
   let refreshing = $state(false)
   let error = $state('')
+
+  // Total unread across every account's INBOX — used as the badge on
+  // the "All Inboxes" entry when unified mode is on. The number is the
+  // same one the tray icon shows; an `unread-count-updated` event from
+  // Rust nudges us to re-read it whenever a poll changes it.
+  let unifiedUnread = $state(0)
+  async function refreshUnifiedUnread() {
+    try {
+      unifiedUnread = await invoke<number>('get_total_unread')
+    } catch (e) {
+      console.warn('get_total_unread failed:', e)
+    }
+  }
+  $effect(() => {
+    void refreshUnifiedUnread()
+    let unlisten: (() => void) | null = null
+    ;(async () => {
+      const { listen } = await import('@tauri-apps/api/event')
+      unlisten = await listen('unread-count-updated', () => {
+        void refreshUnifiedUnread()
+      })
+    })()
+    return () => {
+      unlisten?.()
+    }
+  })
+
+  /** The picker's `<select>` value: the account id, or the sentinel
+      `"__all__"` when unified mode is active. Kept derived so the
+      dropdown follows whatever the parent thinks is selected. */
+  const pickerValue = $derived(unified ? '__all__' : accountId)
 
   // Aggregate unread state across all Talk rooms on the user's first
   // Nextcloud account. Drives the badge on the "Nextcloud Talk"
@@ -199,6 +252,26 @@
     <h1 class="text-lg font-bold text-primary-500">Nimbus Mail</h1>
   </div>
 
+  <!-- Account picker: only rendered when the user has more than one
+       account. With a single account the dropdown is pure chrome, so
+       we hide it to keep the sidebar clean. -->
+  {#if accounts.length > 1}
+    <div class="px-3 pt-3">
+      <label class="sr-only" for="sidebar-account-picker">Account</label>
+      <select
+        id="sidebar-account-picker"
+        class="select w-full text-sm px-2 py-1.5 rounded-md"
+        value={pickerValue}
+        onchange={(e) => onselectaccount?.((e.currentTarget as HTMLSelectElement).value)}
+      >
+        <option value="__all__">All inboxes</option>
+        {#each accounts as a (a.id)}
+          <option value={a.id}>{a.display_name || a.email}</option>
+        {/each}
+      </select>
+    </div>
+  {/if}
+
   <!-- Compose button -->
   <div class="p-3">
     <button class="btn preset-filled-primary-500 w-full" onclick={() => oncompose?.()}>
@@ -226,7 +299,22 @@
       </div>
     </div>
 
-    {#if loading}
+    {#if unified}
+      <!-- Unified mode: only INBOX is meaningful (the per-account
+           folder tree doesn't compose across accounts), so collapse
+           the list to a single highlighted entry. The badge mirrors
+           the tray's total-unread count. -->
+      <button
+        class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm bg-primary-500/10 text-primary-500 font-medium"
+        onclick={() => onselectfolder('INBOX')}
+      >
+        <span>📥</span>
+        <span class="flex-1 text-left truncate">All Inboxes</span>
+        {#if unifiedUnread > 0}
+          <span class="badge preset-filled-primary-500 text-xs">{unifiedUnread}</span>
+        {/if}
+      </button>
+    {:else if loading}
       <p class="px-3 py-2 text-xs text-surface-500">Loading folders…</p>
     {:else if error}
       <p class="px-3 py-2 text-xs text-red-500">{error}</p>


### PR DESCRIPTION
- Sidebar account picker; switching accounts resets folder/uid/search since IMAP UIDs don't translate across accounts.
- Unified inbox: new "All inboxes" picker entry aggregates INBOX across accounts. EmailEnvelope gains account_id so rows can render a per-account label and route the open-message click. New get_unified_cached_envelopes / fetch_unified_envelopes commands, plus Cache::get_unified_envelopes aggregating via ORDER BY internal_date.
- Compose "From:" picker (hidden for single-account users). send_email now uses the picked account id, so the right SMTP/JMAP credentials and identity go on the wire.
- Per-account signatures: Account.signature: Option<String>, editable in AccountSetup + AccountSettings (debounced save), appended with the RFC 3676 "-- " separator to brand-new messages. Replies, forwards and rehydrated drafts are left alone so we don't clobber existing body content.

Search across accounts and signature-swap on mid-compose account change are deliberately deferred.