### PR TITLE
Theming: light/dark mode + curated Skeleton theme picker (#17)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -25,6 +25,31 @@ pub struct AppSettings {
     pub notifications_enabled: bool,
     /// Launch hidden to tray on app start.
     pub start_minimized: bool,
+    /// Skeleton UI theme name (e.g. `"cerberus"`, `"modern"`,
+    /// `"pine"`). The frontend keeps the canonical list of themes
+    /// it knows how to render; this value is the user's selection
+    /// and is set on `<html data-theme="…">` at startup.
+    pub theme_name: String,
+    /// Whether the UI follows the OS light/dark preference, or
+    /// is pinned to one. Applied via `<html data-mode="…">`.
+    pub theme_mode: ThemeMode,
+}
+
+/// Light/dark mode selection. `System` follows the OS preference
+/// (`prefers-color-scheme`) and reacts live when the user changes
+/// their OS theme; `Light` / `Dark` pin the mode regardless.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeMode {
+    System,
+    Light,
+    Dark,
+}
+
+impl Default for ThemeMode {
+    fn default() -> Self {
+        Self::System
+    }
 }
 
 impl Default for AppSettings {
@@ -35,6 +60,8 @@ impl Default for AppSettings {
             background_sync_interval_secs: 300,
             notifications_enabled: true,
             start_minimized: false,
+            theme_name: "cerberus".to_string(),
+            theme_mode: ThemeMode::System,
         }
     }
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -34,6 +34,7 @@
     type SearchFilters,
   } from './lib/SearchBar.svelte'
   import SearchResults from './lib/SearchResults.svelte'
+  import { applyTheme, installSystemModeListener, type ThemeMode } from './lib/theme'
 
   // ── View state ──────────────────────────────────────────────
   // Which view is currently shown. Starts as 'loading' until we
@@ -159,6 +160,8 @@
     background_sync_interval_secs: number
     notifications_enabled: boolean
     start_minimized: boolean
+    theme_name: string
+    theme_mode: ThemeMode
   }
 
   // Cached settings snapshot — refreshed when the settings command is
@@ -232,6 +235,17 @@
       console.warn('get_app_settings failed', err)
     }
   }
+
+  /** Re-apply the theme + (re)install the OS-mode listener whenever
+      the user's theme preferences change. The effect's cleanup
+      function tears down the previous listener before the next run
+      installs a new one, so we never leak `matchMedia` subscribers
+      when the user toggles between System / Light / Dark. */
+  $effect(() => {
+    if (!appPrefs) return
+    applyTheme(appPrefs.theme_name, appPrefs.theme_mode)
+    return installSystemModeListener(appPrefs.theme_mode, appPrefs.theme_name)
+  })
 
   $effect(() => {
     loadAppPrefs()
@@ -548,7 +562,11 @@
 
 <!-- Account settings -->
 {:else if currentView === 'settings'}
-  <AccountSettings onclose={goToInbox} onaddaccount={goToSetup} />
+  <AccountSettings
+    onclose={goToInbox}
+    onaddaccount={goToSetup}
+    onappprefschanged={(p) => (appPrefs = p)}
+  />
 
 <!-- Contacts view: sidebar stays put so the user can jump back to mail. -->
 {:else if currentView === 'contacts' && activeAccountId}

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,6 +1,22 @@
 @import 'tailwindcss';
 @import '@skeletonlabs/skeleton';
+
+/* Curated theme set. Adding a new theme = one import line here plus
+   one entry in `lib/theme.ts`'s `THEMES` list. */
 @import '@skeletonlabs/skeleton/themes/cerberus';
+@import '@skeletonlabs/skeleton/themes/modern';
+@import '@skeletonlabs/skeleton/themes/pine';
+@import '@skeletonlabs/skeleton/themes/rose';
+@import '@skeletonlabs/skeleton/themes/vintage';
+
+/* Tailwind v4's `dark:` variant defaults to `prefers-color-scheme`.
+   We override it to look at `data-mode="dark"` on the `<html>` element
+   so the JS layer (`lib/theme.ts`) can choose between following the
+   OS preference (System mode) or pinning Light / Dark explicitly. In
+   System mode the JS still listens to `prefers-color-scheme` and
+   flips `data-mode` itself, so the CSS only ever has to consult one
+   signal. */
+@custom-variant dark (&:where([data-mode='dark'], [data-mode='dark'] *));
 
 html,
 body {

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -9,6 +9,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import NextcloudSettings from './NextcloudSettings.svelte'
+  import { THEMES, applyTheme, type ThemeMode } from './theme'
 
   // ── Types ───────────────────────────────────────────────────
   // Mirrors the Rust `Account` struct from nimbus-core
@@ -29,8 +30,13 @@
   interface Props {
     onclose: () => void         // Go back to the inbox view
     onaddaccount: () => void    // Switch to the setup wizard to add another account
+    /** Notify the parent (App.svelte) whenever app-wide preferences
+        change so it can keep its cached snapshot — and the theme
+        `$effect` it drives — in sync. Optional so callers that don't
+        care about live updates aren't forced to handle it. */
+    onappprefschanged?: (prefs: AppSettings) => void
   }
-  let { onclose, onaddaccount }: Props = $props()
+  let { onclose, onaddaccount, onappprefschanged }: Props = $props()
 
   // ── State ───────────────────────────────────────────────────
   let accounts = $state<Account[]>([])
@@ -47,6 +53,8 @@
     background_sync_interval_secs: number
     notifications_enabled: boolean
     start_minimized: boolean
+    theme_name: string
+    theme_mode: ThemeMode
   }
 
   let appSettings = $state<AppSettings>({
@@ -55,6 +63,8 @@
     background_sync_interval_secs: 300,
     notifications_enabled: true,
     start_minimized: false,
+    theme_name: 'cerberus',
+    theme_mode: 'system',
   })
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
@@ -81,6 +91,9 @@
   let saveTimer: ReturnType<typeof setTimeout> | null = null
   function scheduleSave() {
     prefsSaveStatus = 'saving'
+    // Tell the parent immediately so its derived state (notification
+    // toggle, theme `$effect`) reacts without waiting for the debounce.
+    onappprefschanged?.({ ...appSettings })
     if (saveTimer) clearTimeout(saveTimer)
     saveTimer = setTimeout(async () => {
       try {
@@ -94,6 +107,17 @@
         prefsSaveStatus = 'error'
       }
     }, 400)
+  }
+
+  /** Theme picker handler — apply the change to the DOM immediately
+      so the user sees it before the debounced save fires. We still go
+      through `scheduleSave` so the persistence + parent-notify path
+      is unchanged. */
+  function onThemeChange(name: string, mode: ThemeMode) {
+    appSettings.theme_name = name
+    appSettings.theme_mode = mode
+    applyTheme(name, mode)
+    scheduleSave()
   }
 
   async function runCheckMailNow() {
@@ -256,6 +280,56 @@
           />
           <span>Start minimized to tray</span>
         </label>
+      </div>
+    </div>
+
+    <!-- Appearance (Issue #17) — theme + light/dark mode picker.
+         Changes apply live via `onThemeChange` so the user sees the
+         result before navigating away from settings. -->
+    <div class="card p-4 bg-surface-100 dark:bg-surface-800 rounded-lg mb-6">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="text-base font-semibold">Appearance</h2>
+      </div>
+
+      <div class="space-y-4 text-sm">
+        <div>
+          <p class="font-medium mb-2">Mode</p>
+          <div class="flex gap-2">
+            {#each ['system', 'light', 'dark'] as const as mode}
+              <button
+                type="button"
+                class="btn btn-sm {appSettings.theme_mode === mode
+                  ? 'preset-filled-primary-500'
+                  : 'preset-outlined-surface-500'}"
+                onclick={() => onThemeChange(appSettings.theme_name, mode)}
+              >
+                {mode === 'system' ? 'Follow OS' : mode === 'light' ? 'Light' : 'Dark'}
+              </button>
+            {/each}
+          </div>
+          <p class="text-xs text-surface-400 mt-1">
+            "Follow OS" tracks your system light/dark preference live.
+          </p>
+        </div>
+
+        <div>
+          <p class="font-medium mb-2">Theme</p>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {#each THEMES as theme (theme.id)}
+              <button
+                type="button"
+                class="text-left p-3 rounded-md border transition-colors {appSettings.theme_name ===
+                theme.id
+                  ? 'border-primary-500 bg-primary-500/10'
+                  : 'border-surface-300 dark:border-surface-700 hover:bg-surface-200 dark:hover:bg-surface-700'}"
+                onclick={() => onThemeChange(theme.id, appSettings.theme_mode)}
+              >
+                <div class="font-medium">{theme.label}</div>
+                <div class="text-xs text-surface-500 mt-0.5">{theme.description}</div>
+              </button>
+            {/each}
+          </div>
+        </div>
       </div>
     </div>
 

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -253,7 +253,7 @@
     float: left;
     pointer-events: none;
     height: 0;
-    color: #9ca3af;
+    color: var(--color-surface-400);
   }
   /* Basic table styling so it's visible in the editor. */
   :global(.tiptap table) {
@@ -263,29 +263,43 @@
   }
   :global(.tiptap th),
   :global(.tiptap td) {
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--color-surface-300);
     padding: 0.375rem 0.625rem;
     text-align: left;
     min-width: 80px;
   }
+  :global([data-mode='dark'] .tiptap th),
+  :global([data-mode='dark'] .tiptap td) {
+    border-color: var(--color-surface-700);
+  }
   :global(.tiptap th) {
-    background: #f3f4f6;
+    background: var(--color-surface-100);
     font-weight: 600;
+  }
+  :global([data-mode='dark'] .tiptap th) {
+    background: var(--color-surface-800);
   }
   :global(.tiptap img) {
     max-width: 100%;
     height: auto;
   }
   :global(.tiptap blockquote) {
-    border-left: 3px solid #d1d5db;
+    border-left: 3px solid var(--color-surface-300);
     padding-left: 0.75rem;
     margin: 0.5rem 0;
-    color: #6b7280;
+    color: var(--color-surface-600);
+  }
+  :global([data-mode='dark'] .tiptap blockquote) {
+    border-left-color: var(--color-surface-700);
+    color: var(--color-surface-400);
   }
   :global(.tiptap hr) {
     border: none;
-    border-top: 1px solid #d1d5db;
+    border-top: 1px solid var(--color-surface-300);
     margin: 1rem 0;
+  }
+  :global([data-mode='dark'] .tiptap hr) {
+    border-top-color: var(--color-surface-700);
   }
   :global(.tiptap ul),
   :global(.tiptap ol) {
@@ -294,7 +308,7 @@
   }
   :global(.tiptap ul) { list-style-type: disc; }
   :global(.tiptap ol) { list-style-type: decimal; }
-  :global(.tiptap a) { color: #3b82f6; text-decoration: underline; }
+  :global(.tiptap a) { color: var(--color-primary-500); text-decoration: underline; }
 </style>
 
 {#if $editor}
@@ -433,7 +447,7 @@
   </div>
 
   <!-- Editor area -->
-  <div class="border border-surface-200 dark:border-surface-700 rounded-b-md bg-white dark:bg-surface-950 overflow-y-auto" style="max-height: 360px;">
+  <div class="border border-surface-200 dark:border-surface-700 rounded-b-md bg-surface-50 dark:bg-surface-950 overflow-y-auto" style="max-height: 360px;">
     <EditorContent editor={$editor} />
   </div>
 {/if}

--- a/ui/src/lib/theme.ts
+++ b/ui/src/lib/theme.ts
@@ -1,0 +1,95 @@
+/**
+ * Theme application helper.
+ *
+ * The Rust `AppSettings` struct stores two preferences:
+ *   - `theme_name` — which Skeleton theme to use (cerberus, pine, …)
+ *   - `theme_mode` — `"system" | "light" | "dark"`
+ *
+ * This module turns those into the `data-theme` and `data-mode`
+ * attributes on `<html>` that Skeleton's CSS variables and the
+ * Tailwind `dark:` variant (overridden in `app.css`) react to.
+ *
+ * `system` mode means "follow the OS". We don't hand that string to
+ * the CSS — instead this module reads `prefers-color-scheme` and sets
+ * `data-mode="light"` or `"dark"` itself, then keeps doing so as the
+ * OS preference changes. That way the CSS only ever has to look at a
+ * concrete `light` / `dark` value and never branches on "system".
+ */
+
+export type ThemeMode = 'system' | 'light' | 'dark'
+
+export interface ThemeOption {
+  /** Skeleton theme slug — matches the file name under
+      `@skeletonlabs/skeleton/themes/<slug>.css`. */
+  id: string
+  /** Human-readable label for the picker. */
+  label: string
+  /** One-line description shown next to the label so the user knows
+      what they're picking without trying it first. */
+  description: string
+}
+
+/**
+ * Themes the picker exposes. Adding more is two steps:
+ *   1. Add an `@import` for the theme in `app.css`.
+ *   2. Add an entry here.
+ *
+ * Skeleton ships ~22 themes total — we curate to keep the picker
+ * scannable and the CSS bundle reasonable.
+ */
+export const THEMES: ThemeOption[] = [
+  { id: 'cerberus', label: 'Cerberus', description: 'Bold default with warm accents' },
+  { id: 'modern', label: 'Modern', description: 'Clean, neutral, business-like' },
+  { id: 'pine', label: 'Pine', description: 'Calm forest greens' },
+  { id: 'rose', label: 'Rose', description: 'Soft pink, warm and friendly' },
+  { id: 'vintage', label: 'Vintage', description: 'Warm sepia, retro feel' },
+]
+
+/** Fallback if a saved `theme_name` no longer exists in `THEMES`
+    (e.g. user downgraded to a build that dropped the theme). */
+export const DEFAULT_THEME_ID = 'cerberus'
+
+const DARK_MEDIA = '(prefers-color-scheme: dark)'
+
+/**
+ * Apply a theme + mode to the document. Idempotent — safe to call
+ * on every settings change without diffing.
+ *
+ * For `system` mode this resolves the OS preference once and writes
+ * a concrete `light`/`dark` value. The matchMedia listener installed
+ * by `installSystemModeListener` takes care of the live updates as
+ * the OS preference flips later.
+ */
+export function applyTheme(name: string, mode: ThemeMode): void {
+  const themeId = THEMES.some((t) => t.id === name) ? name : DEFAULT_THEME_ID
+  document.documentElement.dataset.theme = themeId
+
+  const concreteMode: 'light' | 'dark' =
+    mode === 'system' ? (prefersDark() ? 'dark' : 'light') : mode
+  document.documentElement.dataset.mode = concreteMode
+}
+
+/**
+ * Subscribe to OS theme changes so `system` mode follows them live.
+ * Returns an unsubscribe function. Caller owns the lifecycle — the
+ * App-level `$effect` in `App.svelte` re-installs whenever the user
+ * switches mode (tearing down the old listener for `light`/`dark`).
+ *
+ * For non-system modes this is a no-op subscription that just hands
+ * back a no-op cleanup, so callers don't have to branch.
+ */
+export function installSystemModeListener(
+  mode: ThemeMode,
+  themeName: string,
+): () => void {
+  if (mode !== 'system' || !window.matchMedia) return () => {}
+
+  const mql = window.matchMedia(DARK_MEDIA)
+  const handler = () => applyTheme(themeName, 'system')
+  mql.addEventListener('change', handler)
+  return () => mql.removeEventListener('change', handler)
+}
+
+function prefersDark(): boolean {
+  return !!window.matchMedia && window.matchMedia(DARK_MEDIA).matches
+}


### PR DESCRIPTION
Closes #17.

## Summary
- Adds `theme_name` and `theme_mode` to `AppSettings` (forward-compat via `#[serde(default)]`) so existing users' settings files keep parsing.
- Imports five curated Skeleton themes (cerberus, modern, pine, rose, vintage) and overrides Tailwind v4's `dark:` variant to follow `data-mode="dark"` on `<html>`. The JS layer decides whether to follow the OS preference or pin Light/Dark — the CSS only ever sees a concrete value.
- New `lib/theme.ts` keeps the canonical theme list and the `applyTheme` / `installSystemModeListener` helpers. Adding a new theme later is two lines: one `@import` in `app.css`, one entry in `THEMES`.
- `App.svelte` applies the theme on startup and re-applies on every prefs change. The `$effect`'s cleanup tears down the matchMedia listener so toggling System ↔ Dark doesn't leak subscribers.
- New "Appearance" section in `AccountSettings.svelte` — three mode buttons (Follow OS / Light / Dark) and a 2-col grid of theme cards with descriptions. Picker changes apply to the DOM live, then ride the existing debounced save path. A new `onappprefschanged` callback keeps App's cached prefs in sync.
- Swept `RichTextEditor.svelte` for hard-coded grayscale hex colors (placeholder, table borders, blockquote, hr, link) — now use Skeleton CSS variables + `[data-mode='dark']` overrides.

## Acceptance criteria
- ✅ Detect OS theme preference and apply automatically (System is the default mode)
- ✅ Manual toggle between light and dark mode
- ✅ Theme picker with Skeleton built-in themes (5 curated; trivial to expand)
- ✅ Persist theme preference (rides existing `app_settings.json` infrastructure)
- ⚠️ "Ensure all components look correct in both modes" — the static sweep caught the hex colors in `RichTextEditor`. Visual verification across every view in every theme/mode combination needs a live human eye (see Test plan).

## Test plan
- [ ] `cargo tauri dev` starts without errors
- [ ] On first launch (no saved theme), app follows the OS light/dark preference
- [ ] Switching the OS theme while app is in "Follow OS" mode flips the UI live (no restart)
- [ ] Picking each theme (Cerberus / Modern / Pine / Rose / Vintage) repaints all five
- [ ] Pinning Light / Dark overrides the OS preference
- [ ] After app restart, the saved theme + mode are restored
- [ ] Walk every view (Inbox, Mail reading, Compose with the rich-text editor, Calendar, Contacts, Files, Talk, Settings) in dark mode and confirm nothing's invisible / unreadable
- [ ] `cargo test --workspace` and `npm run check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)