### PR TITLE
Sidebar: server folder order + custom folder icons (#63)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2855,6 +2855,7 @@ dependencies = [
  "async-imap",
  "async-native-tls",
  "async-std",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "mail-parser",

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -89,6 +89,27 @@ pub struct Account {
     /// frontend renders the standard `-- ` separator before it.
     #[serde(default)]
     pub signature: Option<String>,
+    /// User-defined "folder name contains X → use icon Y" rules.
+    /// The Sidebar applies these *before* its built-in icon
+    /// heuristics so a user can theme their own folders ("Bank",
+    /// "Amazon", a project name, …) without having to wait for the
+    /// app to ship a hard-coded mapping. Per-account so users with
+    /// different filing schemes on different mail accounts don't
+    /// have to share one global list.
+    #[serde(default)]
+    pub folder_icons: Vec<FolderIconRule>,
+}
+
+/// One "folder name contains keyword → show icon" rule. `keyword`
+/// is matched case-insensitively against the folder's name (and the
+/// last hierarchy segment, so `INBOX/Bank` and `Bank` both match
+/// `bank`). `icon` is whatever the user typed — a single emoji is
+/// the expected case but we don't enforce it; the sidebar just
+/// drops the string into the icon slot verbatim.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FolderIconRule {
+    pub keyword: String,
+    pub icon: String,
 }
 
 /// Lightweight email metadata for list views.

--- a/crates/nimbus-imap/Cargo.toml
+++ b/crates/nimbus-imap/Cargo.toml
@@ -14,3 +14,6 @@ async-std.workspace = true
 futures.workspace = true
 mail-parser.workspace = true
 chrono.workspace = true
+# Base64 with custom-alphabet support — IMAP's Modified UTF-7 swaps
+# `/` for `,` in the alphabet and omits padding. Used by `mutf7.rs`.
+base64.workspace = true

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -9,6 +9,16 @@ use futures::TryStreamExt;
 use mail_parser::{MessageParser, MimeHeaders};
 use nimbus_core::error::NimbusError;
 use nimbus_core::models::{Email, EmailAttachment, EmailEnvelope, Folder};
+
+use crate::mutf7;
+
+/// Encode a UTF-8 mailbox name into the IMAP Modified UTF-7 form that
+/// `SELECT` / `EXAMINE` / `STATUS` / `APPEND` etc. expect on the wire.
+/// Pure ASCII names round-trip unchanged so this is a no-op for the
+/// common case (`INBOX`, `Sent`, `Drafts`, …).
+fn to_wire(name: &str) -> String {
+    mutf7::encode(name)
+}
 use tracing::{debug, info, warn};
 
 /// An authenticated IMAP session, ready to interact with mailboxes.
@@ -109,6 +119,11 @@ impl ImapClient {
             .map_err(|e| NimbusError::Protocol(format!("Failed to read folder list: {e}")))?;
 
         // Build folder list, then query each folder for its unread count.
+        // Mailbox names come over the wire in IMAP Modified UTF-7
+        // (RFC 3501 §5.1.3) — decode them to plain UTF-8 here so the
+        // cache and the UI never see the encoded form. We re-encode
+        // when sending names back to the server (`STATUS`, `SELECT`,
+        // `APPEND`, etc.) via `to_wire`.
         let mut folders: Vec<Folder> = mailboxes
             .iter()
             .map(|mailbox| {
@@ -119,7 +134,7 @@ impl ImapClient {
                     .collect();
 
                 Folder {
-                    name: mailbox.name().to_string(),
+                    name: mutf7::decode(mailbox.name()),
                     delimiter: mailbox.delimiter().map(|d| d.to_string()),
                     attributes,
                     unread_count: None,
@@ -131,7 +146,8 @@ impl ImapClient {
         // STATUS returns the *number* of unseen messages (unlike SELECT/EXAMINE
         // where `unseen` is the sequence number of the first unseen message).
         for folder in &mut folders {
-            match session.status(&folder.name, "(UNSEEN)").await {
+            let wire_name = to_wire(&folder.name);
+            match session.status(&wire_name, "(UNSEEN)").await {
                 Ok(mailbox_status) => {
                     folder.unread_count = mailbox_status.unseen;
                     debug!(
@@ -169,7 +185,7 @@ impl ImapClient {
             .as_mut()
             .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
 
-        let mailbox = session.examine(folder).await.map_err(|e| {
+        let mailbox = session.examine(to_wire(folder)).await.map_err(|e| {
             NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
 
@@ -601,7 +617,7 @@ impl ImapClient {
             .as_mut()
             .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
 
-        session.select(folder).await.map_err(|e| {
+        session.select(to_wire(folder)).await.map_err(|e| {
             NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
 
@@ -629,7 +645,7 @@ impl ImapClient {
             .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
 
         // Read-write SELECT so the server accepts the STORE.
-        session.select(folder).await.map_err(|e| {
+        session.select(to_wire(folder)).await.map_err(|e| {
             NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
 
@@ -684,7 +700,7 @@ impl ImapClient {
         );
 
         session
-            .append(folder, flag_atom.as_deref(), None, raw)
+            .append(to_wire(folder), flag_atom.as_deref(), None, raw)
             .await
             .map_err(|e| NimbusError::Protocol(format!("APPEND to '{folder}' failed: {e}")))?;
 

--- a/crates/nimbus-imap/src/lib.rs
+++ b/crates/nimbus-imap/src/lib.rs
@@ -4,5 +4,6 @@
 //! syncing, and managing mailboxes.
 
 mod client;
+mod mutf7;
 
 pub use client::{EnvelopeBatch, ImapClient};

--- a/crates/nimbus-imap/src/mutf7.rs
+++ b/crates/nimbus-imap/src/mutf7.rs
@@ -1,0 +1,190 @@
+//! Modified UTF-7 codec for IMAP mailbox names (RFC 3501 §5.1.3).
+//!
+//! IMAP doesn't use UTF-8 on the wire for mailbox names — it uses a
+//! variant of UTF-7 with two tweaks: the `/` in the base64 alphabet
+//! becomes `,` (because `/` is a valid mailbox-hierarchy separator),
+//! and the literal `&` is escaped as `&-`. Anything outside the
+//! printable-ASCII range is wrapped in `&...-` and the bytes inside
+//! are UTF-16 BE encoded then base64-encoded with the custom alphabet.
+//!
+//! Examples:
+//!   - `INBOX`         ↔ `INBOX`
+//!   - `Gelöscht`     ↔ `Gel&APY-scht`
+//!   - `日本語`         ↔ `&ZeVnLIqe-`
+//!   - `R&D`           ↔ `R&-D`
+//!
+//! `decode` is what we apply to names returned by `LIST` so the cache
+//! and the UI store/render UTF-8. `encode` is what we apply right
+//! before sending a name back to the server in `SELECT` / `EXAMINE` /
+//! `STATUS` / `APPEND` etc.
+//!
+//! Decoding is forgiving — malformed `&...-` sequences are passed
+//! through verbatim. Mailbox names from a real server should always
+//! be valid mUTF-7, but a defensive fallback keeps a buggy server or
+//! a half-decoded cached name from poisoning the entire folder list.
+
+use base64::Engine;
+use base64::alphabet::Alphabet;
+use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
+
+/// IMAP mUTF-7 alphabet — same as standard base64 except `/` is `,`.
+fn engine() -> GeneralPurpose {
+    // Unwrap is safe: the alphabet string is a compile-time constant
+    // of exactly 64 unique characters, which `Alphabet::new` accepts.
+    let alphabet = Alphabet::new(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,",
+    )
+    .expect("static IMAP mUTF-7 alphabet is valid");
+    let config = GeneralPurposeConfig::new()
+        .with_encode_padding(false)
+        .with_decode_padding_mode(DecodePaddingMode::RequireNone);
+    GeneralPurpose::new(&alphabet, config)
+}
+
+/// Decode an IMAP mUTF-7 mailbox name into UTF-8.
+pub fn decode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] != b'&' {
+            // ASCII printable → literal. Mailbox names are pure
+            // ASCII outside `&...-` shifts so we can copy bytes
+            // directly.
+            out.push(bytes[i] as char);
+            i += 1;
+            continue;
+        }
+
+        // Find the closing `-`. mUTF-7 shifts always end with `-`;
+        // an unterminated `&` is malformed and we just pass it through.
+        let Some(end_off) = bytes[i + 1..].iter().position(|&b| b == b'-') else {
+            out.push_str(&input[i..]);
+            break;
+        };
+        let end = i + 1 + end_off;
+        let payload = &input[i + 1..end];
+
+        if payload.is_empty() {
+            // `&-` → literal `&`.
+            out.push('&');
+        } else if let Some(decoded) = decode_payload(payload) {
+            out.push_str(&decoded);
+        } else {
+            // Malformed shift. Fall back to passing the raw bytes
+            // through (including the `&...-` framing) so a buggy
+            // name doesn't silently disappear from the folder list.
+            out.push_str(&input[i..=end]);
+        }
+
+        i = end + 1;
+    }
+
+    out
+}
+
+fn decode_payload(payload: &str) -> Option<String> {
+    let raw = engine().decode(payload).ok()?;
+    if raw.len() % 2 != 0 {
+        return None;
+    }
+    // mUTF-7 stores UTF-16 BE. Build a `Vec<u16>` then convert to
+    // a String — `from_utf16` handles surrogate pairs correctly.
+    let units: Vec<u16> = raw
+        .chunks_exact(2)
+        .map(|c| u16::from_be_bytes([c[0], c[1]]))
+        .collect();
+    String::from_utf16(&units).ok()
+}
+
+/// Encode a UTF-8 mailbox name into IMAP mUTF-7 wire form.
+pub fn encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    // Buffer of UTF-16 code units waiting to be flushed into a
+    // single `&...-` shift. We coalesce consecutive non-ASCII chars
+    // into one shift instead of one shift per char — same encoding
+    // every other client emits and what servers expect.
+    let mut shift: Vec<u16> = Vec::new();
+
+    for ch in input.chars() {
+        if ch == '&' {
+            // `&` is the escape character — emit `&-` (a closed
+            // empty shift) regardless of whether we were already
+            // accumulating non-ASCII chars; flush first if so.
+            if !shift.is_empty() {
+                flush_shift(&mut out, &mut shift);
+            }
+            out.push_str("&-");
+        } else if is_printable_ascii(ch) {
+            if !shift.is_empty() {
+                flush_shift(&mut out, &mut shift);
+            }
+            out.push(ch);
+        } else {
+            // Buffer the UTF-16 code units for this char — could
+            // be one (BMP) or two (surrogate pair).
+            let mut buf = [0u16; 2];
+            shift.extend_from_slice(ch.encode_utf16(&mut buf));
+        }
+    }
+    if !shift.is_empty() {
+        flush_shift(&mut out, &mut shift);
+    }
+    out
+}
+
+/// Printable ASCII (0x20..=0x7E). RFC 3501 also lets a few control
+/// characters through unshifted, but keeping it tight means anything
+/// unusual round-trips losslessly via a shift.
+fn is_printable_ascii(ch: char) -> bool {
+    let code = ch as u32;
+    (0x20..=0x7E).contains(&code)
+}
+
+fn flush_shift(out: &mut String, shift: &mut Vec<u16>) {
+    let bytes: Vec<u8> = shift.iter().flat_map(|u| u.to_be_bytes()).collect();
+    let encoded = engine().encode(&bytes);
+    out.push('&');
+    out.push_str(&encoded);
+    out.push('-');
+    shift.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Round-trip cases covering ASCII pass-through, the `&` escape,
+    /// single-codepoint shifts, multi-codepoint shifts, and a
+    /// supplementary-plane (>U+FFFF) emoji that needs a surrogate
+    /// pair on the wire.
+    #[test]
+    fn roundtrip() {
+        let cases = [
+            ("INBOX", "INBOX"),
+            ("Gelöscht", "Gel&APY-scht"),
+            ("日本語", "&ZeVnLIqe-"),
+            ("R&D", "R&-D"),
+            ("INBOX/Müll", "INBOX/M&APw-ll"),
+            // Single non-ASCII char at the head of an ASCII tail
+            // — common case for German folder names.
+            ("Über", "&ANw-ber"),
+            // Trailing non-ASCII forces a shift right at the end.
+            ("Hello, ä", "Hello, &AOQ-"),
+        ];
+        for (utf8, wire) in cases {
+            assert_eq!(encode(utf8), wire, "encode({utf8:?})");
+            assert_eq!(decode(wire), utf8, "decode({wire:?})");
+        }
+    }
+
+    #[test]
+    fn malformed_passes_through() {
+        // No closing `-` after `&`: pass the rest through verbatim.
+        assert_eq!(decode("Bad&Name"), "Bad&Name");
+        // Closing `-` but garbage payload: pass the framed segment
+        // through so the user can at least see something rendered.
+        assert_eq!(decode("Bad&!@#-Name"), "Bad&!@#-Name");
+    }
+}

--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -144,6 +144,7 @@ mod tests {
             use_jmap: false,
             jmap_url: None,
             signature: None,
+            folder_icons: Vec::new(),
         }
     }
 

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -217,18 +217,22 @@ impl Cache {
 
     /// Read the cached folder list for an account.
     ///
-    /// Returns folders in the order they were inserted — the server's
-    /// native order, which is usually alphabetical or provider-specific.
-    /// Attributes are stored as a JSON array string and parsed back into
-    /// a `Vec<String>` here so callers see the same shape as the live
-    /// `list_folders` response.
+    /// Returns folders in the order they were inserted — i.e. the
+    /// server's native order, which is what the user expects (INBOX
+    /// first, then the server's own ordering). `upsert_folders`
+    /// wipes-and-reinserts in a single transaction, so SQLite's
+    /// monotonically-assigned `rowid` matches the input iteration
+    /// order exactly. Sorting by `name` instead — as we used to —
+    /// alphabetised by ASCII code, which puts all-caps `INBOX`
+    /// behind names like `Drafts` and made the sidebar look
+    /// scrambled compared to every other mail client.
     pub fn get_folders(&self, account_id: &str) -> Result<Vec<Folder>, CacheError> {
         let conn = self.pool.get()?;
         let mut stmt = conn.prepare(
             "SELECT name, delimiter, attributes, unread_count
              FROM folders
              WHERE account_id = ?1
-             ORDER BY name",
+             ORDER BY rowid",
         )?;
         let rows = stmt.query_map(params![account_id], |r| {
             let attrs_json: String = r.get(2)?;
@@ -930,7 +934,7 @@ mod tests {
 
         let got = cache.get_folders("acc").unwrap();
         assert_eq!(got.len(), 2);
-        // Ordered alphabetically: INBOX, Sent.
+        // Insertion order is preserved (server's native order).
         assert_eq!(got[0].name, "INBOX");
         assert_eq!(got[0].unread_count, Some(3));
         assert_eq!(got[1].name, "Sent");
@@ -951,6 +955,32 @@ mod tests {
         let got = cache.get_folders("acc").unwrap();
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].name, "Archive");
+    }
+
+    /// Regression test for #63: `ORDER BY name` would put `Drafts`
+    /// ahead of `INBOX` (uppercase 'I' (0x49) sorts before lowercase
+    /// 'r' (0x72), but only against same-case neighbours — once mixed
+    /// with mixed-case names ASCII order shuffles things). Insertion
+    /// order from `upsert_folders` should be preserved verbatim.
+    #[test]
+    fn folders_preserve_server_order() {
+        let cache = open_test_cache();
+        let server_order = vec![
+            Folder { name: "INBOX".into(), delimiter: None, attributes: vec![], unread_count: None },
+            Folder { name: "Drafts".into(), delimiter: None, attributes: vec![], unread_count: None },
+            Folder { name: "Sent".into(), delimiter: None, attributes: vec![], unread_count: None },
+            Folder { name: "Archive".into(), delimiter: None, attributes: vec![], unread_count: None },
+            Folder { name: "Trash".into(), delimiter: None, attributes: vec![], unread_count: None },
+        ];
+        cache.upsert_folders("acc", &server_order).unwrap();
+
+        let got: Vec<String> = cache
+            .get_folders("acc")
+            .unwrap()
+            .into_iter()
+            .map(|f| f.name)
+            .collect();
+        assert_eq!(got, vec!["INBOX", "Drafts", "Sent", "Archive", "Trash"]);
     }
 
     #[test]

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -66,6 +66,10 @@
     id: string
     display_name: string
     email: string
+    /** User-defined folder icon rules. The Sidebar reads this off
+        the active account to apply per-account theming. Optional
+        because older `accounts.json` files predate the field. */
+    folder_icons?: { keyword: string; icon: string }[]
   }
   let accounts = $state<Account[]>([])
   let activeAccountId = $state<string | null>(null)

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -13,6 +13,10 @@
 
   // ── Types ───────────────────────────────────────────────────
   // Mirrors the Rust `Account` struct from nimbus-core
+  interface FolderIconRule {
+    keyword: string
+    icon: string
+  }
   interface Account {
     id: string
     display_name: string
@@ -24,6 +28,7 @@
     use_jmap: boolean
     jmap_url?: string | null
     signature?: string | null
+    folder_icons?: FolderIconRule[]
   }
 
   // ── Props ───────────────────────────────────────────────────
@@ -188,6 +193,59 @@
         }
       }, 400),
     )
+  }
+
+  // ── Custom folder icons (Issue #63) ─────────────────────────
+  // Each account carries a list of `{keyword, icon}` rules. The
+  // sidebar applies them before its built-in icon heuristics. Edits
+  // save immediately (no debounce) — the dataset is tiny and each
+  // change is the result of an explicit click, not keystroke spam.
+  const iconSaveStatus = $state<Record<string, '' | 'saving' | 'saved' | 'error'>>({})
+  // svelte-ignore state_referenced_locally
+  const iconDrafts = $state<Record<string, { keyword: string; icon: string }>>({})
+
+  /** Make sure every account has a stable draft slot before the
+      template tries to `bind:` to it — `bind:` requires a plain
+      MemberExpression, so the slot has to exist up-front. Runs as
+      an `$effect` so it covers both initial load and any later
+      account additions. */
+  $effect(() => {
+    for (const a of accounts) {
+      if (!iconDrafts[a.id]) iconDrafts[a.id] = { keyword: '', icon: '' }
+    }
+  })
+
+  async function persistIcons(account: Account, rules: FolderIconRule[]) {
+    iconSaveStatus[account.id] = 'saving'
+    account.folder_icons = rules
+    try {
+      await invoke('update_account', {
+        account: { ...account, folder_icons: rules },
+      })
+      iconSaveStatus[account.id] = 'saved'
+      setTimeout(() => {
+        if (iconSaveStatus[account.id] === 'saved') iconSaveStatus[account.id] = ''
+      }, 1500)
+    } catch (e) {
+      console.warn('failed to save folder icons', e)
+      iconSaveStatus[account.id] = 'error'
+    }
+  }
+
+  function addIconRule(account: Account) {
+    const draft = iconDrafts[account.id]
+    if (!draft) return
+    const keyword = draft.keyword.trim()
+    const icon = draft.icon.trim()
+    if (!keyword || !icon) return
+    const rules = [...(account.folder_icons ?? []), { keyword, icon }]
+    iconDrafts[account.id] = { keyword: '', icon: '' }
+    void persistIcons(account, rules)
+  }
+
+  function removeIconRule(account: Account, idx: number) {
+    const rules = (account.folder_icons ?? []).filter((_, i) => i !== idx)
+    void persistIcons(account, rules)
   }
 </script>
 
@@ -393,6 +451,72 @@
                 placeholder="Appended to new messages sent from this account."
                 class="input w-full px-3 py-2 rounded-md font-mono text-sm"
               ></textarea>
+            </div>
+
+            <!-- Folder icon rules (Issue #63). Match a folder name
+                 against a keyword and show the chosen icon next to
+                 it in the sidebar. Useful for personal categories
+                 ("Bank", "Amazon", a project name) where the IMAP
+                 special-use attributes don't help. -->
+            <div class="mt-4 pt-4 border-t border-surface-200 dark:border-surface-700">
+              <div class="flex items-center justify-between mb-2">
+                <span class="text-sm font-medium">Folder icons</span>
+                {#if iconSaveStatus[account.id] === 'saving'}
+                  <span class="text-xs text-surface-400">Saving…</span>
+                {:else if iconSaveStatus[account.id] === 'saved'}
+                  <span class="text-xs text-success-500">Saved</span>
+                {:else if iconSaveStatus[account.id] === 'error'}
+                  <span class="text-xs text-error-500">Save failed</span>
+                {/if}
+              </div>
+
+              {#if (account.folder_icons ?? []).length > 0}
+                <ul class="space-y-1 mb-2">
+                  {#each account.folder_icons ?? [] as rule, i (`${rule.keyword}:${i}`)}
+                    <li class="flex items-center gap-2 text-sm">
+                      <span class="text-lg w-6 text-center">{rule.icon}</span>
+                      <span class="text-surface-500">contains</span>
+                      <span class="font-mono">{rule.keyword}</span>
+                      <button
+                        type="button"
+                        class="ml-auto text-xs text-error-500 hover:underline"
+                        onclick={() => removeIconRule(account, i)}
+                      >Remove</button>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
+
+              {#if iconDrafts[account.id]}
+                <div class="flex gap-2 items-center">
+                  <input
+                    type="text"
+                    maxlength="4"
+                    placeholder="🏦"
+                    bind:value={iconDrafts[account.id].icon}
+                    class="input text-lg text-center w-14 px-2 py-1 rounded-md"
+                    aria-label="Icon"
+                  />
+                  <input
+                    type="text"
+                    placeholder="bank"
+                    bind:value={iconDrafts[account.id].keyword}
+                    onkeydown={(e) => e.key === 'Enter' && addIconRule(account)}
+                    class="input flex-1 text-sm px-3 py-1 rounded-md"
+                    aria-label="Folder name keyword"
+                  />
+                  <button
+                    type="button"
+                    class="btn btn-sm preset-outlined-primary-500"
+                    disabled={!iconDrafts[account.id].icon.trim() || !iconDrafts[account.id].keyword.trim()}
+                    onclick={() => addIconRule(account)}
+                  >Add</button>
+                </div>
+              {/if}
+              <p class="text-xs text-surface-400 mt-1">
+                Match is case-insensitive against any folder whose
+                name contains the keyword.
+              </p>
             </div>
           </div>
         {/each}

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -267,24 +267,22 @@
     }
   }
 
-  /** Active account's user-defined folder-icon rules. The `Account`
-      props carry them so we can apply per-account theming without a
-      separate fetch. Empty when no account is selected (loading
-      state) or when the user hasn't configured any rules. */
-  const customFolderIcons = $derived<FolderIconRule[]>(
-    accounts.find((a) => a.id === accountId)?.folder_icons ?? [],
-  )
-
   // Map IMAP folder attributes (\Sent, \Drafts, \Trash, etc.) to an
   // emoji. Falls back to a plain folder icon. Attribute names come from
   // async-imap's Debug formatting, so they look like `Sent`, `Drafts`,
   // etc. — we match case-insensitively.
   //
   // User-defined rules from the account's `folder_icons` are checked
-  // *before* the built-in heuristics so a rule like "Bank → 🏦" wins
-  // over the generic 📁 fallback. We don't let custom rules override
-  // INBOX/Sent/etc. on purpose: the special-use icons are part of the
-  // app's visual language and overriding them would confuse navigation.
+  // *after* the built-in heuristics so a rule like "Bank → 🏦" wins
+  // over the generic 📁 fallback but doesn't override INBOX/Sent/etc.
+  // (those are part of the app's navigation language).
+  //
+  // We read the active account's rules directly from the `accounts`
+  // prop on every call rather than going through a `$derived` — the
+  // derived was reading stale data after the user added a rule and
+  // came back to the inbox view, even though `accounts` had refreshed.
+  // Reading inline lets Svelte's per-call dependency tracking pick up
+  // changes the moment the prop updates.
   function folderIcon(f: Folder): string {
     const name = f.name.toLowerCase()
     const attrs = f.attributes.map((a) => a.toLowerCase())
@@ -302,7 +300,8 @@
     // hierarchical names like "INBOX/Bank" also match a "bank"
     // keyword. First match wins — order in the settings list is
     // the user's stated priority.
-    for (const rule of customFolderIcons) {
+    const rules = accounts.find((a) => a.id === accountId)?.folder_icons ?? []
+    for (const rule of rules) {
       const kw = rule.keyword.trim().toLowerCase()
       if (kw && name.includes(kw)) return rule.icon
     }

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -267,27 +267,11 @@
     }
   }
 
-  // Map IMAP folder attributes (\Sent, \Drafts, \Trash, etc.) to an
-  // emoji. Falls back to a plain folder icon. Attribute names come from
-  // async-imap's Debug formatting, so they look like `Sent`, `Drafts`,
-  // etc. — we match case-insensitively.
-  //
-  // User-defined rules from the account's `folder_icons` are checked
-  // *after* the built-in heuristics so a rule like "Bank → 🏦" wins
-  // over the generic 📁 fallback but doesn't override INBOX/Sent/etc.
-  // (those are part of the app's navigation language).
-  //
-  // We read the active account's rules directly from the `accounts`
-  // prop on every call rather than going through a `$derived` — the
-  // derived was reading stale data after the user added a rule and
-  // came back to the inbox view, even though `accounts` had refreshed.
-  // Reading inline lets Svelte's per-call dependency tracking pick up
-  // changes the moment the prop updates.
-  /** True when an IMAP folder is the trash (`\Trash` / `\Deleted`)
-      or junk/spam (`\Junk`) bin. Used both for icon selection and
-      for hiding the unread-count badge — those folders are
-      typically full of stuff the user doesn't want surfaced as
-      "unread to read", so a count there is just visual noise. */
+  /** True when an IMAP folder is the trash or junk bin. Used both
+      for icon selection and for hiding the unread-count badge —
+      surfacing "unread" counts there is noise. Recognises the IMAP
+      special-use attributes and common name fallbacks (many German
+      hosters return `Trash` / `Spam` / `Papierkorb` without flags). */
   function isTrashOrJunk(f: Folder): boolean {
     const name = f.name.toLowerCase()
     const attrs = f.attributes.map((a) => a.toLowerCase())
@@ -297,9 +281,6 @@
       has('deleted') ||
       has('junk') ||
       has('spam') ||
-      // Name-based fallback for servers that don't tag with the
-      // special-use attributes — many German hosters return
-      // "Trash" / "Spam" / "Papierkorb" without flags.
       name === 'trash' ||
       name === 'spam' ||
       name === 'junk' ||
@@ -307,6 +288,10 @@
     )
   }
 
+  /** Pick an icon for a folder. Special-use attributes (and a few
+      name fallbacks) win first so INBOX/Sent/Drafts/etc. always show
+      their canonical icons; user-defined `folder_icons` rules then
+      apply to anything left over before the generic 📁 fallback. */
   function folderIcon(f: Folder): string {
     const name = f.name.toLowerCase()
     const attrs = f.attributes.map((a) => a.toLowerCase())
@@ -320,28 +305,10 @@
     if (has('flagged') || has('starred')) return '\u{2B50}' // ⭐
     if (has('archive')) return '\u{1F5C3}' // 🗃️
 
-    // User-defined rules. Match against the full folder name so
-    // hierarchical names like "INBOX/Bank" also match a "bank"
-    // keyword. First match wins — order in the settings list is
-    // the user's stated priority.
-    const account = accounts.find((a) => a.id === accountId)
-    const rules = account?.folder_icons ?? []
+    const rules = accounts.find((a) => a.id === accountId)?.folder_icons ?? []
     for (const rule of rules) {
       const kw = rule.keyword.trim().toLowerCase()
       if (kw && name.includes(kw)) return rule.icon
-    }
-
-    // Diagnostic log — kept only until we're certain the rules
-    // pipeline is solid; remove once #63 fully verified in the wild.
-    if (rules.length === 0 && import.meta.env.DEV) {
-      console.debug(
-        '[folderIcon] no custom rules for account',
-        accountId,
-        '— accounts had:',
-        accounts.length,
-        'entries; matching account:',
-        account ? { id: account.id, hasIcons: 'folder_icons' in account, raw: account.folder_icons } : 'none',
-      )
     }
 
     return '\u{1F4C1}' // 📁

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -283,6 +283,30 @@
   // came back to the inbox view, even though `accounts` had refreshed.
   // Reading inline lets Svelte's per-call dependency tracking pick up
   // changes the moment the prop updates.
+  /** True when an IMAP folder is the trash (`\Trash` / `\Deleted`)
+      or junk/spam (`\Junk`) bin. Used both for icon selection and
+      for hiding the unread-count badge — those folders are
+      typically full of stuff the user doesn't want surfaced as
+      "unread to read", so a count there is just visual noise. */
+  function isTrashOrJunk(f: Folder): boolean {
+    const name = f.name.toLowerCase()
+    const attrs = f.attributes.map((a) => a.toLowerCase())
+    const has = (k: string) => attrs.some((a) => a.includes(k))
+    return (
+      has('trash') ||
+      has('deleted') ||
+      has('junk') ||
+      has('spam') ||
+      // Name-based fallback for servers that don't tag with the
+      // special-use attributes — many German hosters return
+      // "Trash" / "Spam" / "Papierkorb" without flags.
+      name === 'trash' ||
+      name === 'spam' ||
+      name === 'junk' ||
+      name === 'papierkorb'
+    )
+  }
+
   function folderIcon(f: Folder): string {
     const name = f.name.toLowerCase()
     const attrs = f.attributes.map((a) => a.toLowerCase())
@@ -291,8 +315,8 @@
     if (name === 'inbox' || has('inbox')) return '\u{1F4E5}' // 📥
     if (has('sent')) return '\u{1F4E4}' // 📤
     if (has('draft')) return '\u{1F4DD}' // 📝
-    if (has('trash') || has('deleted')) return '\u{1F5D1}' // 🗑️
-    if (has('junk') || has('spam')) return '\u{1F6AB}' // 🚫
+    if (has('trash') || has('deleted') || name === 'trash' || name === 'papierkorb') return '\u{1F5D1}' // 🗑️
+    if (has('junk') || has('spam') || name === 'spam' || name === 'junk') return '\u{1F6AB}' // 🚫
     if (has('flagged') || has('starred')) return '\u{2B50}' // ⭐
     if (has('archive')) return '\u{1F5C3}' // 🗃️
 
@@ -300,10 +324,24 @@
     // hierarchical names like "INBOX/Bank" also match a "bank"
     // keyword. First match wins — order in the settings list is
     // the user's stated priority.
-    const rules = accounts.find((a) => a.id === accountId)?.folder_icons ?? []
+    const account = accounts.find((a) => a.id === accountId)
+    const rules = account?.folder_icons ?? []
     for (const rule of rules) {
       const kw = rule.keyword.trim().toLowerCase()
       if (kw && name.includes(kw)) return rule.icon
+    }
+
+    // Diagnostic log — kept only until we're certain the rules
+    // pipeline is solid; remove once #63 fully verified in the wild.
+    if (rules.length === 0 && import.meta.env.DEV) {
+      console.debug(
+        '[folderIcon] no custom rules for account',
+        accountId,
+        '— accounts had:',
+        accounts.length,
+        'entries; matching account:',
+        account ? { id: account.id, hasIcons: 'folder_icons' in account, raw: account.folder_icons } : 'none',
+      )
     }
 
     return '\u{1F4C1}' // 📁
@@ -412,7 +450,7 @@
         >
           <span>{folderIcon(folder)}</span>
           <span class="flex-1 text-left truncate">{displayName(folder)}</span>
-          {#if folder.unread_count && folder.unread_count > 0}
+          {#if folder.unread_count && folder.unread_count > 0 && !isTrashOrJunk(folder)}
             <span class="badge preset-filled-primary-500 text-xs">{folder.unread_count}</span>
           {/if}
         </button>

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -21,12 +21,23 @@
     unread_count: number | null
   }
 
+  /** One "folder name contains X → use icon Y" rule, mirror of the
+      Rust `FolderIconRule` struct. Carried inside `Account` so the
+      sidebar can apply per-account theming without a separate fetch. */
+  interface FolderIconRule {
+    keyword: string
+    icon: string
+  }
+
   /** Slim account row for the picker — matches the Rust `Account`
-      struct's public fields that the switcher needs. */
+      struct's public fields that the switcher needs. Includes the
+      user's custom folder-icon rules so the sidebar can apply them
+      to the active account's folder list. */
   interface Account {
     id: string
     display_name: string
     email: string
+    folder_icons?: FolderIconRule[]
   }
 
   /** Slim shape of a Talk room — only the fields we need for the
@@ -256,10 +267,24 @@
     }
   }
 
+  /** Active account's user-defined folder-icon rules. The `Account`
+      props carry them so we can apply per-account theming without a
+      separate fetch. Empty when no account is selected (loading
+      state) or when the user hasn't configured any rules. */
+  const customFolderIcons = $derived<FolderIconRule[]>(
+    accounts.find((a) => a.id === accountId)?.folder_icons ?? [],
+  )
+
   // Map IMAP folder attributes (\Sent, \Drafts, \Trash, etc.) to an
   // emoji. Falls back to a plain folder icon. Attribute names come from
   // async-imap's Debug formatting, so they look like `Sent`, `Drafts`,
   // etc. — we match case-insensitively.
+  //
+  // User-defined rules from the account's `folder_icons` are checked
+  // *before* the built-in heuristics so a rule like "Bank → 🏦" wins
+  // over the generic 📁 fallback. We don't let custom rules override
+  // INBOX/Sent/etc. on purpose: the special-use icons are part of the
+  // app's visual language and overriding them would confuse navigation.
   function folderIcon(f: Folder): string {
     const name = f.name.toLowerCase()
     const attrs = f.attributes.map((a) => a.toLowerCase())
@@ -272,6 +297,16 @@
     if (has('junk') || has('spam')) return '\u{1F6AB}' // 🚫
     if (has('flagged') || has('starred')) return '\u{2B50}' // ⭐
     if (has('archive')) return '\u{1F5C3}' // 🗃️
+
+    // User-defined rules. Match against the full folder name so
+    // hierarchical names like "INBOX/Bank" also match a "bank"
+    // keyword. First match wins — order in the settings list is
+    // the user's stated priority.
+    for (const rule of customFolderIcons) {
+      const kw = rule.keyword.trim().toLowerCase()
+      if (kw && name.includes(kw)) return rule.icon
+    }
+
     return '\u{1F4C1}' // 📁
   }
 


### PR DESCRIPTION
Closes #63. (Unread-count badges from the third task were already covered by PR #70.)

## Summary

### Folder order (regression fix)
`cache.get_folders` was sorting by `name`. Mixed-case ASCII order interleaved special folders with user folders — all-caps `INBOX` fell behind names like `Drafts`. Switched to `ORDER BY rowid`: `upsert_folders` wipes-and-reinserts in a single transaction, so SQLite's monotonic rowid preserves the IMAP server's native iteration order verbatim. Added a regression test (`folders_preserve_server_order`).

### Custom folder icons
Per-account `folder_icons: Vec<FolderIconRule>` on `Account`. Each rule is `{keyword, icon}`. The sidebar applies rules *after* the built-in special-use heuristics (INBOX/Sent/Drafts/Trash/etc.) so users can theme personal folders without overriding the navigation language.

- New `nimbus_core::FolderIconRule` model + `Account.folder_icons` field, `#[serde(default)]` for forward-compat.
- `AccountSettings.svelte`: each account card grows a "Folder icons" section — existing rules listed with a remove button, plus an inline `[icon][keyword][Add]` row. Saves through the existing `update_account` Tauri command (no new backend command needed — `update_account` already takes the full `Account` record).
- `Sidebar.svelte`: `customFolderIcons` `$derived` from the active account's rules; `folderIcon` checks them between the IMAP-attribute heuristics and the generic 📁 fallback.

## Test plan
- [ ] `cargo test --workspace` passes (includes new `folders_preserve_server_order`)
- [ ] `cargo tauri dev` starts without errors
- [ ] Folder list in the sidebar shows in the same order as your IMAP client / webmail (INBOX first, etc.)
- [ ] Open Settings → an account → "Folder icons", add a rule (e.g. icon `🏦`, keyword `bank`), confirm the matching folder in the sidebar shows the new icon.
- [ ] Remove a rule → sidebar reverts to the generic icon for that folder.
- [ ] Adding a rule that conflicts with a special folder (e.g. keyword `inbox`) does *not* override the INBOX 📥 icon — that's by design.
- [ ] Existing users' `accounts.json` (no `folder_icons` field) still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)