### PR TITLE
Contacts: more fields + shared sync-status row (#66)

### DIFF
--- a/crates/nimbus-carddav/src/lib.rs
+++ b/crates/nimbus-carddav/src/lib.rs
@@ -65,5 +65,5 @@ mod xml_util;
 
 pub use discovery::{Addressbook, list_addressbooks};
 pub use sync::{RawContact, SyncDelta, sync_addressbook};
-pub use vcard::{ParsedVcard, build_vcard, parse_vcard};
+pub use vcard::{ParsedVcard, VcardAddress, build_vcard, parse_vcard};
 pub use write::{WriteOutcome, create_contact, delete_contact, update_contact};

--- a/crates/nimbus-carddav/src/sync.rs
+++ b/crates/nimbus-carddav/src/sync.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use nimbus_core::NimbusError;
 
 use crate::client::{absolute_url, build, normalize_server_url, report};
-use crate::vcard::{ParsedVcard, parse_vcard};
+use crate::vcard::{ParsedVcard, VcardAddress, parse_vcard};
 use crate::xml_util::{local_name, read_text_until, skip_subtree};
 
 /// One contact resource as seen on the server, with all the bookkeeping
@@ -59,6 +59,22 @@ pub struct RawContact {
     pub organization: Option<String>,
     pub photo_mime: Option<String>,
     pub photo_data: Option<Vec<u8>>,
+    /// Job title (vCard `TITLE`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Birthday (vCard `BDAY`) as the literal vCard text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub birthday: Option<String>,
+    /// Free-form note (vCard `NOTE`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    /// Postal addresses (vCard `ADR`). Carries the original "home"/
+    /// "work"/"other" hint so the UI can group them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub addresses: Vec<VcardAddress>,
+    /// Personal/work URLs (vCard `URL`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub urls: Vec<String>,
     /// Raw vCard text — kept so we can re-parse without re-syncing
     /// if the model evolves later.
     pub vcard_raw: String,
@@ -365,6 +381,11 @@ fn parse_multiget_response(
         organization: parsed.organization,
         photo_mime: parsed.photo_mime,
         photo_data: parsed.photo_data,
+        title: parsed.title,
+        birthday: parsed.birthday,
+        note: parsed.note,
+        addresses: parsed.addresses,
+        urls: parsed.urls,
         vcard_raw,
     }))
 }

--- a/crates/nimbus-carddav/src/vcard.rs
+++ b/crates/nimbus-carddav/src/vcard.rs
@@ -31,8 +31,27 @@ pub struct ParsedVcard {
     pub emails: Vec<String>,
     pub phones: Vec<String>,
     pub organization: Option<String>,
+    pub title: Option<String>,
+    pub addresses: Vec<VcardAddress>,
+    pub birthday: Option<String>,
+    pub urls: Vec<String>,
+    pub note: Option<String>,
     pub photo_mime: Option<String>,
     pub photo_data: Option<Vec<u8>>,
+}
+
+/// One vCard `ADR` property. Mirrors `nimbus_core::models::ContactAddress`
+/// so the carddav crate can stay free of the core models dependency.
+/// `Serialize + Deserialize` so it round-trips inside `RawContact`
+/// over the Tauri IPC boundary.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct VcardAddress {
+    pub kind: String,
+    pub street: String,
+    pub locality: String,
+    pub region: String,
+    pub postal_code: String,
+    pub country: String,
 }
 
 /// Parse a single vCard string. The input is the raw `BEGIN:VCARD … END:VCARD`
@@ -52,6 +71,11 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
     let mut emails: Vec<String> = Vec::new();
     let mut phones: Vec<String> = Vec::new();
     let mut organization: Option<String> = None;
+    let mut title: Option<String> = None;
+    let mut addresses: Vec<VcardAddress> = Vec::new();
+    let mut birthday: Option<String> = None;
+    let mut urls: Vec<String> = Vec::new();
+    let mut note: Option<String> = None;
     let mut photo_mime: Option<String> = None;
     let mut photo_data: Option<Vec<u8>> = None;
 
@@ -88,6 +112,58 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
                     organization = Some(first);
                 }
             }
+            "TITLE" => {
+                let v = value.trim().to_string();
+                if !v.is_empty() {
+                    title = Some(v);
+                }
+            }
+            "ADR" => {
+                // ADR is PO-box;Extended;Street;Locality;Region;Postal;Country.
+                // PO-box and Extended are commonly empty; keep them absent
+                // from our flat model.
+                let parts: Vec<&str> = value.split(';').collect();
+                let street = parts.get(2).copied().unwrap_or("").trim().to_string();
+                let locality = parts.get(3).copied().unwrap_or("").trim().to_string();
+                let region = parts.get(4).copied().unwrap_or("").trim().to_string();
+                let postal_code = parts.get(5).copied().unwrap_or("").trim().to_string();
+                let country = parts.get(6).copied().unwrap_or("").trim().to_string();
+                if street.is_empty()
+                    && locality.is_empty()
+                    && region.is_empty()
+                    && postal_code.is_empty()
+                    && country.is_empty()
+                {
+                    continue;
+                }
+                let kind = address_kind(prop);
+                addresses.push(VcardAddress {
+                    kind,
+                    street,
+                    locality,
+                    region,
+                    postal_code,
+                    country,
+                });
+            }
+            "BDAY" => {
+                let v = value.trim().to_string();
+                if !v.is_empty() {
+                    birthday = Some(v);
+                }
+            }
+            "URL" => {
+                let v = value.trim().to_string();
+                if !v.is_empty() && !urls.contains(&v) {
+                    urls.push(v);
+                }
+            }
+            "NOTE" => {
+                let v = value.trim().to_string();
+                if !v.is_empty() {
+                    note = Some(v);
+                }
+            }
             "PHOTO" => {
                 if let Some((mime, bytes)) = decode_photo(prop, value) {
                     photo_mime = Some(mime);
@@ -118,9 +194,36 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
         emails,
         phones,
         organization,
+        title,
+        addresses,
+        birthday,
+        urls,
+        note,
         photo_mime,
         photo_data,
     })
+}
+
+/// Pull a "home" / "work" / "other" hint from a vCard property's
+/// `TYPE` parameter. vCard 4 lets the type be a comma-separated list
+/// (e.g. `TYPE="home,pref"`) — we take the first recognised value.
+fn address_kind(prop: &Property) -> String {
+    if let Some(params) = &prop.params {
+        for (key, vals) in params {
+            if !key.eq_ignore_ascii_case("TYPE") {
+                continue;
+            }
+            for v in vals {
+                for piece in v.split(',') {
+                    let lower = piece.trim().to_ascii_lowercase();
+                    if lower == "home" || lower == "work" {
+                        return lower;
+                    }
+                }
+            }
+        }
+    }
+    "other".to_string()
 }
 
 /// Decode a PHOTO property into `(mime, bytes)`.
@@ -220,6 +323,38 @@ pub fn build_vcard(card: &ParsedVcard) -> String {
     }
     if let Some(org) = &card.organization {
         push_line(&mut out, &format!("ORG:{}", escape_value(org)));
+    }
+    if let Some(t) = &card.title {
+        push_line(&mut out, &format!("TITLE:{}", escape_value(t)));
+    }
+    for adr in &card.addresses {
+        // `home`/`work`/`other` ride through in the TYPE param so a
+        // round-trip keeps the user's grouping intact.
+        let typ = if adr.kind.is_empty() {
+            String::new()
+        } else {
+            format!(";TYPE={}", adr.kind)
+        };
+        // Empty PO-box and Extended slots, then street/locality/region/
+        // postal/country in RFC 6350 order.
+        let payload = format!(
+            ";;{};{};{};{};{}",
+            escape_value(&adr.street),
+            escape_value(&adr.locality),
+            escape_value(&adr.region),
+            escape_value(&adr.postal_code),
+            escape_value(&adr.country),
+        );
+        push_line(&mut out, &format!("ADR{typ}:{payload}"));
+    }
+    if let Some(b) = &card.birthday {
+        push_line(&mut out, &format!("BDAY:{}", escape_value(b)));
+    }
+    for url in &card.urls {
+        push_line(&mut out, &format!("URL:{}", escape_value(url)));
+    }
+    if let Some(n) = &card.note {
+        push_line(&mut out, &format!("NOTE:{}", escape_value(n)));
     }
     if let (Some(mime), Some(bytes)) = (&card.photo_mime, &card.photo_data) {
         // vCard 4 PHOTO as data URI — single property, no params,
@@ -325,8 +460,7 @@ mod tests {
             emails: vec!["alice@example.com".into(), "alice@work.com".into()],
             phones: vec!["+1 555 0100".into()],
             organization: Some("Example Corp".into()),
-            photo_mime: None,
-            photo_data: None,
+            ..Default::default()
         };
         let raw = build_vcard(&original);
         assert!(raw.starts_with("BEGIN:VCARD\r\nVERSION:4.0\r\n"));
@@ -378,6 +512,63 @@ mod tests {
         }
         // At least one folded continuation line present.
         assert!(raw.contains("\r\n "));
+    }
+
+    #[test]
+    fn parses_extended_fields() {
+        let raw = "BEGIN:VCARD\r\n\
+                   VERSION:4.0\r\n\
+                   UID:ext-1\r\n\
+                   FN:Erika Mustermann\r\n\
+                   TITLE:CTO\r\n\
+                   BDAY:1985-10-31\r\n\
+                   URL:https://example.com\r\n\
+                   URL:https://example.com/blog\r\n\
+                   NOTE:Met at the conference\r\n\
+                   ADR;TYPE=work:;;Hauptstr. 1;Berlin;BE;10115;DE\r\n\
+                   ADR;TYPE=home:;;Side St 7;Munich;BY;80331;DE\r\n\
+                   END:VCARD\r\n";
+        let p = parse_vcard(raw).unwrap();
+        assert_eq!(p.title.as_deref(), Some("CTO"));
+        assert_eq!(p.birthday.as_deref(), Some("1985-10-31"));
+        assert_eq!(p.urls.len(), 2);
+        assert_eq!(p.note.as_deref(), Some("Met at the conference"));
+        assert_eq!(p.addresses.len(), 2);
+        assert_eq!(p.addresses[0].kind, "work");
+        assert_eq!(p.addresses[0].street, "Hauptstr. 1");
+        assert_eq!(p.addresses[0].locality, "Berlin");
+        assert_eq!(p.addresses[1].kind, "home");
+    }
+
+    #[test]
+    fn extended_fields_round_trip() {
+        let original = ParsedVcard {
+            uid: "rt-1".into(),
+            display_name: "Erika Mustermann".into(),
+            title: Some("CTO".into()),
+            birthday: Some("1985-10-31".into()),
+            urls: vec!["https://example.com".into()],
+            note: Some("hi".into()),
+            addresses: vec![VcardAddress {
+                kind: "work".into(),
+                street: "Hauptstr. 1".into(),
+                locality: "Berlin".into(),
+                region: "BE".into(),
+                postal_code: "10115".into(),
+                country: "DE".into(),
+            }],
+            ..Default::default()
+        };
+        let raw = build_vcard(&original);
+        let parsed = parse_vcard(&raw).expect("re-parse");
+        assert_eq!(parsed.title.as_deref(), Some("CTO"));
+        assert_eq!(parsed.birthday.as_deref(), Some("1985-10-31"));
+        assert_eq!(parsed.urls, vec!["https://example.com"]);
+        assert_eq!(parsed.note.as_deref(), Some("hi"));
+        assert_eq!(parsed.addresses.len(), 1);
+        assert_eq!(parsed.addresses[0].kind, "work");
+        assert_eq!(parsed.addresses[0].street, "Hauptstr. 1");
+        assert_eq!(parsed.addresses[0].country, "DE");
     }
 
     #[test]

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -377,6 +377,47 @@ pub struct Contact {
     /// Raw decoded photo bytes. Serialised as a JSON byte array so the
     /// frontend can wrap it in a `Blob` URL for `<img src>`.
     pub photo_data: Option<Vec<u8>>,
+    /// Job title (vCard `TITLE`) — separate from `organization`'s
+    /// company name. Often paired with org in the contact card UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Postal addresses (vCard `ADR`). Multiple allowed; each carries
+    /// a kind hint (`home` / `work` / `other`) so the UI can group
+    /// them like Nextcloud Contacts does.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub addresses: Vec<ContactAddress>,
+    /// Birthday (vCard `BDAY`). Stored as the raw vCard text — date
+    /// formats vary (`19851031`, `1985-10-31`, `--10-31` for missing
+    /// year) and parsing here would lose information the UI can still
+    /// render verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub birthday: Option<String>,
+    /// Personal/work URLs (vCard `URL`). Multiple allowed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub urls: Vec<String>,
+    /// Free-form note (vCard `NOTE`). Single multi-line string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// One postal address from a vCard `ADR` property.
+///
+/// vCard 4 splits the address into seven fields (PO box, extended,
+/// street, locality, region, postal code, country). We omit the
+/// PO-box and extended slots — Nextcloud Contacts doesn't surface
+/// them either — and keep the rest as plain strings the UI renders
+/// in standard "street, city region postal, country" order.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContactAddress {
+    /// "home", "work", or "other". Lower-cased, and `"other"` is the
+    /// fallback when the vCard `TYPE` parameter is absent or
+    /// unrecognised.
+    pub kind: String,
+    pub street: String,
+    pub locality: String,
+    pub region: String,
+    pub postal_code: String,
+    pub country: String,
 }
 
 /// Represents a calendar event from CalDAV / Nextcloud.

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -253,6 +253,28 @@ impl Cache {
         Ok(out)
     }
 
+    /// Most-recent `last_synced_at` across every calendar for the
+    /// given Nextcloud account, in UTC. Mirror of
+    /// `latest_addressbook_sync_at` — same shape, same purpose
+    /// (settings-row "synced 12m ago" chip).
+    pub fn latest_calendar_sync_at(
+        &self,
+        nc_account_id: &str,
+    ) -> Result<Option<DateTime<Utc>>, CacheError> {
+        let conn = self.pool.get()?;
+        let ts: Option<i64> = conn
+            .query_row(
+                "SELECT MAX(last_synced_at)
+                 FROM calendars
+                 WHERE nextcloud_account_id = ?1",
+                params![nc_account_id],
+                |r| r.get(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(ts.and_then(|t| Utc.timestamp_opt(t, 0).single()))
+    }
+
     /// Read the sync bookmark for a single calendar.
     pub fn get_calendar_sync_state(
         &self,

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -20,7 +20,7 @@
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::{OptionalExtension, params};
 
-use nimbus_core::models::Contact;
+use nimbus_core::models::{Contact, ContactAddress};
 
 use crate::cache::{Cache, CacheError};
 
@@ -37,6 +37,15 @@ pub struct ContactRow {
     pub organization: Option<String>,
     pub photo_mime: Option<String>,
     pub photo_data: Option<Vec<u8>>,
+    /// Job title (vCard `TITLE`).
+    pub title: Option<String>,
+    /// Birthday (vCard `BDAY`) as the literal vCard string —
+    /// formats vary, the UI renders verbatim.
+    pub birthday: Option<String>,
+    /// Free-form note (vCard `NOTE`).
+    pub note: Option<String>,
+    pub addresses: Vec<ContactAddress>,
+    pub urls: Vec<String>,
     pub vcard_raw: String,
 }
 
@@ -110,24 +119,34 @@ impl Cache {
                 "INSERT INTO contacts
                     (id, nextcloud_account_id, addressbook, vcard_uid, href, etag,
                      display_name, emails_json, phones_json, organization,
-                     photo_mime, photo_data, vcard_raw, cached_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                     photo_mime, photo_data, vcard_raw, cached_at,
+                     title, birthday, note, addresses_json, urls_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                         ?15, ?16, ?17, ?18, ?19)
                  ON CONFLICT (nextcloud_account_id, addressbook, vcard_uid) DO UPDATE SET
-                    href         = excluded.href,
-                    etag         = excluded.etag,
-                    display_name = excluded.display_name,
-                    emails_json  = excluded.emails_json,
-                    phones_json  = excluded.phones_json,
-                    organization = excluded.organization,
-                    photo_mime   = excluded.photo_mime,
-                    photo_data   = excluded.photo_data,
-                    vcard_raw    = excluded.vcard_raw,
-                    cached_at    = excluded.cached_at",
+                    href           = excluded.href,
+                    etag           = excluded.etag,
+                    display_name   = excluded.display_name,
+                    emails_json    = excluded.emails_json,
+                    phones_json    = excluded.phones_json,
+                    organization   = excluded.organization,
+                    photo_mime     = excluded.photo_mime,
+                    photo_data     = excluded.photo_data,
+                    vcard_raw      = excluded.vcard_raw,
+                    cached_at      = excluded.cached_at,
+                    title          = excluded.title,
+                    birthday       = excluded.birthday,
+                    note           = excluded.note,
+                    addresses_json = excluded.addresses_json,
+                    urls_json      = excluded.urls_json",
             )?;
             for c in upserts {
                 let id = format!("{nc_account_id}::{}", c.vcard_uid);
                 let emails = serde_json::to_string(&c.emails).unwrap_or_else(|_| "[]".into());
                 let phones = serde_json::to_string(&c.phones).unwrap_or_else(|_| "[]".into());
+                let addresses =
+                    serde_json::to_string(&c.addresses).unwrap_or_else(|_| "[]".into());
+                let urls = serde_json::to_string(&c.urls).unwrap_or_else(|_| "[]".into());
                 stmt.execute(params![
                     id,
                     nc_account_id,
@@ -143,6 +162,11 @@ impl Cache {
                     c.photo_data,
                     c.vcard_raw,
                     now,
+                    c.title,
+                    c.birthday,
+                    c.note,
+                    addresses,
+                    urls,
                 ])?;
             }
         }
@@ -171,6 +195,28 @@ impl Cache {
 
         tx.commit()?;
         Ok(())
+    }
+
+    /// Most-recent `last_synced_at` across every addressbook for the
+    /// given Nextcloud account, in UTC. `Ok(None)` means we've never
+    /// completed a sync for this account — the settings UI uses that
+    /// to show "Never synced" rather than a misleading "0s ago".
+    pub fn latest_addressbook_sync_at(
+        &self,
+        nc_account_id: &str,
+    ) -> Result<Option<DateTime<Utc>>, CacheError> {
+        let conn = self.pool.get()?;
+        let ts: Option<i64> = conn
+            .query_row(
+                "SELECT MAX(last_synced_at)
+                 FROM addressbook_sync_state
+                 WHERE nextcloud_account_id = ?1",
+                params![nc_account_id],
+                |r| r.get(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(ts.and_then(|t| Utc.timestamp_opt(t, 0).single()))
     }
 
     /// Read the addressbook sync bookmark, if any.
@@ -217,7 +263,8 @@ impl Cache {
             Some(nc) => {
                 stmt = conn.prepare(
                     "SELECT id, nextcloud_account_id, display_name, emails_json,
-                            phones_json, organization, photo_mime
+                            phones_json, organization, photo_mime,
+                            title, birthday, note, addresses_json, urls_json
                      FROM contacts
                      WHERE nextcloud_account_id = ?1
                      ORDER BY display_name COLLATE NOCASE",
@@ -227,7 +274,8 @@ impl Cache {
             None => {
                 stmt = conn.prepare(
                     "SELECT id, nextcloud_account_id, display_name, emails_json,
-                            phones_json, organization, photo_mime
+                            phones_json, organization, photo_mime,
+                            title, birthday, note, addresses_json, urls_json
                      FROM contacts
                      ORDER BY display_name COLLATE NOCASE",
                 )?;
@@ -282,7 +330,8 @@ impl Cache {
         // doesn't render avatars, so shipping bytes is pure waste.
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, display_name, emails_json,
-                    phones_json, organization, photo_mime
+                    phones_json, organization, photo_mime,
+                    title, birthday, note, addresses_json, urls_json
              FROM contacts
              WHERE emails_json != '[]'
                AND (display_name LIKE ?1 ESCAPE '\\' COLLATE NOCASE
@@ -361,24 +410,33 @@ impl Cache {
         let id = format!("{nc_account_id}::{}", row.vcard_uid);
         let emails = serde_json::to_string(&row.emails).unwrap_or_else(|_| "[]".into());
         let phones = serde_json::to_string(&row.phones).unwrap_or_else(|_| "[]".into());
+        let addresses = serde_json::to_string(&row.addresses).unwrap_or_else(|_| "[]".into());
+        let urls = serde_json::to_string(&row.urls).unwrap_or_else(|_| "[]".into());
         let now = Utc::now().timestamp();
         conn.execute(
             "INSERT INTO contacts
                 (id, nextcloud_account_id, addressbook, vcard_uid, href, etag,
                  display_name, emails_json, phones_json, organization,
-                 photo_mime, photo_data, vcard_raw, cached_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                 photo_mime, photo_data, vcard_raw, cached_at,
+                 title, birthday, note, addresses_json, urls_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                     ?15, ?16, ?17, ?18, ?19)
              ON CONFLICT (nextcloud_account_id, addressbook, vcard_uid) DO UPDATE SET
-                href         = excluded.href,
-                etag         = excluded.etag,
-                display_name = excluded.display_name,
-                emails_json  = excluded.emails_json,
-                phones_json  = excluded.phones_json,
-                organization = excluded.organization,
-                photo_mime   = excluded.photo_mime,
-                photo_data   = excluded.photo_data,
-                vcard_raw    = excluded.vcard_raw,
-                cached_at    = excluded.cached_at",
+                href           = excluded.href,
+                etag           = excluded.etag,
+                display_name   = excluded.display_name,
+                emails_json    = excluded.emails_json,
+                phones_json    = excluded.phones_json,
+                organization   = excluded.organization,
+                photo_mime     = excluded.photo_mime,
+                photo_data     = excluded.photo_data,
+                vcard_raw      = excluded.vcard_raw,
+                cached_at      = excluded.cached_at,
+                title          = excluded.title,
+                birthday       = excluded.birthday,
+                note           = excluded.note,
+                addresses_json = excluded.addresses_json,
+                urls_json      = excluded.urls_json",
             params![
                 id,
                 nc_account_id,
@@ -394,6 +452,11 @@ impl Cache {
                 row.photo_data,
                 row.vcard_raw,
                 now,
+                row.title,
+                row.birthday,
+                row.note,
+                addresses,
+                urls,
             ],
         )?;
         Ok(())
@@ -430,6 +493,8 @@ impl Cache {
 fn row_to_contact_no_photo(r: &rusqlite::Row<'_>) -> rusqlite::Result<Contact> {
     let emails_json: String = r.get(3)?;
     let phones_json: String = r.get(4)?;
+    let addresses_json: String = r.get(10)?;
+    let urls_json: String = r.get(11)?;
     Ok(Contact {
         id: r.get(0)?,
         nextcloud_account_id: r.get(1)?,
@@ -439,6 +504,11 @@ fn row_to_contact_no_photo(r: &rusqlite::Row<'_>) -> rusqlite::Result<Contact> {
         organization: r.get(5)?,
         photo_mime: r.get(6)?,
         photo_data: None,
+        title: r.get(7)?,
+        birthday: r.get(8)?,
+        note: r.get(9)?,
+        addresses: serde_json::from_str(&addresses_json).unwrap_or_default(),
+        urls: serde_json::from_str(&urls_json).unwrap_or_default(),
     })
 }
 
@@ -466,6 +536,11 @@ mod tests {
             organization: None,
             photo_mime: None,
             photo_data: None,
+            title: None,
+            birthday: None,
+            note: None,
+            addresses: Vec::new(),
+            urls: Vec::new(),
             vcard_raw: format!("BEGIN:VCARD\r\nUID:{uid}\r\nEND:VCARD\r\n"),
         }
     }

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -535,6 +535,28 @@ const MIGRATIONS: &[&str] = &[
     ALTER TABLE accounts
         ADD COLUMN trusted_certs_json TEXT NOT NULL DEFAULT '[]';
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v9 → v10: extra contact fields (Issue #66).
+    //
+    // Adds the fields the new contact-card view exposes — title,
+    // birthday, addresses, urls, note. We store the variable-length
+    // ones (addresses, urls) as JSON blobs alongside the existing
+    // `emails_json` / `phones_json` columns; the singletons get
+    // their own scalar columns.
+    //
+    // NOT NULL with sensible empty defaults so older contact rows
+    // (written before this column existed) decode straight back to
+    // an empty list / NULL singleton without a separate backfill.
+    // The `vcard_raw` blob still carries the source data so a future
+    // re-parse can pull anything we missed.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE contacts ADD COLUMN title TEXT;
+    ALTER TABLE contacts ADD COLUMN birthday TEXT;
+    ALTER TABLE contacts ADD COLUMN note TEXT;
+    ALTER TABLE contacts ADD COLUMN addresses_json TEXT NOT NULL DEFAULT '[]';
+    ALTER TABLE contacts ADD COLUMN urls_json TEXT NOT NULL DEFAULT '[]';
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -673,6 +673,60 @@ fn search_contacts(
     cache.search_contacts(&query, limit).map_err(Into::into)
 }
 
+/// Aggregate sync status for the Settings UI's Contacts and
+/// Calendars rows. Both surfaces want the same shape: when did we
+/// last successfully sync, and what's the cached count? — so we
+/// share the struct and reuse the `SyncStatusRow` Svelte component.
+#[derive(Debug, Clone, Serialize)]
+struct SyncStatus {
+    /// RFC 3339 timestamp of the most recent successful sync across
+    /// every addressbook / calendar for this account, or `None` if
+    /// the account has never finished one. The frontend formats it
+    /// relative ("12m ago" / "Synced just now").
+    last_synced_at: Option<String>,
+    /// Cached row count for this account (contacts or calendars).
+    /// Mostly informational — the row title carries the meaningful
+    /// "are we up to date?" signal.
+    count: u32,
+}
+
+#[tauri::command]
+fn get_contacts_sync_status(
+    nc_id: String,
+    cache: State<'_, Cache>,
+) -> Result<SyncStatus, NimbusError> {
+    let last = cache
+        .latest_addressbook_sync_at(&nc_id)
+        .map_err(NimbusError::from)?
+        .map(|t| t.to_rfc3339());
+    let count = cache
+        .count_contacts(&nc_id)
+        .map_err(NimbusError::from)?;
+    Ok(SyncStatus {
+        last_synced_at: last,
+        count,
+    })
+}
+
+#[tauri::command]
+fn get_calendars_sync_status(
+    nc_id: String,
+    cache: State<'_, Cache>,
+) -> Result<SyncStatus, NimbusError> {
+    let last = cache
+        .latest_calendar_sync_at(&nc_id)
+        .map_err(NimbusError::from)?
+        .map(|t| t.to_rfc3339());
+    let count = cache
+        .list_calendars(&nc_id)
+        .map(|cs| cs.len() as u32)
+        .unwrap_or(0);
+    Ok(SyncStatus {
+        last_synced_at: last,
+        count,
+    })
+}
+
 /// Fetched separately from `get_contacts` because photo bytes are
 /// huge and Tauri serialises them as JSON number arrays — shipping
 /// every photo with the list payload made the contacts view feel
@@ -709,6 +763,22 @@ fn raw_contact_to_row(c: &RawContact) -> ContactRow {
         organization: c.organization.clone(),
         photo_mime: c.photo_mime.clone(),
         photo_data: c.photo_data.clone(),
+        title: c.title.clone(),
+        birthday: c.birthday.clone(),
+        note: c.note.clone(),
+        addresses: c
+            .addresses
+            .iter()
+            .map(|a| nimbus_core::models::ContactAddress {
+                kind: a.kind.clone(),
+                street: a.street.clone(),
+                locality: a.locality.clone(),
+                region: a.region.clone(),
+                postal_code: a.postal_code.clone(),
+                country: a.country.clone(),
+            })
+            .collect(),
+        urls: c.urls.clone(),
         vcard_raw: c.vcard_raw.clone(),
     }
 }
@@ -730,6 +800,11 @@ fn raw_contact_to_row(c: &RawContact) -> ContactRow {
 // addressbook) by contact id; the UI never has to carry those around.
 
 /// Editable fields for a contact, shared by create and update.
+/// The "extended" block (title, birthday, note, addresses, urls)
+/// is optional so older UI versions that don't surface those
+/// fields keep working — `update_contact` merges over the cached
+/// vCard, so missing fields preserve whatever's on the server
+/// instead of clobbering it.
 #[derive(Debug, Clone, Deserialize)]
 struct ContactInput {
     display_name: String,
@@ -738,6 +813,16 @@ struct ContactInput {
     organization: Option<String>,
     photo_mime: Option<String>,
     photo_data: Option<Vec<u8>>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    birthday: Option<String>,
+    #[serde(default)]
+    note: Option<String>,
+    #[serde(default)]
+    addresses: Option<Vec<nimbus_core::models::ContactAddress>>,
+    #[serde(default)]
+    urls: Option<Vec<String>>,
 }
 
 /// Create a new contact on Nextcloud and cache it locally.
@@ -774,18 +859,7 @@ async fn create_contact(
     )
     .await?;
 
-    let row = ContactRow {
-        href: outcome.href.clone(),
-        etag: outcome.etag.clone(),
-        vcard_uid: uid.clone(),
-        display_name: parsed.display_name.clone(),
-        emails: parsed.emails.clone(),
-        phones: parsed.phones.clone(),
-        organization: parsed.organization.clone(),
-        photo_mime: parsed.photo_mime.clone(),
-        photo_data: parsed.photo_data.clone(),
-        vcard_raw: vcard,
-    };
+    let row = parsed_to_row(&outcome.href, &outcome.etag, &uid, &parsed, vcard);
     cache
         .upsert_single_contact(&nc_id, &addressbook_name, &row)
         .map_err(NimbusError::from)?;
@@ -807,7 +881,57 @@ async fn update_contact(
     let account = load_nextcloud_account(&handle.nextcloud_account_id)?;
     let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
 
-    let parsed = input_to_parsed(&handle.vcard_uid, &input);
+    // Merge the form fields over the existing parsed vCard so fields
+    // the edit form doesn't surface (addresses, birthday, urls, note,
+    // title, …) round-trip instead of being silently wiped on every
+    // edit. The form-editable fields below replace whatever was there.
+    let mut parsed = match nimbus_carddav::parse_vcard(&handle.vcard_raw) {
+        Ok(p) => p,
+        Err(_) => ParsedVcard {
+            uid: handle.vcard_uid.clone(),
+            ..Default::default()
+        },
+    };
+    parsed.uid = handle.vcard_uid.clone();
+    parsed.display_name = input.display_name.clone();
+    parsed.emails = input.emails.clone();
+    parsed.phones = input.phones.clone();
+    parsed.organization = input.organization.clone();
+    if input.photo_data.is_some() {
+        parsed.photo_mime = input.photo_mime.clone();
+        parsed.photo_data = input.photo_data.clone();
+    }
+    // Extended fields: a UI that surfaces them sends the new value
+    // (or `None` to clear); a UI that doesn't sends `Option::None`
+    // for the *whole field*, in which case we leave the cached
+    // value alone. The distinction is made via `serde(default)` on
+    // `ContactInput` — `None` only ever appears when the JSON omits
+    // the key entirely, never when the user explicitly cleared it.
+    if let Some(t) = &input.title {
+        parsed.title = if t.is_empty() { None } else { Some(t.clone()) };
+    }
+    if let Some(b) = &input.birthday {
+        parsed.birthday = if b.is_empty() { None } else { Some(b.clone()) };
+    }
+    if let Some(n) = &input.note {
+        parsed.note = if n.is_empty() { None } else { Some(n.clone()) };
+    }
+    if let Some(addrs) = &input.addresses {
+        parsed.addresses = addrs
+            .iter()
+            .map(|a| nimbus_carddav::VcardAddress {
+                kind: a.kind.clone(),
+                street: a.street.clone(),
+                locality: a.locality.clone(),
+                region: a.region.clone(),
+                postal_code: a.postal_code.clone(),
+                country: a.country.clone(),
+            })
+            .collect();
+    }
+    if let Some(urls) = &input.urls {
+        parsed.urls = urls.clone();
+    }
     let vcard = build_vcard(&parsed);
 
     let outcome = carddav_update_contact(
@@ -819,18 +943,7 @@ async fn update_contact(
     )
     .await?;
 
-    let row = ContactRow {
-        href: outcome.href.clone(),
-        etag: outcome.etag.clone(),
-        vcard_uid: handle.vcard_uid.clone(),
-        display_name: parsed.display_name.clone(),
-        emails: parsed.emails.clone(),
-        phones: parsed.phones.clone(),
-        organization: parsed.organization.clone(),
-        photo_mime: parsed.photo_mime.clone(),
-        photo_data: parsed.photo_data.clone(),
-        vcard_raw: vcard,
-    };
+    let row = parsed_to_row(&outcome.href, &outcome.etag, &handle.vcard_uid, &parsed, vcard);
     cache
         .upsert_single_contact(&handle.nextcloud_account_id, &handle.addressbook, &row)
         .map_err(NimbusError::from)?;
@@ -1453,6 +1566,67 @@ fn input_to_parsed(uid: &str, input: &ContactInput) -> ParsedVcard {
         organization: input.organization.clone(),
         photo_mime: input.photo_mime.clone(),
         photo_data: input.photo_data.clone(),
+        title: input.title.clone(),
+        birthday: input.birthday.clone(),
+        note: input.note.clone(),
+        addresses: input
+            .addresses
+            .as_ref()
+            .map(|list| {
+                list.iter()
+                    .map(|a| nimbus_carddav::VcardAddress {
+                        kind: a.kind.clone(),
+                        street: a.street.clone(),
+                        locality: a.locality.clone(),
+                        region: a.region.clone(),
+                        postal_code: a.postal_code.clone(),
+                        country: a.country.clone(),
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        urls: input.urls.clone().unwrap_or_default(),
+        ..Default::default()
+    }
+}
+
+/// Build a `ContactRow` from a freshly-PUT vCard's outcome. Extracted
+/// so create/update both ship the same set of extended fields
+/// (addresses, birthday, urls, note, title) into the cache.
+fn parsed_to_row(
+    href: &str,
+    etag: &str,
+    uid: &str,
+    parsed: &ParsedVcard,
+    vcard_raw: String,
+) -> ContactRow {
+    ContactRow {
+        href: href.to_string(),
+        etag: etag.to_string(),
+        vcard_uid: uid.to_string(),
+        display_name: parsed.display_name.clone(),
+        emails: parsed.emails.clone(),
+        phones: parsed.phones.clone(),
+        organization: parsed.organization.clone(),
+        photo_mime: parsed.photo_mime.clone(),
+        photo_data: parsed.photo_data.clone(),
+        title: parsed.title.clone(),
+        birthday: parsed.birthday.clone(),
+        note: parsed.note.clone(),
+        addresses: parsed
+            .addresses
+            .iter()
+            .map(|a| nimbus_core::models::ContactAddress {
+                kind: a.kind.clone(),
+                street: a.street.clone(),
+                locality: a.locality.clone(),
+                region: a.region.clone(),
+                postal_code: a.postal_code.clone(),
+                country: a.country.clone(),
+            })
+            .collect(),
+        urls: parsed.urls.clone(),
+        vcard_raw,
     }
 }
 
@@ -1470,6 +1644,11 @@ fn row_to_contact(nc_account_id: &str, row: &ContactRow) -> Contact {
         organization: row.organization.clone(),
         photo_mime: row.photo_mime.clone(),
         photo_data: row.photo_data.clone(),
+        title: row.title.clone(),
+        birthday: row.birthday.clone(),
+        note: row.note.clone(),
+        addresses: row.addresses.clone(),
+        urls: row.urls.clone(),
     }
 }
 
@@ -2792,6 +2971,8 @@ fn main() {
             upload_to_nextcloud,
             save_bytes_to_path,
             sync_nextcloud_contacts,
+            get_contacts_sync_status,
+            get_calendars_sync_status,
             get_contacts,
             search_contacts,
             get_contact_photo,

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -738,13 +738,11 @@
       >
         + New event
       </button>
-      <button
-        class="btn preset-tonal-surface text-sm"
-        disabled={syncing}
-        onclick={() => void syncInBackground()}
-      >
-        Sync now
-      </button>
+      <!-- "Sync now" lives in Settings → Nextcloud → Calendars now;
+           keeping a button here was the second sync-trigger surface
+           and made the row in settings feel redundant. The "Syncing…"
+           badge above still tells the user when a background sync
+           that *was* triggered from settings is in flight. -->
       <button class="btn preset-tonal-surface text-sm" onclick={onclose}>
         Close
       </button>
@@ -758,8 +756,9 @@
     <p class="px-6 py-4 text-sm text-red-500">{error}</p>
   {:else if calendars.length === 0}
     <p class="px-6 py-4 text-sm text-surface-500">
-      No calendars cached yet. Click <strong>Sync now</strong> to pull them
-      from your Nextcloud account.
+      No calendars cached yet. Open
+      <strong>Settings → Nextcloud → Calendars</strong> and click
+      <strong>Sync now</strong> to pull them from your Nextcloud account.
     </p>
   {:else}
     <div class="flex flex-1 min-h-0">

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -24,6 +24,14 @@
     username: string
     display_name?: string | null
   }
+  interface ContactAddress {
+    kind: string
+    street: string
+    locality: string
+    region: string
+    postal_code: string
+    country: string
+  }
   interface Contact {
     id: string
     nextcloud_account_id: string
@@ -33,6 +41,11 @@
     organization: string | null
     photo_mime: string | null
     photo_data: number[] | null
+    title?: string | null
+    birthday?: string | null
+    note?: string | null
+    addresses?: ContactAddress[]
+    urls?: string[]
   }
   interface ContactInput {
     display_name: string
@@ -41,6 +54,14 @@
     organization: string | null
     photo_mime: string | null
     photo_data: number[] | null
+    /** Optional extended fields. The Rust side merges them over the
+        cached vCard so omitting a field preserves whatever was on
+        the server, instead of clearing it. */
+    title?: string | null
+    birthday?: string | null
+    note?: string | null
+    addresses?: ContactAddress[]
+    urls?: string[]
   }
   interface AddressbookSummary {
     path: string
@@ -67,6 +88,15 @@
   let formEmails = $state('') // newline-separated
   let formPhones = $state('') // newline-separated
   let formOrg = $state('')
+  let formTitle = $state('')
+  let formBirthday = $state('')
+  let formNote = $state('')
+  let formUrls = $state('') // newline-separated
+  // Addresses are an array of records, edited in place. We model a
+  // single concatenated free-text field per address keeping
+  // street/locality/region/postal/country on separate lines so the
+  // form stays readable without exploding into one input per slot.
+  let formAddresses = $state<ContactAddress[]>([])
   let formAccountId = $state('')       // only used for create
   let formAddressbookUrl = $state('')  // only used for create
   let formAddressbookName = $state('') // only used for create
@@ -193,6 +223,11 @@
     formEmails = c.email.join('\n')
     formPhones = c.phone.join('\n')
     formOrg = c.organization ?? ''
+    formTitle = c.title ?? ''
+    formBirthday = c.birthday ?? ''
+    formNote = c.note ?? ''
+    formUrls = (c.urls ?? []).join('\n')
+    formAddresses = (c.addresses ?? []).map((a) => ({ ...a }))
     selectedPhotoBytes = null
     // We still need the bytes (not just a URL) so save can re-emit
     // them in the vCard — without this, an edit drops the avatar.
@@ -207,11 +242,37 @@
     formEmails = ''
     formPhones = ''
     formOrg = ''
+    formTitle = ''
+    formBirthday = ''
+    formNote = ''
+    formUrls = ''
+    formAddresses = []
     selectedPhotoBytes = null
     if (!formAccountId && accounts.length > 0) {
       formAccountId = accounts[0].id
     }
     if (formAccountId) void loadAddressbooksFor(formAccountId)
+  }
+
+  /** Add a blank address row. Defaults to "home" so the picker has
+      something selected — RFC 6350's TYPE param is optional but
+      Nextcloud Contacts always groups by it, so we may as well too. */
+  function addAddress() {
+    formAddresses = [
+      ...formAddresses,
+      {
+        kind: 'home',
+        street: '',
+        locality: '',
+        region: '',
+        postal_code: '',
+        country: '',
+      },
+    ]
+  }
+
+  function removeAddress(idx: number) {
+    formAddresses = formAddresses.filter((_, i) => i !== idx)
   }
 
   function cancelEdit() {
@@ -284,6 +345,20 @@
       organization: formOrg.trim() || null,
       photo_mime: existingMime,
       photo_data: existingMime ? selectedPhotoBytes : null,
+      title: formTitle.trim() || null,
+      birthday: formBirthday.trim() || null,
+      note: formNote.trim() || null,
+      urls: splitLines(formUrls),
+      // Strip empty rows so the user can't end up with a phantom
+      // address from forgetting to fill in the slots they added.
+      addresses: formAddresses.filter(
+        (a) =>
+          a.street.trim() ||
+          a.locality.trim() ||
+          a.region.trim() ||
+          a.postal_code.trim() ||
+          a.country.trim(),
+      ),
     }
   }
 
@@ -483,9 +558,83 @@
           ></textarea>
         </label>
 
+        <div class="grid grid-cols-2 gap-3">
+          <label class="label">
+            <span>Organization</span>
+            <input class="input" bind:value={formOrg} placeholder="Example Corp" />
+          </label>
+          <label class="label">
+            <span>Job title</span>
+            <input class="input" bind:value={formTitle} placeholder="Product Manager" />
+          </label>
+        </div>
+
         <label class="label">
-          <span>Organization</span>
-          <input class="input" bind:value={formOrg} placeholder="Example Corp" />
+          <span>Birthday</span>
+          <input
+            class="input"
+            bind:value={formBirthday}
+            placeholder="1985-10-31"
+          />
+        </label>
+
+        <label class="label">
+          <span>Websites <span class="text-surface-500">(one per line)</span></span>
+          <textarea
+            class="textarea"
+            rows="2"
+            bind:value={formUrls}
+            placeholder="https://example.com"
+          ></textarea>
+        </label>
+
+        <!-- Postal addresses. Variable-length so we render with an
+             explicit add/remove instead of a free-text textarea —
+             matches the Nextcloud Contacts UI's per-address card and
+             keeps street/city/region/postal/country round-tripping
+             cleanly through the vCard ADR field. -->
+        <div class="space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-medium">Addresses</span>
+            <button type="button" class="btn btn-sm preset-tonal" onclick={addAddress}>
+              + Add address
+            </button>
+          </div>
+          {#each formAddresses as addr, i (i)}
+            <div class="card p-3 bg-surface-50 dark:bg-surface-900/50 rounded-md space-y-2">
+              <div class="flex items-center gap-2">
+                <select class="select w-32" bind:value={addr.kind}>
+                  <option value="home">Home</option>
+                  <option value="work">Work</option>
+                  <option value="other">Other</option>
+                </select>
+                <button
+                  type="button"
+                  class="ml-auto text-xs text-error-500 hover:underline"
+                  onclick={() => removeAddress(i)}
+                >Remove</button>
+              </div>
+              <input class="input" bind:value={addr.street} placeholder="Street" />
+              <div class="grid grid-cols-2 gap-2">
+                <input class="input" bind:value={addr.locality} placeholder="City" />
+                <input class="input" bind:value={addr.region} placeholder="Region / State" />
+              </div>
+              <div class="grid grid-cols-2 gap-2">
+                <input class="input" bind:value={addr.postal_code} placeholder="Postal code" />
+                <input class="input" bind:value={addr.country} placeholder="Country" />
+              </div>
+            </div>
+          {/each}
+        </div>
+
+        <label class="label">
+          <span>Notes</span>
+          <textarea
+            class="textarea"
+            rows="3"
+            bind:value={formNote}
+            placeholder="Anything you want to remember about this contact"
+          ></textarea>
         </label>
 
         {#if selectedId === 'new'}

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -15,6 +15,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import SyncStatusRow from './SyncStatusRow.svelte'
 
   // ── Types (mirror the Rust models) ──────────────────────────
   interface NextcloudCapabilities {
@@ -48,13 +49,21 @@
   }
   // Per-account sync view-model. Keyed by account id so rows
   // render independently and one account's spinner doesn't block
-  // another's. `lastSyncedAt` is only set after a successful run.
-  interface ContactsState {
+  // another's. `lastSyncedAt` comes from the cache via
+  // `get_{contacts,calendars}_sync_status` — RFC 3339 from Rust,
+  // which `SyncStatusRow` formats as a relative phrase.
+  interface SyncRowState {
     syncing: boolean
-    lastSyncedAt: number | null  // ms epoch
-    lastReport: SyncContactsReport | null
-    count: number                 // contacts cached locally
+    lastSyncedAt: string | null
+    count: number
     error: string
+  }
+
+  // Same Tauri payload shape for both contacts and calendars
+  // sync-status reads.
+  interface SyncStatus {
+    last_synced_at: string | null
+    count: number
   }
 
   // ── State ───────────────────────────────────────────────────
@@ -62,10 +71,11 @@
   let loading = $state(true)
   let error = $state('')
 
-  // Per-account contacts state, keyed by NC account id. Lives
-  // outside `accounts` so resorting/refreshing the list doesn't
-  // wipe in-flight sync status.
-  let contactsState = $state<Record<string, ContactsState>>({})
+  // Per-account contacts/calendars state, keyed by NC account id.
+  // Lives outside `accounts` so resorting/refreshing the list
+  // doesn't wipe in-flight sync status.
+  let contactsState = $state<Record<string, SyncRowState>>({})
+  let calendarsState = $state<Record<string, SyncRowState>>({})
 
   // Connect flow
   let serverInput = $state('')
@@ -83,30 +93,46 @@
     error = ''
     try {
       accounts = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
-      // Seed contacts state for any new accounts, and refresh the
-      // cached count for existing ones. Count failure is non-fatal —
-      // we just leave the old value.
+      // Seed sync-row state for any new accounts and refresh the
+      // cached counts + last-sync timestamps for existing ones.
+      // Failures are non-fatal — we just keep the old values so a
+      // transient cache hiccup doesn't blank the row.
       for (const a of accounts) {
-        if (!contactsState[a.id]) {
-          contactsState[a.id] = {
-            syncing: false,
-            lastSyncedAt: null,
-            lastReport: null,
-            count: 0,
-            error: '',
-          }
-        }
-        try {
-          const rows = await invoke<unknown[]>('get_contacts', { ncId: a.id })
-          contactsState[a.id].count = rows.length
-        } catch (e) {
-          console.warn('get_contacts failed for', a.id, e)
-        }
+        ensureRow(contactsState, a.id)
+        ensureRow(calendarsState, a.id)
+        await refreshContactsStatus(a.id)
+        await refreshCalendarsStatus(a.id)
       }
     } catch (e) {
       error = formatError(e) || 'Failed to load Nextcloud connections'
     } finally {
       loading = false
+    }
+  }
+
+  function ensureRow(map: Record<string, SyncRowState>, id: string) {
+    if (!map[id]) {
+      map[id] = { syncing: false, lastSyncedAt: null, count: 0, error: '' }
+    }
+  }
+
+  async function refreshContactsStatus(ncId: string) {
+    try {
+      const s = await invoke<SyncStatus>('get_contacts_sync_status', { ncId })
+      contactsState[ncId].lastSyncedAt = s.last_synced_at
+      contactsState[ncId].count = s.count
+    } catch (e) {
+      console.warn('get_contacts_sync_status failed for', ncId, e)
+    }
+  }
+
+  async function refreshCalendarsStatus(ncId: string) {
+    try {
+      const s = await invoke<SyncStatus>('get_calendars_sync_status', { ncId })
+      calendarsState[ncId].lastSyncedAt = s.last_synced_at
+      calendarsState[ncId].count = s.count
+    } catch (e) {
+      console.warn('get_calendars_sync_status failed for', ncId, e)
     }
   }
 
@@ -127,19 +153,10 @@
       const report = await invoke<SyncContactsReport>('sync_nextcloud_contacts', {
         ncId: acct.id,
       })
-      state.lastReport = report
-      state.lastSyncedAt = Date.now()
       if (report.errors.length > 0) {
         state.error = report.errors.join('; ')
       }
-      // Refresh the cached count — the sync report gives deltas, not
-      // an absolute total.
-      try {
-        const rows = await invoke<unknown[]>('get_contacts', { ncId: acct.id })
-        state.count = rows.length
-      } catch (e) {
-        console.warn('get_contacts refresh failed', e)
-      }
+      await refreshContactsStatus(acct.id)
     } catch (e) {
       state.error = formatError(e) || 'Sync failed'
     } finally {
@@ -147,15 +164,27 @@
     }
   }
 
-  function formatRelative(ts: number | null): string {
-    if (ts === null) return 'never'
-    const diffMs = Date.now() - ts
-    if (diffMs < 60_000) return 'just now'
-    const mins = Math.floor(diffMs / 60_000)
-    if (mins < 60) return `${mins}m ago`
-    const hours = Math.floor(mins / 60)
-    if (hours < 24) return `${hours}h ago`
-    return `${Math.floor(hours / 24)}d ago`
+  /** Mirror of `syncContacts` for calendars — same backend pattern,
+      same UI shape, both feed the same `SyncStatusRow` component. */
+  async function syncCalendars(acct: NextcloudAccount) {
+    const state = calendarsState[acct.id]
+    if (!state || state.syncing) return
+    state.syncing = true
+    state.error = ''
+    try {
+      const report = await invoke<{ errors: string[] }>(
+        'sync_nextcloud_calendars',
+        { ncId: acct.id },
+      )
+      if (report.errors.length > 0) {
+        state.error = report.errors.join('; ')
+      }
+      await refreshCalendarsStatus(acct.id)
+    } catch (e) {
+      state.error = formatError(e) || 'Sync failed'
+    } finally {
+      state.syncing = false
+    }
   }
 
   async function startConnect() {
@@ -303,30 +332,29 @@
 
             <!-- Contacts sync row -->
             {#if acct.capabilities?.carddav !== false}
-              <div class="flex items-center justify-between pt-2 border-t border-surface-300/40 dark:border-surface-700/60">
-                <div class="text-sm">
-                  <p>
-                    <span class="font-medium">Contacts:</span>
-                    {cs?.count ?? 0} cached
-                  </p>
-                  <p class="text-xs text-surface-500">
-                    Last sync: {formatRelative(cs?.lastSyncedAt ?? null)}
-                    {#if cs?.lastReport && (cs.lastReport.upserted > 0 || cs.lastReport.deleted > 0)}
-                      · {cs.lastReport.upserted} updated, {cs.lastReport.deleted} removed
-                    {/if}
-                  </p>
-                  {#if cs?.error}
-                    <p class="text-xs text-red-500 mt-1">{cs.error}</p>
-                  {/if}
-                </div>
-                <button
-                  class="btn btn-sm preset-outlined-primary-500"
-                  onclick={() => syncContacts(acct)}
-                  disabled={cs?.syncing}
-                >
-                  {cs?.syncing ? 'Syncing…' : 'Sync now'}
-                </button>
-              </div>
+              {@const cls = calendarsState[acct.id]}
+              <SyncStatusRow
+                label="Contacts"
+                count={cs?.count ?? null}
+                lastSyncedAt={cs?.lastSyncedAt ?? null}
+                syncing={cs?.syncing ?? false}
+                error={cs?.error ?? null}
+                onsync={() => syncContacts(acct)}
+              />
+              <!-- Calendars sync row — same component, same shape, so
+                   the two surfaces stay visually identical. CalendarView
+                   no longer carries its own sync UI; the user comes
+                   here to refresh. -->
+              {#if acct.capabilities?.caldav !== false}
+                <SyncStatusRow
+                  label="Calendars"
+                  count={cls?.count ?? null}
+                  lastSyncedAt={cls?.lastSyncedAt ?? null}
+                  syncing={cls?.syncing ?? false}
+                  error={cls?.error ?? null}
+                  onsync={() => syncCalendars(acct)}
+                />
+              {/if}
             {/if}
           </div>
         {/each}

--- a/ui/src/lib/SyncStatusRow.svelte
+++ b/ui/src/lib/SyncStatusRow.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  /**
+   * SyncStatusRow — one settings-panel row showing a sync status
+   * with a "Sync now" button. Used twice in NextcloudSettings:
+   * once for Contacts (CardDAV) and once for Calendars (CalDAV),
+   * so both surfaces stay visually identical and any future
+   * sync-able data type plugs in by passing the same props.
+   *
+   * The component is presentation-only: it doesn't talk to the
+   * backend itself. The parent owns the sync invocation and
+   * passes the resulting state in.
+   */
+
+  interface Props {
+    /** Row label — "Contacts" / "Calendars" / future categories. */
+    label: string
+    /** Total cached items for context — "12 cached". When zero
+        the chip is dropped so a brand-new account doesn't show
+        "0 cached" before its first sync. */
+    count?: number | null
+    /** RFC 3339 timestamp of the last successful sync, or `null`
+        if the account has never finished one. */
+    lastSyncedAt?: string | null
+    /** True while a sync is in flight — disables the button and
+        flips its label to "Syncing…". */
+    syncing?: boolean
+    /** Most recent sync error to surface, or empty/null for none. */
+    error?: string | null
+    /** Click handler for the "Sync now" button. Required — without
+        it the row is read-only and the button gets hidden. */
+    onsync?: () => void
+  }
+
+  let {
+    label,
+    count = null,
+    lastSyncedAt = null,
+    syncing = false,
+    error = null,
+    onsync,
+  }: Props = $props()
+
+  /** Format a sync timestamp as a relative phrase ("just now",
+      "12m ago", "3d ago"). Computed inside an `$effect` so it
+      ticks once a minute and the row updates without the parent
+      having to push a refresh signal — feels alive without being
+      a perf concern (one closure, one setInterval per mount). */
+  let now = $state(Date.now())
+  $effect(() => {
+    const t = window.setInterval(() => {
+      now = Date.now()
+    }, 60_000)
+    return () => window.clearInterval(t)
+  })
+
+  const relative = $derived.by(() => {
+    if (!lastSyncedAt) return 'Never synced'
+    const ts = Date.parse(lastSyncedAt)
+    if (Number.isNaN(ts)) return 'Never synced'
+    const diffMs = now - ts
+    if (diffMs < 60_000) return 'Synced just now'
+    const mins = Math.floor(diffMs / 60_000)
+    if (mins < 60) return `Synced ${mins}m ago`
+    const hours = Math.floor(mins / 60)
+    if (hours < 24) return `Synced ${hours}h ago`
+    return `Synced ${Math.floor(hours / 24)}d ago`
+  })
+</script>
+
+<div
+  class="flex items-center justify-between pt-2 border-t border-surface-300/40 dark:border-surface-700/60"
+>
+  <div class="text-sm min-w-0">
+    <p class="font-medium truncate">
+      {label}
+      {#if count !== null && count > 0}
+        <span class="text-surface-500 font-normal">· {count} cached</span>
+      {/if}
+    </p>
+    <p class="text-xs text-surface-500">
+      {syncing ? 'Syncing…' : relative}
+    </p>
+    {#if error}
+      <p class="text-xs text-error-500 mt-1 break-all">{error}</p>
+    {/if}
+  </div>
+  {#if onsync}
+    <button
+      type="button"
+      class="btn btn-sm preset-outlined-primary-500 shrink-0"
+      onclick={onsync}
+      disabled={syncing}
+    >
+      {syncing ? 'Syncing…' : 'Sync now'}
+    </button>
+  {/if}
+</div>


### PR DESCRIPTION
Closes #66.

## Summary

### More contact fields
The contact view used to surface only name / emails / phones / organization / photo. Anyone with addresses, birthday, websites or notes saw none of that, and edits silently dropped those fields when re-emitting the vCard. Added end-to-end support for vCard `TITLE`, `BDAY`, `URL`, `NOTE`, and `ADR`:

- `nimbus_core::Contact` grows the new fields plus a `ContactAddress` struct.
- `nimbus_carddav::vcard` parses + emits the new properties (with regression tests for round-trip and address `TYPE` hint).
- Cache schema v9→v10 adds `title` / `birthday` / `note` columns and `addresses_json` / `urls_json` blobs. NOT NULL with empty defaults so old rows decode straight back.
- `ContactRow` and the sync delta path carry the new fields.
- `update_contact` re-parses the cached vCard and merges form input over it, so a UI version that doesn't surface a field preserves whatever was on the server instead of clearing it.
- `ContactsView` grows form inputs: title, birthday, URLs, per-row addresses block (add/remove + kind picker + slot inputs), notes textarea.

### Shared sync-status row
Two surfaces (NextcloudSettings, CalendarView) had their own ad-hoc sync UI. Replaced both with `SyncStatusRow.svelte` — one component, props `{label, count, lastSyncedAt, syncing, error, onsync}`, ticks its own minute-level relative-time formatter.

- New Tauri commands `get_contacts_sync_status` and `get_calendars_sync_status` aggregate `MAX(last_synced_at)` across every addressbook / calendar for an account, paired with the cached row count.
- Cache helpers `latest_addressbook_sync_at` and `latest_calendar_sync_at` back them.
- `NextcloudSettings.svelte` now shows two identical `SyncStatusRow`s per account (Contacts + Calendars).
- `CalendarView.svelte` drops its "Sync now" button; the empty-state copy points at Settings → Nextcloud → Calendars to keep one canonical sync trigger.

## Test plan
- [ ] `cargo test --workspace` passes (vCard round-trip + cache migration tests)
- [ ] `cargo tauri dev` starts; existing accounts come up with the new sync rows showing the right last-synced timestamp
- [ ] Pick a contact that has an address / birthday / URL on Nextcloud; the new fields appear populated
- [ ] Add an address (street + city + postal), save, re-open contact → values stick
- [ ] Edit a contact's name and save → the new fields aren't wiped (merge logic)
- [ ] Settings → Contacts "Sync now" + Calendars "Sync now" both work; the timestamp ticks to "just now" after the run
- [ ] Calendar view no longer has a "Sync now" button; the empty-state copy points at settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)