### PR TITLE
CalendarView: cluster-aware lane layout for overlapping events

### DIFF
--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -262,36 +262,60 @@
       })
     }
 
-    // Lane assignment per day for overlap handling. Same algorithm
-    // Google/Outlook use: sort by start, assign each event to the
-    // lowest-numbered lane whose last event has already ended. The
-    // day's total lane count then becomes the divisor for block
-    // widths. Simple first-pass: one lane count per day — two
-    // overlapping clusters share the widest-cluster's width even if
-    // they're not mutually overlapping. Good enough for V1; can
-    // narrow later with cluster-aware layout.
+    // Cluster-aware lane assignment per day.
+    //
+    // Two passes:
+    //
+    // 1. Walk events in start-time order and group consecutive
+    //    overlapping events into a "cluster". An event joins the
+    //    current cluster when its start is before the cluster's
+    //    running bottom (the latest end-time anyone in the cluster
+    //    reaches); otherwise it opens a new cluster. Standalone
+    //    events become single-event clusters.
+    //
+    // 2. Inside each cluster, assign each event to the lowest-numbered
+    //    lane whose previous occupant has already ended — same
+    //    algorithm Google / Outlook use. The cluster's lane count
+    //    becomes the width divisor *for that cluster's events only*,
+    //    so a 15:30 event with no neighbours stays full width even on
+    //    a day where 08:00 events are sharing two lanes.
     for (const bucket of buckets) {
       bucket.timed.sort((a, b) => a.topPx - b.topPx)
-      const laneEnds: number[] = [] // each lane's current bottom (px)
+
+      type Cluster = { events: typeof bucket.timed; bottom: number }
+      const clusters: Cluster[] = []
       for (const p of bucket.timed) {
-        const bottom = p.topPx + p.heightPx
-        let assigned = -1
-        for (let i = 0; i < laneEnds.length; i++) {
-          if (laneEnds[i] <= p.topPx) {
-            assigned = i
-            laneEnds[i] = bottom
-            break
-          }
+        const last = clusters[clusters.length - 1]
+        if (last && p.topPx < last.bottom) {
+          last.events.push(p)
+          last.bottom = Math.max(last.bottom, p.topPx + p.heightPx)
+        } else {
+          clusters.push({ events: [p], bottom: p.topPx + p.heightPx })
         }
-        if (assigned === -1) {
-          assigned = laneEnds.length
-          laneEnds.push(bottom)
-        }
-        p.lane = assigned
       }
-      const laneCount = Math.max(1, laneEnds.length)
-      for (const p of bucket.timed) {
-        p.laneCount = laneCount
+
+      for (const cluster of clusters) {
+        const laneEnds: number[] = [] // each lane's current bottom (px)
+        for (const p of cluster.events) {
+          const bottom = p.topPx + p.heightPx
+          let assigned = -1
+          for (let i = 0; i < laneEnds.length; i++) {
+            if (laneEnds[i] <= p.topPx) {
+              assigned = i
+              laneEnds[i] = bottom
+              break
+            }
+          }
+          if (assigned === -1) {
+            assigned = laneEnds.length
+            laneEnds.push(bottom)
+          }
+          p.lane = assigned
+        }
+        const laneCount = Math.max(1, laneEnds.length)
+        for (const p of cluster.events) {
+          p.laneCount = laneCount
+        }
       }
     }
 


### PR DESCRIPTION
The day-level lane layout shrank every event to the day's max overlap width, so a single non-overlapping event got squeezed alongside any pair of overlapping neighbours. The screenshot in the bug report shows three boxes (08:10 \"Dr…\", 09:00 \"Bad…\", 15:30 \"Fris…\") all rendered at half-width, when the 15:30 one has nothing to share a column with.

## Fix

Cluster-aware lane assignment — same algorithm Google / Outlook use:

1. Sort the day's events by start time.
2. Group consecutive overlapping events into a cluster. An event joins the current cluster when its start is before the cluster's running bottom (the latest end-time anyone in the cluster reaches); otherwise it opens a new cluster.
3. Inside each cluster, assign each event to the lowest-numbered lane whose previous occupant has ended. The cluster's lane count becomes the width divisor *for that cluster only*, so a standalone event lands back at full width.

## Test plan
- [ ] `cargo tauri dev`, open Calendar view
- [ ] Day with two overlapping events + one standalone → standalone is full-width, the two overlapping ones share half-width
- [ ] Day with three mutually-overlapping events → all three at 1/3 width (cluster of 3)
- [ ] Day with single events scattered → all full-width
- [ ] `cargo test --workspace` and `npm run check` pass

Branched off `main`, doesn't touch any line that PR #74 modifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)