### PR TITLE
Contacts: typed phone numbers + email addresses

### DIFF
--- a/crates/nimbus-carddav/src/lib.rs
+++ b/crates/nimbus-carddav/src/lib.rs
@@ -65,5 +65,5 @@ mod xml_util;
 
 pub use discovery::{Addressbook, list_addressbooks};
 pub use sync::{RawContact, SyncDelta, sync_addressbook};
-pub use vcard::{ParsedVcard, VcardAddress, VcardPhone, build_vcard, parse_vcard};
+pub use vcard::{ParsedVcard, VcardAddress, VcardEmail, VcardPhone, build_vcard, parse_vcard};
 pub use write::{WriteOutcome, create_contact, delete_contact, update_contact};

--- a/crates/nimbus-carddav/src/lib.rs
+++ b/crates/nimbus-carddav/src/lib.rs
@@ -65,5 +65,5 @@ mod xml_util;
 
 pub use discovery::{Addressbook, list_addressbooks};
 pub use sync::{RawContact, SyncDelta, sync_addressbook};
-pub use vcard::{ParsedVcard, VcardAddress, build_vcard, parse_vcard};
+pub use vcard::{ParsedVcard, VcardAddress, VcardPhone, build_vcard, parse_vcard};
 pub use write::{WriteOutcome, create_contact, delete_contact, update_contact};

--- a/crates/nimbus-carddav/src/sync.rs
+++ b/crates/nimbus-carddav/src/sync.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use nimbus_core::NimbusError;
 
 use crate::client::{absolute_url, build, normalize_server_url, report};
-use crate::vcard::{ParsedVcard, VcardAddress, parse_vcard};
+use crate::vcard::{ParsedVcard, VcardAddress, VcardPhone, parse_vcard};
 use crate::xml_util::{local_name, read_text_until, skip_subtree};
 
 /// One contact resource as seen on the server, with all the bookkeeping
@@ -55,7 +55,8 @@ pub struct RawContact {
     pub vcard_uid: String,
     pub display_name: String,
     pub emails: Vec<String>,
-    pub phones: Vec<String>,
+    /// Phone numbers paired with the vCard `TEL;TYPE=…` kind hint.
+    pub phones: Vec<VcardPhone>,
     pub organization: Option<String>,
     pub photo_mime: Option<String>,
     pub photo_data: Option<Vec<u8>>,

--- a/crates/nimbus-carddav/src/sync.rs
+++ b/crates/nimbus-carddav/src/sync.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use nimbus_core::NimbusError;
 
 use crate::client::{absolute_url, build, normalize_server_url, report};
-use crate::vcard::{ParsedVcard, VcardAddress, VcardPhone, parse_vcard};
+use crate::vcard::{ParsedVcard, VcardAddress, VcardEmail, VcardPhone, parse_vcard};
 use crate::xml_util::{local_name, read_text_until, skip_subtree};
 
 /// One contact resource as seen on the server, with all the bookkeeping
@@ -54,7 +54,8 @@ pub struct RawContact {
     pub etag: String,
     pub vcard_uid: String,
     pub display_name: String,
-    pub emails: Vec<String>,
+    /// Email addresses paired with the vCard `EMAIL;TYPE=…` kind.
+    pub emails: Vec<VcardEmail>,
     /// Phone numbers paired with the vCard `TEL;TYPE=…` kind hint.
     pub phones: Vec<VcardPhone>,
     pub organization: Option<String>,

--- a/crates/nimbus-carddav/src/vcard.rs
+++ b/crates/nimbus-carddav/src/vcard.rs
@@ -28,7 +28,7 @@ use nimbus_core::NimbusError;
 pub struct ParsedVcard {
     pub uid: String,
     pub display_name: String,
-    pub emails: Vec<String>,
+    pub emails: Vec<VcardEmail>,
     pub phones: Vec<VcardPhone>,
     pub organization: Option<String>,
     pub title: Option<String>,
@@ -63,6 +63,15 @@ pub struct VcardPhone {
     pub value: String,
 }
 
+/// One vCard `EMAIL` property. Same shape as `VcardPhone`; the
+/// kind hint comes from `TYPE=home` / `TYPE=work` (with the legacy
+/// `INTERNET` collapsed into `"other"`).
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct VcardEmail {
+    pub kind: String,
+    pub value: String,
+}
+
 /// Parse a single vCard string. The input is the raw `BEGIN:VCARD … END:VCARD`
 /// block; the `ical` parser returns at most one card from it.
 pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
@@ -77,7 +86,7 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
     let mut uid: Option<String> = None;
     let mut formatted_name = String::new();
     let mut structured_name = String::new();
-    let mut emails: Vec<String> = Vec::new();
+    let mut emails: Vec<VcardEmail> = Vec::new();
     let mut phones: Vec<VcardPhone> = Vec::new();
     let mut organization: Option<String> = None;
     let mut title: Option<String> = None;
@@ -103,8 +112,15 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
             }
             "EMAIL" => {
                 let v = value.trim().to_string();
-                if !v.is_empty() && !emails.contains(&v) {
-                    emails.push(v);
+                if v.is_empty() {
+                    continue;
+                }
+                let kind = email_kind(prop);
+                // Dedup by value (kind-agnostic) so a card that
+                // lists the same address with and without a TYPE
+                // doesn't duplicate.
+                if !emails.iter().any(|e| e.value == v) {
+                    emails.push(VcardEmail { kind, value: v });
                 }
             }
             "TEL" => {
@@ -197,7 +213,7 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
     } else if !structured_name.is_empty() {
         structured_name
     } else if let Some(first) = emails.first() {
-        first.clone()
+        first.value.clone()
     } else {
         "(unnamed)".to_string()
     };
@@ -232,6 +248,14 @@ fn address_kind(prop: &Property) -> String {
 /// else (pager, video, text, etc.) falls back to `"other"`.
 fn phone_kind(prop: &Property) -> String {
     pick_type(prop, &["home", "work", "cell", "fax"])
+}
+
+/// Same as `address_kind` for `EMAIL`. Only `home` / `work` are
+/// meaningful; `INTERNET` (a vCard 3 marker for "this is an
+/// internet email address" rather than X.400 — useless today)
+/// and any other value collapse into `"other"`.
+fn email_kind(prop: &Property) -> String {
+    pick_type(prop, &["home", "work"])
 }
 
 /// Walk a property's `TYPE=` parameter (which may be a single value
@@ -346,7 +370,17 @@ pub fn build_vcard(card: &ParsedVcard) -> String {
         &format!("N:{};;;;", escape_value(&card.display_name)),
     );
     for email in &card.emails {
-        push_line(&mut out, &format!("EMAIL:{}", escape_value(email)));
+        // Same `;TYPE=…` round-trip as TEL — empty kind drops the
+        // param (servers don't all accept `TYPE=` with no value).
+        let typ = if email.kind.is_empty() {
+            String::new()
+        } else {
+            format!(";TYPE={}", email.kind)
+        };
+        push_line(
+            &mut out,
+            &format!("EMAIL{typ}:{}", escape_value(&email.value)),
+        );
     }
     for phone in &card.phones {
         // Mirror the address `TYPE` round-trip: emit `TEL;TYPE=cell:…`
@@ -467,7 +501,11 @@ mod tests {
         let p = parse_vcard(raw).unwrap();
         assert_eq!(p.uid, "abc-123");
         assert_eq!(p.display_name, "Alice Example");
-        assert_eq!(p.emails, vec!["alice@example.com"]);
+        assert_eq!(p.emails.len(), 1);
+        // INTERNET collapses to "other" — vCard 3 puts INTERNET on
+        // every email and it carries no useful info.
+        assert_eq!(p.emails[0].kind, "other");
+        assert_eq!(p.emails[0].value, "alice@example.com");
         assert_eq!(p.phones.len(), 1);
         assert_eq!(p.phones[0].kind, "cell");
         assert_eq!(p.phones[0].value, "+1 555 0100");
@@ -500,7 +538,10 @@ mod tests {
         let original = ParsedVcard {
             uid: "abc-123".into(),
             display_name: "Alice Example".into(),
-            emails: vec!["alice@example.com".into(), "alice@work.com".into()],
+            emails: vec![
+                VcardEmail { kind: "home".into(), value: "alice@example.com".into() },
+                VcardEmail { kind: "work".into(), value: "alice@work.com".into() },
+            ],
             phones: vec![
                 VcardPhone { kind: "cell".into(), value: "+1 555 0100".into() },
                 VcardPhone { kind: "work".into(), value: "+1 555 0200".into() },
@@ -514,7 +555,11 @@ mod tests {
         let parsed = parse_vcard(&raw).expect("re-parse");
         assert_eq!(parsed.uid, "abc-123");
         assert_eq!(parsed.display_name, "Alice Example");
-        assert_eq!(parsed.emails, vec!["alice@example.com", "alice@work.com"]);
+        assert_eq!(parsed.emails.len(), 2);
+        assert_eq!(parsed.emails[0].kind, "home");
+        assert_eq!(parsed.emails[0].value, "alice@example.com");
+        assert_eq!(parsed.emails[1].kind, "work");
+        assert_eq!(parsed.emails[1].value, "alice@work.com");
         assert_eq!(parsed.phones.len(), 2);
         assert_eq!(parsed.phones[0].kind, "cell");
         assert_eq!(parsed.phones[0].value, "+1 555 0100");

--- a/crates/nimbus-carddav/src/vcard.rs
+++ b/crates/nimbus-carddav/src/vcard.rs
@@ -29,7 +29,7 @@ pub struct ParsedVcard {
     pub uid: String,
     pub display_name: String,
     pub emails: Vec<String>,
-    pub phones: Vec<String>,
+    pub phones: Vec<VcardPhone>,
     pub organization: Option<String>,
     pub title: Option<String>,
     pub addresses: Vec<VcardAddress>,
@@ -54,6 +54,15 @@ pub struct VcardAddress {
     pub country: String,
 }
 
+/// One vCard `TEL` property — the number plus a kind hint pulled
+/// from `TYPE=`. Mirrors `nimbus_core::models::ContactPhone`; same
+/// dependency-direction reasoning as `VcardAddress`.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct VcardPhone {
+    pub kind: String,
+    pub value: String,
+}
+
 /// Parse a single vCard string. The input is the raw `BEGIN:VCARD … END:VCARD`
 /// block; the `ical` parser returns at most one card from it.
 pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
@@ -69,7 +78,7 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
     let mut formatted_name = String::new();
     let mut structured_name = String::new();
     let mut emails: Vec<String> = Vec::new();
-    let mut phones: Vec<String> = Vec::new();
+    let mut phones: Vec<VcardPhone> = Vec::new();
     let mut organization: Option<String> = None;
     let mut title: Option<String> = None;
     let mut addresses: Vec<VcardAddress> = Vec::new();
@@ -100,8 +109,15 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
             }
             "TEL" => {
                 let v = value.trim().to_string();
-                if !v.is_empty() && !phones.contains(&v) {
-                    phones.push(v);
+                if v.is_empty() {
+                    continue;
+                }
+                let kind = phone_kind(prop);
+                // Dedup by value (kind-agnostic) — vCards from older
+                // syncs sometimes carry the same number twice with
+                // and without a TYPE; we keep the first occurrence.
+                if !phones.iter().any(|p| p.value == v) {
+                    phones.push(VcardPhone { kind, value: v });
                 }
             }
             "ORG" => {
@@ -208,6 +224,20 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
 /// `TYPE` parameter. vCard 4 lets the type be a comma-separated list
 /// (e.g. `TYPE="home,pref"`) — we take the first recognised value.
 fn address_kind(prop: &Property) -> String {
+    pick_type(prop, &["home", "work"])
+}
+
+/// Same as `address_kind` but with the vCard `TEL` value set
+/// — `cell` (mobile), `fax`, plus the home/work pair. Anything
+/// else (pager, video, text, etc.) falls back to `"other"`.
+fn phone_kind(prop: &Property) -> String {
+    pick_type(prop, &["home", "work", "cell", "fax"])
+}
+
+/// Walk a property's `TYPE=` parameter (which may be a single value
+/// or a comma-separated list) and return the first piece that
+/// matches one of `accepted`. Returns `"other"` if nothing matches.
+fn pick_type(prop: &Property, accepted: &[&str]) -> String {
     if let Some(params) = &prop.params {
         for (key, vals) in params {
             if !key.eq_ignore_ascii_case("TYPE") {
@@ -216,7 +246,7 @@ fn address_kind(prop: &Property) -> String {
             for v in vals {
                 for piece in v.split(',') {
                     let lower = piece.trim().to_ascii_lowercase();
-                    if lower == "home" || lower == "work" {
+                    if accepted.iter().any(|a| *a == lower) {
                         return lower;
                     }
                 }
@@ -319,7 +349,18 @@ pub fn build_vcard(card: &ParsedVcard) -> String {
         push_line(&mut out, &format!("EMAIL:{}", escape_value(email)));
     }
     for phone in &card.phones {
-        push_line(&mut out, &format!("TEL:{}", escape_value(phone)));
+        // Mirror the address `TYPE` round-trip: emit `TEL;TYPE=cell:…`
+        // so kind survives the round-trip. Empty kind drops the param
+        // (some servers reject `TYPE=` with no value).
+        let typ = if phone.kind.is_empty() {
+            String::new()
+        } else {
+            format!(";TYPE={}", phone.kind)
+        };
+        push_line(
+            &mut out,
+            &format!("TEL{typ}:{}", escape_value(&phone.value)),
+        );
     }
     if let Some(org) = &card.organization {
         push_line(&mut out, &format!("ORG:{}", escape_value(org)));
@@ -427,7 +468,9 @@ mod tests {
         assert_eq!(p.uid, "abc-123");
         assert_eq!(p.display_name, "Alice Example");
         assert_eq!(p.emails, vec!["alice@example.com"]);
-        assert_eq!(p.phones, vec!["+1 555 0100"]);
+        assert_eq!(p.phones.len(), 1);
+        assert_eq!(p.phones[0].kind, "cell");
+        assert_eq!(p.phones[0].value, "+1 555 0100");
         assert_eq!(p.organization.as_deref(), Some("Example Corp"));
         assert!(p.photo_data.is_none());
     }
@@ -458,7 +501,10 @@ mod tests {
             uid: "abc-123".into(),
             display_name: "Alice Example".into(),
             emails: vec!["alice@example.com".into(), "alice@work.com".into()],
-            phones: vec!["+1 555 0100".into()],
+            phones: vec![
+                VcardPhone { kind: "cell".into(), value: "+1 555 0100".into() },
+                VcardPhone { kind: "work".into(), value: "+1 555 0200".into() },
+            ],
             organization: Some("Example Corp".into()),
             ..Default::default()
         };
@@ -469,7 +515,11 @@ mod tests {
         assert_eq!(parsed.uid, "abc-123");
         assert_eq!(parsed.display_name, "Alice Example");
         assert_eq!(parsed.emails, vec!["alice@example.com", "alice@work.com"]);
-        assert_eq!(parsed.phones, vec!["+1 555 0100"]);
+        assert_eq!(parsed.phones.len(), 2);
+        assert_eq!(parsed.phones[0].kind, "cell");
+        assert_eq!(parsed.phones[0].value, "+1 555 0100");
+        assert_eq!(parsed.phones[1].kind, "work");
+        assert_eq!(parsed.phones[1].value, "+1 555 0200");
         assert_eq!(parsed.organization.as_deref(), Some("Example Corp"));
     }
 

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -370,7 +370,10 @@ pub struct Contact {
     pub nextcloud_account_id: String,
     pub display_name: String,
     pub email: Vec<String>,
-    pub phone: Vec<String>,
+    /// Phone numbers paired with a kind hint (vCard `TEL;TYPE=…`).
+    /// Same shape pattern as `addresses` so the UI can group "home /
+    /// work / mobile / fax / other" the way Nextcloud Contacts does.
+    pub phone: Vec<ContactPhone>,
     pub organization: Option<String>,
     /// MIME type of `photo_data` (e.g. "image/jpeg"); `None` if no photo.
     pub photo_mime: Option<String>,
@@ -418,6 +421,19 @@ pub struct ContactAddress {
     pub region: String,
     pub postal_code: String,
     pub country: String,
+}
+
+/// One phone number from a vCard `TEL` property paired with a kind
+/// hint pulled from its `TYPE=` parameter. vCard 4 lets `TYPE` carry
+/// a comma-separated list — we pick the first recognised value
+/// (`home` / `work` / `cell` / `fax`) and fall back to `"other"` so
+/// no entry ever loses its value just because we couldn't classify
+/// it. Mirrors the `ContactAddress` pattern so the UI grouping
+/// works the same way Nextcloud Contacts does.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContactPhone {
+    pub kind: String,
+    pub value: String,
 }
 
 /// Represents a calendar event from CalDAV / Nextcloud.

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -369,7 +369,10 @@ pub struct Contact {
     /// group contacts by source if a user has more than one NC server.
     pub nextcloud_account_id: String,
     pub display_name: String,
-    pub email: Vec<String>,
+    /// Email addresses paired with a kind hint (vCard `EMAIL;TYPE=…`).
+    /// Same shape pattern as `phone` and `addresses` so the UI can
+    /// group "home / work / other" the way Nextcloud Contacts does.
+    pub email: Vec<ContactEmail>,
     /// Phone numbers paired with a kind hint (vCard `TEL;TYPE=…`).
     /// Same shape pattern as `addresses` so the UI can group "home /
     /// work / mobile / fax / other" the way Nextcloud Contacts does.
@@ -432,6 +435,17 @@ pub struct ContactAddress {
 /// works the same way Nextcloud Contacts does.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContactPhone {
+    pub kind: String,
+    pub value: String,
+}
+
+/// One email address from a vCard `EMAIL` property paired with a
+/// kind hint pulled from its `TYPE=` parameter. Recognises `home`
+/// and `work`; `INTERNET` (a vCard-3 legacy meaning "this is an
+/// email address") is treated as no information and falls back to
+/// `"other"`. Same shape as `ContactPhone`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContactEmail {
     pub kind: String,
     pub value: String,
 }

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -20,7 +20,7 @@
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::{OptionalExtension, params};
 
-use nimbus_core::models::{Contact, ContactAddress, ContactPhone};
+use nimbus_core::models::{Contact, ContactAddress, ContactEmail, ContactPhone};
 
 use crate::cache::{Cache, CacheError};
 
@@ -32,7 +32,10 @@ pub struct ContactRow {
     pub etag: String,
     pub vcard_uid: String,
     pub display_name: String,
-    pub emails: Vec<String>,
+    /// Email addresses paired with the vCard `EMAIL;TYPE=…` kind
+    /// hint. Same backward-compat story as `phones` — JSON column
+    /// reads tolerate the legacy `Vec<String>` shape.
+    pub emails: Vec<ContactEmail>,
     /// Phone numbers paired with the vCard `TEL;TYPE=…` kind hint.
     /// Stored as JSON in `phones_json`; reads tolerate the legacy
     /// `Vec<String>` shape so existing rows keep working until the
@@ -503,7 +506,7 @@ fn row_to_contact_no_photo(r: &rusqlite::Row<'_>) -> rusqlite::Result<Contact> {
         id: r.get(0)?,
         nextcloud_account_id: r.get(1)?,
         display_name: r.get(2)?,
-        email: serde_json::from_str(&emails_json).unwrap_or_default(),
+        email: decode_emails(&emails_json),
         phone: decode_phones(&phones_json),
         organization: r.get(5)?,
         photo_mime: r.get(6)?,
@@ -538,6 +541,25 @@ fn decode_phones(json: &str) -> Vec<ContactPhone> {
     Vec::new()
 }
 
+/// Mirror of `decode_phones` for `emails_json`. Same shape evolution
+/// (`[String]` → `[{kind, value}]`), same legacy-rows-stay-readable
+/// guarantee.
+fn decode_emails(json: &str) -> Vec<ContactEmail> {
+    if let Ok(typed) = serde_json::from_str::<Vec<ContactEmail>>(json) {
+        return typed;
+    }
+    if let Ok(plain) = serde_json::from_str::<Vec<String>>(json) {
+        return plain
+            .into_iter()
+            .map(|v| ContactEmail {
+                kind: "other".to_string(),
+                value: v,
+            })
+            .collect();
+    }
+    Vec::new()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -557,7 +579,10 @@ mod tests {
             etag: format!("etag-{uid}"),
             vcard_uid: uid.into(),
             display_name: name.into(),
-            emails: vec![email.into()],
+            emails: vec![ContactEmail {
+                kind: "other".into(),
+                value: email.into(),
+            }],
             phones: vec![],
             organization: None,
             photo_mime: None,
@@ -617,7 +642,8 @@ mod tests {
         // Hit by email
         let r = cache.search_contacts("reggae", 10).unwrap();
         assert_eq!(r.len(), 1);
-        assert_eq!(r[0].email, vec!["bob@reggae.com"]);
+        assert_eq!(r[0].email.len(), 1);
+        assert_eq!(r[0].email[0].value, "bob@reggae.com");
 
         // count_contacts
         assert_eq!(cache.count_contacts("nc1").unwrap(), 2);

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -20,7 +20,7 @@
 use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::{OptionalExtension, params};
 
-use nimbus_core::models::{Contact, ContactAddress};
+use nimbus_core::models::{Contact, ContactAddress, ContactPhone};
 
 use crate::cache::{Cache, CacheError};
 
@@ -33,7 +33,11 @@ pub struct ContactRow {
     pub vcard_uid: String,
     pub display_name: String,
     pub emails: Vec<String>,
-    pub phones: Vec<String>,
+    /// Phone numbers paired with the vCard `TEL;TYPE=…` kind hint.
+    /// Stored as JSON in `phones_json`; reads tolerate the legacy
+    /// `Vec<String>` shape so existing rows keep working until the
+    /// next sync rewrites them in the new shape.
+    pub phones: Vec<ContactPhone>,
     pub organization: Option<String>,
     pub photo_mime: Option<String>,
     pub photo_data: Option<Vec<u8>>,
@@ -500,7 +504,7 @@ fn row_to_contact_no_photo(r: &rusqlite::Row<'_>) -> rusqlite::Result<Contact> {
         nextcloud_account_id: r.get(1)?,
         display_name: r.get(2)?,
         email: serde_json::from_str(&emails_json).unwrap_or_default(),
-        phone: serde_json::from_str(&phones_json).unwrap_or_default(),
+        phone: decode_phones(&phones_json),
         organization: r.get(5)?,
         photo_mime: r.get(6)?,
         photo_data: None,
@@ -510,6 +514,28 @@ fn row_to_contact_no_photo(r: &rusqlite::Row<'_>) -> rusqlite::Result<Contact> {
         addresses: serde_json::from_str(&addresses_json).unwrap_or_default(),
         urls: serde_json::from_str(&urls_json).unwrap_or_default(),
     })
+}
+
+/// Read `phones_json` tolerantly. The new shape is `[{kind, value}]`
+/// (vCard `TEL;TYPE=…`); rows written before this column was typed
+/// have the old `[String]` shape, which we lift to a typed array
+/// with `kind = "other"` so no number ever vanishes from the UI.
+/// On the next sync, the rewrite from CardDAV puts the proper kind
+/// in place.
+fn decode_phones(json: &str) -> Vec<ContactPhone> {
+    if let Ok(typed) = serde_json::from_str::<Vec<ContactPhone>>(json) {
+        return typed;
+    }
+    if let Ok(plain) = serde_json::from_str::<Vec<String>>(json) {
+        return plain
+            .into_iter()
+            .map(|v| ContactPhone {
+                kind: "other".to_string(),
+                value: v,
+            })
+            .collect();
+    }
+    Vec::new()
 }
 
 #[cfg(test)]
@@ -550,7 +576,10 @@ mod tests {
         let cache = open_test_cache();
         let phone_only = ContactRow {
             emails: vec![],
-            phones: vec!["+1 555 1234".into()],
+            phones: vec![ContactPhone {
+                kind: "cell".into(),
+                value: "+1 555 1234".into(),
+            }],
             ..row("u9", "Phone Only", "")
         };
         cache

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -758,7 +758,14 @@ fn raw_contact_to_row(c: &RawContact) -> ContactRow {
         etag: c.etag.clone(),
         vcard_uid: c.vcard_uid.clone(),
         display_name: c.display_name.clone(),
-        emails: c.emails.clone(),
+        emails: c
+            .emails
+            .iter()
+            .map(|e| nimbus_core::models::ContactEmail {
+                kind: e.kind.clone(),
+                value: e.value.clone(),
+            })
+            .collect(),
         phones: c
             .phones
             .iter()
@@ -815,7 +822,7 @@ fn raw_contact_to_row(c: &RawContact) -> ContactRow {
 #[derive(Debug, Clone, Deserialize)]
 struct ContactInput {
     display_name: String,
-    emails: Vec<String>,
+    emails: Vec<nimbus_core::models::ContactEmail>,
     phones: Vec<nimbus_core::models::ContactPhone>,
     organization: Option<String>,
     photo_mime: Option<String>,
@@ -901,7 +908,14 @@ async fn update_contact(
     };
     parsed.uid = handle.vcard_uid.clone();
     parsed.display_name = input.display_name.clone();
-    parsed.emails = input.emails.clone();
+    parsed.emails = input
+        .emails
+        .iter()
+        .map(|e| nimbus_carddav::VcardEmail {
+            kind: e.kind.clone(),
+            value: e.value.clone(),
+        })
+        .collect();
     parsed.phones = input
         .phones
         .iter()
@@ -1575,7 +1589,14 @@ fn input_to_parsed(uid: &str, input: &ContactInput) -> ParsedVcard {
     ParsedVcard {
         uid: uid.to_string(),
         display_name: input.display_name.clone(),
-        emails: input.emails.clone(),
+        emails: input
+            .emails
+            .iter()
+            .map(|e| nimbus_carddav::VcardEmail {
+                kind: e.kind.clone(),
+                value: e.value.clone(),
+            })
+            .collect(),
         phones: input
             .phones
             .iter()
@@ -1626,7 +1647,14 @@ fn parsed_to_row(
         etag: etag.to_string(),
         vcard_uid: uid.to_string(),
         display_name: parsed.display_name.clone(),
-        emails: parsed.emails.clone(),
+        emails: parsed
+            .emails
+            .iter()
+            .map(|e| nimbus_core::models::ContactEmail {
+                kind: e.kind.clone(),
+                value: e.value.clone(),
+            })
+            .collect(),
         phones: parsed
             .phones
             .iter()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -759,7 +759,14 @@ fn raw_contact_to_row(c: &RawContact) -> ContactRow {
         vcard_uid: c.vcard_uid.clone(),
         display_name: c.display_name.clone(),
         emails: c.emails.clone(),
-        phones: c.phones.clone(),
+        phones: c
+            .phones
+            .iter()
+            .map(|p| nimbus_core::models::ContactPhone {
+                kind: p.kind.clone(),
+                value: p.value.clone(),
+            })
+            .collect(),
         organization: c.organization.clone(),
         photo_mime: c.photo_mime.clone(),
         photo_data: c.photo_data.clone(),
@@ -809,7 +816,7 @@ fn raw_contact_to_row(c: &RawContact) -> ContactRow {
 struct ContactInput {
     display_name: String,
     emails: Vec<String>,
-    phones: Vec<String>,
+    phones: Vec<nimbus_core::models::ContactPhone>,
     organization: Option<String>,
     photo_mime: Option<String>,
     photo_data: Option<Vec<u8>>,
@@ -895,7 +902,14 @@ async fn update_contact(
     parsed.uid = handle.vcard_uid.clone();
     parsed.display_name = input.display_name.clone();
     parsed.emails = input.emails.clone();
-    parsed.phones = input.phones.clone();
+    parsed.phones = input
+        .phones
+        .iter()
+        .map(|p| nimbus_carddav::VcardPhone {
+            kind: p.kind.clone(),
+            value: p.value.clone(),
+        })
+        .collect();
     parsed.organization = input.organization.clone();
     if input.photo_data.is_some() {
         parsed.photo_mime = input.photo_mime.clone();
@@ -1562,7 +1576,14 @@ fn input_to_parsed(uid: &str, input: &ContactInput) -> ParsedVcard {
         uid: uid.to_string(),
         display_name: input.display_name.clone(),
         emails: input.emails.clone(),
-        phones: input.phones.clone(),
+        phones: input
+            .phones
+            .iter()
+            .map(|p| nimbus_carddav::VcardPhone {
+                kind: p.kind.clone(),
+                value: p.value.clone(),
+            })
+            .collect(),
         organization: input.organization.clone(),
         photo_mime: input.photo_mime.clone(),
         photo_data: input.photo_data.clone(),
@@ -1606,7 +1627,14 @@ fn parsed_to_row(
         vcard_uid: uid.to_string(),
         display_name: parsed.display_name.clone(),
         emails: parsed.emails.clone(),
-        phones: parsed.phones.clone(),
+        phones: parsed
+            .phones
+            .iter()
+            .map(|p| nimbus_core::models::ContactPhone {
+                kind: p.kind.clone(),
+                value: p.value.clone(),
+            })
+            .collect(),
         organization: parsed.organization.clone(),
         photo_mime: parsed.photo_mime.clone(),
         photo_data: parsed.photo_data.clone(),

--- a/ui/src/lib/AddressAutocomplete.svelte
+++ b/ui/src/lib/AddressAutocomplete.svelte
@@ -29,12 +29,20 @@
   import { convertFileSrc, invoke } from '@tauri-apps/api/core'
   import { onDestroy } from 'svelte'
 
+  interface ContactEmail {
+    kind: string
+    value: string
+  }
+  interface ContactPhone {
+    kind: string
+    value: string
+  }
   interface Contact {
     id: string
     nextcloud_account_id: string
     display_name: string
-    email: string[]
-    phone: string[]
+    email: ContactEmail[]
+    phone: ContactPhone[]
     organization: string | null
     photo_mime: string | null
   }
@@ -100,9 +108,11 @@
     debounceTimer = window.setTimeout(() => runSearch(token), DEBOUNCE_MS)
   }
 
-  /** Pick the first non-empty email address. */
+  /** Pick the first non-empty email address. Each entry now
+      carries a kind hint (Home / Work / Other from vCard
+      `EMAIL;TYPE=…`); the autocomplete only needs the value. */
   function primaryEmail(c: Contact): string {
-    return c.email.find((e) => e.length > 0) ?? ''
+    return c.email.find((e) => e.value.length > 0)?.value ?? ''
   }
 
   /**

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -38,11 +38,17 @@
     kind: string
     value: string
   }
+  interface ContactEmail {
+    /** "home" / "work" / "other" — pulled from the vCard
+        `EMAIL;TYPE=…` parameter. */
+    kind: string
+    value: string
+  }
   interface Contact {
     id: string
     nextcloud_account_id: string
     display_name: string
-    email: string[]
+    email: ContactEmail[]
     phone: ContactPhone[]
     organization: string | null
     photo_mime: string | null
@@ -55,7 +61,7 @@
   }
   interface ContactInput {
     display_name: string
-    emails: string[]
+    emails: ContactEmail[]
     phones: ContactPhone[]
     organization: string | null
     photo_mime: string | null
@@ -91,7 +97,10 @@
   // copy the matching contact's fields into these so edits don't
   // mutate the cached row until the user saves.
   let formName = $state('')
-  let formEmails = $state('') // newline-separated
+  // Same per-row treatment as phones — each email carries a kind
+  // picker (Home / Work / Other) so the vCard `EMAIL;TYPE=…`
+  // round-trips and Nextcloud Contacts groups identically.
+  let formEmails = $state<ContactEmail[]>([])
   // Phones are now per-row records so each carries a kind picker
   // ("home" / "work" / "mobile" / "fax" / "other"), matching what
   // Nextcloud Contacts shows.
@@ -134,7 +143,7 @@
     return contacts.filter(
       (c) =>
         c.display_name.toLowerCase().includes(q) ||
-        c.email.some((e) => e.toLowerCase().includes(q)) ||
+        c.email.some((e) => e.value.toLowerCase().includes(q)) ||
         (c.organization ?? '').toLowerCase().includes(q),
     )
   })
@@ -229,7 +238,7 @@
     const c = contacts.find((x) => x.id === id)
     if (!c) return
     formName = c.display_name
-    formEmails = c.email.join('\n')
+    formEmails = c.email.map((e) => ({ ...e }))
     formPhones = c.phone.map((p) => ({ ...p }))
     formOrg = c.organization ?? ''
     formTitle = c.title ?? ''
@@ -248,7 +257,7 @@
     deleteConfirm = false
     formError = ''
     formName = ''
-    formEmails = ''
+    formEmails = []
     formPhones = []
     formOrg = ''
     formTitle = ''
@@ -292,6 +301,16 @@
 
   function removePhone(idx: number) {
     formPhones = formPhones.filter((_, i) => i !== idx)
+  }
+
+  /** Add a blank email row. Defaults to "home" — typical for a
+      personal contact entry; the user can flip to Work / Other. */
+  function addEmail() {
+    formEmails = [...formEmails, { kind: 'home', value: '' }]
+  }
+
+  function removeEmail(idx: number) {
+    formEmails = formEmails.filter((_, i) => i !== idx)
   }
 
   function cancelEdit() {
@@ -359,7 +378,11 @@
         : null
     return {
       display_name: formName.trim(),
-      emails: splitLines(formEmails),
+      // Drop empty-value rows the same way phones do — an unfilled
+      // "Add email" slot shouldn't ship to the server as a blank.
+      emails: formEmails
+        .filter((e) => e.value.trim())
+        .map((e) => ({ kind: e.kind, value: e.value.trim() })),
       // Drop empty-value rows so an unfilled "Add phone" slot
       // doesn't end up as a blank entry on the server.
       phones: formPhones
@@ -515,7 +538,7 @@
             <span class="flex flex-col min-w-0 text-left">
               <span class="truncate">{c.display_name || '(no name)'}</span>
               {#if c.email.length > 0}
-                <span class="text-xs text-surface-500 truncate normal-case">{c.email[0]}</span>
+                <span class="text-xs text-surface-500 truncate normal-case">{c.email[0].value}</span>
               {/if}
             </span>
           </button>
@@ -561,15 +584,37 @@
           <input class="input" bind:value={formName} placeholder="Jane Doe" />
         </label>
 
-        <label class="label">
-          <span>Email addresses <span class="text-surface-500">(one per line)</span></span>
-          <textarea
-            class="textarea"
-            rows="3"
-            bind:value={formEmails}
-            placeholder="jane@example.com"
-          ></textarea>
-        </label>
+        <!-- Email addresses — same per-row treatment as phones so
+             each carries a Home / Work / Other picker. The kind
+             round-trips to the vCard `EMAIL;TYPE=…` parameter. -->
+        <div class="space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-medium">Email addresses</span>
+            <button type="button" class="btn btn-sm preset-tonal" onclick={addEmail}>
+              + Add email
+            </button>
+          </div>
+          {#each formEmails as email, i (i)}
+            <div class="flex items-center gap-2">
+              <select class="select w-28" bind:value={email.kind}>
+                <option value="home">Home</option>
+                <option value="work">Work</option>
+                <option value="other">Other</option>
+              </select>
+              <input
+                class="input flex-1"
+                type="email"
+                bind:value={email.value}
+                placeholder="jane@example.com"
+              />
+              <button
+                type="button"
+                class="text-xs text-error-500 hover:underline"
+                onclick={() => removeEmail(i)}
+              >Remove</button>
+            </div>
+          {/each}
+        </div>
 
         <!-- Phone numbers — per-row so each carries a kind picker
              (mobile / work / home / fax / other) and Nextcloud

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -32,12 +32,18 @@
     postal_code: string
     country: string
   }
+  interface ContactPhone {
+    /** "home" / "work" / "cell" / "fax" / "other" — pulled from the
+        vCard `TEL;TYPE=…` parameter. */
+    kind: string
+    value: string
+  }
   interface Contact {
     id: string
     nextcloud_account_id: string
     display_name: string
     email: string[]
-    phone: string[]
+    phone: ContactPhone[]
     organization: string | null
     photo_mime: string | null
     photo_data: number[] | null
@@ -50,7 +56,7 @@
   interface ContactInput {
     display_name: string
     emails: string[]
-    phones: string[]
+    phones: ContactPhone[]
     organization: string | null
     photo_mime: string | null
     photo_data: number[] | null
@@ -86,7 +92,10 @@
   // mutate the cached row until the user saves.
   let formName = $state('')
   let formEmails = $state('') // newline-separated
-  let formPhones = $state('') // newline-separated
+  // Phones are now per-row records so each carries a kind picker
+  // ("home" / "work" / "mobile" / "fax" / "other"), matching what
+  // Nextcloud Contacts shows.
+  let formPhones = $state<ContactPhone[]>([])
   let formOrg = $state('')
   let formTitle = $state('')
   let formBirthday = $state('')
@@ -221,7 +230,7 @@
     if (!c) return
     formName = c.display_name
     formEmails = c.email.join('\n')
-    formPhones = c.phone.join('\n')
+    formPhones = c.phone.map((p) => ({ ...p }))
     formOrg = c.organization ?? ''
     formTitle = c.title ?? ''
     formBirthday = c.birthday ?? ''
@@ -240,7 +249,7 @@
     formError = ''
     formName = ''
     formEmails = ''
-    formPhones = ''
+    formPhones = []
     formOrg = ''
     formTitle = ''
     formBirthday = ''
@@ -273,6 +282,16 @@
 
   function removeAddress(idx: number) {
     formAddresses = formAddresses.filter((_, i) => i !== idx)
+  }
+
+  /** Add a blank phone row. Defaults to "cell" — by far the most
+      common kind for a freshly-added number on a personal contact. */
+  function addPhone() {
+    formPhones = [...formPhones, { kind: 'cell', value: '' }]
+  }
+
+  function removePhone(idx: number) {
+    formPhones = formPhones.filter((_, i) => i !== idx)
   }
 
   function cancelEdit() {
@@ -341,7 +360,11 @@
     return {
       display_name: formName.trim(),
       emails: splitLines(formEmails),
-      phones: splitLines(formPhones),
+      // Drop empty-value rows so an unfilled "Add phone" slot
+      // doesn't end up as a blank entry on the server.
+      phones: formPhones
+        .filter((p) => p.value.trim())
+        .map((p) => ({ kind: p.kind, value: p.value.trim() })),
       organization: formOrg.trim() || null,
       photo_mime: existingMime,
       photo_data: existingMime ? selectedPhotoBytes : null,
@@ -548,15 +571,39 @@
           ></textarea>
         </label>
 
-        <label class="label">
-          <span>Phone numbers <span class="text-surface-500">(one per line)</span></span>
-          <textarea
-            class="textarea"
-            rows="2"
-            bind:value={formPhones}
-            placeholder="+1 555 0100"
-          ></textarea>
-        </label>
+        <!-- Phone numbers — per-row so each carries a kind picker
+             (mobile / work / home / fax / other) and Nextcloud
+             Contacts groups identically on its side. Same shape as
+             the addresses block below. -->
+        <div class="space-y-2">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-medium">Phone numbers</span>
+            <button type="button" class="btn btn-sm preset-tonal" onclick={addPhone}>
+              + Add phone
+            </button>
+          </div>
+          {#each formPhones as phone, i (i)}
+            <div class="flex items-center gap-2">
+              <select class="select w-28" bind:value={phone.kind}>
+                <option value="cell">Mobile</option>
+                <option value="work">Work</option>
+                <option value="home">Home</option>
+                <option value="fax">Fax</option>
+                <option value="other">Other</option>
+              </select>
+              <input
+                class="input flex-1"
+                bind:value={phone.value}
+                placeholder="+1 555 0100"
+              />
+              <button
+                type="button"
+                class="text-xs text-error-500 hover:underline"
+                onclick={() => removePhone(i)}
+              >Remove</button>
+            </div>
+          {/each}
+        </div>
 
         <div class="grid grid-cols-2 gap-3">
           <label class="label">


### PR DESCRIPTION
Phones used to be a flat \`Vec<String>\`, so the vCard \`TEL;TYPE=…\` parameter was lost on parse and never round-tripped. Nextcloud Contacts groups numbers by kind and the user couldn't reproduce that distinction here. Mirrors the addresses pattern that landed in PR #74.

## Plumbing
- \`nimbus_core::ContactPhone { kind, value }\` joins \`ContactAddress\` as the second typed contact-list shape.
- \`nimbus_carddav\` parses the \`TEL\` \`TYPE\` parameter through a shared \`pick_type\` helper (also used by \`address_kind\`), recognising \`home\` / \`work\` / \`cell\` / \`fax\` and falling back to \`other\`. \`build_vcard\` emits \`TEL;TYPE=<kind>:…\`.
- \`RawContact.phones\` and \`ContactRow.phones\` widen to \`Vec<…Phone>\` (with serde derives on the carddav-side struct so it round-trips over IPC).
- Cache reads use a new \`decode_phones\` that tries the typed shape first and falls back to interpreting the legacy \`[String]\` JSON as \`{kind: "other", value: …}\` — no schema migration needed; existing rows keep working until the next sync rewrites them in the typed shape.
- \`ContactInput\`, \`raw_contact_to_row\`, \`parsed_to_row\`, \`input_to_parsed\`, and the \`update_contact\` merge all carry kind through the round-trip.

## UI
\`ContactsView\` swaps the newline-textarea for a per-row block matching the addresses one: kind picker (Mobile / Work / Home / Fax / Other) + value input + Remove button, with an \"Add phone\" header button to extend.

## Test plan
- [ ] \`cargo test --workspace\` passes
- [ ] Existing user with cached contacts opens app — phones still appear (legacy \`[String]\` rows decoded with \`kind: \"other\"\`)
- [ ] After a sync, phones from Nextcloud carry their original \`TYPE\` (mobile / work / etc.)
- [ ] Add a phone, pick \"Work\", save → reopen contact → row still shows \"Work\"
- [ ] Edit name only (don't touch phones) → existing typed phones aren't wiped
- [ ] Remove a phone, save → only the remaining phones come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)