### PR TITLE
Compose: IMAP drafts, editing, Trash-first delete, cache reconciliation

### DIFF
--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -762,6 +762,50 @@ impl ImapClient {
         Ok(())
     }
 
+    /// Permanently remove a message from a folder via the two-step IMAP
+    /// dance: `UID STORE +FLAGS (\Deleted)` to mark it, then `EXPUNGE`
+    /// to actually reclaim it from the mailbox. Without the EXPUNGE the
+    /// message would stay visible in every other client until the next
+    /// sync.
+    ///
+    /// Used by the "replace a draft" flow: after appending the edited
+    /// copy to the Drafts folder, we delete the source UID the user
+    /// started editing from so there's exactly one draft on the server
+    /// per mail the user is composing.
+    pub async fn delete_message(&mut self, folder: &str, uid: u32) -> Result<(), NimbusError> {
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        session.select(to_wire(folder)).await.map_err(|e| {
+            NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
+        })?;
+
+        let _updates: Vec<_> = session
+            .uid_store(uid.to_string(), "+FLAGS (\\Deleted)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID STORE (\\Deleted) failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
+
+        // `expunge` streams the list of removed sequence numbers. We
+        // don't care about them specifically — we just need the server
+        // to actually drop the message, which only happens once the
+        // stream is fully drained.
+        let _expunged: Vec<_> = session
+            .expunge()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("EXPUNGE failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read EXPUNGE: {e}")))?;
+
+        info!("Deleted UID {uid} from '{folder}'");
+        Ok(())
+    }
+
     /// Server-side search fallback for messages that aren't cached locally.
     ///
     /// Runs `UID SEARCH` on the given folder with a criterion built from

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -972,6 +972,30 @@ impl ImapClient {
         Ok(())
     }
 
+    /// Return every UID currently in the folder (via `UID SEARCH ALL`).
+    ///
+    /// Used by the envelope-cache reconciler to spot ghost rows: any
+    /// UID in our local cache that isn't in this set has been expunged
+    /// on the server and should be dropped. Cheap on small folders
+    /// (Drafts, Trash, Archive); on large inboxes it's a few KB of
+    /// wire traffic but still a single command, much cheaper than
+    /// re-fetching bodies.
+    pub async fn list_all_uids(&mut self, folder: &str) -> Result<Vec<u32>, NimbusError> {
+        let _ = self.select_folder(folder).await?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        let uids: Vec<u32> = session
+            .uid_search("ALL")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID SEARCH ALL failed: {e}")))?
+            .into_iter()
+            .collect();
+        Ok(uids)
+    }
+
     /// Server-side search fallback for messages that aren't cached locally.
     ///
     /// Runs `UID SEARCH` on the given folder with a criterion built from

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -840,17 +840,47 @@ impl ImapClient {
             .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
 
         info!("delete_message: SELECT '{folder}' for UID {uid}");
-        session.select(to_wire(folder)).await.map_err(|e| {
+        let mailbox = session.select(to_wire(folder)).await.map_err(|e| {
             NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
+        info!(
+            "delete_message: selected '{folder}' (exists={}, uidvalidity={:?}, uidnext={:?})",
+            mailbox.exists, mailbox.uid_validity, mailbox.uid_next
+        );
+
+        // Probe the UID first. If this comes back empty, the UID we
+        // were handed isn't in this folder at all — the envelope
+        // cache is out of sync with the server, or (far more likely
+        // in practice) the backend is driving the wrong folder for
+        // the message the user is looking at. Surfacing *which* of
+        // those it is saves a guessing game next time this fails.
+        let probe: Vec<_> = session
+            .uid_fetch(uid.to_string(), "UID")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID FETCH probe failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID FETCH probe: {e}")))?;
+        info!(
+            "delete_message: UID FETCH {uid} in '{folder}' -> {} hit(s)",
+            probe.len()
+        );
+        if probe.is_empty() {
+            return Err(NimbusError::Protocol(format!(
+                "UID {uid} isn't in folder '{folder}' (exists={}, uidvalidity={:?}). \
+                 The envelope cache is out of sync with the server, or the delete is \
+                 being driven against the wrong folder.",
+                mailbox.exists, mailbox.uid_validity
+            )));
+        }
 
         // STORE the `\Deleted` flag and keep the returned FETCH
-        // responses — if the set is empty the server didn't find our
-        // UID, which is the single biggest failure mode of this flow
-        // (envelope cache had a UID that the server has since
-        // renumbered / expunged out from under us). Surfacing that
-        // explicitly beats silently "succeeding" while the draft
-        // stays put.
+        // responses — if the set is empty the server accepted the
+        // STORE but didn't actually modify anything, which almost
+        // always means the SELECT landed on a read-only view or the
+        // server suppresses the FETCH echo for \Deleted (rare). We
+        // press on to EXPUNGE anyway, but log loudly so it shows up
+        // in traces.
         let updates: Vec<_> = session
             .uid_store(uid.to_string(), "+FLAGS (\\Deleted)")
             .await
@@ -860,16 +890,17 @@ impl ImapClient {
             .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
 
         if updates.is_empty() {
-            return Err(NimbusError::Protocol(format!(
-                "UID STORE (\\Deleted) on UID {uid} in '{folder}' returned no updates — \
-                 the message likely doesn't exist on the server anymore. \
-                 Refresh the folder and try again."
-            )));
+            tracing::warn!(
+                "delete_message: UID STORE (\\Deleted) on UID {uid} in '{folder}' \
+                 returned no FETCH updates even though the UID probe found the message — \
+                 proceeding to EXPUNGE anyway, the flag may have been set silently"
+            );
+        } else {
+            info!(
+                "delete_message: UID STORE flagged {uid} as \\Deleted ({} response(s))",
+                updates.len()
+            );
         }
-        info!(
-            "delete_message: UID STORE flagged {uid} as \\Deleted ({} response(s))",
-            updates.len()
-        );
 
         // Prefer `UID EXPUNGE` (RFC 4315 / UIDPLUS) — it only expunges
         // the specific UID we just marked, leaving any other

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -762,6 +762,67 @@ impl ImapClient {
         Ok(())
     }
 
+    /// Move a message between folders via `UID COPY` + delete.
+    ///
+    /// Why not `UID MOVE` (RFC 6851)? MOVE is cleaner but requires the
+    /// server to advertise the `MOVE` capability, which still isn't
+    /// universal in 2026 — the COPY+EXPUNGE fallback works on every
+    /// IMAP4rev1 server. We pay for one extra round-trip vs MOVE but
+    /// never surprise the user with a "your server doesn't support
+    /// that" error on an Archive/Delete button press.
+    ///
+    /// Used by the Archive and (future) Trash flows in MailView. The
+    /// destination folder must already exist — callers locate it via
+    /// `pick_archive_folder` / `pick_trash_folder` before calling.
+    pub async fn move_message(
+        &mut self,
+        from_folder: &str,
+        uid: u32,
+        to_folder: &str,
+    ) -> Result<(), NimbusError> {
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        session.select(to_wire(from_folder)).await.map_err(|e| {
+            NimbusError::Protocol(format!("Failed to select folder '{from_folder}': {e}"))
+        })?;
+
+        // UID COPY leaves the source copy in place with its flags
+        // intact; the destination gets a server-assigned UID that
+        // we don't need to track here.
+        session
+            .uid_copy(uid.to_string(), to_wire(to_folder))
+            .await
+            .map_err(|e| {
+                NimbusError::Protocol(format!(
+                    "UID COPY {uid} from '{from_folder}' to '{to_folder}' failed: {e}"
+                ))
+            })?;
+
+        // Now remove the source: mark + expunge, same dance as
+        // `delete_message` below.
+        let _updates: Vec<_> = session
+            .uid_store(uid.to_string(), "+FLAGS (\\Deleted)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID STORE (\\Deleted) failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
+
+        let _expunged: Vec<_> = session
+            .expunge()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("EXPUNGE failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read EXPUNGE: {e}")))?;
+
+        info!("Moved UID {uid} from '{from_folder}' to '{to_folder}'");
+        Ok(())
+    }
+
     /// Permanently remove a message from a folder via the two-step IMAP
     /// dance: `UID STORE +FLAGS (\Deleted)` to mark it, then `EXPUNGE`
     /// to actually reclaim it from the mailbox. Without the EXPUNGE the

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -839,11 +839,19 @@ impl ImapClient {
             .as_mut()
             .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
 
+        info!("delete_message: SELECT '{folder}' for UID {uid}");
         session.select(to_wire(folder)).await.map_err(|e| {
             NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
 
-        let _updates: Vec<_> = session
+        // STORE the `\Deleted` flag and keep the returned FETCH
+        // responses — if the set is empty the server didn't find our
+        // UID, which is the single biggest failure mode of this flow
+        // (envelope cache had a UID that the server has since
+        // renumbered / expunged out from under us). Surfacing that
+        // explicitly beats silently "succeeding" while the draft
+        // stays put.
+        let updates: Vec<_> = session
             .uid_store(uid.to_string(), "+FLAGS (\\Deleted)")
             .await
             .map_err(|e| NimbusError::Protocol(format!("UID STORE (\\Deleted) failed: {e}")))?
@@ -851,17 +859,83 @@ impl ImapClient {
             .await
             .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
 
-        // `expunge` streams the list of removed sequence numbers. We
-        // don't care about them specifically — we just need the server
-        // to actually drop the message, which only happens once the
-        // stream is fully drained.
-        let _expunged: Vec<_> = session
-            .expunge()
-            .await
-            .map_err(|e| NimbusError::Protocol(format!("EXPUNGE failed: {e}")))?
-            .try_collect()
-            .await
-            .map_err(|e| NimbusError::Protocol(format!("Failed to read EXPUNGE: {e}")))?;
+        if updates.is_empty() {
+            return Err(NimbusError::Protocol(format!(
+                "UID STORE (\\Deleted) on UID {uid} in '{folder}' returned no updates — \
+                 the message likely doesn't exist on the server anymore. \
+                 Refresh the folder and try again."
+            )));
+        }
+        info!(
+            "delete_message: UID STORE flagged {uid} as \\Deleted ({} response(s))",
+            updates.len()
+        );
+
+        // Prefer `UID EXPUNGE` (RFC 4315 / UIDPLUS) — it only expunges
+        // the specific UID we just marked, leaving any other
+        // `\Deleted`-flagged messages other clients might be juggling
+        // in the same mailbox untouched. Most servers advertise
+        // UIDPLUS; on the ones that don't we fall back to the
+        // broader plain EXPUNGE below, which is still correct for
+        // our use (we only flagged one UID in this session).
+        //
+        // The inner helper consumes the returned stream fully before
+        // returning, which is what lets us fall back to a second
+        // mutable borrow of `session` on the outer error branch
+        // without tripping the borrow checker — if we kept the
+        // Stream around we'd be holding a mutable borrow into the
+        // Err arm.
+        let uid_set = uid.to_string();
+        let try_uid_expunge = async {
+            let stream = session
+                .uid_expunge(&uid_set)
+                .await
+                .map_err(|e| format!("UID EXPUNGE failed: {e}"))?;
+            stream
+                .try_collect::<Vec<_>>()
+                .await
+                .map_err(|e| format!("Failed to read UID EXPUNGE: {e}"))
+        };
+
+        let expunged_count = match try_uid_expunge.await {
+            Ok(expunged) => {
+                info!(
+                    "delete_message: UID EXPUNGE {uid} removed {} message(s)",
+                    expunged.len()
+                );
+                expunged.len()
+            }
+            Err(e) => {
+                // UIDPLUS not supported (or the server rejected the
+                // command for another reason). Fall back to plain
+                // EXPUNGE — we only flagged one UID in this session
+                // so the broader command is still targeted enough.
+                tracing::warn!(
+                    "delete_message: UID EXPUNGE failed ({e}), falling back to EXPUNGE"
+                );
+                let expunged: Vec<_> = session
+                    .expunge()
+                    .await
+                    .map_err(|e| NimbusError::Protocol(format!("EXPUNGE failed: {e}")))?
+                    .try_collect()
+                    .await
+                    .map_err(|e| {
+                        NimbusError::Protocol(format!("Failed to read EXPUNGE: {e}"))
+                    })?;
+                info!(
+                    "delete_message: EXPUNGE removed {} message(s) (fallback)",
+                    expunged.len()
+                );
+                expunged.len()
+            }
+        };
+
+        if expunged_count == 0 {
+            return Err(NimbusError::Protocol(format!(
+                "EXPUNGE in '{folder}' removed 0 messages after flagging UID {uid} — \
+                 the \\Deleted flag didn't stick on this server"
+            )));
+        }
 
         info!("Deleted UID {uid} from '{folder}'");
         Ok(())

--- a/crates/nimbus-smtp/src/client.rs
+++ b/crates/nimbus-smtp/src/client.rs
@@ -1,5 +1,6 @@
 //! SMTP client — connects to a mail server and sends emails.
 
+use lettre::address::Envelope;
 use lettre::message::{
     Attachment as LettreAttachment, Mailbox, MessageBuilder, MultiPart, SinglePart,
     header::ContentType,
@@ -194,7 +195,7 @@ pub fn build_outgoing_message(email: &OutgoingEmail) -> Result<Message, NimbusEr
     })?;
 
     let mut builder: MessageBuilder = Message::builder()
-        .from(from_mailbox)
+        .from(from_mailbox.clone())
         .subject(&email.subject);
 
     for addr in &email.to {
@@ -221,6 +222,24 @@ pub fn build_outgoing_message(email: &OutgoingEmail) -> Result<Message, NimbusEr
             NimbusError::Protocol(format!("Invalid 'reply-to' address '{reply_to}': {e}"))
         })?;
         builder = builder.reply_to(mailbox);
+    }
+
+    // When there are no recipients (a draft the user hasn't addressed
+    // yet), lettre's `build()` would otherwise reject the message with
+    // "missing destination address". The SMTP envelope is irrelevant
+    // for the IMAP-APPEND path that drafts take, so we substitute a
+    // placeholder envelope that reuses From as both sender and
+    // receiver — just enough to satisfy the type, without leaking a
+    // synthetic recipient into the RFC 822 headers the reader sees.
+    // The SMTP send path validates recipients in the UI before
+    // reaching this function, so this branch only trips for drafts.
+    if email.to.is_empty() && email.cc.is_empty() && email.bcc.is_empty() {
+        let envelope = Envelope::new(
+            Some(from_mailbox.email.clone()),
+            vec![from_mailbox.email.clone()],
+        )
+        .map_err(|e| NimbusError::Protocol(format!("Failed to build draft envelope: {e}")))?;
+        builder = builder.envelope(envelope);
     }
 
     if email.attachments.is_empty() {

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -470,6 +470,78 @@ impl Cache {
         Ok(())
     }
 
+    /// Return every cached envelope UID for a folder — used by the
+    /// reconciler that diffs the cache against the server's live UID
+    /// set after each incremental fetch and drops rows whose UIDs no
+    /// longer exist on the server.
+    pub fn list_envelope_uids(
+        &self,
+        account_id: &str,
+        folder: &str,
+    ) -> Result<Vec<u32>, CacheError> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT uid FROM messages
+             WHERE account_id = ?1 AND folder = ?2",
+        )?;
+        let rows = stmt.query_map(params![account_id, folder], |r| r.get::<_, i64>(0))?;
+        let mut uids = Vec::new();
+        for row in rows {
+            uids.push(row? as u32);
+        }
+        Ok(uids)
+    }
+
+    /// Remove a single cached envelope + body after the message has been
+    /// expunged / moved on the server. The incremental envelope fetch
+    /// only pulls UIDs `> highest_seen`, so without an explicit delete
+    /// here the cache accumulates ghost rows for every expunged UID —
+    /// and MailList keeps showing them, handing the user stale UIDs
+    /// that the server has since reassigned or reclaimed.
+    ///
+    /// If the envelope was unread at the time of removal, the folder
+    /// `unread_count` is also decremented so the sidebar badge tracks
+    /// the row disappearing. Same clamp-at-zero guard as
+    /// `mark_envelope_read`. Returns `true` iff a row was actually
+    /// removed — callers can tell the difference between "cleaned up
+    /// a real stale row" and "no row existed in the first place".
+    pub fn remove_envelope(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+    ) -> Result<bool, CacheError> {
+        let mut conn = self.pool.get()?;
+        let tx = conn.transaction()?;
+
+        let was_unread: bool = tx
+            .query_row(
+                "SELECT is_read = 0 FROM messages
+                 WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+                params![account_id, folder, uid as i64],
+                |r| r.get::<_, i64>(0).map(|v| v != 0),
+            )
+            .unwrap_or(false);
+
+        let rows = tx.execute(
+            "DELETE FROM messages
+             WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+            params![account_id, folder, uid as i64],
+        )?;
+
+        if rows > 0 && was_unread {
+            tx.execute(
+                "UPDATE folders
+                 SET unread_count = MAX(COALESCE(unread_count, 0) - 1, 0)
+                 WHERE account_id = ?1 AND name = ?2",
+                params![account_id, folder],
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(rows > 0)
+    }
+
     /// Mark a cached envelope as unread (sets `is_read = 0`) and keep
     /// the folder's `unread_count` in sync by incrementing it iff the
     /// message was previously read. Mirror of `mark_envelope_read`.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2227,6 +2227,103 @@ async fn append_to_sent(
     result
 }
 
+/// Save an in-progress message to the account's IMAP Drafts folder.
+///
+/// Mirrors `send_email` structurally (same `OutgoingEmail` input, same
+/// MIME builder) but skips SMTP entirely — the point is to hand the
+/// message to the server so it shows up in the Drafts mailbox across
+/// devices and the user can finish / send it later. IMAP-only for now;
+/// JMAP accounts get a clear error until the equivalent `Email/set`
+/// create-in-Drafts flow is wired up (tracked separately).
+#[tauri::command]
+async fn save_draft(
+    account_id: String,
+    email: OutgoingEmail,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let account = load_account(&cache, &account_id)?;
+
+    if uses_jmap(&account) {
+        return Err(NimbusError::Other(
+            "Saving drafts via JMAP is not yet implemented — this account uses JMAP".into(),
+        ));
+    }
+
+    let message = build_outgoing_message(&email)?;
+    let raw = message.formatted();
+    append_to_drafts(&account, &raw, &cache).await
+}
+
+/// Locate the account's Drafts folder (via the IMAP `\Drafts` attribute,
+/// or a name-based fallback) and `APPEND` the raw RFC 822 bytes there
+/// with the `\Draft` flag set — that's what tells other clients and the
+/// server that this message is a work-in-progress rather than a
+/// received or already-sent mail.
+async fn append_to_drafts(
+    account: &Account,
+    raw: &[u8],
+    cache: &Cache,
+) -> Result<(), NimbusError> {
+    let drafts_folder = pick_drafts_folder(&account.id, cache);
+    let Some(drafts) = drafts_folder else {
+        return Err(NimbusError::Other(
+            "no Drafts folder found in cached folder list".into(),
+        ));
+    };
+
+    let password = credentials::get_imap_password(&account.id)?;
+    let mut client = ImapClient::connect(
+        &account.imap_host,
+        account.imap_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await?;
+    // `\Draft` is the IMAP flag that marks a message as an unfinished
+    // draft. `\Seen` keeps it out of the unread badge — there's no
+    // point notifying the user about a mail they themselves are
+    // composing.
+    let result = client
+        .append_message(&drafts, raw, &["\\Draft", "\\Seen"])
+        .await;
+    let _ = client.logout().await;
+    result
+}
+
+/// Pick the most likely Drafts folder name from the cached folder list.
+/// Same strategy as `pick_sent_folder`: prefer the IMAP `\Drafts`
+/// special-use attribute, fall back to common English / German / French
+/// names so accounts that haven't been synced yet still land in the
+/// right place.
+fn pick_drafts_folder(account_id: &str, cache: &Cache) -> Option<String> {
+    let folders = cache.get_folders(account_id).ok()?;
+
+    if let Some(by_attr) = folders.iter().find(|f| {
+        f.attributes
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("drafts") || a.eq_ignore_ascii_case("\\drafts"))
+    }) {
+        return Some(by_attr.name.clone());
+    }
+
+    const NAME_HINTS: &[&str] = &[
+        "drafts",
+        "draft",
+        "entwürfe",
+        "entwurf",
+        "brouillons",
+        "brouillon",
+    ];
+    folders
+        .iter()
+        .find(|f| {
+            let lower = f.name.to_lowercase();
+            NAME_HINTS.iter().any(|h| lower.contains(h))
+        })
+        .map(|f| f.name.clone())
+}
+
 /// Pick the most likely Sent folder name from the cached folder list.
 /// Prefers folders flagged with the IMAP `\Sent` special-use attribute
 /// (the canonical, locale-independent answer) and falls back to common
@@ -3003,6 +3100,7 @@ fn main() {
             mark_as_read,
             set_message_read,
             send_email,
+            save_draft,
             get_cached_envelopes,
             get_unified_cached_envelopes,
             get_cached_message,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1949,7 +1949,50 @@ async fn poll_folder(
         batch = client.fetch_envelopes(folder, limit, None).await?;
     }
 
+    // Reconcile the cache against the server's live UID set. Without
+    // this, any UID expunged between polls (by our own delete/archive
+    // paths, by another client, or by the server itself) would linger
+    // as a ghost envelope forever — the incremental fetch above only
+    // ever pulls UIDs *greater* than the bookmark, it never revisits
+    // older ones. Ghosts used to surface as "UID isn't in folder"
+    // errors when the user clicked on them from the mail list.
+    let server_uids = match client.list_all_uids(folder).await {
+        Ok(uids) => uids,
+        Err(e) => {
+            tracing::warn!(
+                "list_all_uids for '{account_id}'/'{folder}' failed (skipping reconcile): {e}"
+            );
+            Vec::new()
+        }
+    };
+
     let _ = client.logout().await;
+
+    if !server_uids.is_empty() || uidvalidity_rotated {
+        let server_set: std::collections::HashSet<u32> = server_uids.into_iter().collect();
+        match cache.list_envelope_uids(account_id, folder) {
+            Ok(cached_uids) => {
+                let mut removed = 0u32;
+                for uid in cached_uids {
+                    if !server_set.contains(&uid) {
+                        match cache.remove_envelope(account_id, folder, uid) {
+                            Ok(true) => removed += 1,
+                            Ok(false) => {}
+                            Err(e) => tracing::warn!(
+                                "remove_envelope (reconcile) for UID {uid} failed: {e}"
+                            ),
+                        }
+                    }
+                }
+                if removed > 0 {
+                    tracing::info!(
+                        "Reconciled '{account_id}'/'{folder}': dropped {removed} ghost UID(s)"
+                    );
+                }
+            }
+            Err(e) => tracing::warn!("list_envelope_uids failed: {e}"),
+        }
+    }
 
     if let Err(e) = cache.upsert_envelopes_for_account(account_id, &batch.envelopes) {
         tracing::warn!("cache.upsert_envelopes failed: {e}");
@@ -2173,7 +2216,33 @@ async fn delete_message(
     .await?;
     let result = client.delete_message(&folder, uid).await;
     let _ = client.logout().await;
+
+    // Clear the cache row whether the delete succeeded OR failed with
+    // "UID not on the server" — in the success case the cache would
+    // otherwise hang onto a ghost row (incremental envelope fetch
+    // never re-examines existing UIDs), and in the failure case the
+    // reason we hit that error *is* a stale cache row, so dropping it
+    // unblocks the user's next refresh.
+    if should_clean_cache_for_delete(&result) {
+        if let Err(e) = cache.remove_envelope(&account_id, &folder, uid) {
+            tracing::warn!("remove_envelope after delete_message failed: {e}");
+        }
+    }
+
     result
+}
+
+/// Did this delete_message result leave the cache holding a definitely-
+/// stale row for the target UID? True when the server confirmed the
+/// delete (Ok) *or* reported the UID isn't there (the probe error we
+/// added to `delete_message`) — in both cases the cached envelope
+/// should come out.
+fn should_clean_cache_for_delete(result: &Result<(), NimbusError>) -> bool {
+    match result {
+        Ok(()) => true,
+        Err(NimbusError::Protocol(msg)) => msg.contains("isn't in folder"),
+        _ => false,
+    }
 }
 
 /// Move the message to the account's Archive folder.
@@ -2223,6 +2292,16 @@ async fn archive_message(
     .await?;
     let result = client.move_message(&folder, uid, &archive).await;
     let _ = client.logout().await;
+
+    if result.is_ok() {
+        // The envelope row for the source folder needs to go — the
+        // next `fetch_envelopes` is an incremental one and won't
+        // notice the move by itself.
+        if let Err(e) = cache.remove_envelope(&account_id, &folder, uid) {
+            tracing::warn!("remove_envelope after archive_message failed: {e}");
+        }
+    }
+
     result
 }
 
@@ -2426,10 +2505,21 @@ async fn save_draft(
 
     // Only attempt the delete if the APPEND actually succeeded —
     // otherwise a flaky APPEND would have us destroy the user's
-    // only remaining copy.
+    // only remaining copy. We also want to clear the cached envelope
+    // for the source UID whether the server-side delete hit an
+    // existing UID or complained that the UID wasn't there (ghost
+    // envelope left over from a previous expunge) — either way the
+    // cached row is wrong and hanging onto it just makes the next
+    // edit attempt fail the same way.
     let result = if append_result.is_ok() {
         if let Some(src) = replace_source {
-            match client.delete_message(&src.folder, src.uid).await {
+            let delete_result = client.delete_message(&src.folder, src.uid).await;
+            if should_clean_cache_for_delete(&delete_result) {
+                if let Err(e) = cache.remove_envelope(&account_id, &src.folder, src.uid) {
+                    tracing::warn!("remove_envelope after save_draft replace failed: {e}");
+                }
+            }
+            match delete_result {
                 Ok(()) => Ok(()),
                 Err(e) => Err(NimbusError::Other(format!(
                     "Draft saved, but removing the previous copy (UID {}) failed: {e}",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2141,11 +2141,12 @@ async fn set_message_read(
 /// Permanently remove a message from a folder on the server.
 ///
 /// Used by the "edit draft" flow: the user opens a draft in Compose,
-/// edits, and clicks Send or Save draft. In either case the old
-/// draft needs to go away so the Drafts mailbox doesn't accumulate
-/// a copy per edit. IMAP-only for now — JMAP would use
-/// `Email/set { destroy }` and is deferred alongside the matching
-/// `save_draft` path.
+/// edits, and clicks Send. The old draft needs to go away so the
+/// Drafts mailbox doesn't accumulate a copy per edit. Also used by
+/// MailView's "Delete" button for outright removal (no Trash
+/// intermediate — callers that want Trash semantics use
+/// `move_to_trash` instead). IMAP-only for now; JMAP would use
+/// `Email/set { destroy }` and is deferred alongside `save_draft`.
 #[tauri::command]
 async fn delete_message(
     account_id: String,
@@ -2173,6 +2174,88 @@ async fn delete_message(
     let result = client.delete_message(&folder, uid).await;
     let _ = client.logout().await;
     result
+}
+
+/// Move the message to the account's Archive folder.
+///
+/// Semantics: single-click "I'm done with this, get it out of my
+/// face" — the message is preserved on the server (unlike
+/// `delete_message`) but pulled out of the current mailbox so the
+/// Inbox stops showing it. If no Archive folder can be located
+/// (server doesn't expose one and no common name matches) the
+/// caller gets a clear error rather than silently deleting.
+#[tauri::command]
+async fn archive_message(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let account = load_account(&cache, &account_id)?;
+
+    if uses_jmap(&account) {
+        return Err(NimbusError::Other(
+            "Archiving via JMAP is not yet implemented — this account uses JMAP".into(),
+        ));
+    }
+
+    let Some(archive) = pick_archive_folder(&account.id, cache.inner()) else {
+        return Err(NimbusError::Other(
+            "no Archive folder found for this account — create one on the server or tell us which folder to use".into(),
+        ));
+    };
+
+    if archive.eq_ignore_ascii_case(&folder) {
+        // Already sitting in Archive. Silently succeed rather than
+        // move-to-self, which some servers reject and others treat
+        // as a noop with a surprising UID change.
+        return Ok(());
+    }
+
+    let password = credentials::get_imap_password(&account.id)?;
+    let mut client = ImapClient::connect(
+        &account.imap_host,
+        account.imap_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await?;
+    let result = client.move_message(&folder, uid, &archive).await;
+    let _ = client.logout().await;
+    result
+}
+
+/// Locate the account's Archive folder via the IMAP `\Archive`
+/// special-use attribute or a name-based fallback. Same strategy as
+/// `pick_sent_folder` / `pick_drafts_folder`.
+fn pick_archive_folder(account_id: &str, cache: &Cache) -> Option<String> {
+    let folders = cache.get_folders(account_id).ok()?;
+
+    if let Some(by_attr) = folders.iter().find(|f| {
+        f.attributes
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("archive") || a.eq_ignore_ascii_case("\\archive"))
+    }) {
+        return Some(by_attr.name.clone());
+    }
+
+    const NAME_HINTS: &[&str] = &[
+        "archive",
+        "archiv",
+        "archives",
+        "archivé",
+        "archivés",
+        "all mail",
+        "[gmail]/all mail",
+    ];
+    folders
+        .iter()
+        .find(|f| {
+            let lower = f.name.to_lowercase();
+            NAME_HINTS.iter().any(|h| lower.contains(h))
+        })
+        .map(|f| f.name.clone())
 }
 
 // ── SMTP commands ───────────────────────────────────────────────
@@ -2264,6 +2347,20 @@ async fn append_to_sent(
     result
 }
 
+/// Payload for the "this save replaces an existing draft" flow.
+/// When Compose opens an existing draft for editing, the frontend
+/// hands the source UID + folder back here so `save_draft` can
+/// APPEND-then-delete inside the same IMAP session — avoiding the
+/// split-connection race where a separate `delete_message` call
+/// would run after the APPEND and sometimes leave the original
+/// behind.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DraftReplaceSource {
+    folder: String,
+    uid: u32,
+}
+
 /// Save an in-progress message to the account's IMAP Drafts folder.
 ///
 /// Mirrors `send_email` structurally (same `OutgoingEmail` input, same
@@ -2272,10 +2369,20 @@ async fn append_to_sent(
 /// devices and the user can finish / send it later. IMAP-only for now;
 /// JMAP accounts get a clear error until the equivalent `Email/set`
 /// create-in-Drafts flow is wired up (tracked separately).
+///
+/// When `replace_source` is set, the save is treated as a
+/// continuation of an existing draft the user opened from Drafts:
+/// we APPEND the new copy into that *same folder* (not whatever
+/// `pick_drafts_folder` thinks Drafts is — the server might have
+/// multiple drafts-like folders and we want the edit to land where
+/// the user is looking) and then EXPUNGE the source UID in the
+/// same session, so from the user's perspective the draft they
+/// were editing is updated in place.
 #[tauri::command]
 async fn save_draft(
     account_id: String,
     email: OutgoingEmail,
+    replace_source: Option<DraftReplaceSource>,
     cache: State<'_, Cache>,
 ) -> Result<(), NimbusError> {
     let account = load_account(&cache, &account_id)?;
@@ -2288,24 +2395,16 @@ async fn save_draft(
 
     let message = build_outgoing_message(&email)?;
     let raw = message.formatted();
-    append_to_drafts(&account, &raw, &cache).await
-}
 
-/// Locate the account's Drafts folder (via the IMAP `\Drafts` attribute,
-/// or a name-based fallback) and `APPEND` the raw RFC 822 bytes there
-/// with the `\Draft` flag set — that's what tells other clients and the
-/// server that this message is a work-in-progress rather than a
-/// received or already-sent mail.
-async fn append_to_drafts(
-    account: &Account,
-    raw: &[u8],
-    cache: &Cache,
-) -> Result<(), NimbusError> {
-    let drafts_folder = pick_drafts_folder(&account.id, cache);
-    let Some(drafts) = drafts_folder else {
-        return Err(NimbusError::Other(
-            "no Drafts folder found in cached folder list".into(),
-        ));
+    // Prefer the source folder when replacing an existing draft so
+    // APPEND and DELETE both target the folder the user actually
+    // opened the draft from. Otherwise fall back to the "find the
+    // account's Drafts folder" heuristic for brand-new drafts.
+    let target_folder = match replace_source.as_ref() {
+        Some(src) => src.folder.clone(),
+        None => pick_drafts_folder(&account.id, cache.inner()).ok_or_else(|| {
+            NimbusError::Other("no Drafts folder found in cached folder list".into())
+        })?,
     };
 
     let password = credentials::get_imap_password(&account.id)?;
@@ -2317,13 +2416,33 @@ async fn append_to_drafts(
         &account.trusted_certs,
     )
     .await?;
-    // `\Draft` is the IMAP flag that marks a message as an unfinished
-    // draft. `\Seen` keeps it out of the unread badge — there's no
-    // point notifying the user about a mail they themselves are
-    // composing.
-    let result = client
-        .append_message(&drafts, raw, &["\\Draft", "\\Seen"])
+
+    // `\Draft` marks the message as an unfinished draft. `\Seen`
+    // keeps it out of the unread badge — there's no point notifying
+    // the user about a mail they themselves just composed.
+    let append_result = client
+        .append_message(&target_folder, &raw, &["\\Draft", "\\Seen"])
         .await;
+
+    // Only attempt the delete if the APPEND actually succeeded —
+    // otherwise a flaky APPEND would have us destroy the user's
+    // only remaining copy.
+    let result = if append_result.is_ok() {
+        if let Some(src) = replace_source {
+            match client.delete_message(&src.folder, src.uid).await {
+                Ok(()) => Ok(()),
+                Err(e) => Err(NimbusError::Other(format!(
+                    "Draft saved, but removing the previous copy (UID {}) failed: {e}",
+                    src.uid
+                ))),
+            }
+        } else {
+            Ok(())
+        }
+    } else {
+        append_result
+    };
+
     let _ = client.logout().await;
     result
 }
@@ -3139,6 +3258,7 @@ fn main() {
             send_email,
             save_draft,
             delete_message,
+            archive_message,
             get_cached_envelopes,
             get_unified_cached_envelopes,
             get_cached_message,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2181,15 +2181,19 @@ async fn set_message_read(
     result
 }
 
-/// Permanently remove a message from a folder on the server.
+/// Remove a message from a folder.
 ///
-/// Used by the "edit draft" flow: the user opens a draft in Compose,
-/// edits, and clicks Send. The old draft needs to go away so the
-/// Drafts mailbox doesn't accumulate a copy per edit. Also used by
-/// MailView's "Delete" button for outright removal (no Trash
-/// intermediate — callers that want Trash semantics use
-/// `move_to_trash` instead). IMAP-only for now; JMAP would use
-/// `Email/set { destroy }` and is deferred alongside `save_draft`.
+/// UX shape matches every major mail client: a first "Delete" press
+/// moves the message to Trash (reversible), a second press (from
+/// Trash itself, or from any folder on accounts without a Trash
+/// folder) permanently expunges it.
+///
+/// Entry points:
+///   - MailView "Delete" button → here.
+///   - `save_draft` replace flow → bypasses this command and calls
+///     the low-level `ImapClient::delete_message` directly, because
+///     "replace this draft with a new version" is update-in-place
+///     and shouldn't litter Trash with editing history.
 #[tauri::command]
 async fn delete_message(
     account_id: String,
@@ -2205,6 +2209,16 @@ async fn delete_message(
         ));
     }
 
+    // Decide move-to-Trash vs permanent. Already-in-Trash comparison
+    // is case-insensitive because the folder name the frontend hands
+    // us is the server-reported name but mail servers don't
+    // guarantee case stability across listings.
+    let trash = pick_trash_folder(&account.id, cache.inner());
+    let destination = match trash.as_deref() {
+        Some(trash) if !folder.eq_ignore_ascii_case(trash) => Some(trash.to_string()),
+        _ => None,
+    };
+
     let password = credentials::get_imap_password(&account.id)?;
     let mut client = ImapClient::connect(
         &account.imap_host,
@@ -2214,7 +2228,10 @@ async fn delete_message(
         &account.trusted_certs,
     )
     .await?;
-    let result = client.delete_message(&folder, uid).await;
+    let result = match destination.as_deref() {
+        Some(trash) => client.move_message(&folder, uid, trash).await,
+        None => client.delete_message(&folder, uid).await,
+    };
     let _ = client.logout().await;
 
     // Clear the cache row whether the delete succeeded OR failed with
@@ -2230,6 +2247,40 @@ async fn delete_message(
     }
 
     result
+}
+
+/// Locate the account's Trash folder via the IMAP `\Trash` special-use
+/// attribute or a name-based fallback. Same strategy as the Sent /
+/// Drafts / Archive pickers. Returns `None` if nothing matches — the
+/// delete path interprets that as "no Trash on this account, fall back
+/// to permanent expunge".
+fn pick_trash_folder(account_id: &str, cache: &Cache) -> Option<String> {
+    let folders = cache.get_folders(account_id).ok()?;
+
+    if let Some(by_attr) = folders.iter().find(|f| {
+        f.attributes
+            .iter()
+            .any(|a| a.eq_ignore_ascii_case("trash") || a.eq_ignore_ascii_case("\\trash"))
+    }) {
+        return Some(by_attr.name.clone());
+    }
+
+    const NAME_HINTS: &[&str] = &[
+        "trash",
+        "bin",
+        "deleted items",
+        "deleted messages",
+        "papierkorb",
+        "corbeille",
+        "[gmail]/trash",
+    ];
+    folders
+        .iter()
+        .find(|f| {
+            let lower = f.name.to_lowercase();
+            NAME_HINTS.iter().any(|h| lower.contains(h))
+        })
+        .map(|f| f.name.clone())
 }
 
 /// Did this delete_message result leave the cache holding a definitely-

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2138,6 +2138,43 @@ async fn set_message_read(
     result
 }
 
+/// Permanently remove a message from a folder on the server.
+///
+/// Used by the "edit draft" flow: the user opens a draft in Compose,
+/// edits, and clicks Send or Save draft. In either case the old
+/// draft needs to go away so the Drafts mailbox doesn't accumulate
+/// a copy per edit. IMAP-only for now — JMAP would use
+/// `Email/set { destroy }` and is deferred alongside the matching
+/// `save_draft` path.
+#[tauri::command]
+async fn delete_message(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let account = load_account(&cache, &account_id)?;
+
+    if uses_jmap(&account) {
+        return Err(NimbusError::Other(
+            "Deleting messages via JMAP is not yet implemented — this account uses JMAP".into(),
+        ));
+    }
+
+    let password = credentials::get_imap_password(&account.id)?;
+    let mut client = ImapClient::connect(
+        &account.imap_host,
+        account.imap_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await?;
+    let result = client.delete_message(&folder, uid).await;
+    let _ = client.logout().await;
+    result
+}
+
 // ── SMTP commands ───────────────────────────────────────────────
 
 /// Send an email via the account's configured SMTP server.
@@ -3101,6 +3138,7 @@ fn main() {
             set_message_read,
             send_email,
             save_draft,
+            delete_message,
             get_cached_envelopes,
             get_unified_cached_envelopes,
             get_cached_message,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -496,6 +496,69 @@
     })
   }
 
+  /** Does the given folder name look like the account's Drafts folder?
+   *  Mirrors the Rust-side `pick_drafts_folder` name-hint list (the
+   *  authoritative `\Drafts` special-use attribute lives on the server
+   *  and we don't propagate it to the frontend yet, so this is the
+   *  pragmatic "good enough" heuristic). */
+  const DRAFTS_NAME_HINTS = ['drafts', 'draft', 'entwürfe', 'entwurf', 'brouillons', 'brouillon']
+  function isDraftsFolderName(name: string): boolean {
+    const lower = name.toLowerCase()
+    return DRAFTS_NAME_HINTS.some((h) => lower.includes(h))
+  }
+  const isDraftsFolder = $derived(isDraftsFolderName(selectedFolder))
+
+  /** Open a draft from the Drafts folder back in Compose for editing.
+   *  Mirrors the reply/forward entry points but additionally:
+   *    - downloads every attachment's bytes so the user can re-send
+   *      or re-save without the attachments silently dropping;
+   *    - records the source UID/folder in `draftSource` so Compose
+   *      can expunge the server-side copy once the edit is sent or
+   *      re-saved (otherwise the Drafts mailbox accumulates one
+   *      copy per edit).
+   *  The reply-style guard fields (`in_reply_to`) stay unset: this is
+   *  a continuation of the user's own work, not a response to someone
+   *  else, so the signature effect correctly skips re-inserting. */
+  type DraftMail = OpenMail & {
+    account_id: string
+    folder: string
+    bcc?: string[]
+    body_html: string | null
+    attachments: { filename: string; content_type: string; part_id: number }[]
+  }
+  async function onEditDraft(mail: DraftMail) {
+    if (selectedUid == null) return
+    const uid = selectedUid
+    // Pull every attachment's bytes. Parallel — even mid-size drafts
+    // rarely have more than a couple of attachments, and the IMAP
+    // backend already reuses one connection per `fetch_message`
+    // command internally.
+    const attachments = await Promise.all(
+      mail.attachments.map(async (att) => ({
+        filename: att.filename,
+        content_type: att.content_type,
+        data: await invoke<number[]>('download_email_attachment', {
+          accountId: mail.account_id,
+          folder: mail.folder,
+          uid,
+          partId: att.part_id,
+        }),
+      })),
+    )
+    openCompose({
+      to: mail.to.join(', '),
+      cc: mail.cc.join(', '),
+      bcc: (mail.bcc ?? []).join(', '),
+      subject: mail.subject,
+      // Prefer the HTML body — the editor is a rich-text editor and
+      // will pass the HTML through unchanged (`textToHtml` detects
+      // tags). Fall back to plain text for the rare HTML-less draft.
+      body: mail.body_html ?? mail.body_text ?? '',
+      attachments,
+      draftSource: { folder: mail.folder, uid },
+    })
+  }
+
   function onForward(mail: OpenMail) {
     // Forwards use the same blockquote treatment as replies so the
     // original message sits inside a visually distinct container.
@@ -801,6 +864,8 @@
       onreplyall={onReplyAll}
       onforward={onForward}
       oncreatetalk={onCreateTalkFromMail}
+      isDraftsFolder={isDraftsFolder}
+      oneditdraft={onEditDraft}
     />
     {#if composeInitial !== null}
       <Compose

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -407,6 +407,16 @@
     refreshToken++
   }
 
+  /** The currently shown message has been archived or deleted on the
+   *  server. Drop the selection so the reading pane returns to the
+   *  "pick a message" placeholder, and bump `refreshToken` so MailList
+   *  + Sidebar re-query the server and the row disappears. */
+  function onMessageRemoved() {
+    selectedUid = null
+    selectedMessageAccountId = null
+    refreshToken++
+  }
+
   // Open the Compose modal. Called with no arg for a blank new message,
   // or with a prefill for reply/reply-all/forward.
   function openCompose(initial: ComposeInitial = {}) {
@@ -872,6 +882,7 @@
       oncreatetalk={onCreateTalkFromMail}
       isDraftsFolder={isDraftsFolder}
       oneditdraft={onEditDraft}
+      onmessageremoved={onMessageRemoved}
     />
     {#if composeInitial !== null}
       <Compose

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -415,6 +415,12 @@
 
   function closeCompose() {
     composeInitial = null
+    // Force the mail list + sidebar to re-query the server. Compose's
+    // save-draft / send paths modify the Drafts and Sent folders
+    // (APPEND + expunge) without touching the envelope cache, so the
+    // UI would otherwise stay on the pre-compose view until the user
+    // clicked another folder.
+    refreshToken++
   }
 
   /** Build a quoted reply body as HTML.
@@ -555,7 +561,7 @@
       // tags). Fall back to plain text for the rare HTML-less draft.
       body: mail.body_html ?? mail.body_text ?? '',
       attachments,
-      draftSource: { folder: mail.folder, uid },
+      draftSource: { accountId: mail.account_id, folder: mail.folder, uid },
     })
   }
 

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -76,6 +76,12 @@
         action — the latter creates the room first and then opens
         Compose to invite the participants. */
     talkLink?: { name: string; url: string }
+    /** When Compose is opened by clicking "Edit" on an existing draft
+        in the Drafts folder, this points at the server-side copy we
+        opened from. Once the user sends or re-saves, that copy needs
+        to be expunged so the mailbox holds exactly one version of the
+        message. Unset for brand-new composes and replies/forwards. */
+    draftSource?: { folder: string; uid: number }
   }
 
   interface Props {
@@ -604,6 +610,11 @@
           attachments,
         },
       })
+      // We APPEND a fresh copy to Drafts (the backend has no "replace
+      // by UID" primitive); the previous copy, if any, is expunged
+      // afterwards so the mailbox holds exactly one version of the
+      // draft the user is actively editing.
+      await expungeDraftSource()
       onclose()
     } catch (e: any) {
       error = formatError(e) || 'Failed to save draft'
@@ -701,6 +712,10 @@
           attachments,
         },
       })
+      // Clean up the server-side draft we opened from (if any) so
+      // the user doesn't end up with a "sent" copy in Sent AND the
+      // unfinished draft still sitting in Drafts.
+      await expungeDraftSource()
       onclose()
     } catch (e: any) {
       error = formatError(e) || 'Failed to send'
@@ -713,6 +728,26 @@
     // No local persistence — if the user wants to resume later they
     // need to click "Save draft" first (which APPENDs to IMAP Drafts).
     onclose()
+  }
+
+  /** Expunge the server-side draft the user opened Compose from, if
+      any. Called after a successful send or re-save so a single
+      editing session can't leave orphan copies piling up in the
+      Drafts folder. Failures are logged but not surfaced — the send
+      / re-save already succeeded, and the stale draft will catch up
+      on the next sync or be cleaned up manually. */
+  async function expungeDraftSource() {
+    const src = initial?.draftSource
+    if (!src) return
+    try {
+      await invoke('delete_message', {
+        accountId: fromAccountId,
+        folder: src.folder,
+        uid: src.uid,
+      })
+    } catch (e) {
+      console.warn('Failed to delete source draft:', e)
+    }
   }
 </script>
 

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -80,8 +80,13 @@
         in the Drafts folder, this points at the server-side copy we
         opened from. Once the user sends or re-saves, that copy needs
         to be expunged so the mailbox holds exactly one version of the
-        message. Unset for brand-new composes and replies/forwards. */
-    draftSource?: { folder: string; uid: number }
+        message. `accountId` is snapshotted separately from the
+        Compose-level `accountId` prop because the user might switch
+        the From: picker mid-edit — we always want to expunge against
+        the account the draft actually lives on, not whichever account
+        the outgoing copy is now headed for. Unset for brand-new
+        composes and replies/forwards. */
+    draftSource?: { accountId: string; folder: string; uid: number }
   }
 
   interface Props {
@@ -613,8 +618,14 @@
       // We APPEND a fresh copy to Drafts (the backend has no "replace
       // by UID" primitive); the previous copy, if any, is expunged
       // afterwards so the mailbox holds exactly one version of the
-      // draft the user is actively editing.
-      await expungeDraftSource()
+      // draft the user is actively editing. If the expunge fails the
+      // save itself was fine — we stay open with a hint so the user
+      // can see what went wrong and manually delete the stale copy.
+      const expungeErr = await expungeDraftSource()
+      if (expungeErr) {
+        error = `Draft saved, but removing the old copy failed: ${expungeErr}`
+        return
+      }
       onclose()
     } catch (e: any) {
       error = formatError(e) || 'Failed to save draft'
@@ -714,8 +725,15 @@
       })
       // Clean up the server-side draft we opened from (if any) so
       // the user doesn't end up with a "sent" copy in Sent AND the
-      // unfinished draft still sitting in Drafts.
-      await expungeDraftSource()
+      // unfinished draft still sitting in Drafts. A failure here is
+      // non-fatal — the mail already went out — but we still want
+      // the user to notice so they can manually discard the stale
+      // draft rather than find it sitting in Drafts days later.
+      const expungeErr = await expungeDraftSource()
+      if (expungeErr) {
+        error = `Sent, but removing the original draft failed: ${expungeErr}`
+        return
+      }
       onclose()
     } catch (e: any) {
       error = formatError(e) || 'Failed to send'
@@ -733,20 +751,23 @@
   /** Expunge the server-side draft the user opened Compose from, if
       any. Called after a successful send or re-save so a single
       editing session can't leave orphan copies piling up in the
-      Drafts folder. Failures are logged but not surfaced — the send
-      / re-save already succeeded, and the stale draft will catch up
-      on the next sync or be cleaned up manually. */
-  async function expungeDraftSource() {
+      Drafts folder. A failure here means the new copy made it but the
+      old one didn't — we surface a clear hint so the user knows to
+      clean up manually (and so we notice the bug in testing) rather
+      than silently ending up with two copies. */
+  async function expungeDraftSource(): Promise<string | null> {
     const src = initial?.draftSource
-    if (!src) return
+    if (!src) return null
     try {
       await invoke('delete_message', {
-        accountId: fromAccountId,
+        accountId: src.accountId,
         folder: src.folder,
         uid: src.uid,
       })
+      return null
     } catch (e) {
       console.warn('Failed to delete source draft:', e)
+      return formatError(e) || 'Failed to remove the old draft copy'
     }
   }
 </script>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -601,8 +601,19 @@
     error = ''
     sending = true
     try {
+      // `replaceSource` lets the backend APPEND + EXPUNGE in a single
+      // IMAP session — critical for "edit an existing draft" because
+      // two separate commands were sometimes leaving the original
+      // copy behind (server hadn't flushed the APPEND before the
+      // DELETE ran on a fresh connection). Letting the backend batch
+      // the two also guarantees APPEND and DELETE target the *same*
+      // folder (the one the user opened the draft from), even on
+      // servers where `pick_drafts_folder` would otherwise choose a
+      // different `\Drafts`-attributed mailbox than the one the user
+      // is looking at.
+      const src = initial?.draftSource
       await invoke('save_draft', {
-        accountId: fromAccountId,
+        accountId: src?.accountId ?? fromAccountId,
         email: {
           from: fromAddress,
           to: splitAddrs(to),
@@ -614,18 +625,8 @@
           body_html: bodyHtml || null,
           attachments,
         },
+        replaceSource: src ? { folder: src.folder, uid: src.uid } : null,
       })
-      // We APPEND a fresh copy to Drafts (the backend has no "replace
-      // by UID" primitive); the previous copy, if any, is expunged
-      // afterwards so the mailbox holds exactly one version of the
-      // draft the user is actively editing. If the expunge fails the
-      // save itself was fine — we stay open with a hint so the user
-      // can see what went wrong and manually delete the stale copy.
-      const expungeErr = await expungeDraftSource()
-      if (expungeErr) {
-        error = `Draft saved, but removing the old copy failed: ${expungeErr}`
-        return
-      }
       onclose()
     } catch (e: any) {
       error = formatError(e) || 'Failed to save draft'

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -158,7 +158,14 @@
   // Imperative handle into the rich-text editor — populated once the
   // editor mounts. We use it to append Nextcloud share links into the
   // body without disturbing the user's cursor or undo history.
-  let editorApi: EditorApi | null = null
+  // `$state` (rather than a plain `let`) is load-bearing here: the
+  // signature `$effect` below depends on this becoming non-null to
+  // know when to append. With a plain `let`, the effect's first run
+  // happens before the child `RichTextEditor`'s `onready` fires, it
+  // sees `editorApi` still null and exits — and because plain `let`s
+  // aren't tracked, it never re-runs when the handle is finally set.
+  // Making it `$state` subscribes the effect to the assignment.
+  let editorApi = $state<EditorApi | null>(null)
   // The editor content as HTML — kept in sync via the RichTextEditor's
   // onchange callback. The initial body (from reply/forward/draft) is
   // plain text, so we convert newlines to <br> for the WYSIWYG view.

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -123,7 +123,23 @@
   // `!initial` check would mis-classify every blank compose as a reply
   // and skip both draft restoration and signature insertion.
   // svelte-ignore state_referenced_locally
-  const saved = !isReplyOrForward(initial) ? loadDraft() : null
+  const saved = !isReplyOrForward(initial) ? loadMeaningfulDraft() : null
+
+  /** Load a persisted draft *only if* it has any user content — the
+      autosave effect writes an empty placeholder at mount, so a naive
+      `loadDraft()` on the next compose would return that empty object
+      and be treated as "there's work to restore". That mis-classifies
+      every subsequent blank compose as a draft-continuation and
+      suppresses the signature `$effect` below. Treating an empty
+      object as "no draft" brings the first-compose behavior (signature
+      appended, nothing to restore) back to every compose the user
+      didn't actually type into. */
+  function loadMeaningfulDraft() {
+    const d = loadDraft()
+    if (!d) return null
+    if (!d.to && !d.cc && !d.bcc && !d.subject && !d.body) return null
+    return d
+  }
 
   /** Does this initial prefill carry quoted reply / forward content?
       Other prefills (FilesView attachments, TalkView links) leave the

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -104,60 +104,29 @@
   )
   const fromAddress = $derived(fromAccount?.email ?? '')
 
-  // Drafts are namespaced by the *initial* account so a reply draft
-  // doesn't collide with the new-mail draft sitting on a different
-  // account. Switching accounts mid-compose keeps using the same
-  // draft key — the saved draft was started from this account.
-  // svelte-ignore state_referenced_locally
-  const DRAFT_KEY = `nimbus-draft:${accountId}`
-
   // ── Form state ──────────────────────────────────────────────
-  // If we got an explicit initial (reply/forward), use it. Otherwise
-  // try to rehydrate a locally saved draft so the user doesn't lose
-  // work when they accidentally close the window. Props are snapshotted
-  // at mount — the modal is remounted when the parent opens a new one.
-  //
-  // We discriminate "this is a reply/forward" by the presence of `body`
-  // or `in_reply_to` rather than by `!initial`, because `openCompose()`
-  // defaults `initial` to `{}` (truthy) for blank composes — a plain
-  // `!initial` check would mis-classify every blank compose as a reply
-  // and skip both draft restoration and signature insertion.
-  // svelte-ignore state_referenced_locally
-  const saved = !isReplyOrForward(initial) ? loadMeaningfulDraft() : null
-
-  /** Load a persisted draft *only if* it has any user content — the
-      autosave effect writes an empty placeholder at mount, so a naive
-      `loadDraft()` on the next compose would return that empty object
-      and be treated as "there's work to restore". That mis-classifies
-      every subsequent blank compose as a draft-continuation and
-      suppresses the signature `$effect` below. Treating an empty
-      object as "no draft" brings the first-compose behavior (signature
-      appended, nothing to restore) back to every compose the user
-      didn't actually type into. */
-  function loadMeaningfulDraft() {
-    const d = loadDraft()
-    if (!d) return null
-    if (!d.to && !d.cc && !d.bcc && !d.subject && !d.body) return null
-    return d
-  }
+  // Seeded from `initial` (reply / forward / "share this file" entry
+  // points) or blank. Drafts are no longer kept in localStorage —
+  // persistence now goes through the Drafts IMAP folder via the
+  // Save draft button, so there's nothing to rehydrate from here.
 
   /** Does this initial prefill carry quoted reply / forward content?
       Other prefills (FilesView attachments, TalkView links) leave the
       body empty, so the user is effectively starting a blank compose
-      with extras and should still get their saved draft + signature. */
+      with extras and should still get the signature appended. */
   function isReplyOrForward(init?: ComposeInitial): boolean {
     return !!(init && (init.body || init.in_reply_to))
   }
   // svelte-ignore state_referenced_locally
-  let to = $state(initial?.to ?? saved?.to ?? '')
+  let to = $state(initial?.to ?? '')
   // svelte-ignore state_referenced_locally
-  let cc = $state(initial?.cc ?? saved?.cc ?? '')
+  let cc = $state(initial?.cc ?? '')
   // svelte-ignore state_referenced_locally
-  let bcc = $state(initial?.bcc ?? saved?.bcc ?? '')
+  let bcc = $state(initial?.bcc ?? '')
   // svelte-ignore state_referenced_locally
-  let subject = $state(initial?.subject ?? saved?.subject ?? '')
+  let subject = $state(initial?.subject ?? '')
   // svelte-ignore state_referenced_locally
-  let body = $state(initial?.body ?? saved?.body ?? '')
+  let body = $state(initial?.body ?? '')
   // svelte-ignore state_referenced_locally
   let attachments = $state<Attachment[]>(initial?.attachments ?? [])
   // Whether the Nextcloud file picker modal is mounted. Picker is lazy
@@ -232,10 +201,10 @@
       `$derived` that may evaluate to `undefined` during the
       `$state(initialBodyHtml())` synchronous init — the effect runs
       after that, by which time the props have flowed through.
-      Skipped for replies / forwards / restored drafts: those already
-      carry their intended body content. */
+      Skipped for replies / forwards: those already carry their
+      intended body content. */
   $effect(() => {
-    if (isReplyOrForward(initial) || saved) return
+    if (isReplyOrForward(initial)) return
     if (!editorApi || !fromAccount) return
     const nextSig = signatureBlock(fromAccount.signature)
 
@@ -320,7 +289,6 @@
 
   let sending = $state(false)
   let error = $state('')
-  let savedHint = $state('')
 
   // ── Talk room + Calendar event creation from Compose ────────
   // Both flows piggyback on the existing modals (`CreateTalkRoomModal`,
@@ -613,41 +581,35 @@
     }
   }
 
-  // Autosave draft whenever the user edits a field. Skip the write
-  // for replies/forwards because `loadDraft()` only restores blank
-  // composes — autosaving a reply here would otherwise leak its
-  // body into the next blank-compose's draft slot for this account.
-  $effect(() => {
-    const draft = { to, cc, bcc, subject, body: bodyHtml }
-    if (isReplyOrForward(initial)) return
+  /** Persist the current compose state to the account's IMAP Drafts
+      folder via `save_draft` on the backend. The draft lands in the
+      Drafts mailbox (visible across devices); the compose modal then
+      closes. `sending` gates the button so a second click mid-flight
+      doesn't double-APPEND the same draft. */
+  async function saveDraft() {
+    error = ''
+    sending = true
     try {
-      localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
-    } catch {
-      // localStorage full or disabled — silently ignore.
+      await invoke('save_draft', {
+        accountId: fromAccountId,
+        email: {
+          from: fromAddress,
+          to: splitAddrs(to),
+          cc: splitAddrs(cc),
+          bcc: splitAddrs(bcc),
+          reply_to: null,
+          subject,
+          body_text: htmlToText(bodyHtml),
+          body_html: bodyHtml || null,
+          attachments,
+        },
+      })
+      onclose()
+    } catch (e: any) {
+      error = formatError(e) || 'Failed to save draft'
+    } finally {
+      sending = false
     }
-  })
-
-  function loadDraft(): null | { to: string; cc: string; bcc: string; subject: string; body: string } {
-    try {
-      const raw = localStorage.getItem(DRAFT_KEY)
-      return raw ? JSON.parse(raw) : null
-    } catch {
-      return null
-    }
-  }
-
-  function clearDraft() {
-    try {
-      localStorage.removeItem(DRAFT_KEY)
-    } catch {
-      // ignore
-    }
-  }
-
-  function saveDraft() {
-    // The effect already wrote it — just give the user confirmation.
-    savedHint = 'Draft saved'
-    setTimeout(() => (savedHint = ''), 1500)
   }
 
   // Split a comma/semicolon-separated address list into trimmed addresses.
@@ -739,7 +701,6 @@
           attachments,
         },
       })
-      clearDraft()
       onclose()
     } catch (e: any) {
       error = formatError(e) || 'Failed to send'
@@ -749,7 +710,8 @@
   }
 
   function cancel() {
-    // Draft is kept in localStorage so the user can resume later.
+    // No local persistence — if the user wants to resume later they
+    // need to click "Save draft" first (which APPENDs to IMAP Drafts).
     onclose()
   }
 </script>
@@ -896,10 +858,7 @@
         }
         onclick={openEventEditor}
       >{openingEvent ? (createdTalkLink ? 'Loading…' : 'Creating Talk room…') : '📅 Add event'}</button>
-      <button class="btn preset-outlined-surface-500" onclick={saveDraft}>Save draft</button>
-      {#if savedHint}
-        <span class="text-xs text-surface-500">{savedHint}</span>
-      {/if}
+      <button class="btn preset-outlined-surface-500" disabled={sending} onclick={saveDraft}>Save draft</button>
       <button class="btn preset-outlined-surface-500 ml-auto" onclick={cancel}>Cancel</button>
     </footer>
   </div>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -750,7 +750,15 @@
       <button class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100" onclick={cancel} aria-label="Close">✕</button>
     </header>
 
-    <div class="flex-1 overflow-y-auto p-5 space-y-3">
+    <!-- Body is a flex column so the RichTextEditor slot can claim
+         `flex-1` and grow as the user resizes the modal taller.
+         `min-h-0` is the usual incantation that lets a flex child
+         actually shrink below its content size; without it the editor
+         would never release height back to the container. We drop the
+         outer `overflow-y-auto` because the editor manages its own
+         internal scroll, and swap `space-y-3` (margins don't play well
+         with `flex-1` siblings) for `gap-3`. -->
+    <div class="flex-1 min-h-0 flex flex-col p-5 gap-3">
       <!-- From: picker. Shown as a real <select> when the user has
            more than one account, otherwise collapsed to a static label
            so single-account users see no extra chrome. -->
@@ -801,12 +809,16 @@
         <input id="compose-subject" class="input flex-1 px-3 py-2 text-sm rounded-md" bind:value={subject} />
       </div>
 
-      <RichTextEditor
-        content={bodyHtml}
-        onchange={(html) => { bodyHtml = html }}
-        onready={(api) => { editorApi = api }}
-        onrequestncimage={() => { showNcImagePicker = true }}
-      />
+      <!-- `flex-1 min-h-0` makes this the stretchy slot in the body
+           column; the editor inside uses `h-full` to fill it. -->
+      <div class="flex-1 min-h-0 flex flex-col">
+        <RichTextEditor
+          content={bodyHtml}
+          onchange={(html) => { bodyHtml = html }}
+          onready={(api) => { editorApi = api }}
+          onrequestncimage={() => { showNcImagePicker = true }}
+        />
+      </div>
 
       {#if attachments.length > 0}
         <div class="flex flex-wrap gap-2">

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -480,7 +480,7 @@
         class="btn btn-sm preset-outlined-surface-500"
         disabled={removing}
         onclick={deleteMessage}
-        title="Permanently delete this message from the server"
+        title="Move this message to Trash (permanently deletes if already in Trash or if the account has no Trash folder)"
       >{removing ? '…' : 'Delete'}</button>
     </div>
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -55,6 +55,14 @@
         subject + thread participants. Wired from `App.svelte` so the
         resulting Compose window stacks on top of the inbox view. */
     oncreatetalk?: (mail: Email) => void
+    /** True when the currently selected folder is the account's
+        Drafts mailbox. Swaps the toolbar over from the reply/forward
+        cluster to a single "Edit" action, because Reply-to-a-draft
+        doesn't model anything useful. */
+    isDraftsFolder?: boolean
+    /** Open the shown draft back in Compose for editing. Fires only
+        from the "Edit" button inside the drafts toolbar. */
+    oneditdraft?: (mail: Email) => void
   }
   let {
     accountId,
@@ -65,6 +73,8 @@
     onreplyall,
     onforward,
     oncreatetalk,
+    isDraftsFolder = false,
+    oneditdraft,
   }: Props = $props()
 
   let email = $state<Email | null>(null)
@@ -380,23 +390,34 @@
       {/if}
     </div>
 
-    <!-- Action bar -->
+    <!-- Action bar. The Drafts folder shows an "Edit" action instead
+         of the reply/forward/mark-read cluster — a draft is the user's
+         own unfinished work, so re-opening it in Compose is the only
+         gesture that makes sense. -->
     <div class="flex items-center gap-2 px-6 py-2 border-b border-surface-200 dark:border-surface-700 text-sm">
-      <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreply?.(email)}>Reply</button>
-      <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreplyall?.(email)}>Reply All</button>
-      <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onforward?.(email)}>Forward</button>
-      {#if oncreatetalk}
+      {#if isDraftsFolder}
         <button
-          class="btn btn-sm preset-outlined-primary-500"
-          onclick={() => email && oncreatetalk?.(email)}
-          title="Create a Nextcloud Talk room with the participants of this thread"
-        >💬 Talk</button>
+          class="btn btn-sm preset-filled-primary-500"
+          onclick={() => email && oneditdraft?.(email)}
+          title="Open this draft in Compose to keep editing"
+        >✏️ Edit draft</button>
+      {:else}
+        <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreply?.(email)}>Reply</button>
+        <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onreplyall?.(email)}>Reply All</button>
+        <button class="btn btn-sm preset-outlined-surface-500" onclick={() => email && onforward?.(email)}>Forward</button>
+        {#if oncreatetalk}
+          <button
+            class="btn btn-sm preset-outlined-primary-500"
+            onclick={() => email && oncreatetalk?.(email)}
+            title="Create a Nextcloud Talk room with the participants of this thread"
+          >💬 Talk</button>
+        {/if}
+        <button
+          class="btn btn-sm preset-outlined-surface-500"
+          onclick={toggleRead}
+          title={email.is_read ? 'Mark this message as unread' : 'Mark this message as read'}
+        >{email.is_read ? 'Mark unread' : 'Mark read'}</button>
       {/if}
-      <button
-        class="btn btn-sm preset-outlined-surface-500"
-        onclick={toggleRead}
-        title={email.is_read ? 'Mark this message as unread' : 'Mark this message as read'}
-      >{email.is_read ? 'Mark unread' : 'Mark read'}</button>
       <div class="flex-1"></div>
       <button class="btn btn-sm preset-outlined-surface-500">Archive</button>
       <button class="btn btn-sm preset-outlined-surface-500">Delete</button>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -63,6 +63,10 @@
     /** Open the shown draft back in Compose for editing. Fires only
         from the "Edit" button inside the drafts toolbar. */
     oneditdraft?: (mail: Email) => void
+    /** Fires after the message has been successfully archived or
+        deleted on the server. The parent clears the selected UID and
+        bumps the MailList refresh so the row disappears. */
+    onmessageremoved?: () => void
   }
   let {
     accountId,
@@ -75,6 +79,7 @@
     oncreatetalk,
     isDraftsFolder = false,
     oneditdraft,
+    onmessageremoved,
   }: Props = $props()
 
   let email = $state<Email | null>(null)
@@ -352,6 +357,52 @@
       setBusy(att.part_id, false)
     }
   }
+
+  // ---------------------------------------------------------------------
+  // Archive / Delete — top-bar actions that remove the current message
+  // from the visible folder. Both follow the same optimistic shape:
+  // disable the buttons, run the Tauri command, and notify the parent
+  // so it can deselect + refresh the mail list. Errors bubble back into
+  // the same `error` banner the load path uses.
+  // ---------------------------------------------------------------------
+  let removing = $state(false)
+
+  async function archiveMessage() {
+    if (!email || uid == null) return
+    removing = true
+    try {
+      await invoke('archive_message', {
+        accountId: email.account_id,
+        folder: email.folder,
+        uid,
+      })
+      onmessageremoved?.()
+    } catch (e) {
+      error = formatError(e) || 'Failed to archive'
+    } finally {
+      removing = false
+    }
+  }
+
+  async function deleteMessage() {
+    if (!email || uid == null) return
+    // No confirm dialog yet — matches the "click = commit" shape of
+    // the rest of the toolbar. A Trash-folder intermediate (and
+    // undo) can come later; for now Delete is outright expunge.
+    removing = true
+    try {
+      await invoke('delete_message', {
+        accountId: email.account_id,
+        folder: email.folder,
+        uid,
+      })
+      onmessageremoved?.()
+    } catch (e) {
+      error = formatError(e) || 'Failed to delete'
+    } finally {
+      removing = false
+    }
+  }
 </script>
 
 <main class="flex-1 flex flex-col overflow-hidden">
@@ -419,8 +470,18 @@
         >{email.is_read ? 'Mark unread' : 'Mark read'}</button>
       {/if}
       <div class="flex-1"></div>
-      <button class="btn btn-sm preset-outlined-surface-500">Archive</button>
-      <button class="btn btn-sm preset-outlined-surface-500">Delete</button>
+      <button
+        class="btn btn-sm preset-outlined-surface-500"
+        disabled={removing}
+        onclick={archiveMessage}
+        title="Move this message to the Archive folder"
+      >{removing ? '…' : 'Archive'}</button>
+      <button
+        class="btn btn-sm preset-outlined-surface-500"
+        disabled={removing}
+        onclick={deleteMessage}
+        title="Permanently delete this message from the server"
+      >{removing ? '…' : 'Delete'}</button>
     </div>
 
     <!-- Attachments — only renders when the message actually has any. -->

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -529,6 +529,13 @@
 </style>
 
 {#if $editor}
+<!-- Wrapper: `h-full flex flex-col min-h-0` lets the editor fill whatever
+     vertical space its parent gives it (e.g. when the Compose modal is
+     resized taller). The toolbar stays at natural height; the content
+     area below claims the remaining space via `flex-1`. Works in a
+     block parent too — `h-full` is simply ignored and the editor falls
+     back to its intrinsic 200 px minimum. -->
+<div class="h-full flex flex-col min-h-0">
   <!-- Toolbar -->
   <div class="flex flex-wrap items-center gap-0.5 px-2 py-1.5 border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 text-sm">
     <!-- Font family picker — dropdown because 6 named families
@@ -709,8 +716,12 @@
     </button>
   </div>
 
-  <!-- Editor area -->
-  <div class="border border-surface-200 dark:border-surface-700 rounded-b-md bg-surface-50 dark:bg-surface-950 overflow-y-auto" style="max-height: 360px;">
+  <!-- Editor area. `flex-1 min-h-0` lets it shrink/grow with the
+       wrapper's available height; `overflow-y-auto` scrolls internally
+       once the content exceeds what fits. When the Compose modal is
+       resized taller, this is what absorbs the new space. -->
+  <div class="flex-1 min-h-0 border border-surface-200 dark:border-surface-700 rounded-b-md bg-surface-50 dark:bg-surface-950 overflow-y-auto">
     <EditorContent editor={$editor} />
   </div>
+</div>
 {/if}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -364,14 +364,60 @@
   ]
   let showFontPicker = $state(false)
 
+  /** Label for the toolbar button, reflecting the font at the current
+      cursor position. `$editor` is a svelte-tiptap store that re-emits
+      on every editor transaction, so this function re-runs after every
+      selection change or edit — the label flips in step with the
+      cursor. Falls back to the generic "Font" when the cursor sits in
+      text carrying a family we don't have a pretty label for. */
+  function currentFontLabel(): string {
+    if (!$editor) return 'Font'
+    const css = ($editor.getAttributes('textStyle')?.fontFamily as string | undefined) ?? ''
+    const match = FONT_FAMILIES.find((f) => f.css === css)
+    return match?.label ?? 'Font'
+  }
+
   function setFont(css: string) {
     showFontPicker = false
     if (!$editor) return
-    if (css === '') {
-      $editor.chain().focus().unsetFontFamily().run()
-    } else {
-      $editor.chain().focus().setFontFamily(css).run()
+    const ed = $editor
+
+    // Non-empty selection: apply the mark to the selected range. This
+    // has always worked via Tiptap's `setFontFamily` helper and we
+    // keep using it so existing behavior (selected text rewrites to
+    // the new face) is unchanged.
+    if (!ed.state.selection.empty) {
+      if (css === '') {
+        ed.chain().focus().unsetFontFamily().run()
+      } else {
+        ed.chain().focus().setFontFamily(css).run()
+      }
+      return
     }
+
+    // Empty selection: we want the *next* typed characters to use the
+    // picked font. Tiptap's `setFontFamily` delegates to ProseMirror's
+    // `setMark`, which on an empty selection adds to `storedMarks` —
+    // in theory that's enough. In practice, because the toolbar
+    // button steals focus on click and the click-to-editor focus
+    // handoff produces an extra selection transaction, the stored
+    // mark was getting cleared before the user's next keystroke.
+    //
+    // Dispatching `addStoredMark` as a standalone transaction —
+    // *after* we explicitly return focus to the editor — sidesteps
+    // the focus-handoff race: by the time this tr lands, the editor
+    // owns focus and the selection is stable, so the mark stays
+    // attached to the cursor position and rides along with the next
+    // character the user types.
+    ed.commands.focus()
+    const { state, view } = ed
+    const markType = state.schema.marks.textStyle
+    if (!markType) return
+    let tr = state.tr
+    tr = css === ''
+      ? tr.removeStoredMark(markType)
+      : tr.addStoredMark(markType.create({ fontFamily: css }))
+    view.dispatch(tr)
   }
 
   // ── Table grid picker state ────────────────────────────────
@@ -540,9 +586,12 @@
   <div class="flex flex-wrap items-center gap-0.5 px-2 py-1.5 border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 text-sm">
     <!-- Font family picker — dropdown because 6 named families
          wouldn't fit as individual toolbar buttons. The trigger
-         shows the generic "Font" label since the active selection
-         can span multiple families. Clicking outside closes the
-         menu (see global listener inside the `$effect` below). -->
+         label tracks the font at the cursor: `currentFontLabel`
+         reads Tiptap's active textStyle attrs via `$editor`, which
+         re-emits on every transaction, so the button reflects
+         moves through text of different faces in real time.
+         Clicking outside closes the menu (see global listener
+         inside the `$effect` below). -->
     <div class="relative inline-block">
       <button
         type="button"
@@ -550,7 +599,7 @@
         title="Font family"
         onclick={() => (showFontPicker = !showFontPicker)}
       >
-        Font ▾
+        {currentFontLabel()} ▾
       </button>
       {#if showFontPicker}
         <div


### PR DESCRIPTION
## Summary

Recovered work that drifted past PR #62's merge point — 13 commits on top of current main, all verified (`cargo check` + `svelte-check` pass). Mix of #62 polish follow-ups and new scope that built on them. Kept as a single PR because each commit builds on the prior and splitting would require painful cherry-picking.

### #62 polish follow-ups
- Editor grows with the modal when the user resizes Compose taller (`flex-1 min-h-0` rework of Compose body + RichTextEditor root)
- Signature `\$effect` now tracks `editorApi` as `\$state` so the signature actually appears (was flaky due to parent-vs-child effect ordering)
- Empty-autosave-draft no longer poisons the next compose's signature-insertion guard
- Font picker button reflects the font at the cursor in real time
- Font picker: empty-selection typing now uses the picked font (direct `addStoredMark` after focus settles, sidesteps the click-focus-handoff race)

### IMAP Drafts storage (new)
- **Save draft** button now APPENDs the current message to the account's Drafts mailbox (`\Draft \Seen`), dropping the localStorage autosave entirely — drafts now live on the server, visible across devices
- `pick_drafts_folder` helper mirrors `pick_sent_folder` (prefers `\Drafts` attribute, falls back to common name hints)
- `build_outgoing_message` accepts drafts with no recipient via an envelope override — lettre would otherwise reject them
- **Edit draft** action in MailView opens the draft back in Compose pre-filled with to/cc/bcc/subject/body + downloaded attachment bytes, with `draftSource = { accountId, folder, uid }` so Compose can clean up the source on save/send
- `save_draft` takes an optional `replaceSource` and handles APPEND + EXPUNGE of the source in one IMAP session (no more cross-connection race)

### Archive + Delete buttons (new)
- New `move_message` IMAP primitive (`UID COPY` + `\Deleted` + `EXPUNGE` — server-agnostic, no MOVE capability required)
- New `archive_message` Tauri command + `pick_archive_folder` helper
- **Delete** now moves to Trash first (new `pick_trash_folder`); expunges permanently only when already in Trash or on accounts without a Trash folder
- MailView's Delete / Archive buttons wired, `onmessageremoved` callback clears selection + bumps refresh

### Cache bug fix (critical)
- Envelope cache was accumulating ghost UIDs — the incremental fetch (`UID FETCH (prior_highest+1):*`) only pulled new messages, never dropped expunged ones. MailList handed those ghost UIDs to `delete_message`, producing the "UID 6 isn't in folder 'Drafts' (exists=2)" bug.
- New `Cache::remove_envelope` called after every successful delete/archive/draft-replace
- `poll_folder` now runs `UID SEARCH ALL` (new `ImapClient::list_all_uids`) after each incremental fetch and drops cache rows whose UID isn't in the live server set — catches ghosts from external clients too

## Test plan
- [ ] New draft → Save as Draft → appears in Drafts mailbox on server (check via webmail)
- [ ] Edit a draft from Drafts → change something → Save as Draft → exactly one copy remains (not two)
- [ ] Edit a draft → Send → gone from Drafts, present in Sent
- [ ] Delete any message → moves to Trash
- [ ] Delete from Trash → permanently gone
- [ ] Archive → moves to Archive folder
- [ ] Signature reliably appears on blank compose (open twice in a row)
- [ ] Resize Compose taller → editor area grows
- [ ] Font dropdown shows current font name, clicking Arial on empty cursor → next typed char is Arial
- [ ] Any lingering ghost drafts from before this PR get auto-cleaned on next folder refresh

## Reviewer notes
- JMAP paths return clear "not yet implemented" errors for `save_draft`, `delete_message`, `archive_message` — deferred alongside the existing JMAP-send-draft gap
- No schema migrations
- `UID EXPUNGE` (RFC 4315 / UIDPLUS) used where supported with a fallback to plain EXPUNGE

🤖 Generated with [Claude Code](https://claude.com/claude-code)