### PR TITLE
Compose: @ contact mentions and / attachment references (#61)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -298,6 +298,13 @@ pub struct Attachment {
     pub content_type: String,
     /// Raw file contents
     pub data: Vec<u8>,
+    /// RFC 2392 Content-ID, used when the body HTML contains a
+    /// `<a href="cid:…">` reference to this attachment (the `/`
+    /// attachment-picker shortcut in Compose). Optional because
+    /// legacy attachment payloads predate the field — we treat an
+    /// absent `content_id` the same as "no inline reference".
+    #[serde(default)]
+    pub content_id: Option<String>,
 }
 
 /// A persistent Nextcloud connection.

--- a/crates/nimbus-smtp/src/client.rs
+++ b/crates/nimbus-smtp/src/client.rs
@@ -3,7 +3,7 @@
 use lettre::address::Envelope;
 use lettre::message::{
     Attachment as LettreAttachment, Mailbox, MessageBuilder, MultiPart, SinglePart,
-    header::ContentType,
+    header::{ContentDisposition, ContentId, ContentType},
 };
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::client::{Tls, TlsParameters};
@@ -357,10 +357,29 @@ fn build_with_attachments(
             .parse::<ContentType>()
             .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
 
-        let lettre_attachment = LettreAttachment::new(attachment.filename.clone())
-            .body(attachment.data.clone(), content_type);
+        let part = match &attachment.content_id {
+            // No content-id: use lettre's stock Attachment helper. Emits
+            // `Content-Disposition: attachment; filename=...` + the
+            // content type; exactly the previous behaviour.
+            None => LettreAttachment::new(attachment.filename.clone())
+                .body(attachment.data.clone(), content_type),
+            // With a content-id: we need *both* disposition=attachment
+            // (so recipients see it in their attachment tray) AND a
+            // Content-ID header (so `<a href="cid:<id>">` in the HTML
+            // body can resolve back to this part). Lettre's
+            // `Attachment::new_inline` sets Content-ID but flips
+            // disposition to `inline`, and `Attachment::new` can't
+            // add Content-ID at all — so we build the SinglePart by
+            // hand instead, stacking exactly the three headers we
+            // need. Angle brackets on the id are the RFC 2392 shape.
+            Some(cid) => SinglePart::builder()
+                .header(ContentDisposition::attachment(&attachment.filename))
+                .header(ContentId::from(format!("<{cid}>")))
+                .header(content_type)
+                .body(attachment.data.clone()),
+        };
 
-        mp.singlepart(lettre_attachment)
+        mp.singlepart(part)
     });
 
     builder

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/extension-horizontal-rule": "^3.22.3",
         "@tiptap/extension-image": "^3.22.3",
         "@tiptap/extension-link": "^3.22.3",
+        "@tiptap/extension-mention": "^3.22.4",
         "@tiptap/extension-placeholder": "^3.22.3",
         "@tiptap/extension-table": "^3.22.3",
         "@tiptap/extension-table-cell": "^3.22.3",
@@ -28,6 +29,7 @@
         "@tiptap/extension-underline": "^3.22.3",
         "@tiptap/pm": "^3.22.3",
         "@tiptap/starter-kit": "^3.22.3",
+        "@tiptap/suggestion": "^3.22.4",
         "svelte-tiptap": "^3.0.1"
       },
       "devDependencies": {
@@ -1206,6 +1208,21 @@
         "@tiptap/extension-list": "^3.22.3"
       }
     },
+    "node_modules/@tiptap/extension-mention": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.22.4.tgz",
+      "integrity": "sha512-ZUJ1gCZlH+JGTAT7lVpZjcMAzvIi9hXIyBjOmjL+737NlF+Cfgo+fjHqFQgOSsiO9LEyc3ZMSclmbzII1Jy6IQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4",
+        "@tiptap/suggestion": "3.22.4"
+      }
+    },
     "node_modules/@tiptap/extension-ordered-list": {
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.3.tgz",
@@ -1435,6 +1452,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.22.4.tgz",
+      "integrity": "sha512-1buvLZemITTeKmPf2wGFWvvhRFKjdQ+JgMqc67xBraOKeDd8wQi1e2XlhCYAtlVMm5f6j+qlLC/MvwuHI2jHeQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.22.4",
+        "@tiptap/pm": "3.22.4"
       }
     },
     "node_modules/@tsconfig/svelte": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@tiptap/extension-horizontal-rule": "^3.22.3",
     "@tiptap/extension-image": "^3.22.3",
     "@tiptap/extension-link": "^3.22.3",
+    "@tiptap/extension-mention": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.3",
     "@tiptap/extension-table": "^3.22.3",
     "@tiptap/extension-table-cell": "^3.22.3",
@@ -44,6 +45,7 @@
     "@tiptap/extension-underline": "^3.22.3",
     "@tiptap/pm": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",
+    "@tiptap/suggestion": "^3.22.4",
     "svelte-tiptap": "^3.0.1"
   }
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -559,6 +559,15 @@
           uid,
           partId: att.part_id,
         }),
+        // Fresh content_id — the `/` editor shortcut references
+        // attachments by this id, so each one needs a value even
+        // when we're rehydrating a draft. Any `cid:` refs already
+        // baked into the old draft body are intentionally broken
+        // by this: fixing them up would mean parsing the stored
+        // HTML and rewriting refs, which is scope-heavier and can
+        // wait. For a freshly-edited draft you just re-pick the
+        // attachment via `/` to relink.
+        content_id: crypto.randomUUID().replaceAll('-', ''),
       })),
     )
     openCompose({

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -52,6 +52,13 @@
     filename: string
     content_type: string
     data: number[]
+    /** RFC 2392 Content-ID, assigned when the attachment is picked
+     *  so the body HTML can reference it via `<a href="cid:…">`.
+     *  The `/` attachment-picker shortcut in the editor inserts
+     *  those links; recipients' mail clients that honour cid: get a
+     *  clickable anchor, others see a plain-text link that falls
+     *  through to the attachment tray below the message. */
+    content_id?: string
   }
 
   export interface ComposeInitial {
@@ -681,6 +688,17 @@
     to = [...current, ...additions].join(', ')
   }
 
+  /** Generate a stable, collision-resistant RFC 2392 Content-ID for
+      a freshly picked attachment. We tag every attachment the user
+      adds so the `/` shortcut in the editor can reference any of
+      them — even the ones the user ultimately doesn't link to just
+      carry an unused id, which is cheap. UUID v4 from the
+      browser's Web Crypto API; we strip the hyphens so the id
+      round-trips cleanly through headers without extra quoting. */
+  function makeContentId(): string {
+    return crypto.randomUUID().replaceAll('-', '')
+  }
+
   async function onPickFiles(e: Event) {
     const input = e.target as HTMLInputElement
     if (!input.files) return
@@ -691,6 +709,7 @@
         filename: file.name,
         content_type: file.type || 'application/octet-stream',
         data: Array.from(new Uint8Array(buf)),
+        content_id: makeContentId(),
       })
     }
     attachments = [...attachments, ...picked]
@@ -923,7 +942,14 @@
 
 {#if showNcPicker}
   <NextcloudFilePicker
-    onpicked={(picked) => { attachments = [...attachments, ...picked] }}
+    onpicked={(picked) => {
+      // Stamp a content_id on each newly-arrived attachment so the
+      // `/` editor shortcut can reference it — the Nextcloud picker
+      // doesn't carry the field in its own `Attachment` shape, so
+      // Compose is the earliest point where we can assign one.
+      const stamped = picked.map((a) => ({ ...a, content_id: makeContentId() }))
+      attachments = [...attachments, ...stamped]
+    }}
     onlinks={(links) => {
       // Drop a small "Shared via Nextcloud" block at the end of the
       // message body. Each link is its own paragraph so it survives

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -16,9 +16,12 @@
    * is tracked separately.
    */
 
-  import { invoke } from '@tauri-apps/api/core'
+  import { convertFileSrc, invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
-  import RichTextEditor, { type EditorApi } from './RichTextEditor.svelte'
+  import RichTextEditor, {
+    type EditorApi,
+    type ContactSuggestion,
+  } from './RichTextEditor.svelte'
   import AddressAutocomplete from './AddressAutocomplete.svelte'
   import NextcloudFilePicker from './NextcloudFilePicker.svelte'
   import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
@@ -659,6 +662,149 @@
     return m ? m[1].trim() : trimmed
   }
 
+  /** Same parser as `bareAddr`, but also pulls the display name out
+      of the `"Name" <addr>` wrapper so the @ picker can show the
+      friendly form for participants the user has typed without a
+      matching address-book entry. */
+  function parseAddress(piece: string): { name: string; email: string } {
+    const trimmed = piece.trim()
+    if (!trimmed) return { name: '', email: '' }
+    const m = trimmed.match(/^\s*"?([^"<]*?)"?\s*<([^>]+)>\s*$/)
+    if (m) return { name: m[1].trim(), email: m[2].trim() }
+    return { name: '', email: trimmed }
+  }
+
+  // ── Contact picker (`@` mention) data plumbing ─────────────
+  // Cache the full address book once at mount; the `@` query then
+  // filters in-memory. Cheap because contacts rarely number above
+  // a few hundred per Nextcloud account, and the alternative
+  // (round-tripping `search_contacts` on every keystroke) would
+  // both add latency and complicate the participants-first
+  // ordering we owe the user.
+  interface ContactKindValue { kind: string; value: string }
+  interface ContactRow {
+    id: string
+    nextcloud_account_id: string
+    display_name: string
+    email: ContactKindValue[]
+    phone: ContactKindValue[]
+    organization: string | null
+    photo_mime: string | null
+  }
+  let allContacts = $state<ContactRow[]>([])
+  $effect(() => {
+    invoke<ContactRow[]>('get_contacts')
+      .then((rows) => {
+        allContacts = rows
+      })
+      .catch((e) => {
+        // No Nextcloud accounts / sync hasn't run / etc. — we
+        // degrade to "participants only" silently rather than
+        // breaking the @ flow with an error toast.
+        console.warn('get_contacts failed (mention picker continues with participants only):', e)
+      })
+  })
+
+  /** Materialize the parts of the contact-row Tiptap needs. The
+   *  full ContactRow has multiple emails per contact; the picker
+   *  is per-email so each address gets its own row. */
+  function suggestionFor(c: ContactRow, email: string): ContactSuggestion {
+    return {
+      id: email,
+      label: c.display_name || email,
+      email,
+      photoUrl: c.photo_mime ? convertFileSrc(c.id, 'contact-photo') : null,
+      hint: c.organization ?? null,
+    }
+  }
+
+  /** Hand the editor's `@` picker the two-tier list:
+   *  - `participants`: addresses the user has already added to To/Cc
+   *    (in that order, deduped). These show first in the popup so
+   *    the most likely target — someone already on the mail — is
+   *    one keystroke away.
+   *  - `others`: address-book matches that aren't already a
+   *    participant. Capped to 8 to keep the popup tight. */
+  async function contactQuery(query: string) {
+    const q = query.trim().toLowerCase()
+    const participantEmails = new Set<string>()
+    const participants: ContactSuggestion[] = []
+
+    for (const field of [to, cc]) {
+      for (const piece of splitAddrs(field)) {
+        const { name, email } = parseAddress(piece)
+        if (!email) continue
+        const key = email.toLowerCase()
+        if (participantEmails.has(key)) continue
+        participantEmails.add(key)
+        // Enrich with the address-book row if we have one — gives
+        // the row a photo + organization hint, and a real display
+        // name when the user typed only the bare address.
+        const full = allContacts.find((c) =>
+          c.email.some((e) => e.value.toLowerCase() === key),
+        )
+        if (full) {
+          participants.push(suggestionFor(full, email))
+        } else {
+          participants.push({
+            id: email,
+            label: name || email,
+            email,
+            photoUrl: null,
+            hint: null,
+          })
+        }
+      }
+    }
+
+    const matchesQuery = (s: ContactSuggestion) =>
+      !q || s.label.toLowerCase().includes(q) || s.email.toLowerCase().includes(q)
+    const filteredParticipants = participants.filter(matchesQuery)
+
+    const others: ContactSuggestion[] = []
+    const seenOthers = new Set<string>()
+    for (const c of allContacts) {
+      for (const e of c.email) {
+        const email = e.value
+        const key = email.toLowerCase()
+        if (!email || participantEmails.has(key) || seenOthers.has(key)) continue
+        const sug = suggestionFor(c, email)
+        if (!matchesQuery(sug)) continue
+        seenOthers.add(key)
+        others.push(sug)
+        if (others.length >= 8) break
+      }
+      if (others.length >= 8) break
+    }
+
+    return { participants: filteredParticipants, others }
+  }
+
+  /** Auto-add the picked contact to Cc when the email isn't already
+      somewhere on the recipient list. Issue #61 specifically asks
+      for Cc (not To) so a tangential `@`-mention doesn't promote
+      a side reference into a primary recipient. */
+  function onContactPicked(c: ContactSuggestion) {
+    const seen = new Set<string>()
+    for (const f of [to, cc, bcc]) {
+      for (const piece of splitAddrs(f)) {
+        const e = bareAddr(piece).toLowerCase()
+        if (e) seen.add(e)
+      }
+    }
+    if (seen.has(c.email.toLowerCase())) return
+    const formatted = c.label && c.label !== c.email
+      ? `"${c.label.replace(/"/g, '\\"')}" <${c.email}>`
+      : c.email
+    const trimmed = cc.trim()
+    cc = trimmed
+      ? `${trimmed}${trimmed.endsWith(',') ? ' ' : ', '}${formatted}, `
+      : `${formatted}, `
+    // Make sure the user can see the Cc field they were just
+    // auto-credited into — otherwise the change feels invisible.
+    showCcBcc = true
+  }
+
   /**
    * Merge newly invited addresses back into the email's To field.
    * Used by both the Talk-room-created and calendar-event-saved
@@ -878,6 +1024,11 @@
           onchange={(html) => { bodyHtml = html }}
           onready={(api) => { editorApi = api }}
           onrequestncimage={() => { showNcImagePicker = true }}
+          oncontactquery={contactQuery}
+          oncontactpicked={onContactPicked}
+          attachmentsForRef={attachments
+            .filter((a): a is Attachment & { content_id: string } => !!a.content_id)
+            .map((a) => ({ content_id: a.content_id, filename: a.filename }))}
         />
       </div>
 

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -27,6 +27,8 @@
   import TableRow from '@tiptap/extension-table-row'
   import TableCell from '@tiptap/extension-table-cell'
   import TableHeader from '@tiptap/extension-table-header'
+  import Mention from '@tiptap/extension-mention'
+  import type { Range } from '@tiptap/core'
 
   /**
    * Imperative handle the parent gets via `onready`. Tiptap is
@@ -67,6 +69,48 @@
      *  the button falls back to the plain URL prompt so embedders
      *  without Nextcloud (tests, future standalone usage) still work. */
     onrequestncimage?: () => void
+    /** Async query for the `@` contact picker. Returns two parallel
+     *  lists — `participants` (currently in To/Cc/Bcc) shown above the
+     *  divider, `others` (rest of the address book matching `query`)
+     *  below. The popup wires the keyboard / click → `oncontactpicked`. */
+    oncontactquery?: (query: string) => Promise<{
+      participants: ContactSuggestion[]
+      others: ContactSuggestion[]
+    }>
+    /** Fires after a `@` contact mention has been inserted. Compose
+     *  uses this to add the contact to Cc when the email isn't
+     *  already on To/Cc/Bcc — keeps the recipient list and the
+     *  body's mentions in sync. */
+    oncontactpicked?: (contact: ContactSuggestion) => void
+    /** Live attachment list for the `/` reference picker. Each entry
+     *  needs `content_id` (the cid: target) and `filename`. The
+     *  editor reads this snapshot at every keystroke of the picker —
+     *  no separate event needed when the parent's attachments
+     *  change. */
+    attachmentsForRef?: AttachmentRef[]
+  }
+
+  /** A row in the `@` contact picker. */
+  export interface ContactSuggestion {
+    /** Stable key — typically the email. */
+    id: string
+    /** Display name shown in the chip and the popup. */
+    label: string
+    /** Email address used in the mailto: href and plain-text
+     *  serialization. */
+    email: string
+    /** Optional avatar URL (e.g. `convertFileSrc(id, 'contact-photo')`). */
+    photoUrl?: string | null
+    /** Optional secondary line in the popup row (e.g. organization). */
+    hint?: string | null
+  }
+
+  /** A row in the `/` attachment picker. */
+  export interface AttachmentRef {
+    /** RFC 2392 Content-ID, used as the `cid:` target on the
+     *  inserted link. Stamped at attachment-pick time in Compose. */
+    content_id: string
+    filename: string
   }
   let {
     content = '',
@@ -74,7 +118,113 @@
     onchange,
     onready,
     onrequestncimage,
+    oncontactquery,
+    oncontactpicked,
+    attachmentsForRef = [],
   }: Props = $props()
+
+  // \u2500\u2500 Inline `@` and `/` picker state \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+  // Tiptap's suggestion plugin owns the trigger detection and
+  // emits lifecycle hooks; we mirror the relevant bits into Svelte
+  // state so the popup renders declaratively below the editor.
+  // Two independent slots so `@` and `/` can't both be open at once
+  // wins out by sharing `pickerKey` \u2014 only one is mounted at a time.
+  interface PickerPosition {
+    left: number
+    top: number
+  }
+  interface MentionPickerState {
+    visible: boolean
+    items: ContactSuggestion[]
+    /** Number of `participants` items at the head of `items`. The
+     *  popup draws a divider after `participantsCount - 1` so the
+     *  user can tell "already on this mail" from "rest of the
+     *  address book". Zero = no divider. */
+    participantsCount: number
+    selectedIndex: number
+    position: PickerPosition
+    command: ((c: ContactSuggestion) => void) | null
+  }
+  let mentionPicker = $state<MentionPickerState>({
+    visible: false,
+    items: [],
+    participantsCount: 0,
+    selectedIndex: 0,
+    position: { left: 0, top: 0 },
+    command: null,
+  })
+
+  interface AttachmentPickerState {
+    visible: boolean
+    items: AttachmentRef[]
+    selectedIndex: number
+    position: PickerPosition
+    command: ((a: AttachmentRef) => void) | null
+  }
+  let attachmentPicker = $state<AttachmentPickerState>({
+    visible: false,
+    items: [],
+    selectedIndex: 0,
+    position: { left: 0, top: 0 },
+    command: null,
+  })
+
+  /** Compute the popup anchor from the trigger char's bounding
+   *  rect. Clamped to the viewport so a `@` typed near the right
+   *  edge of the modal doesn't push the popup off-screen. */
+  function anchorBelow(rect: DOMRect | null | undefined): PickerPosition {
+    if (!rect) return { left: 8, top: 8 }
+    const gap = 4
+    return {
+      left: Math.max(8, Math.min(rect.left, window.innerWidth - 280)),
+      top: rect.bottom + gap,
+    }
+  }
+
+  /** Forward editor keystrokes to the visible picker (arrows /
+   *  enter / tab / escape) and return whether we consumed them.
+   *  Tiptap suggestion uses the boolean to decide whether to let
+   *  the keystroke fall through to the editor. Each picker has
+   *  its own handler because they own different state slots, but
+   *  both share the same key-mapping. */
+  function handleMentionKey(event: KeyboardEvent): boolean {
+    const len = mentionPicker.items.length
+    if (len === 0) return event.key === 'Escape'
+    if (event.key === 'ArrowDown') {
+      mentionPicker.selectedIndex = (mentionPicker.selectedIndex + 1) % len
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      mentionPicker.selectedIndex =
+        (mentionPicker.selectedIndex - 1 + len) % len
+      return true
+    }
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      const item = mentionPicker.items[mentionPicker.selectedIndex]
+      if (item && mentionPicker.command) mentionPicker.command(item)
+      return true
+    }
+    return event.key === 'Escape'
+  }
+  function handleAttachmentKey(event: KeyboardEvent): boolean {
+    const len = attachmentPicker.items.length
+    if (len === 0) return event.key === 'Escape'
+    if (event.key === 'ArrowDown') {
+      attachmentPicker.selectedIndex = (attachmentPicker.selectedIndex + 1) % len
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      attachmentPicker.selectedIndex =
+        (attachmentPicker.selectedIndex - 1 + len) % len
+      return true
+    }
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      const item = attachmentPicker.items[attachmentPicker.selectedIndex]
+      if (item && attachmentPicker.command) attachmentPicker.command(item)
+      return true
+    }
+    return event.key === 'Escape'
+  }
 
   // svelte-ignore state_referenced_locally
   const editor = createEditor({
@@ -233,6 +383,207 @@
       TableRow,
       TableCell,
       TableHeader,
+      // ── `@` contact mention ────────────────────────────────
+      // Renamed from the default `mention` so it can coexist with
+      // the `/` attachment-ref extension below (Tiptap's Mention is
+      // a single Node type — to register two we extend twice with
+      // different `name`s). Renders to the wire as
+      // `<a href="mailto:…" data-contact-mention>@Alice</a>` so
+      // non-Tiptap clients see a clickable mailto link, while the
+      // `data-` marker lets us re-parse it on draft round-trip.
+      Mention.extend({
+        name: 'contactMention',
+        renderHTML({ node, HTMLAttributes }) {
+          const email = node.attrs.id ?? ''
+          const label = node.attrs.label ?? email
+          return [
+            'a',
+            { ...HTMLAttributes, href: `mailto:${email}` },
+            `@${label}`,
+          ]
+        },
+        // Plain-text serialization: feed `body_text` an RFC-style
+        // address rather than just the bare display name so the
+        // text-only fallback still tells a recipient who Alice is.
+        renderText({ node }) {
+          const label = node.attrs.label ?? node.attrs.id ?? ''
+          const email = node.attrs.id ?? ''
+          if (label && email && label !== email) return `${label} <${email}>`
+          return email || label
+        },
+        parseHTML() {
+          return [
+            {
+              tag: 'a[data-contact-mention]',
+              getAttrs: (el) => {
+                const href = (el as HTMLElement).getAttribute('href') ?? ''
+                const email = href.replace(/^mailto:/, '')
+                const text = (el as HTMLElement).textContent ?? ''
+                const label = text.replace(/^@/, '') || email
+                return { id: email, label }
+              },
+            },
+          ]
+        },
+      }).configure({
+        HTMLAttributes: {
+          'data-contact-mention': '',
+          class:
+            'inline-block px-1 rounded bg-primary-500/15 text-primary-700 dark:text-primary-300 no-underline',
+        },
+        suggestion: {
+          char: '@',
+          // `items` is called every time the query changes. We
+          // delegate to the parent's `oncontactquery` (Compose hands
+          // back the merged participants + address-book list) and
+          // stash `participantsCount` on the array so the popup
+          // hooks can read it back without changing Tiptap's
+          // expected return shape.
+          items: async ({ query }) => {
+            if (!oncontactquery) return []
+            const { participants, others } = await oncontactquery(query)
+            const merged = [...participants, ...others]
+            ;(merged as unknown as { __pcount: number }).__pcount = participants.length
+            return merged
+          },
+          command: ({ editor, range, props }) => {
+            const c = props as ContactSuggestion
+            editor
+              .chain()
+              .focus()
+              .insertContentAt(range, [
+                { type: 'contactMention', attrs: { id: c.email, label: c.label } },
+                { type: 'text', text: ' ' },
+              ])
+              .run()
+            oncontactpicked?.(c)
+          },
+          render: () => ({
+            onStart: (props) => {
+              const items = props.items as ContactSuggestion[]
+              const pcount =
+                (items as unknown as { __pcount?: number }).__pcount ?? 0
+              mentionPicker.items = items
+              mentionPicker.participantsCount = pcount
+              mentionPicker.selectedIndex = 0
+              mentionPicker.command = (c) =>
+                (props.command as (data: ContactSuggestion) => void)(c)
+              mentionPicker.position = anchorBelow(props.clientRect?.())
+              mentionPicker.visible = true
+            },
+            onUpdate: (props) => {
+              const items = props.items as ContactSuggestion[]
+              const pcount =
+                (items as unknown as { __pcount?: number }).__pcount ?? 0
+              mentionPicker.items = items
+              mentionPicker.participantsCount = pcount
+              mentionPicker.selectedIndex = 0
+              mentionPicker.command = (c) =>
+                (props.command as (data: ContactSuggestion) => void)(c)
+              mentionPicker.position = anchorBelow(props.clientRect?.())
+            },
+            onKeyDown: ({ event }) => handleMentionKey(event),
+            onExit: () => {
+              mentionPicker.visible = false
+              mentionPicker.items = []
+              mentionPicker.command = null
+            },
+          }),
+        },
+      }),
+
+      // ── `/` attachment reference ───────────────────────────
+      // Same Mention machinery, different node + char + render. The
+      // inserted node is a clickable `cid:` link — recipients on
+      // Nimbus (or any client that resolves `cid:` href) get a
+      // direct jump to the attachment; on Gmail / web clients it
+      // falls back to plain link text with the attachment still
+      // visible in the message's attachment tray.
+      Mention.extend({
+        name: 'attachmentRef',
+        renderHTML({ node, HTMLAttributes }) {
+          const cid = node.attrs.id ?? ''
+          const label = node.attrs.label ?? cid
+          return [
+            'a',
+            { ...HTMLAttributes, href: `cid:${cid}` },
+            `📎 ${label}`,
+          ]
+        },
+        renderText({ node }) {
+          // Plain-text fallback is just the filename — `cid:` URIs
+          // mean nothing to a human reading the text/plain part.
+          return node.attrs.label ?? ''
+        },
+        parseHTML() {
+          return [
+            {
+              tag: 'a[data-attachment-ref]',
+              getAttrs: (el) => {
+                const href = (el as HTMLElement).getAttribute('href') ?? ''
+                const id = href.replace(/^cid:/, '')
+                const text = (el as HTMLElement).textContent ?? ''
+                const label = text.replace(/^📎\s*/, '') || id
+                return { id, label }
+              },
+            },
+          ]
+        },
+      }).configure({
+        HTMLAttributes: {
+          'data-attachment-ref': '',
+          class: 'inline-block text-primary-600 dark:text-primary-400 underline',
+        },
+        suggestion: {
+          char: '/',
+          items: ({ query }) => {
+            const q = query.trim().toLowerCase()
+            return attachmentsForRef
+              .filter((a) => a.content_id)
+              .filter((a) => !q || a.filename.toLowerCase().includes(q))
+              .slice(0, 8)
+          },
+          command: ({ editor, range, props }) => {
+            // Tiptap types `props` as MentionNodeAttrs; we always
+            // pass our own AttachmentRef shape from `items` above,
+            // so the unknown-cast is the standard escape hatch.
+            const a = props as unknown as AttachmentRef
+            editor
+              .chain()
+              .focus()
+              .insertContentAt(range, [
+                { type: 'attachmentRef', attrs: { id: a.content_id, label: a.filename } },
+                { type: 'text', text: ' ' },
+              ])
+              .run()
+          },
+          render: () => ({
+            onStart: (props) => {
+              attachmentPicker.items = props.items as unknown as AttachmentRef[]
+              attachmentPicker.selectedIndex = 0
+              attachmentPicker.command = props.command as unknown as (
+                data: AttachmentRef,
+              ) => void
+              attachmentPicker.position = anchorBelow(props.clientRect?.())
+              attachmentPicker.visible = true
+            },
+            onUpdate: (props) => {
+              attachmentPicker.items = props.items as unknown as AttachmentRef[]
+              attachmentPicker.selectedIndex = 0
+              attachmentPicker.command = props.command as unknown as (
+                data: AttachmentRef,
+              ) => void
+              attachmentPicker.position = anchorBelow(props.clientRect?.())
+            },
+            onKeyDown: ({ event }) => handleAttachmentKey(event),
+            onExit: () => {
+              attachmentPicker.visible = false
+              attachmentPicker.items = []
+              attachmentPicker.command = null
+            },
+          }),
+        },
+      }),
     ],
     // svelte-ignore state_referenced_locally
     content,
@@ -773,4 +1124,101 @@
     <EditorContent editor={$editor} />
   </div>
 </div>
+
+<!-- ── `@` contact picker popup ────────────────────────────
+     `position: fixed` anchored to the trigger char's bounding rect
+     (computed in `anchorBelow`). z-60 so we sit on top of the
+     Compose modal's z-50 backdrop. The whole panel only renders
+     while the suggestion plugin says it should be visible — the
+     popup never lingers in the DOM tree when no `@` is active. -->
+{#if mentionPicker.visible}
+  <ul
+    class="fixed z-60 max-h-72 min-w-72 overflow-y-auto rounded-md border border-surface-300
+           dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg py-1 text-sm"
+    style="left: {mentionPicker.position.left}px; top: {mentionPicker.position.top}px;"
+    role="listbox"
+  >
+    {#if mentionPicker.items.length === 0}
+      <li class="px-3 py-2 text-xs text-surface-500">No matching contacts</li>
+    {:else}
+      {#each mentionPicker.items as c, i (c.id)}
+        <li
+          role="option"
+          aria-selected={i === mentionPicker.selectedIndex}
+          class="flex items-center gap-3 px-3 py-1.5 cursor-pointer
+                 {i === mentionPicker.selectedIndex
+                   ? 'bg-primary-500/15'
+                   : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
+          onmousedown={(e) => {
+            // mousedown so we commit before the editor sees a
+            // focus-loss and tears the popup down.
+            e.preventDefault()
+            mentionPicker.command?.(c)
+          }}
+        >
+          {#if c.photoUrl}
+            <img src={c.photoUrl} alt="" loading="lazy"
+                 class="w-7 h-7 rounded-full object-cover shrink-0" />
+          {:else}
+            <div class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-700
+                        flex items-center justify-center text-[10px] font-semibold shrink-0">
+              {c.label.trim().charAt(0).toUpperCase() || '?'}
+            </div>
+          {/if}
+          <div class="flex-1 min-w-0">
+            <p class="font-medium truncate">{c.label}</p>
+            <p class="text-xs text-surface-500 truncate">
+              {c.email}{#if c.hint} · {c.hint}{/if}
+            </p>
+          </div>
+        </li>
+        <!-- Divider after the last `participants` row, but only when
+             there are also `others` below it. Pure visual separator
+             — not selectable, not in the keyboard cycle. -->
+        {#if i === mentionPicker.participantsCount - 1
+              && i < mentionPicker.items.length - 1}
+          <li
+            aria-hidden="true"
+            class="my-1 mx-2 border-t border-surface-200 dark:border-surface-700"
+          ></li>
+        {/if}
+      {/each}
+    {/if}
+  </ul>
+{/if}
+
+<!-- ── `/` attachment picker popup ─────────────────────────
+     Same shape as the contact picker, narrower because rows are
+     just a filename + a paperclip glyph. Only attachments with a
+     `content_id` show up — everything else has nothing to link to. -->
+{#if attachmentPicker.visible}
+  <ul
+    class="fixed z-60 max-h-72 min-w-64 overflow-y-auto rounded-md border border-surface-300
+           dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg py-1 text-sm"
+    style="left: {attachmentPicker.position.left}px; top: {attachmentPicker.position.top}px;"
+    role="listbox"
+  >
+    {#if attachmentPicker.items.length === 0}
+      <li class="px-3 py-2 text-xs text-surface-500">No attachments to reference</li>
+    {:else}
+      {#each attachmentPicker.items as a, i (a.content_id)}
+        <li
+          role="option"
+          aria-selected={i === attachmentPicker.selectedIndex}
+          class="flex items-center gap-2 px-3 py-1.5 cursor-pointer
+                 {i === attachmentPicker.selectedIndex
+                   ? 'bg-primary-500/15'
+                   : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
+          onmousedown={(e) => {
+            e.preventDefault()
+            attachmentPicker.command?.(a)
+          }}
+        >
+          <span class="text-base shrink-0">📎</span>
+          <span class="truncate">{a.filename}</span>
+        </li>
+      {/each}
+    {/if}
+  </ul>
+{/if}
 {/if}


### PR DESCRIPTION
Closes #61.

## Summary

Inline shortcuts inside the Compose editor that pull from contacts and the current attachment list:

- **`@` opens the contact picker.** Rows show current To/Cc participants at the top (enriched from the address book when a match is found), then the rest of the cached address book matching the query — separated by a visual divider, both capped for a tight popup.
- **`/` opens the attachment picker.** Lists every current attachment that carries a `content_id`, filtered by the query.
- **Auto-add to Cc** — when the picked contact's email isn't already on To/Cc/Bcc, it's appended to Cc automatically and the Cc field unfolds. Matches the issue's "add them automatically" ask, scoped to Cc so tangential `@`-mentions don't promote side references into primary recipients.
- **Content-ID plumbing** — every attachment is stamped with a fresh UUID `content_id` at pick time (local file picker, Nextcloud picker, and the edit-draft rehydration path). `build_with_attachments` emits it as a `Content-ID` header alongside `Content-Disposition: attachment` so the `cid:` link resolves on the recipient side.

## Wire format

Both shortcuts insert plain HTML anchors that degrade gracefully on clients that don't know about them:

- `@Alice` → `<a href="mailto:alice@example.com" data-contact-mention>@Alice</a>`
  - Plain-text fallback (body_text): `Alice <alice@example.com>`
- `/report.pdf` → `<a href="cid:<uuid>" data-attachment-ref>📎 report.pdf</a>`
  - Plain-text fallback: `report.pdf`

The `data-*` markers let Tiptap re-parse its own output on draft round-trip without losing the chip styling or the auto-add-to-Cc semantics.

## Recipient compatibility caveat

Per pre-implementation discussion with Nick: `<a href="cid:...">` for non-image attachments is patchy across clients. Starting simple to validate UX:

- **Nimbus → Nimbus**: clickable (next MailView change wires `cid:` resolution there)
- **Thunderbird / Apple Mail**: usually clickable, sometimes "scroll to attachment tray"
- **Gmail / Outlook web / mobile**: often just inert link text with the attachment still visible below

A "share via Nextcloud public URL" fallback is a reasonable next step if compatibility becomes a pain point.

## Dependencies

- `@tiptap/extension-mention@^3`
- `@tiptap/suggestion@^3`

Sibling versions of the existing tiptap-3 stack; no other frontend / backend changes required for the extensions themselves.

## Test plan
- [ ] Type `@al` in Compose body → participants matching "al" show first, divider, address-book matches below
- [ ] ↑ ↓ Enter/Tab Esc all drive the mention picker
- [ ] Picking a contact not on the mail → Cc field unfolds with the new address
- [ ] Attach a file, type `/rep` → filename picker, Enter inserts `📎 report.pdf` link
- [ ] Send the mail, open it in Nimbus → cid: link is present in the rendered HTML, attachment is in the attachment tray
- [ ] Send to Gmail (or other non-cid-aware client) → attachment visible, link text present (not clickable is acceptable)
- [ ] Save draft with mentions + attachment refs → reopen in Compose → chips reappear (round-trip via `data-*` markers)

## Reviewer notes
- The popup component is inline in `RichTextEditor.svelte` (anchored via `position: fixed` + clientRect from Tiptap suggestion). No Floating UI / Tippy dep.
- Compose caches the full address book once via `get_contacts` on mount; the query filters in memory for keystroke-latency reasons.
- Edit-draft rehydration stamps fresh `content_id`s on re-downloaded attachments. Preserving original cid: refs from the stored HTML is deferred — re-pick via `/` relinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)