### PR TITLE
Calendar UI: add / rename / recolor / delete + hide toggles (#82)

### DIFF
--- a/crates/nimbus-caldav/src/calendars.rs
+++ b/crates/nimbus-caldav/src/calendars.rs
@@ -1,0 +1,247 @@
+//! Calendar-collection operations: create, rename + recolor, delete.
+//!
+//! Event-level CRUD lives in `write.rs` — this module handles the
+//! *container* it all lives in. All three ops are plain DAV requests
+//! against Nextcloud's CalDAV endpoint:
+//!
+//! - **Create** uses the `MKCALENDAR` method (RFC 4791 §5.3.1).
+//!   The response is an empty 201; the server picks the etag + ctag
+//!   for the new collection, which the caller picks up on the next
+//!   calendar-home PROPFIND sync.
+//! - **Rename / recolor** use `PROPPATCH` (RFC 4918 §9.2) with the
+//!   DAV `displayname` and/or Apple `calendar-color` properties.
+//!   Both can ride in one request so "edit calendar" in the UI is
+//!   a single round-trip.
+//! - **Delete** reuses the existing `delete_resource` helper — same
+//!   shape as `write::delete_event`, just pointed at the collection
+//!   href instead of an event href. No `If-Match` gate: collections
+//!   don't carry an etag the way individual events do.
+
+use quick_xml::escape::escape;
+use reqwest::{Method, StatusCode};
+
+use nimbus_core::NimbusError;
+
+use crate::client::{build, delete_resource};
+
+/// Create a new calendar collection under the user's calendar home.
+///
+/// `calendar_home_url` is the absolute URL returned by the CalDAV
+/// discovery step (e.g. `https://nc.example.com/remote.php/dav/calendars/alice/`).
+/// `path_segment` is the URL-safe slug for the new collection —
+/// callers typically generate a UUID so two concurrent creates
+/// can't collide on the wire, and so renames don't rewrite URLs
+/// downstream. The absolute URL we MKCALENDAR against is
+/// `{calendar_home}/{path_segment}/`.
+///
+/// `color` is optional; when set, it's written as the Apple-namespace
+/// `calendar-color` property so Nextcloud and every mainstream
+/// CalDAV client (Apple Calendar, Thunderbird, DAVx⁵) render the
+/// same swatch we show in our sidebar. Format is `#RRGGBB` or
+/// `#RRGGBBAA` — the caller enforces that shape; we pass it through.
+///
+/// Returns the full URL of the new collection so the caller can
+/// insert a cache row immediately (the next full sync overwrites
+/// with the authoritative ctag / sync-token).
+pub async fn create_calendar(
+    calendar_home_url: &str,
+    username: &str,
+    app_password: &str,
+    path_segment: &str,
+    display_name: &str,
+    color: Option<&str>,
+) -> Result<String, NimbusError> {
+    let http = build()?;
+    let url = join_collection_url(calendar_home_url, path_segment);
+
+    let body = build_mkcalendar_body(display_name, color);
+
+    let method = Method::from_bytes(b"MKCALENDAR")
+        .map_err(|e| NimbusError::Other(format!("MKCALENDAR method: {e}")))?;
+    let resp = http
+        .request(method, &url)
+        .basic_auth(username, Some(app_password))
+        .header("Content-Type", "application/xml; charset=utf-8")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("MKCALENDAR {url}: {e}")))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        // 405 = "already exists on this path" — surface the error
+        // directly rather than swallow it, so the UI can tell the
+        // user to pick a different name.
+        let msg = resp.text().await.unwrap_or_default();
+        return Err(NimbusError::Nextcloud(format!(
+            "MKCALENDAR {url} returned HTTP {status}: {msg}"
+        )));
+    }
+
+    Ok(url)
+}
+
+/// PROPPATCH a calendar collection with a new display name and/or
+/// color. Either (or both) may be `None`; if both are `None` we
+/// short-circuit without hitting the server.
+pub async fn update_calendar(
+    calendar_url: &str,
+    username: &str,
+    app_password: &str,
+    display_name: Option<&str>,
+    color: Option<&str>,
+) -> Result<(), NimbusError> {
+    if display_name.is_none() && color.is_none() {
+        return Ok(());
+    }
+
+    let http = build()?;
+    let body = build_proppatch_body(display_name, color);
+
+    let method = Method::from_bytes(b"PROPPATCH")
+        .map_err(|e| NimbusError::Other(format!("PROPPATCH method: {e}")))?;
+    let resp = http
+        .request(method, calendar_url)
+        .basic_auth(username, Some(app_password))
+        .header("Content-Type", "application/xml; charset=utf-8")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("PROPPATCH {calendar_url}: {e}")))?;
+
+    let status = resp.status();
+    // 207 Multi-Status is the normal success reply. A malformed body
+    // or unknown property surfaces as a per-property `<D:status>` —
+    // we'd need to parse the multistatus for that granularity, but
+    // for the two properties we set (both well-known) Nextcloud
+    // returns 207 + all-200 or a hard 4xx/5xx. The overall HTTP
+    // status is a good enough gate for now.
+    if !status.is_success() {
+        let msg = resp.text().await.unwrap_or_default();
+        return Err(NimbusError::Nextcloud(format!(
+            "PROPPATCH {calendar_url} returned HTTP {status}: {msg}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Delete a calendar collection at `calendar_url`. 404 is treated
+/// as success (already gone) — same forgiving policy `delete_event`
+/// uses.
+pub async fn delete_calendar(
+    calendar_url: &str,
+    username: &str,
+    app_password: &str,
+) -> Result<(), NimbusError> {
+    let http = build()?;
+    let resp = delete_resource(&http, calendar_url, username, app_password, None).await?;
+    let status = resp.status();
+    if !status.is_success() && status != StatusCode::NOT_FOUND {
+        let msg = resp.text().await.unwrap_or_default();
+        return Err(NimbusError::Nextcloud(format!(
+            "DELETE {calendar_url} returned HTTP {status}: {msg}"
+        )));
+    }
+    Ok(())
+}
+
+/// Join `calendar_home/{slug}/` with the usual trailing-slash
+/// normalization. Nextcloud is picky about the trailing `/` — a
+/// collection URL without it 301-redirects, and a PROPPATCH that
+/// follows the redirect gets dropped on the floor in some proxy
+/// setups.
+fn join_collection_url(calendar_home: &str, slug: &str) -> String {
+    let base = calendar_home.trim_end_matches('/');
+    let clean = slug.trim_matches('/');
+    format!("{base}/{clean}/")
+}
+
+fn build_mkcalendar_body(display_name: &str, color: Option<&str>) -> String {
+    // The XML namespace block follows the RFC 4791 example nearly
+    // verbatim. The Apple ns (`http://apple.com/ns/ical/`) isn't in
+    // the RFC but every mainstream server + client ships support
+    // for `calendar-color` there, which is why Nextcloud's web UI
+    // can read / write our colour on the same wire.
+    let mut props = String::new();
+    props.push_str("<D:displayname>");
+    props.push_str(&escape(display_name));
+    props.push_str("</D:displayname>");
+    if let Some(c) = color {
+        props.push_str("<I:calendar-color>");
+        props.push_str(&escape(c));
+        props.push_str("</I:calendar-color>");
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<C:mkcalendar xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav" xmlns:I="http://apple.com/ns/ical/">
+  <D:set>
+    <D:prop>{props}</D:prop>
+  </D:set>
+</C:mkcalendar>"#
+    )
+}
+
+fn build_proppatch_body(display_name: Option<&str>, color: Option<&str>) -> String {
+    let mut props = String::new();
+    if let Some(name) = display_name {
+        props.push_str("<D:displayname>");
+        props.push_str(&escape(name));
+        props.push_str("</D:displayname>");
+    }
+    if let Some(c) = color {
+        props.push_str("<I:calendar-color>");
+        props.push_str(&escape(c));
+        props.push_str("</I:calendar-color>");
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="utf-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:I="http://apple.com/ns/ical/">
+  <D:set>
+    <D:prop>{props}</D:prop>
+  </D:set>
+</D:propertyupdate>"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn join_collection_url_handles_trailing_slashes() {
+        assert_eq!(
+            join_collection_url("https://x/dav/cal/", "work"),
+            "https://x/dav/cal/work/"
+        );
+        assert_eq!(
+            join_collection_url("https://x/dav/cal", "/work/"),
+            "https://x/dav/cal/work/"
+        );
+    }
+
+    #[test]
+    fn mkcalendar_body_escapes_angle_brackets() {
+        let body = build_mkcalendar_body("Work & <Life>", Some("#ff0000"));
+        assert!(body.contains("Work &amp; &lt;Life&gt;"));
+        assert!(body.contains("<I:calendar-color>#ff0000</I:calendar-color>"));
+    }
+
+    #[test]
+    fn mkcalendar_body_omits_color_when_none() {
+        let body = build_mkcalendar_body("Work", None);
+        assert!(body.contains("<D:displayname>Work</D:displayname>"));
+        assert!(!body.contains("calendar-color"));
+    }
+
+    #[test]
+    fn proppatch_body_includes_only_set_properties() {
+        let rename_only = build_proppatch_body(Some("New"), None);
+        assert!(rename_only.contains("<D:displayname>New</D:displayname>"));
+        assert!(!rename_only.contains("calendar-color"));
+
+        let color_only = build_proppatch_body(None, Some("#00ff00"));
+        assert!(!color_only.contains("displayname"));
+        assert!(color_only.contains("<I:calendar-color>#00ff00</I:calendar-color>"));
+    }
+}

--- a/crates/nimbus-caldav/src/lib.rs
+++ b/crates/nimbus-caldav/src/lib.rs
@@ -22,6 +22,7 @@
 //!   editor builds a `CalendarEvent`, [`ical::build_ics`] renders it,
 //!   and [`write::create_event`] / [`write::update_event`] PUTs it.
 
+pub mod calendars;
 pub mod client;
 pub mod discovery;
 pub mod expand;
@@ -30,6 +31,7 @@ pub mod sync;
 pub mod write;
 mod xml_util;
 
+pub use calendars::{create_calendar, delete_calendar, update_calendar};
 pub use discovery::{Calendar, list_calendars};
 pub use expand::expand_event;
 pub use ical::{build_ics, parse_ics};

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -54,6 +54,13 @@ pub struct CalendarRow {
     /// agents don't set it.
     pub color: Option<String>,
     pub ctag: Option<String>,
+    /// When `true`, the CalendarView sidebar filters this calendar
+    /// out of the per-account list and its events don't paint in the
+    /// agenda. Local-only state — never written back to the server,
+    /// so the same Nextcloud account can have different "hidden"
+    /// sets across devices without stepping on each other. Toggled
+    /// from NextcloudSettings' per-calendar visibility checkboxes.
+    pub hidden: bool,
 }
 
 /// One VEVENT ready for upsert. Mirrors `nimbus_caldav::RawEvent`'s
@@ -109,6 +116,11 @@ pub struct CachedCalendar {
     /// the server on the next sync to get "what's changed since".
     pub sync_token: Option<String>,
     pub last_synced_at: Option<DateTime<Utc>>,
+    /// Local visibility toggle. When `true` the CalendarView sidebar
+    /// hides the row and the agenda skips its events. Mirrors the
+    /// `hidden` column on the cache and never round-trips to the
+    /// server, so per-device preferences stay local.
+    pub hidden: bool,
 }
 
 /// Sync bookmark for a single calendar. Separate from `CachedCalendar`
@@ -172,10 +184,15 @@ impl Cache {
         // here — those are only valid after a real sync, and a
         // discovery run shouldn't pretend otherwise.
         {
+            // `hidden` is deliberately NOT in the UPDATE set — it's a
+            // local-only toggle and the server doesn't know about it,
+            // so a post-sync upsert shouldn't overwrite what the user
+            // picked in Settings. On first insert we stamp whatever
+            // the row carries (defaults to `false` from discovery).
             let mut stmt = tx.prepare(
                 "INSERT INTO calendars
-                    (id, nextcloud_account_id, path, display_name, color, ctag)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                    (id, nextcloud_account_id, path, display_name, color, ctag, hidden)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                  ON CONFLICT (nextcloud_account_id, path) DO UPDATE SET
                     display_name = excluded.display_name,
                     color        = COALESCE(excluded.color, calendars.color),
@@ -190,6 +207,7 @@ impl Cache {
                     r.display_name,
                     r.color,
                     r.ctag,
+                    r.hidden as i64,
                 ])?;
             }
         }
@@ -219,6 +237,58 @@ impl Cache {
         Ok(())
     }
 
+    /// Patch an existing calendar's display name / color in place.
+    /// Either argument may be `None`; both `None` is a no-op. The
+    /// server-side change is driven separately via
+    /// `nimbus_caldav::update_calendar` — this only keeps our cache
+    /// in sync so the UI paints the new value without waiting for
+    /// the next full sync.
+    pub fn update_calendar_metadata(
+        &self,
+        calendar_id: &str,
+        display_name: Option<&str>,
+        color: Option<&str>,
+    ) -> Result<(), CacheError> {
+        if display_name.is_none() && color.is_none() {
+            return Ok(());
+        }
+        let conn = self.pool.get()?;
+        conn.execute(
+            "UPDATE calendars
+             SET display_name = COALESCE(?2, display_name),
+                 color        = COALESCE(?3, color)
+             WHERE id = ?1",
+            params![calendar_id, display_name, color],
+        )?;
+        Ok(())
+    }
+
+    /// Toggle a calendar's local visibility. Purely client-side —
+    /// never touches the server. Drives the CalendarView sidebar
+    /// filter and the agenda's event query.
+    pub fn set_calendar_hidden(
+        &self,
+        calendar_id: &str,
+        hidden: bool,
+    ) -> Result<(), CacheError> {
+        let conn = self.pool.get()?;
+        conn.execute(
+            "UPDATE calendars SET hidden = ?2 WHERE id = ?1",
+            params![calendar_id, hidden as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Drop a calendar row + all its cached events (via CASCADE on
+    /// `calendar_events.calendar_id`). Called after a successful
+    /// CalDAV DELETE so the sidebar forgets the collection without
+    /// waiting for the next discovery sweep to prune it.
+    pub fn remove_calendar(&self, calendar_id: &str) -> Result<(), CacheError> {
+        let conn = self.pool.get()?;
+        conn.execute("DELETE FROM calendars WHERE id = ?1", params![calendar_id])?;
+        Ok(())
+    }
+
     /// All cached calendars for one Nextcloud account, alphabetised
     /// by display name.
     pub fn list_calendars(
@@ -228,13 +298,14 @@ impl Cache {
         let conn = self.pool.get()?;
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, path, display_name, color,
-                    ctag, sync_token, last_synced_at
+                    ctag, sync_token, last_synced_at, hidden
              FROM calendars
              WHERE nextcloud_account_id = ?1
              ORDER BY display_name COLLATE NOCASE",
         )?;
         let rows = stmt.query_map(params![nc_account_id], |r| {
             let ts: Option<i64> = r.get(7)?;
+            let hidden: i64 = r.get(8)?;
             Ok(CachedCalendar {
                 id: r.get(0)?,
                 nextcloud_account_id: r.get(1)?,
@@ -244,6 +315,7 @@ impl Cache {
                 ctag: r.get(5)?,
                 sync_token: r.get(6)?,
                 last_synced_at: ts.and_then(|t| Utc.timestamp_opt(t, 0).single()),
+                hidden: hidden != 0,
             })
         })?;
         let mut out = Vec::new();
@@ -875,6 +947,7 @@ mod tests {
             display_name: name.into(),
             color: Some("#2bb0ed".into()),
             ctag: Some(format!("ctag-{path}")),
+            hidden: false,
         }
     }
 

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -237,6 +237,40 @@ impl Cache {
         Ok(())
     }
 
+    /// Insert a single freshly-created calendar without pruning.
+    /// `upsert_calendars` is the reconcile path — it assumes the
+    /// incoming list is the complete server-side truth and deletes
+    /// anything missing. After a MKCALENDAR we only know about the
+    /// one new collection, so we add it directly and let the next
+    /// full sync fill in `ctag` / `sync_token`. Idempotent on the
+    /// (nc_account_id, path) uniqueness constraint — a replay after
+    /// discovery already grabbed the row is a no-op on the stored
+    /// values.
+    pub fn insert_calendar(
+        &self,
+        nc_account_id: &str,
+        row: &CalendarRow,
+    ) -> Result<String, CacheError> {
+        let conn = self.pool.get()?;
+        let id = format!("{nc_account_id}::{}", row.path);
+        conn.execute(
+            "INSERT INTO calendars
+                (id, nextcloud_account_id, path, display_name, color, ctag, hidden)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT (nextcloud_account_id, path) DO NOTHING",
+            params![
+                id,
+                nc_account_id,
+                row.path,
+                row.display_name,
+                row.color,
+                row.ctag,
+                row.hidden as i64,
+            ],
+        )?;
+        Ok(id)
+    }
+
     /// Patch an existing calendar's display name / color in place.
     /// Either argument may be `None`; both `None` is a no-op. The
     /// server-side change is driven separately via

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -572,6 +572,19 @@ const MIGRATIONS: &[&str] = &[
     ALTER TABLE accounts
         ADD COLUMN folder_icon_overrides_json TEXT NOT NULL DEFAULT '{}';
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v11 → v12: per-calendar visibility toggle (Issue #82).
+    //
+    // Local-only state — never synced to the server. Drives the
+    // "hide this calendar from the sidebar" checkboxes in
+    // NextcloudSettings and the `hidden` filter in CalendarView.
+    // Default 0 (visible) so existing calendars roll forward
+    // unchanged; the toggle is opt-in per calendar.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE calendars
+        ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,9 +10,10 @@ mod badge;
 
 use nimbus_caldav::{
     Calendar as CaldavCalendar, RawEvent, build_ics as caldav_build_ics,
-    create_event as caldav_create_event, delete_event as caldav_delete_event,
+    create_calendar as caldav_create_calendar, create_event as caldav_create_event,
+    delete_calendar as caldav_delete_calendar, delete_event as caldav_delete_event,
     list_calendars as caldav_list_calendars, sync_calendar as caldav_sync_calendar,
-    update_event as caldav_update_event,
+    update_calendar as caldav_update_calendar, update_event as caldav_update_event,
 };
 use nimbus_carddav::{
     Addressbook, ParsedVcard, RawContact, build_vcard, create_contact as carddav_create_contact,
@@ -1082,6 +1083,12 @@ struct CalendarSummary {
     display_name: String,
     color: Option<String>,
     last_synced_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Local visibility flag. `true` means the user asked for this
+    /// calendar to stay off the sidebar + agenda. Surfaced on every
+    /// summary so both the Settings checkboxes and the CalendarView
+    /// filter can read straight off a single fetch.
+    #[serde(default)]
+    hidden: bool,
 }
 
 /// Summary returned to the UI after a calendar sync run.
@@ -1125,6 +1132,11 @@ async fn list_nextcloud_calendars(
             color: c.color,
             // Discovery alone doesn't produce a sync timestamp.
             last_synced_at: None,
+            // Raw discovery can't know about local toggles — the
+            // cache-backed `get_cached_calendars` path does. This
+            // command is only used by the setup probe, so defaulting
+            // to visible is fine.
+            hidden: false,
         })
         .collect())
 }
@@ -1260,8 +1272,134 @@ fn get_cached_calendars(
             display_name: c.display_name,
             color: c.color,
             last_synced_at: c.last_synced_at,
+            hidden: c.hidden,
         })
         .collect())
+}
+
+// ── Calendar management commands (Issue #82) ─────────────────
+//
+// CalDAV wrappers that add / rename / recolor / delete a calendar
+// collection on the server and keep the local cache in step. Each
+// mutates exactly one calendar row; the next `sync_nextcloud_
+// calendars` run reconciles etag / sync-token / event deltas.
+// `set_nextcloud_calendar_hidden` is the only one that doesn't
+// talk to the server — hidden is a local-only flag.
+
+/// Create a new calendar on the server and seed a cache row.
+///
+/// The path segment is a fresh UUID so two concurrent creates can't
+/// collide on the wire and so a later rename never rewrites URLs
+/// downstream (the slug stays stable regardless of display name).
+/// Returns the newly-inserted summary so the UI can add it to the
+/// sidebar without a follow-up fetch.
+#[tauri::command]
+async fn create_nextcloud_calendar(
+    nc_id: String,
+    display_name: String,
+    color: Option<String>,
+    cache: State<'_, Cache>,
+) -> Result<CalendarSummary, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    let server = account.server_url.trim_end_matches('/');
+    let home = format!("{server}/remote.php/dav/calendars/{}/", account.username);
+    let slug = uuid::Uuid::new_v4().to_string();
+
+    let url = caldav_create_calendar(
+        &home,
+        &account.username,
+        &app_password,
+        &slug,
+        &display_name,
+        color.as_deref(),
+    )
+    .await?;
+
+    // Seed the cache so the sidebar paints the new calendar
+    // instantly. `ctag` / `sync_token` land on the next full sync —
+    // no event rows yet anyway, so the bookkeeping gap is cosmetic.
+    let row = CalendarRow {
+        path: url.clone(),
+        display_name: display_name.clone(),
+        color: color.clone(),
+        ctag: None,
+        hidden: false,
+    };
+    let id = cache.insert_calendar(&nc_id, &row)?;
+
+    Ok(CalendarSummary {
+        id,
+        nextcloud_account_id: nc_id,
+        display_name,
+        color,
+        last_synced_at: None,
+        hidden: false,
+    })
+}
+
+/// Rename and/or recolor an existing calendar via a single CalDAV
+/// `PROPPATCH`. Either argument may be `None` — passing both `None`
+/// is a no-op server-side and cache-side.
+#[tauri::command]
+async fn update_nextcloud_calendar(
+    calendar_id: String,
+    display_name: Option<String>,
+    color: Option<String>,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let (nc_id, path) = cache
+        .get_calendar_server_path(&calendar_id)?
+        .ok_or_else(|| NimbusError::Other(format!("no cached calendar with id '{calendar_id}'")))?;
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    caldav_update_calendar(
+        &path,
+        &account.username,
+        &app_password,
+        display_name.as_deref(),
+        color.as_deref(),
+    )
+    .await?;
+
+    cache.update_calendar_metadata(&calendar_id, display_name.as_deref(), color.as_deref())?;
+    Ok(())
+}
+
+/// Delete a calendar on the server + drop the cached row (events
+/// cascade). The server's DELETE is destructive and irreversible on
+/// most Nextcloud setups — callers (i.e. the UI) are expected to
+/// confirm with the user before invoking this.
+#[tauri::command]
+async fn delete_nextcloud_calendar(
+    calendar_id: String,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let (nc_id, path) = cache
+        .get_calendar_server_path(&calendar_id)?
+        .ok_or_else(|| NimbusError::Other(format!("no cached calendar with id '{calendar_id}'")))?;
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    caldav_delete_calendar(&path, &account.username, &app_password).await?;
+    cache.remove_calendar(&calendar_id)?;
+    Ok(())
+}
+
+/// Flip a calendar's local visibility flag. Purely client-side — no
+/// CalDAV traffic — so the same server-side calendar can have
+/// different visibility on different devices without fighting over
+/// a single server setting.
+#[tauri::command]
+fn set_nextcloud_calendar_hidden(
+    calendar_id: String,
+    hidden: bool,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    cache.set_calendar_hidden(&calendar_id, hidden)?;
+    Ok(())
 }
 
 /// Events in `[range_start, range_end)` across the given calendars,
@@ -3584,6 +3722,10 @@ fn main() {
             list_nextcloud_calendars,
             sync_nextcloud_calendars,
             get_cached_calendars,
+            create_nextcloud_calendar,
+            update_nextcloud_calendar,
+            delete_nextcloud_calendar,
+            set_nextcloud_calendar_hidden,
             get_cached_events,
             create_calendar_event,
             update_calendar_event,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1165,6 +1165,10 @@ async fn sync_nextcloud_calendars(
             display_name: c.display_name.clone().unwrap_or_else(|| c.name.clone()),
             color: c.color.clone(),
             ctag: c.ctag.clone(),
+            // Fresh inserts default to visible; the `upsert_calendars`
+            // ON CONFLICT clause leaves `hidden` untouched on updates
+            // so an existing local toggle survives re-sync.
+            hidden: false,
         })
         .collect();
     cache.upsert_calendars(&nc_id, &rows)?;

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -1237,9 +1237,14 @@
 </div>
 
 {#if creatingDraft}
+  <!-- Only pass the *visible* calendars to the editor — the
+       dropdown is how the user picks where a new event lands, and
+       a hidden calendar shouldn't be a reachable destination. Edit
+       mode is unreachable on hidden calendars anyway (their events
+       never paint on the grid), so the same filter applies there. -->
   <EventEditor
     mode="create"
-    {calendars}
+    calendars={visibleCalendars}
     draft={creatingDraft}
     onclose={closeEditor}
     onsaved={onEditorSaved}
@@ -1247,7 +1252,7 @@
 {:else if editingEvent}
   <EventEditor
     mode="edit"
-    {calendars}
+    calendars={visibleCalendars}
     event={editingEvent}
     onclose={closeEditor}
     onsaved={onEditorSaved}

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -52,6 +52,10 @@
     display_name: string
     color: string | null
     last_synced_at: string | null
+    /** Local visibility flag — `true` means the calendar is hidden
+     *  from the sidebar list and its events are skipped in the
+     *  agenda. Toggled per-calendar via NextcloudSettings. */
+    hidden?: boolean
   }
   interface EventAttendee {
     email: string
@@ -128,11 +132,186 @@
   let loadedRangeEnd = $state<Date>(new Date(0))
 
   // Per-calendar visibility — a Set of calendar ids that are
-  // currently *hidden*. Outlook-style "uncheck a calendar to remove
-  // its events from the grid". A Set rather than a positive list so
-  // newly-discovered calendars default to visible without needing a
-  // separate "show new calendars" workflow.
-  let hiddenCalendarIds = $state<Set<string>>(new Set())
+  // currently *hidden*. The toggle itself lives in NextcloudSettings
+  // (persisted to the cache's `hidden` column); here we just derive a
+  // Set from the `calendars` list so the agenda filter stays O(1) on
+  // every event lookup. A Set rather than a positive list so newly-
+  // discovered calendars default to visible automatically.
+  const hiddenCalendarIds = $derived(
+    new Set(calendars.filter((c) => c.hidden).map((c) => c.id)),
+  )
+  /** Calendars the sidebar list renders — everything except the
+   *  ones the user opted to hide from Settings. */
+  const visibleCalendars = $derived(calendars.filter((c) => !c.hidden))
+
+  // ── Calendar management (Issue #82) ─────────────────────────
+  // Right-click a calendar row → Rename / Change color / Delete.
+  // Top-level `+` button → new calendar modal with name + color.
+  // Each operation owns its own `$state` slot, mirroring the
+  // folder-management pattern in Sidebar.svelte so the same UX
+  // shape carries across the app.
+
+  /** Right-click menu state — anchors a popup at `{x, y}` for the
+   *  selected calendar. */
+  let calendarContextMenu = $state<{
+    calendar: CalendarSummary
+    x: number
+    y: number
+  } | null>(null)
+
+  /** Inline rename — `calendar_id` while the row's text is swapped
+   *  for an `<input>`. Matches the folder-rename pattern. */
+  let renamingCalendarId = $state<string | null>(null)
+  let calendarRenameValue = $state('')
+
+  /** Active color-picker modal, if any. `color` is the current
+   *  working swatch — `commit` writes it via `update_calendar`. */
+  let colorPicker = $state<{ calendar: CalendarSummary; color: string } | null>(null)
+
+  /** "New calendar" modal state. Only open when non-null; `ncId`
+   *  is the target Nextcloud account (auto-picked when there's
+   *  only one, user-picked otherwise via a small account select). */
+  let newCalendarForm = $state<{
+    ncId: string
+    displayName: string
+    color: string
+  } | null>(null)
+
+  /** Destructive-op confirm. */
+  let deleteCalendarConfirm = $state<CalendarSummary | null>(null)
+
+  /** Shared busy / error slots — gate double-clicks during an
+   *  in-flight CalDAV request, surface errors inline. */
+  let calendarOpBusy = $state(false)
+  let calendarOpError = $state('')
+
+  const COLOR_PRESETS = [
+    '#2bb0ed', '#4caf50', '#8e44ad', '#e67e22', '#e74c3c', '#f39c12',
+    '#16a085', '#34495e', '#c0392b', '#d35400', '#27ae60', '#2980b9',
+  ]
+
+  function openCalendarContextMenu(e: MouseEvent, calendar: CalendarSummary) {
+    e.preventDefault()
+    // Any existing edit loses focus when the menu opens on a
+    // different row — cleaner than juggling priorities.
+    renamingCalendarId = null
+    calendarContextMenu = { calendar, x: e.clientX, y: e.clientY }
+  }
+
+  function closeCalendarContextMenu() {
+    calendarContextMenu = null
+    calendarOpError = ''
+  }
+
+  $effect(() => {
+    if (!calendarContextMenu) return
+    const onDocMouseDown = () => closeCalendarContextMenu()
+    const onDocKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeCalendarContextMenu()
+    }
+    document.addEventListener('mousedown', onDocMouseDown)
+    document.addEventListener('keydown', onDocKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown)
+      document.removeEventListener('keydown', onDocKey)
+    }
+  })
+
+  /** Refresh the calendar list + events from the cache after a
+   *  mutation. Uses the current visible range so the agenda picks
+   *  up any CASCADE deletes from the removed calendar. */
+  async function refreshCalendars() {
+    if (loadedRangeStart.getTime() > 0) {
+      await reloadFromCache(loadedRangeStart, loadedRangeEnd)
+    }
+  }
+
+  async function commitCalendarRename() {
+    if (!renamingCalendarId || calendarOpBusy) return
+    const id = renamingCalendarId
+    const current = calendars.find((c) => c.id === id)
+    const newName = calendarRenameValue.trim()
+    if (!current || !newName || newName === current.display_name) {
+      renamingCalendarId = null
+      calendarRenameValue = ''
+      return
+    }
+    calendarOpBusy = true
+    try {
+      await invoke('update_nextcloud_calendar', {
+        calendarId: id,
+        displayName: newName,
+        color: null,
+      })
+      renamingCalendarId = null
+      calendarRenameValue = ''
+      await refreshCalendars()
+    } catch (e) {
+      calendarOpError = formatError(e) || 'Failed to rename calendar'
+    } finally {
+      calendarOpBusy = false
+    }
+  }
+
+  function cancelCalendarRename() {
+    renamingCalendarId = null
+    calendarRenameValue = ''
+  }
+
+  async function commitColorChange() {
+    if (!colorPicker || calendarOpBusy) return
+    const { calendar, color } = colorPicker
+    calendarOpBusy = true
+    try {
+      await invoke('update_nextcloud_calendar', {
+        calendarId: calendar.id,
+        displayName: null,
+        color,
+      })
+      colorPicker = null
+      await refreshCalendars()
+    } catch (e) {
+      calendarOpError = formatError(e) || 'Failed to change color'
+    } finally {
+      calendarOpBusy = false
+    }
+  }
+
+  async function commitNewCalendar() {
+    if (!newCalendarForm || calendarOpBusy) return
+    const { ncId, displayName, color } = newCalendarForm
+    const trimmed = displayName.trim()
+    if (!trimmed) return
+    calendarOpBusy = true
+    try {
+      await invoke('create_nextcloud_calendar', {
+        ncId,
+        displayName: trimmed,
+        color,
+      })
+      newCalendarForm = null
+      await refreshCalendars()
+    } catch (e) {
+      calendarOpError = formatError(e) || 'Failed to create calendar'
+    } finally {
+      calendarOpBusy = false
+    }
+  }
+
+  async function confirmCalendarDelete() {
+    if (!deleteCalendarConfirm || calendarOpBusy) return
+    const { id } = deleteCalendarConfirm
+    calendarOpBusy = true
+    try {
+      await invoke('delete_nextcloud_calendar', { calendarId: id })
+      deleteCalendarConfirm = null
+      await refreshCalendars()
+    } catch (e) {
+      calendarOpError = formatError(e) || 'Failed to delete calendar'
+    } finally {
+      calendarOpBusy = false
+    }
+  }
 
   // ── Event editor state ──────────────────────────────────────
   // The editor is mounted lazily — only when one of these holds a
@@ -577,19 +756,6 @@
     return colorById.get(eventCalendarId(ev)) ?? '#2bb0ed'
   }
 
-  function toggleCalendar(id: string) {
-    // Svelte 5 reactivity for Sets/Maps requires reassignment — mutating
-    // in place won't trigger derived recomputation. Rebuild the Set
-    // each toggle so `weekBuckets` re-runs.
-    const next = new Set(hiddenCalendarIds)
-    if (next.has(id)) {
-      next.delete(id)
-    } else {
-      next.add(id)
-    }
-    hiddenCalendarIds = next
-  }
-
   // All-day overflow: if a day has more than the visible cap, show
   // the first N and a "+M more" affordance. Collapsed detail UI is a
   // follow-up — today this just prevents the strip from growing
@@ -793,33 +959,81 @@
       <aside
         class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100/60 dark:bg-surface-800/40 overflow-y-auto p-3"
       >
-        <div class="text-xs font-semibold uppercase tracking-wider text-surface-500 mb-2 px-1">
-          Calendars
+        <!-- Section header. The `+` mirrors the Mail sidebar's
+             "new folder" affordance so the add-calendar UX lives
+             where the user already expects to look for it. Visibility
+             toggles live in NextcloudSettings — this list only shows
+             the calendars the user actually wants to see. -->
+        <div class="flex items-center justify-between mb-2 px-1">
+          <span class="text-xs font-semibold uppercase tracking-wider text-surface-500">
+            Calendars
+          </span>
+          <button
+            class="w-5 h-5 rounded-md flex items-center justify-center text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700 disabled:opacity-50"
+            title="New calendar"
+            aria-label="New calendar"
+            disabled={calendarOpBusy || accounts.length === 0}
+            onclick={() => {
+              calendarContextMenu = null
+              renamingCalendarId = null
+              newCalendarForm = {
+                ncId: accounts[0]?.id ?? '',
+                displayName: '',
+                color: COLOR_PRESETS[0],
+              }
+              calendarOpError = ''
+            }}
+          >+</button>
         </div>
         <ul class="space-y-1">
-          {#each calendars as c (c.id)}
-            {@const visible = !hiddenCalendarIds.has(c.id)}
+          {#each visibleCalendars as c (c.id)}
             <li>
-              <label
-                class="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-200/60 dark:hover:bg-surface-700/40 cursor-pointer text-sm"
-              >
-                <input
-                  type="checkbox"
-                  class="checkbox"
-                  checked={visible}
-                  onchange={() => toggleCalendar(c.id)}
-                />
-                <span
-                  class="w-3 h-3 rounded-sm shrink-0"
-                  style="background-color: {c.color ?? '#2bb0ed'};"
-                ></span>
-                <span class="truncate" title={c.display_name}>
-                  {c.display_name}
-                </span>
-              </label>
+              {#if renamingCalendarId === c.id}
+                <div class="flex items-center gap-2 px-2 py-1">
+                  <span
+                    class="w-3 h-3 rounded-sm shrink-0"
+                    style="background-color: {c.color ?? '#2bb0ed'};"
+                  ></span>
+                  <!-- svelte-ignore a11y_autofocus -->
+                  <input
+                    type="text"
+                    class="input flex-1 text-sm px-2 py-0.5 rounded"
+                    bind:value={calendarRenameValue}
+                    disabled={calendarOpBusy}
+                    autofocus
+                    onkeydown={(e) => {
+                      if (e.key === 'Enter') { e.preventDefault(); void commitCalendarRename() }
+                      else if (e.key === 'Escape') { e.preventDefault(); cancelCalendarRename() }
+                    }}
+                    onblur={() => { if (renamingCalendarId) void commitCalendarRename() }}
+                  />
+                </div>
+              {:else}
+                <div
+                  class="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-200/60 dark:hover:bg-surface-700/40 text-sm cursor-default"
+                  role="listitem"
+                  oncontextmenu={(e) => openCalendarContextMenu(e, c)}
+                >
+                  <span
+                    class="w-3 h-3 rounded-sm shrink-0"
+                    style="background-color: {c.color ?? '#2bb0ed'};"
+                  ></span>
+                  <span class="flex-1 truncate" title={c.display_name}>
+                    {c.display_name}
+                  </span>
+                </div>
+              {/if}
             </li>
           {/each}
+          {#if visibleCalendars.length === 0 && calendars.length > 0}
+            <li class="px-2 py-1 text-xs text-surface-500">
+              All calendars are hidden. Toggle visibility in Settings.
+            </li>
+          {/if}
         </ul>
+        {#if calendarOpError}
+          <p class="mt-2 px-1 text-xs text-red-500 wrap-break-word">{calendarOpError}</p>
+        {/if}
       </aside>
 
       <!-- Main grid area. Both header and time grid live in a single
@@ -1038,6 +1252,234 @@
     onclose={closeEditor}
     onsaved={onEditorSaved}
   />
+{/if}
+
+<!-- Right-click context menu for a calendar row. `position: fixed`
+     at the click point, z-60 so it sits above modal overlays. -->
+{#if calendarContextMenu}
+  <div
+    class="fixed z-60 min-w-44 rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg py-1 text-sm"
+    style="left: {Math.min(calendarContextMenu.x, window.innerWidth - 200)}px; top: {Math.min(calendarContextMenu.y, window.innerHeight - 150)}px;"
+    role="menu"
+    tabindex="-1"
+    onmousedown={(e) => e.stopPropagation()}
+  >
+    <button
+      class="w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800 disabled:opacity-50 disabled:hover:bg-transparent"
+      disabled={calendarOpBusy}
+      onclick={() => {
+        const c = calendarContextMenu!.calendar
+        calendarContextMenu = null
+        renamingCalendarId = c.id
+        calendarRenameValue = c.display_name
+      }}
+    >Rename</button>
+    <button
+      class="w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800 disabled:opacity-50 disabled:hover:bg-transparent"
+      disabled={calendarOpBusy}
+      onclick={() => {
+        const c = calendarContextMenu!.calendar
+        calendarContextMenu = null
+        colorPicker = { calendar: c, color: c.color ?? COLOR_PRESETS[0] }
+      }}
+    >Change color…</button>
+    <button
+      class="w-full text-left px-3 py-1.5 hover:bg-red-500/10 text-red-600 dark:text-red-400 disabled:opacity-50 disabled:hover:bg-transparent"
+      disabled={calendarOpBusy}
+      onclick={() => {
+        const c = calendarContextMenu!.calendar
+        calendarContextMenu = null
+        deleteCalendarConfirm = c
+      }}
+    >Delete…</button>
+  </div>
+{/if}
+
+<!-- New calendar modal. Name + color swatch grid + optional NC
+     account picker (only rendered when the user has >1 connected). -->
+{#if newCalendarForm}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget) newCalendarForm = null }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+      <h3 class="text-base font-semibold mb-3">New calendar</h3>
+
+      {#if accounts.length > 1}
+        <label class="block text-xs text-surface-500 mb-1" for="new-cal-account">Nextcloud account</label>
+        <select
+          id="new-cal-account"
+          class="select w-full text-sm px-2 py-1.5 rounded-md mb-3"
+          bind:value={newCalendarForm.ncId}
+          disabled={calendarOpBusy}
+        >
+          {#each accounts as a (a.id)}
+            <option value={a.id}>{a.display_name || a.username}</option>
+          {/each}
+        </select>
+      {/if}
+
+      <label class="block text-xs text-surface-500 mb-1" for="new-cal-name">Name</label>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        id="new-cal-name"
+        type="text"
+        class="input w-full text-sm px-2 py-1.5 rounded-md mb-3"
+        placeholder="Work, Family, …"
+        bind:value={newCalendarForm.displayName}
+        disabled={calendarOpBusy}
+        autofocus
+        onkeydown={(e) => {
+          if (e.key === 'Enter' && newCalendarForm?.displayName.trim()) {
+            e.preventDefault()
+            void commitNewCalendar()
+          }
+        }}
+      />
+
+      <!-- Color grid. Click-to-select; the chosen swatch shows a
+           ring. Kept as a fixed palette — matches what Nextcloud
+           web offers, and `MKCALENDAR` accepts any hex anyway if a
+           user wants a custom tone (there's a native color input
+           in the "Change color" flow for that). -->
+      <div class="text-xs text-surface-500 mb-1">Color</div>
+      <div class="flex flex-wrap gap-1.5 mb-4">
+        {#each COLOR_PRESETS as swatch (swatch)}
+          <button
+            type="button"
+            class="w-7 h-7 rounded-full transition-transform
+                   {newCalendarForm.color === swatch
+                     ? 'ring-2 ring-offset-2 ring-offset-surface-50 dark:ring-offset-surface-900 ring-primary-500'
+                     : 'hover:scale-110'}"
+            style="background-color: {swatch};"
+            title={swatch}
+            aria-label="Color {swatch}"
+            onclick={() => { newCalendarForm!.color = swatch }}
+          ></button>
+        {/each}
+      </div>
+
+      {#if calendarOpError}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{calendarOpError}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500"
+          disabled={calendarOpBusy}
+          onclick={() => (newCalendarForm = null)}
+        >Cancel</button>
+        <button
+          class="btn preset-filled-primary-500"
+          disabled={calendarOpBusy || !newCalendarForm.displayName.trim()}
+          onclick={() => void commitNewCalendar()}
+        >{calendarOpBusy ? 'Creating…' : 'Create'}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Color picker modal. Presets + a native `<input type="color">`
+     for anything outside the palette. -->
+{#if colorPicker}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget) colorPicker = null }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+      <h3 class="text-base font-semibold mb-1">Change color</h3>
+      <p class="text-xs text-surface-500 mb-4">
+        For <span class="font-medium text-surface-700 dark:text-surface-300">{colorPicker.calendar.display_name}</span>
+      </p>
+
+      <div class="flex flex-wrap gap-1.5 mb-4">
+        {#each COLOR_PRESETS as swatch (swatch)}
+          <button
+            type="button"
+            class="w-7 h-7 rounded-full transition-transform
+                   {colorPicker.color === swatch
+                     ? 'ring-2 ring-offset-2 ring-offset-surface-50 dark:ring-offset-surface-900 ring-primary-500'
+                     : 'hover:scale-110'}"
+            style="background-color: {swatch};"
+            title={swatch}
+            aria-label="Color {swatch}"
+            onclick={() => { colorPicker!.color = swatch }}
+          ></button>
+        {/each}
+      </div>
+
+      <div class="flex items-center gap-2 mb-4">
+        <label class="text-xs text-surface-500 shrink-0" for="color-picker-custom">Custom:</label>
+        <input
+          id="color-picker-custom"
+          type="color"
+          class="w-10 h-8 border border-surface-300 dark:border-surface-600 rounded"
+          bind:value={colorPicker.color}
+          disabled={calendarOpBusy}
+        />
+        <span class="text-xs text-surface-500 font-mono">{colorPicker.color}</span>
+      </div>
+
+      {#if calendarOpError}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{calendarOpError}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500"
+          disabled={calendarOpBusy}
+          onclick={() => (colorPicker = null)}
+        >Cancel</button>
+        <button
+          class="btn preset-filled-primary-500"
+          disabled={calendarOpBusy}
+          onclick={() => void commitColorChange()}
+        >{calendarOpBusy ? 'Saving…' : 'Save'}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Delete-calendar confirm. Destructive ops always pass through
+     an explicit confirm because the server-side DELETE is
+     irreversible on most Nextcloud setups. -->
+{#if deleteCalendarConfirm}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget) deleteCalendarConfirm = null }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+      <h3 class="text-base font-semibold mb-2">Delete calendar?</h3>
+      <p class="text-sm text-surface-700 dark:text-surface-300 mb-4">
+        Delete <span class="font-medium">{deleteCalendarConfirm.display_name}</span> and every event in it?
+        This can't be undone.
+      </p>
+      {#if calendarOpError}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{calendarOpError}</p>
+      {/if}
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500"
+          disabled={calendarOpBusy}
+          onclick={() => (deleteCalendarConfirm = null)}
+        >Cancel</button>
+        <button
+          class="btn preset-filled-error-500"
+          disabled={calendarOpBusy}
+          onclick={() => void confirmCalendarDelete()}
+        >{calendarOpBusy ? 'Deleting…' : 'Delete'}</button>
+      </div>
+    </div>
+  </div>
 {/if}
 
 <style>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -49,6 +49,10 @@
     display_name: string
     color: string | null
     last_synced_at: string | null
+    /** Local visibility flag — hidden calendars are filtered out
+     *  before the event-editor dropdown sees them so the "Add
+     *  event" flow matches the CalendarView sidebar. */
+    hidden?: boolean
   }
 
   interface Attachment {
@@ -458,9 +462,16 @@
           console.warn('get_cached_calendars failed:', e)
         }
       }
-      calendars = all
-      if (all.length === 0) {
-        error = 'No calendars cached yet. Open the Calendar tab once to sync.'
+      // Hidden calendars stay out of the "Add event" picker —
+      // consistent with the CalendarView sidebar. The flag is
+      // local-only, so the same Nextcloud account can expose
+      // different sets on different devices without server round-
+      // trips.
+      calendars = all.filter((c) => !c.hidden)
+      if (calendars.length === 0) {
+        error = all.length === 0
+          ? 'No calendars cached yet. Open the Calendar tab once to sync.'
+          : 'All calendars are hidden. Toggle visibility in Settings.'
         return
       }
       // Auto-create a Talk room so the event's URL field carries the

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -171,7 +171,14 @@
       aria-label="All inboxes"
       onclick={() => onselectaccount('__all__')}
     >
-      ALL
+      <!-- Inbox glyph matches the Mail rail icon + the "All
+           Inboxes" folder entry, so the "this is the aggregate"
+           meaning carries across every surface the user sees. The
+           `text-lg` override pushes the emoji up from the parent's
+           `text-xs` (sized for the other avatars' two-letter
+           initials) so it reads at the same visual weight as the
+           nav icons below the divider. -->
+      <span class="text-lg leading-none">&#x1F4E5;</span>
     </button>
   {/if}
   {#each accounts as a (a.id)}

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -77,6 +77,47 @@
   let contactsState = $state<Record<string, SyncRowState>>({})
   let calendarsState = $state<Record<string, SyncRowState>>({})
 
+  // Per-account cached calendar list for the visibility checkboxes
+  // under "Calendars". Reloaded after a sync + after a visibility
+  // toggle so the UI reflects the current `hidden` column.
+  interface CalendarSummary {
+    id: string
+    nextcloud_account_id: string
+    display_name: string
+    color: string | null
+    last_synced_at: string | null
+    hidden?: boolean
+  }
+  let calendarsList = $state<Record<string, CalendarSummary[]>>({})
+
+  async function loadCalendarsList(ncId: string) {
+    try {
+      const list = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
+      calendarsList[ncId] = list
+    } catch (e) {
+      console.warn('get_cached_calendars failed for', ncId, e)
+    }
+  }
+
+  /** Flip a calendar's `hidden` flag. Optimistic: update the local
+   *  list first so the checkbox commits instantly, then invoke the
+   *  Rust command. If the command errors we roll back and surface
+   *  the error through the calendars sync row. */
+  async function toggleCalendarHidden(ncId: string, calendarId: string, hidden: boolean) {
+    const list = calendarsList[ncId] ?? []
+    const prev = list.slice()
+    calendarsList[ncId] = list.map((c) =>
+      c.id === calendarId ? { ...c, hidden } : c,
+    )
+    try {
+      await invoke('set_nextcloud_calendar_hidden', { calendarId, hidden })
+    } catch (e) {
+      calendarsList[ncId] = prev
+      const state = calendarsState[ncId]
+      if (state) state.error = formatError(e) || 'Failed to toggle calendar visibility'
+    }
+  }
+
   // Connect flow
   let serverInput = $state('')
   let connecting = $state(false)      // true while a login is in flight
@@ -102,6 +143,7 @@
         ensureRow(calendarsState, a.id)
         await refreshContactsStatus(a.id)
         await refreshCalendarsStatus(a.id)
+        await loadCalendarsList(a.id)
       }
     } catch (e) {
       error = formatError(e) || 'Failed to load Nextcloud connections'
@@ -180,6 +222,10 @@
         state.error = report.errors.join('; ')
       }
       await refreshCalendarsStatus(acct.id)
+      // A sync reconciles the calendar list server-side — could add,
+      // rename, or remove calendars. Refresh the per-account list so
+      // the visibility checkboxes reflect what's actually there now.
+      await loadCalendarsList(acct.id)
     } catch (e) {
       state.error = formatError(e) || 'Sync failed'
     } finally {
@@ -354,6 +400,47 @@
                   error={cls?.error ?? null}
                   onsync={() => syncCalendars(acct)}
                 />
+                <!-- Per-calendar visibility. Drives the `hidden`
+                     column via `set_nextcloud_calendar_hidden`, which
+                     the CalendarView sidebar reads when filtering.
+                     Only renders when there's something to toggle —
+                     a freshly-connected account without a sync yet
+                     sees just the sync row above. -->
+                {#if (calendarsList[acct.id]?.length ?? 0) > 0}
+                  <div class="pl-6 pb-2 pr-3">
+                    <div class="text-[10px] font-semibold text-surface-500 uppercase tracking-wider mb-1">
+                      Visibility
+                    </div>
+                    <ul class="space-y-0.5">
+                      {#each calendarsList[acct.id] as c (c.id)}
+                        <li>
+                          <label
+                            class="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-200/60 dark:hover:bg-surface-700/40 cursor-pointer text-xs"
+                          >
+                            <input
+                              type="checkbox"
+                              class="checkbox"
+                              checked={!c.hidden}
+                              onchange={(e) =>
+                                void toggleCalendarHidden(
+                                  acct.id,
+                                  c.id,
+                                  !(e.currentTarget as HTMLInputElement).checked,
+                                )}
+                            />
+                            <span
+                              class="w-2.5 h-2.5 rounded-sm shrink-0"
+                              style="background-color: {c.color ?? '#2bb0ed'};"
+                            ></span>
+                            <span class="truncate" title={c.display_name}>
+                              {c.display_name}
+                            </span>
+                          </label>
+                        </li>
+                      {/each}
+                    </ul>
+                  </div>
+                {/if}
               {/if}
             {/if}
           </div>


### PR DESCRIPTION
Closes #82.

## Summary

Four new pieces of calendar UX wired end-to-end through fresh CalDAV primitives, cache columns, Tauri commands, and Svelte components:

- **Add** a new calendar from the CalendarView sidebar's `+` header button → modal with name + preset color swatches + (if >1 NC account) an account picker.
- **Rename** an existing calendar via right-click → *Rename* → inline edit (same Enter/Escape/blur pattern as the Mail folder rename).
- **Change color** via right-click → *Change color…* → modal with preset palette + native `<input type=\"color\">` for custom hex.
- **Delete** via right-click → *Delete…* → confirm modal. IMAP-flavoured "server's DELETE is destructive" — events cascade out of the cache.
- **Hide calendars** from the sidebar via per-calendar visibility checkboxes under *Settings → Nextcloud → Calendars*. Flag is local-only (per-device) — the same Nextcloud account can show a different set on desktop vs phone.

## How the pieces fit

**Protocol (nimbus-caldav, new `calendars.rs`):**
- `create_calendar` → `MKCALENDAR` (RFC 4791 §5.3.1) with DAV `displayname` + Apple-namespace `calendar-color` in one body.
- `update_calendar` → `PROPPATCH` (RFC 4918 §9.2) for either / both properties in one round-trip.
- `delete_calendar` → `HTTP DELETE` reusing the existing `delete_resource` helper.

**Cache (nimbus-store):**
- Schema migration **v11 → v12** adds `hidden INTEGER NOT NULL DEFAULT 0` on `calendars`. Existing rows roll forward as visible.
- `CalendarRow.hidden` + `CachedCalendar.hidden` round-trip through `upsert_calendars` and `list_calendars`. The ON CONFLICT path leaves `hidden` alone so a post-discovery sync can't overwrite a user toggle.
- New helpers: `insert_calendar` (for fresh MKCALENDAR rows, ON CONFLICT DO NOTHING so a follow-up discovery doesn't clobber), `update_calendar_metadata`, `set_calendar_hidden`, `remove_calendar`.

**Tauri commands (src-tauri/src/main.rs):**
- `create_nextcloud_calendar(nc_id, display_name, color?)` — UUID slug for the path so two concurrent creates can't race and a rename doesn't rewrite the URL.
- `update_nextcloud_calendar(calendar_id, display_name?, color?)` — single PROPPATCH for rename + recolor.
- `delete_nextcloud_calendar(calendar_id)`.
- `set_nextcloud_calendar_hidden(calendar_id, hidden)` — local-only; no CalDAV traffic.
- `CalendarSummary` gains a `hidden` field so the sidebar filter and the Settings checkboxes read straight off the same list.

**Frontend (CalendarView, NextcloudSettings, EventEditor):**
- CalendarView's ephemeral `hiddenCalendarIds: Set<string>` is replaced with a `$derived` over `calendars.hidden`. Sidebar renders `visibleCalendars` (= filtered); agenda filter still hits the same Set, just now sourced from the persisted column.
- Right-click context menu positioned at cursor, dismissed on Esc / click-outside.
- All mutations share a `calendarOpBusy` re-entrancy guard (same pattern as the folder paths) so Enter + blur during an in-flight CalDAV request can't double-submit.
- EventEditor dropdown now gets `visibleCalendars` from both CalendarView and Compose's "Add event" path — hidden calendars stop being reachable destinations for new events.
- **Unrelated polish**: IconRail's "all accounts" avatar now shows 📥 instead of the `ALL` text so the aggregate indicator matches the Mail rail icon + All-Inboxes folder row everywhere.

## Test plan
- [ ] `+` → create calendar → name + color land on the server (verify via Nextcloud web UI)
- [ ] Right-click → Rename → inline edit commits on Enter / reverts on Escape
- [ ] Right-click → Change color → swatch picker updates the row + agenda tints
- [ ] Right-click → Delete → confirm → calendar + its events are gone
- [ ] Settings → Nextcloud → Calendars → uncheck a calendar → it disappears from the CalendarView sidebar + the event-editor dropdown + Compose's Add-event dropdown
- [ ] Re-check → it reappears; event grid re-paints its events
- [ ] First launch after pulling: `cargo tauri dev` runs migration v11 → v12 without error (existing rows roll forward as visible)
- [ ] IconRail: confirm the top avatar shows 📥 in both light + dark mode

## Reviewer notes
- No JMAP paths touched — all three tasks are Nextcloud / CalDAV-specific.
- `insert_calendar` does not prune — `upsert_calendars` remains the reconcile path. Add-then-sync works because `ON CONFLICT DO NOTHING` preserves our seeded row.
- Color format: `#RRGGBB` or `#RRGGBBAA` — the frontend picker enforces that shape; backend passes it through to `calendar-color`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)