### PR TITLE
Nextcloud attachment polish (closes #65)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -372,6 +372,14 @@ pub struct NextcloudCapabilities {
     pub caldav: bool,
     /// CardDAV contact endpoint is available.
     pub carddav: bool,
+    /// Nextcloud Office / Collabora (the `richdocuments` app id) is
+    /// installed and enabled. When true, the attachment-click flow
+    /// can open `.docx` / `.odt` / `.xlsx` etc. in an embedded
+    /// editor; when false the UI falls back to plain download.
+    /// `#[serde(default)]` so capability snapshots cached before
+    /// this field existed deserialise as `false`.
+    #[serde(default)]
+    pub office: bool,
 }
 
 /// Represents a contact from CardDAV / Nextcloud.

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -33,18 +33,6 @@ pub struct AppSettings {
     /// Whether the UI follows the OS light/dark preference, or
     /// is pinned to one. Applied via `<html data-mode="…">`.
     pub theme_mode: ThemeMode,
-    /// Optional base URL of a self-hosted Stirling-PDF instance
-    /// (e.g. `https://pdf.example.com`). When set, the
-    /// attachment-click flow opens `.pdf` files in Stirling-PDF's
-    /// embedded viewer; when empty / unset, PDFs go through the
-    /// same Nextcloud `index.php/f/<id>` deep link Office docs use,
-    /// which routes to Nextcloud's built-in PDF viewer. Single-
-    /// instance for now — easy to migrate to per-NC-account later
-    /// (the dispatch already loads the active NC account before
-    /// reaching this fallback). Stored without trailing slash;
-    /// runtime trims defensively if a user pastes one.
-    #[serde(default)]
-    pub stirling_pdf_url: Option<String>,
 }
 
 /// Light/dark mode selection. `System` follows the OS preference
@@ -80,7 +68,6 @@ impl Default for AppSettings {
             background_sync_interval_secs: 60,
             notifications_enabled: true,
             start_minimized: false,
-            stirling_pdf_url: None,
             theme_name: "cerberus".to_string(),
             theme_mode: ThemeMode::System,
         }

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -33,6 +33,18 @@ pub struct AppSettings {
     /// Whether the UI follows the OS light/dark preference, or
     /// is pinned to one. Applied via `<html data-mode="…">`.
     pub theme_mode: ThemeMode,
+    /// Optional base URL of a self-hosted Stirling-PDF instance
+    /// (e.g. `https://pdf.example.com`). When set, the
+    /// attachment-click flow opens `.pdf` files in Stirling-PDF's
+    /// embedded viewer; when empty / unset, PDFs go through the
+    /// same Nextcloud `index.php/f/<id>` deep link Office docs use,
+    /// which routes to Nextcloud's built-in PDF viewer. Single-
+    /// instance for now — easy to migrate to per-NC-account later
+    /// (the dispatch already loads the active NC account before
+    /// reaching this fallback). Stored without trailing slash;
+    /// runtime trims defensively if a user pastes one.
+    #[serde(default)]
+    pub stirling_pdf_url: Option<String>,
 }
 
 /// Light/dark mode selection. `System` follows the OS preference
@@ -68,6 +80,7 @@ impl Default for AppSettings {
             background_sync_interval_secs: 60,
             notifications_enabled: true,
             start_minimized: false,
+            stirling_pdf_url: None,
             theme_name: "cerberus".to_string(),
             theme_mode: ThemeMode::System,
         }

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -255,6 +255,16 @@ pub struct EmailAttachment {
     /// Zero-based index into the parsed message's attachment list.
     /// Used as a stable handle for re-fetching the bytes on demand.
     pub part_id: u32,
+    /// RFC 2392 Content-ID, when the MIME part carried one. Lifted
+    /// from the message's `Content-ID` header by `mail-parser` —
+    /// without the surrounding angle brackets — so a body anchor
+    /// `<a href="cid:abc-123">` can resolve to this attachment by
+    /// `cid_str.eq_ignore_ascii_case(att.content_id.as_deref()?)`.
+    /// `None` when the attachment isn't referenced inline.
+    /// `#[serde(default)]` keeps cached payloads from before this
+    /// field existed deserialising cleanly as `None`.
+    #[serde(default)]
+    pub content_id: Option<String>,
 }
 
 /// Represents an IMAP mailbox folder.

--- a/crates/nimbus-core/src/tls.rs
+++ b/crates/nimbus-core/src/tls.rs
@@ -30,6 +30,7 @@ use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, Server
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, SignatureScheme};
 use sha2::{Digest, Sha256};
+use tracing::{debug, warn};
 
 use crate::models::TrustedCert;
 
@@ -52,6 +53,7 @@ pub fn build_client_config(extra_roots: &[TrustedCert]) -> Arc<ClientConfig> {
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
     if extra_roots.is_empty() {
+        debug!("TLS client config: webpki-roots only (no per-account trusted certs)");
         return Arc::new(
             ClientConfig::builder()
                 .with_root_certificates(roots)
@@ -59,12 +61,27 @@ pub fn build_client_config(extra_roots: &[TrustedCert]) -> Arc<ClientConfig> {
         );
     }
 
+    let fingerprints: Vec<String> = extra_roots
+        .iter()
+        // Normalise stored fingerprints once at config-build time:
+        // lowercased, separator-stripped. The verifier compares
+        // against this canonical form so a fingerprint stored with
+        // colons / uppercase from a previous build still matches a
+        // freshly-computed one (or vice versa). Belt-and-braces
+        // against accidental format drift across versions.
+        .map(|c| canonicalize_fingerprint(&c.sha256))
+        .collect();
+    debug!(
+        "TLS client config: {} trusted fingerprint(s): {:?}",
+        fingerprints.len(),
+        fingerprints
+    );
     let inner = WebPkiServerVerifier::builder(Arc::new(roots))
         .build()
         .expect("webpki-roots verifier build");
     let verifier = Arc::new(FingerprintVerifier {
         inner,
-        trusted_fingerprints: extra_roots.iter().map(|c| c.sha256.clone()).collect(),
+        trusted_fingerprints: fingerprints,
     });
     Arc::new(
         ClientConfig::builder()
@@ -72,6 +89,17 @@ pub fn build_client_config(extra_roots: &[TrustedCert]) -> Arc<ClientConfig> {
             .with_custom_certificate_verifier(verifier)
             .with_no_client_auth(),
     )
+}
+
+/// Strip the `:` separators and lowercase a SHA-256 fingerprint
+/// string so trust comparisons are insensitive to formatting drift
+/// between the prompt UI, the trust-list write path, and the
+/// verifier. `aa:bb:CC` and `AABBCC` both end up as `aabbcc`.
+fn canonicalize_fingerprint(fp: &str) -> String {
+    fp.chars()
+        .filter(|c| c.is_ascii_hexdigit())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
 }
 
 /// Custom rustls verifier that accepts a cert if **either**:
@@ -105,11 +133,33 @@ impl ServerCertVerifier for FingerprintVerifier {
             .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
         {
             Ok(v) => Ok(v),
-            Err(_) => {
-                let fp = fingerprint_sha256(end_entity.as_ref());
-                if self.trusted_fingerprints.iter().any(|t| t == &fp) {
+            Err(webpki_err) => {
+                // Walk the entire presented chain — leaf and every
+                // intermediate. Some servers send the chain in the
+                // order specified by RFC 5246 (leaf first); others
+                // reorder it; and the user's "trust this" prompt
+                // captures only one DER blob. Comparing every cert
+                // in the chain against the trusted fingerprints
+                // means a reorder doesn't cause a false rejection.
+                let leaf_fp = canonicalize_fingerprint(&fingerprint_sha256(end_entity.as_ref()));
+                let intermediate_fps: Vec<String> = intermediates
+                    .iter()
+                    .map(|c| canonicalize_fingerprint(&fingerprint_sha256(c.as_ref())))
+                    .collect();
+                let chain_fps: Vec<&String> =
+                    std::iter::once(&leaf_fp).chain(intermediate_fps.iter()).collect();
+
+                let matched = chain_fps
+                    .iter()
+                    .any(|fp| self.trusted_fingerprints.iter().any(|t| t == *fp));
+                if matched {
                     Ok(ServerCertVerified::assertion())
                 } else {
+                    warn!(
+                        "TLS verify rejected: webpki={webpki_err}, leaf={leaf_fp}, \
+                         intermediates={intermediate_fps:?}, trusted={:?}",
+                        self.trusted_fingerprints
+                    );
                     Err(rustls::Error::InvalidCertificate(
                         rustls::CertificateError::UnknownIssuer,
                     ))

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -60,16 +60,22 @@ async fn tls_connect(
 /// Probe the IMAP server's TLS certificate without verifying it.
 /// Used by the "trust this server?" flow: when the regular connect
 /// fails because the cert isn't in any trust store we know about,
-/// the UI calls this to capture the leaf cert (DER) so the user
-/// can be shown its fingerprint and decide whether to trust it.
+/// the UI calls this to capture the chain (leaf + intermediates)
+/// so the user can be shown the fingerprints and decide whether to
+/// trust the server.
 ///
-/// Returns the leaf (end-entity) cert's DER bytes. Caller is
+/// Returns every cert the server presented in handshake order
+/// (leaf first, then intermediates). Trusting the whole chain — not
+/// just the leaf — is the robust thing to do: the server may
+/// reorder certs, the active leaf may be reissued under the same
+/// intermediate, and the verifier matches against the trust list
+/// by walking the entire presented chain anyway. Caller is
 /// responsible for never using this for actual mail traffic — we
 /// drop the connection immediately after the handshake succeeds.
 pub async fn probe_server_certificate(
     host: &str,
     port: u16,
-) -> Result<Vec<u8>, NimbusError> {
+) -> Result<Vec<Vec<u8>>, NimbusError> {
     let addr = format!("{host}:{port}");
     let tcp = TcpStream::connect(&addr)
         .await
@@ -84,12 +90,16 @@ pub async fn probe_server_certificate(
         .map_err(|e| NimbusError::Network(format!("TLS probe failed with {host}: {e}")))?;
 
     let (_io, conn) = tls.get_ref();
-    let leaf = conn
+    let chain: Vec<Vec<u8>> = conn
         .peer_certificates()
-        .and_then(|chain| chain.first())
-        .ok_or_else(|| NimbusError::Protocol(format!("server '{host}' returned no certificate")))?
-        .to_vec();
-    Ok(leaf)
+        .map(|certs| certs.iter().map(|c| c.to_vec()).collect())
+        .unwrap_or_default();
+    if chain.is_empty() {
+        return Err(NimbusError::Protocol(format!(
+            "server '{host}' returned no certificate"
+        )));
+    }
+    Ok(chain)
 }
 
 use tracing::{debug, info, warn};

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -598,11 +598,18 @@ impl ImapClient {
                 // resolved base64/QP by the time we see `contents()`,
                 // so this matches what the user will actually download.
                 let size = Some(part.contents().len() as u64);
+                // RFC 2392 Content-ID, when the part carried one. The
+                // body's `<a href="cid:abc-123">` anchors resolve to
+                // this attachment via case-insensitive equality with
+                // the cid value (no angle brackets — mail-parser
+                // strips them already).
+                let content_id = part.content_id().map(|s| s.to_string());
                 EmailAttachment {
                     filename,
                     content_type,
                     size,
                     part_id,
+                    content_id,
                 }
             })
             .collect();
@@ -717,6 +724,7 @@ impl ImapClient {
 
         let data = part.contents().to_vec();
         let size = Some(data.len() as u64);
+        let content_id = part.content_id().map(|s| s.to_string());
 
         Ok((
             EmailAttachment {
@@ -724,6 +732,7 @@ impl ImapClient {
                 content_type,
                 size,
                 part_id,
+                content_id,
             },
             data,
         ))

--- a/crates/nimbus-nextcloud/src/capabilities.rs
+++ b/crates/nimbus-nextcloud/src/capabilities.rs
@@ -62,6 +62,11 @@ struct Capabilities {
     files: Option<serde_json::Value>,
     /// DAV capabilities — presence implies CalDAV + CardDAV are reachable.
     dav: Option<serde_json::Value>,
+    /// Nextcloud Office / Collabora exposes its capability block
+    /// under the app id `richdocuments`. We don't read any of the
+    /// inner fields — presence alone is the signal that the editor
+    /// URL flow (`apps/richdocuments/index.json`) will work.
+    richdocuments: Option<serde_json::Value>,
 }
 
 /// Query `/ocs/v2.php/cloud/capabilities` and map it to our flat
@@ -111,13 +116,15 @@ pub async fn fetch_capabilities(
         files: env.ocs.data.capabilities.files.is_some(),
         caldav: dav_present,
         carddav: dav_present,
+        office: env.ocs.data.capabilities.richdocuments.is_some(),
     };
     tracing::info!(
-        "Nextcloud capabilities: version={:?} talk={} files={} dav={}",
+        "Nextcloud capabilities: version={:?} talk={} files={} dav={} office={}",
         caps.version,
         caps.talk,
         caps.files,
-        dav_present
+        dav_present,
+        caps.office,
     );
     Ok(caps)
 }

--- a/crates/nimbus-nextcloud/src/files.rs
+++ b/crates/nimbus-nextcloud/src/files.rs
@@ -449,6 +449,125 @@ pub async fn create_directory(
     Ok(())
 }
 
+/// DAV DELETE the resource at `path` — works for both files and
+/// folders. Used by the Office viewer cleanup flow + the temp-dir
+/// sweeper. Treats 404 as success (already gone), same forgiving
+/// policy `nimbus-caldav::delete_calendar` uses.
+pub async fn delete_path(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    path: &str,
+) -> Result<(), NimbusError> {
+    let base = user_dav_base(server_url, username);
+    let inner = normalise_input_path(path);
+    if inner == "/" {
+        return Err(NimbusError::Nextcloud(
+            "refusing to DELETE the user root".into(),
+        ));
+    }
+    let url = format!("{base}{}", encode_path(&inner));
+    tracing::debug!("DELETE {url}");
+
+    let http = client::build()?;
+    let resp = http
+        .delete(&url)
+        .header("OCS-APIRequest", "true")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("DELETE request failed: {e}")))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(NimbusError::Auth(
+            "Nextcloud rejected app password (revoked or expired)".into(),
+        ));
+    }
+    // 404 = already gone, 204/200 = success — all fine.
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(());
+    }
+    if !status.is_success() {
+        return Err(NimbusError::Nextcloud(format!(
+            "DELETE returned HTTP {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Single-resource PROPFIND that returns the Nextcloud `oc:fileid` —
+/// the stable numeric handle every NC app keys on. Used by the
+/// Office viewer flow to build the `index.php/f/<fileid>` deep-link
+/// URL after a fresh upload (the new file's fileid isn't returned
+/// by PUT).
+pub async fn propfind_fileid(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    path: &str,
+) -> Result<String, NimbusError> {
+    let base = user_dav_base(server_url, username);
+    let inner = normalise_input_path(path);
+    let url = format!("{base}{}", encode_path(&inner));
+
+    // Depth 0 — we only care about the resource itself, not children.
+    // The `oc:` namespace is Nextcloud's own; `oc:fileid` is the
+    // numeric id Files / Office / Talk all share.
+    const BODY: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:prop>
+    <oc:fileid/>
+  </d:prop>
+</d:propfind>"#;
+
+    let http = client::build()?;
+    let resp = http
+        .request(
+            reqwest::Method::from_bytes(b"PROPFIND").expect("PROPFIND is a valid HTTP method"),
+            &url,
+        )
+        .header("OCS-APIRequest", "true")
+        .header(CONTENT_TYPE, "application/xml; charset=utf-8")
+        .header("Depth", "0")
+        .basic_auth(username, Some(app_password))
+        .body(BODY)
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("PROPFIND fileid failed: {e}")))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(NimbusError::Auth(
+            "Nextcloud rejected app password (revoked or expired)".into(),
+        ));
+    }
+    if !status.is_success() {
+        return Err(NimbusError::Nextcloud(format!(
+            "PROPFIND fileid returned HTTP {status}"
+        )));
+    }
+
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| NimbusError::Network(format!("PROPFIND body read failed: {e}")))?;
+
+    // Cheap text scan rather than a full quick-xml read — the
+    // response is ~600 bytes and we only want one element.
+    let open = body.find("<oc:fileid>").or_else(|| body.find("<fileid>"));
+    let close = body.find("</oc:fileid>").or_else(|| body.find("</fileid>"));
+    match (open, close) {
+        (Some(o), Some(c)) if c > o => {
+            let start = o + body[o..].find('>').unwrap_or(0) + 1;
+            Ok(body[start..c].trim().to_string())
+        }
+        _ => Err(NimbusError::Protocol(
+            "PROPFIND response missing <oc:fileid>".into(),
+        )),
+    }
+}
+
 // ── Multistatus parser ─────────────────────────────────────────
 
 /// Parse a WebDAV multistatus response into `FileEntry`s.

--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -23,7 +23,10 @@ pub mod talk;
 
 pub use auth::{LoginFlowInit, LoginFlowResult, poll_login, start_login};
 pub use capabilities::fetch_capabilities;
-pub use files::{FileEntry, create_directory, download_file, list_directory, upload_file};
+pub use files::{
+    FileEntry, create_directory, delete_path, download_file, list_directory, propfind_fileid,
+    upload_file,
+};
 pub use shares::{PublicShare, create_public_share};
 pub use talk::{
     ParticipantSource, RoomType, TalkRoom, add_participant, create_room, list_rooms, rename_room,

--- a/crates/nimbus-nextcloud/src/shares.rs
+++ b/crates/nimbus-nextcloud/src/shares.rs
@@ -181,18 +181,44 @@ pub async fn create_public_share(
             "Nextcloud rejected app password (revoked or expired)".into(),
         ));
     }
-    if !status.is_success() {
-        return Err(NimbusError::Nextcloud(format!(
-            "share returned HTTP {status}"
-        )));
-    }
 
+    // Read the body up front (success or failure) so a 4xx still
+    // surfaces Nextcloud's actual reason. Password-policy rejections
+    // come back as HTTP 400 with an OCS envelope whose `meta.message`
+    // says e.g. "Password is too short" — pulling that into the
+    // error makes the bad-password case actionable instead of "share
+    // returned HTTP 400".
     let body = resp
         .text()
         .await
         .map_err(|e| NimbusError::Network(format!("share body read failed: {e}")))?;
 
+    if !status.is_success() {
+        let detail = ocs_message(&body).unwrap_or_else(|| {
+            // Truncate so a verbose HTML error page doesn't blow up
+            // the toast — 240 chars is enough to expose the gist.
+            let trimmed = body.trim();
+            if trimmed.len() > 240 {
+                format!("{}…", &trimmed[..240])
+            } else {
+                trimmed.to_string()
+            }
+        });
+        return Err(NimbusError::Nextcloud(format!(
+            "share returned HTTP {status}: {detail}"
+        )));
+    }
+
     parse_share_response(&body)
+}
+
+/// Try to lift the human-readable `meta.message` out of an OCS
+/// response body. Returns `None` if the body isn't OCS-shaped JSON
+/// or doesn't carry a message — caller falls back to the raw body
+/// in that case.
+fn ocs_message(body: &str) -> Option<String> {
+    let raw: OcsRaw = serde_json::from_str(body).ok()?;
+    raw.ocs.meta.message.filter(|m| !m.is_empty())
 }
 
 /// Parse the OCS envelope and surface either the URL or a meaningful

--- a/crates/nimbus-nextcloud/src/shares.rs
+++ b/crates/nimbus-nextcloud/src/shares.rs
@@ -194,19 +194,20 @@ pub async fn create_public_share(
         .map_err(|e| NimbusError::Network(format!("share body read failed: {e}")))?;
 
     if !status.is_success() {
-        let detail = ocs_message(&body).unwrap_or_else(|| {
-            // Truncate so a verbose HTML error page doesn't blow up
-            // the toast — 240 chars is enough to expose the gist.
-            let trimmed = body.trim();
-            if trimmed.len() > 240 {
-                format!("{}…", &trimmed[..240])
-            } else {
-                trimmed.to_string()
-            }
-        });
-        return Err(NimbusError::Nextcloud(format!(
-            "share returned HTTP {status}: {detail}"
-        )));
+        let detail = ocs_message(&body)
+            .map(|m| friendly_share_error(&m))
+            .unwrap_or_else(|| {
+                // Truncate so a verbose HTML error page doesn't blow
+                // up the toast — 240 chars is enough to expose the
+                // gist.
+                let trimmed = body.trim();
+                if trimmed.len() > 240 {
+                    format!("{}…", &trimmed[..240])
+                } else {
+                    trimmed.to_string()
+                }
+            });
+        return Err(NimbusError::Nextcloud(detail));
     }
 
     parse_share_response(&body)
@@ -219,6 +220,81 @@ pub async fn create_public_share(
 fn ocs_message(body: &str) -> Option<String> {
     let raw: OcsRaw = serde_json::from_str(body).ok()?;
     raw.ocs.meta.message.filter(|m| !m.is_empty())
+}
+
+/// Map well-known Nextcloud password-policy / share-creation
+/// messages to phrasings the user actually understands. The OCS
+/// strings themselves are technically correct ("Password is among
+/// the 1,000,000 most common passwords", "Password needs to be at
+/// least 10 characters long.") but they read like server
+/// diagnostics — surface them as guidance instead. Anything we
+/// don't recognise falls through verbatim so we never hide the
+/// real reason.
+fn friendly_share_error(raw: &str) -> String {
+    let lower = raw.to_lowercase();
+
+    // Length policy. NC's wording varies between minor versions
+    // ("Password needs to be at least N characters long.",
+    // "Password is too short", "The password is too short.") so we
+    // pull the digits when we can and fall back to a generic floor.
+    if lower.contains("password") && (lower.contains("short") || lower.contains("at least"))
+    {
+        if let Some(min_len) = first_number(raw) {
+            return format!(
+                "Password is too short. Choose at least {min_len} characters."
+            );
+        }
+        return "Password is too short. Try a longer one.".to_string();
+    }
+
+    // Common-password blocklist — the policy app rejects the top-N
+    // breach list.
+    if lower.contains("most common passwords") || lower.contains("commonly used password") {
+        return "That password is on a public list of common passwords. Pick something less guessable.".to_string();
+    }
+
+    // Numeric / character-class requirements.
+    if lower.contains("password") && lower.contains("numeric") {
+        return "Password needs at least one number.".to_string();
+    }
+    if lower.contains("password")
+        && (lower.contains("special character") || lower.contains("special-character"))
+    {
+        return "Password needs at least one special character.".to_string();
+    }
+    if lower.contains("password") && lower.contains("upper") {
+        return "Password needs at least one uppercase letter.".to_string();
+    }
+    if lower.contains("password") && lower.contains("lower") {
+        return "Password needs at least one lowercase letter.".to_string();
+    }
+
+    // Fallback — keep the server's text but capitalise + add a final
+    // period so it reads like a sentence rather than a log line.
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "The Nextcloud server rejected the share.".to_string();
+    }
+    let mut out = trimmed.to_string();
+    if !out.ends_with('.') && !out.ends_with('!') && !out.ends_with('?') {
+        out.push('.');
+    }
+    out
+}
+
+/// Pull the first run of ASCII digits out of a string and parse as
+/// `u32`. Used to recover the "at least N" minimum length from the
+/// password-policy app's message regardless of phrasing.
+fn first_number(s: &str) -> Option<u32> {
+    let mut digits = String::new();
+    for c in s.chars() {
+        if c.is_ascii_digit() {
+            digits.push(c);
+        } else if !digits.is_empty() {
+            break;
+        }
+    }
+    digits.parse().ok()
 }
 
 /// Parse the OCS envelope and surface either the URL or a meaningful

--- a/crates/nimbus-nextcloud/src/shares.rs
+++ b/crates/nimbus-nextcloud/src/shares.rs
@@ -134,13 +134,35 @@ pub async fn create_public_share(
     username: &str,
     app_password: &str,
     path: &str,
+    password: Option<&str>,
 ) -> Result<PublicShare, NimbusError> {
     let server = client::normalize_server_url(server_url);
     let url = format!("{server}/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json");
 
-    tracing::debug!("POST {url} for path {path}");
+    tracing::debug!(
+        "POST {url} for path {path} (password: {})",
+        if password.is_some() { "yes" } else { "no" }
+    );
 
     let http = client::build()?;
+    // Build the form pairs dynamically — `password` is only added when
+    // the caller actually supplied one. Passing an empty `password=`
+    // makes Nextcloud reject the request with "Password too short" on
+    // some configurations, so omitting the field entirely is safer
+    // than sending an empty value.
+    let share_type = SHARE_TYPE_PUBLIC_LINK.to_string();
+    let permissions = PERM_READ_ONLY.to_string();
+    let mut form: Vec<(&str, &str)> = vec![
+        ("path", path),
+        ("shareType", &share_type),
+        ("permissions", &permissions),
+    ];
+    if let Some(pw) = password {
+        if !pw.is_empty() {
+            form.push(("password", pw));
+        }
+    }
+
     let resp = http
         .post(&url)
         .header("OCS-APIRequest", "true")
@@ -148,11 +170,7 @@ pub async fn create_public_share(
         .basic_auth(username, Some(app_password))
         // The form encoder URL-encodes for us, so we pass the raw path
         // (with spaces / unicode) and Nextcloud receives the right thing.
-        .form(&[
-            ("path", path),
-            ("shareType", &SHARE_TYPE_PUBLIC_LINK.to_string()),
-            ("permissions", &PERM_READ_ONLY.to_string()),
-        ])
+        .form(&form)
         .send()
         .await
         .map_err(|e| NimbusError::Network(format!("share request failed: {e}")))?;

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,6 +5,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:webview:allow-create-webview-window",
+    "core:window:allow-close",
     "notification:default",
     "dialog:default"
   ]

--- a/src-tauri/gen/schemas/capabilities.json
+++ b/src-tauri/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default capabilities for the Nimbus main window.","local":true,"windows":["main"],"permissions":["core:default","notification:default","dialog:default"]}}
+{"default":{"identifier":"default","description":"Default capabilities for the Nimbus main window.","local":true,"windows":["main"],"permissions":["core:default","core:webview:allow-create-webview-window","core:window:allow-close","notification:default","dialog:default"]}}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -424,13 +424,16 @@ async fn download_nextcloud_file(
 /// into the email body — a lighter alternative to attaching the bytes
 /// for big files or files the recipient might want to re-download.
 ///
-/// The share is read-only with no password and no expiry; per-share
-/// options can be added as a separate command (`update_nextcloud_share`)
-/// once the UI grows controls for them.
+/// `password` is optional; when supplied the share is gated behind
+/// it on the recipient side. The OCS endpoint enforces the user's
+/// configured password policy (length, complexity), so a too-weak
+/// password surfaces as a `NimbusError::Nextcloud` from the server
+/// rather than a local validation rule we have to maintain.
 #[tauri::command]
 async fn create_nextcloud_share(
     nc_id: String,
     path: String,
+    password: Option<String>,
 ) -> Result<String, NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
@@ -439,6 +442,7 @@ async fn create_nextcloud_share(
         &account.username,
         &app_password,
         &path,
+        password.as_deref(),
     )
     .await?;
     Ok(share.url)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -514,6 +514,202 @@ async fn create_nextcloud_directory(
     .await
 }
 
+// ── Office viewer (issue #65) ────────────────────────────────
+//
+// Click an Office-compatible attachment in MailView → upload its
+// bytes to a per-user temp folder in the user's Nextcloud → return
+// the deep-link URL the frontend opens in a Tauri webview window.
+// On close, the frontend fires `office_close_attachment` which
+// expunges the temp file. A separate `office_sweep_temp` runs at
+// connect-time to clean up anything left behind by a crash mid-edit.
+//
+// Folder layout:
+//   /Nimbus Mail/temp/<uuid>-<filename>
+//
+// The UUID prefix lets concurrent edits coexist without filename
+// collisions and gives the sweeper an obvious "is-this-ours" gate
+// (only delete files inside the temp folder).
+
+/// Root path for Nimbus's per-user temp area on the user's
+/// Nextcloud. Files-app-visible (no leading dot) so the user can
+/// recover anything we somehow lose track of, but tucked under our
+/// app's branded folder so the home screen stays uncluttered.
+const NIMBUS_TEMP_ROOT: &str = "/Nimbus Mail";
+const NIMBUS_TEMP_DIR: &str = "/Nimbus Mail/temp";
+
+/// Result of `office_open_attachment` — the URL the frontend opens
+/// in a fresh webview window plus the temp path it should pass back
+/// to `office_close_attachment` on close.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OfficeOpenResult {
+    /// Absolute URL into Nextcloud's Files app, which routes the
+    /// file id to whichever app is registered as its handler —
+    /// Collabora for Office docs, the PDF viewer for `.pdf`. Pasted
+    /// directly into a `WebviewWindow` `url` arg.
+    url: String,
+    /// Path on the user's Nextcloud (relative to the user root).
+    /// Round-trips back to `office_close_attachment` so the cleanup
+    /// targets the file we just uploaded, not "all temp files".
+    temp_path: String,
+}
+
+/// Best-effort `MKCOL` of `/Nimbus Mail` and `/Nimbus Mail/temp`.
+/// Both are idempotent: `create_directory` returns "folder already
+/// exists" as `NimbusError::Nextcloud` which we swallow so a
+/// pre-existing folder doesn't fail the open. Anything else
+/// propagates so quota / 401 / network errors surface to the user.
+async fn ensure_temp_dir(account: &NextcloudAccount, app_password: &str) -> Result<(), NimbusError> {
+    for dir in [NIMBUS_TEMP_ROOT, NIMBUS_TEMP_DIR] {
+        match nimbus_nextcloud::create_directory(
+            &account.server_url,
+            &account.username,
+            app_password,
+            dir,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(NimbusError::Nextcloud(msg)) if msg.contains("already exists") => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Upload an attachment to the user's Nextcloud temp folder and
+/// return the URL to open it in. Used by MailView when the user
+/// clicks a `cid:` link or a tray button on an Office-compatible
+/// attachment.
+#[tauri::command]
+async fn office_open_attachment(
+    nc_id: String,
+    filename: String,
+    data: Vec<u8>,
+    content_type: Option<String>,
+) -> Result<OfficeOpenResult, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    ensure_temp_dir(&account, &app_password).await?;
+
+    // UUID prefix dodges filename collisions between concurrent
+    // viewer windows, and gives the sweeper a way to recognise our
+    // own files without a metadata round-trip.
+    let safe_name = filename.replace('/', "_").replace('\\', "_");
+    let temp_path = format!(
+        "{}/{}-{}",
+        NIMBUS_TEMP_DIR,
+        uuid::Uuid::new_v4(),
+        safe_name
+    );
+
+    nimbus_nextcloud::upload_file(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &temp_path,
+        data,
+        content_type.as_deref(),
+    )
+    .await?;
+
+    // Resolve the freshly-uploaded file's `oc:fileid` so we can
+    // build the canonical `index.php/f/<id>` deep link. That URL
+    // routes through Nextcloud's "open with default app" — Files
+    // hands `.docx` etc. to Collabora, `.pdf` to the PDF viewer,
+    // so the same code path works for both document types without
+    // app-specific URL templating on our side.
+    let file_id = nimbus_nextcloud::propfind_fileid(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &temp_path,
+    )
+    .await?;
+
+    let server = account.server_url.trim_end_matches('/');
+    let url = format!("{server}/index.php/f/{file_id}");
+
+    Ok(OfficeOpenResult { url, temp_path })
+}
+
+/// Delete a temp file the frontend opened earlier. Best-effort:
+/// 404 is swallowed by `delete_path`, network blips bubble up but
+/// the frontend logs and moves on — leftover files get caught by
+/// `office_sweep_temp` at next connect.
+#[tauri::command]
+async fn office_close_attachment(
+    nc_id: String,
+    temp_path: String,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::delete_path(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &temp_path,
+    )
+    .await
+}
+
+/// Clean up anything stuck in `/Nimbus Mail/temp` from a previous
+/// session — say the user closed Nimbus mid-edit, or `office_close_
+/// attachment` errored on the way out. We list the directory and
+/// DELETE every entry whose `last_modified` is older than the cutoff,
+/// so an in-flight viewer window in another Nimbus instance doesn't
+/// have its file pulled out from under it.
+#[tauri::command]
+async fn office_sweep_temp(nc_id: String) -> Result<u32, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    // If the temp dir doesn't exist yet (fresh install / first
+    // attachment click) treat that as "nothing to sweep". Anything
+    // else propagates.
+    let entries = match nimbus_nextcloud::list_directory(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        NIMBUS_TEMP_DIR,
+    )
+    .await
+    {
+        Ok(e) => e,
+        Err(NimbusError::Nextcloud(msg)) if msg.contains("not found") => return Ok(0),
+        Err(e) => return Err(e),
+    };
+
+    let cutoff = chrono::Utc::now() - chrono::Duration::hours(1);
+    let mut swept = 0u32;
+    for entry in entries {
+        let stale = entry
+            .modified
+            .map(|t| t < cutoff)
+            .unwrap_or(true);
+        if !stale {
+            continue;
+        }
+        let target = format!("{NIMBUS_TEMP_DIR}/{}", entry.name);
+        match nimbus_nextcloud::delete_path(
+            &account.server_url,
+            &account.username,
+            &app_password,
+            &target,
+        )
+        .await
+        {
+            Ok(()) => swept += 1,
+            Err(e) => tracing::warn!("office_sweep_temp: failed to delete {target}: {e}"),
+        }
+    }
+    if swept > 0 {
+        tracing::info!("office_sweep_temp: cleaned {swept} stale file(s)");
+    }
+    Ok(swept)
+}
+
 // ── Nextcloud Talk ──────────────────────────────────────────────
 //
 // Three commands, mirroring the file/share pattern: each call loads
@@ -3737,6 +3933,9 @@ fn main() {
             add_talk_participant,
             rename_talk_room,
             upload_to_nextcloud,
+            office_open_attachment,
+            office_close_attachment,
+            office_sweep_temp,
             save_bytes_to_path,
             sync_nextcloud_contacts,
             get_contacts_sync_status,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -654,6 +654,164 @@ async fn office_close_attachment(
     .await
 }
 
+/// Percent-encode every byte that isn't safe in a URL query value
+/// per RFC 3986 §3.4. Avoids pulling in a whole `url` / `urlencoding`
+/// crate just for the Stirling fileUrl parameter — a few dozen
+/// bytes of code instead of a 50-KB dependency.
+fn percent_encode_query(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            // RFC 3986 unreserved set + a few extras that are safe
+            // inside a query (the spec actually allows more, but
+            // sticking to this set keeps round-tripping bullet-proof
+            // across whatever Stirling version the user has).
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            other => {
+                out.push('%');
+                out.push_str(&format!("{:02X}", other));
+            }
+        }
+    }
+    out
+}
+
+/// Result of `pdf_open_attachment`. Mirrors `OfficeOpenResult` so
+/// the frontend can treat both viewers identically — same webview-
+/// open + cleanup-on-close shape, the only difference is which URL
+/// it points at.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PdfOpenResult {
+    url: String,
+    temp_path: String,
+}
+
+/// Open a PDF attachment in either the user's configured Stirling-PDF
+/// instance (when `AppSettings.stirling_pdf_url` is set) or
+/// Nextcloud's built-in PDF viewer (when it's not). Same temp-upload
+/// + cleanup-on-close machinery as the Office flow:
+///
+///   - Bytes go to `/Nimbus Mail/temp/<uuid>-<filename>` on the user's
+///     Nextcloud.
+///   - For Nextcloud's viewer we use the same `index.php/f/<fileid>`
+///     deep link Office uses; Files routes the fileid to its
+///     registered handler (the PDF viewer for `.pdf`).
+///   - For Stirling-PDF we additionally mint an unprotected public
+///     share so Stirling's frontend can `fetch` the file
+///     server-side — same network-scope your Office viewer already
+///     trusts. The Stirling URL carries `?fileUrl=<encoded>` which
+///     Stirling-PDF accepts on its viewer entry; if a particular
+///     Stirling version doesn't auto-load, the user lands on the
+///     Stirling UI with the URL one paste away.
+///
+/// On `pdf_close_attachment` (or the startup sweep) the temp file
+/// is DAV-DELETED, which atomically invalidates the public-share
+/// token so the URL stops resolving the moment the viewer window
+/// closes — no manual share-revoke step needed.
+#[tauri::command]
+async fn pdf_open_attachment(
+    nc_id: String,
+    filename: String,
+    data: Vec<u8>,
+    content_type: Option<String>,
+    settings: State<'_, SharedSettings>,
+) -> Result<PdfOpenResult, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+
+    ensure_temp_dir(&account, &app_password).await?;
+
+    let safe_name = filename.replace('/', "_").replace('\\', "_");
+    let temp_path = format!(
+        "{}/{}-{}",
+        NIMBUS_TEMP_DIR,
+        uuid::Uuid::new_v4(),
+        safe_name
+    );
+
+    nimbus_nextcloud::upload_file(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &temp_path,
+        data,
+        content_type.as_deref(),
+    )
+    .await?;
+
+    // Stirling URL is read once up front so a settings edit
+    // mid-render still snaps to the value at click-time. Trim
+    // trailing slashes defensively — users routinely paste them
+    // from a browser address bar.
+    let stirling_url = {
+        let s = settings.read().await;
+        s.stirling_pdf_url
+            .as_ref()
+            .map(|u| u.trim().trim_end_matches('/').to_string())
+            .filter(|u| !u.is_empty())
+    };
+
+    let url = match stirling_url {
+        Some(stirling) => {
+            // Mint an anonymous share so Stirling's server can
+            // fetch the bytes without our app password. The share
+            // dies the moment we DELETE the temp file on close —
+            // same lifetime as the viewer window.
+            let share = nimbus_nextcloud::create_public_share(
+                &account.server_url,
+                &account.username,
+                &app_password,
+                &temp_path,
+                None,
+            )
+            .await?;
+            // Append `/download` so Stirling fetches the raw bytes
+            // rather than the share's HTML preview page.
+            let download_url = format!("{}/download", share.url.trim_end_matches('/'));
+            format!(
+                "{}/?fileUrl={}",
+                stirling,
+                percent_encode_query(&download_url)
+            )
+        }
+        None => {
+            let file_id = nimbus_nextcloud::propfind_fileid(
+                &account.server_url,
+                &account.username,
+                &app_password,
+                &temp_path,
+            )
+            .await?;
+            let server = account.server_url.trim_end_matches('/');
+            format!("{server}/index.php/f/{file_id}")
+        }
+    };
+
+    Ok(PdfOpenResult { url, temp_path })
+}
+
+/// DELETE the temp PDF the frontend opened. Same cleanup path as
+/// Office — kept as its own command so the frontend's per-viewer
+/// dispatch stays straightforward.
+#[tauri::command]
+async fn pdf_close_attachment(
+    nc_id: String,
+    temp_path: String,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::delete_path(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &temp_path,
+    )
+    .await
+}
+
 /// Clean up anything stuck in `/Nimbus Mail/temp` from a previous
 /// session — say the user closed Nimbus mid-edit, or `office_close_
 /// attachment` errored on the way out. We list the directory and
@@ -3936,6 +4094,8 @@ fn main() {
             office_open_attachment,
             office_close_attachment,
             office_sweep_temp,
+            pdf_open_attachment,
+            pdf_close_attachment,
             save_bytes_to_path,
             sync_nextcloud_contacts,
             get_contacts_sync_status,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -310,6 +310,30 @@ fn get_nextcloud_accounts() -> Result<Vec<NextcloudAccount>, NimbusError> {
     nextcloud_store::load_accounts()
 }
 
+/// Re-probe `/ocs/v2.php/cloud/capabilities` for one account and
+/// persist the fresh snapshot. Called by Settings on mount so newly-
+/// installed Nextcloud apps (Office, Talk, …) light up their
+/// indicator chip without the user having to disconnect + reconnect.
+///
+/// Soft-fails: a flaky network or revoked password returns the
+/// account's previously-cached capabilities unchanged rather than
+/// erroring out the whole settings panel.
+#[tauri::command]
+async fn refresh_nextcloud_capabilities(nc_id: String) -> Result<NextcloudAccount, NimbusError> {
+    let mut account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    match fetch_capabilities(&account.server_url, &account.username, &app_password).await {
+        Ok(caps) => {
+            account.capabilities = Some(caps);
+            nextcloud_store::upsert_account(account.clone())?;
+        }
+        Err(e) => {
+            tracing::warn!("refresh_nextcloud_capabilities for {nc_id}: {e}");
+        }
+    }
+    Ok(account)
+}
+
 /// Remove a Nextcloud connection and its stored app password.
 ///
 /// Does **not** attempt to revoke the app password on the server —
@@ -3697,6 +3721,7 @@ fn main() {
             start_nextcloud_login,
             poll_nextcloud_login,
             get_nextcloud_accounts,
+            refresh_nextcloud_capabilities,
             remove_nextcloud_account,
             open_url,
             list_nextcloud_files,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -171,37 +171,50 @@ async fn discover_account_settings(
     }
 }
 
-/// Shape returned to the UI by [`probe_server_certificate`]. Lets
-/// the "trust this server?" prompt show the SHA-256 fingerprint
-/// the user should compare against their server, plus the host
-/// they were trying to reach (for sanity-checking).
+/// One cert in a probed chain — DER bytes plus its SHA-256
+/// fingerprint formatted for display. The frontend uses `der` to
+/// build a `TrustedCert` entry and `sha256` to render the
+/// "compare this against your server" prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProbedCertEntry {
+    der: Vec<u8>,
+    sha256: String,
+}
+
+/// Shape returned to the UI by [`probe_server_certificate`]. The
+/// full chain (leaf first, then intermediates) is round-tripped
+/// back so the UI can trust every cert the server presented — not
+/// just the leaf. This survives chain reordering and reissues of
+/// the leaf under the same intermediate without a re-prompt.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ProbedCert {
-    /// Raw DER bytes — round-tripped back via `add_account` /
-    /// `update_account` so the cert can be added to the account's
-    /// `trusted_certs` list. Frontend treats it as opaque.
-    der: Vec<u8>,
-    /// `aa:bb:cc:…` SHA-256 of `der`. Displayed verbatim in the
-    /// trust prompt.
-    sha256: String,
+    /// Probed certificates in handshake order (leaf at index 0).
+    chain: Vec<ProbedCertEntry>,
     host: String,
 }
 
 /// Open a no-verify TLS handshake to a mail server and capture the
-/// leaf certificate. Used by the AccountSetup wizard's "trust this
-/// server?" path: when [`test_connection`] fails because the cert
-/// isn't trusted, the UI calls this to get the fingerprint, asks
-/// the user, and on confirm passes the DER back into `add_account`
-/// as a `trusted_certs` entry.
+/// presented certificate chain. Used by the AccountSetup wizard's
+/// "trust this server?" path and AccountSettings' re-trust button:
+/// when [`test_connection`] fails because the cert isn't trusted,
+/// the UI calls this to get the fingerprints, asks the user, and on
+/// confirm passes every DER back into `add_account` /
+/// `update_account` as `trusted_certs` entries.
 ///
-/// **Safety**: the captured cert is never used for actual mail
+/// **Safety**: the captured certs are never used for actual mail
 /// traffic — the connection is dropped immediately after the
-/// handshake. The user explicitly chooses whether to trust it.
+/// handshake. The user explicitly chooses whether to trust them.
 #[tauri::command]
 async fn probe_server_certificate(host: String, port: u16) -> Result<ProbedCert, NimbusError> {
-    let der = nimbus_imap::probe_server_certificate(&host, port).await?;
-    let sha256 = nimbus_core::tls::fingerprint_sha256(&der);
-    Ok(ProbedCert { der, sha256, host })
+    let chain_der = nimbus_imap::probe_server_certificate(&host, port).await?;
+    let chain = chain_der
+        .into_iter()
+        .map(|der| {
+            let sha256 = nimbus_core::tls::fingerprint_sha256(&der);
+            ProbedCertEntry { der, sha256 }
+        })
+        .collect();
+    Ok(ProbedCert { chain, host })
 }
 
 /// Validate IMAP credentials by actually logging in.
@@ -654,30 +667,6 @@ async fn office_close_attachment(
     .await
 }
 
-/// Percent-encode every byte that isn't safe in a URL query value
-/// per RFC 3986 §3.4. Avoids pulling in a whole `url` / `urlencoding`
-/// crate just for the Stirling fileUrl parameter — a few dozen
-/// bytes of code instead of a 50-KB dependency.
-fn percent_encode_query(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for byte in value.bytes() {
-        match byte {
-            // RFC 3986 unreserved set + a few extras that are safe
-            // inside a query (the spec actually allows more, but
-            // sticking to this set keeps round-tripping bullet-proof
-            // across whatever Stirling version the user has).
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                out.push(byte as char);
-            }
-            other => {
-                out.push('%');
-                out.push_str(&format!("{:02X}", other));
-            }
-        }
-    }
-    out
-}
-
 /// Result of `pdf_open_attachment`. Mirrors `OfficeOpenResult` so
 /// the frontend can treat both viewers identically — same webview-
 /// open + cleanup-on-close shape, the only difference is which URL
@@ -689,35 +678,25 @@ struct PdfOpenResult {
     temp_path: String,
 }
 
-/// Open a PDF attachment in either the user's configured Stirling-PDF
-/// instance (when `AppSettings.stirling_pdf_url` is set) or
-/// Nextcloud's built-in PDF viewer (when it's not). Same temp-upload
-/// + cleanup-on-close machinery as the Office flow:
+/// Open a PDF attachment in Nextcloud's built-in PDF viewer.
+/// Same temp-upload + cleanup-on-close machinery as the Office flow:
 ///
 ///   - Bytes go to `/Nimbus Mail/temp/<uuid>-<filename>` on the user's
 ///     Nextcloud.
-///   - For Nextcloud's viewer we use the same `index.php/f/<fileid>`
-///     deep link Office uses; Files routes the fileid to its
-///     registered handler (the PDF viewer for `.pdf`).
-///   - For Stirling-PDF we additionally mint an unprotected public
-///     share so Stirling's frontend can `fetch` the file
-///     server-side — same network-scope your Office viewer already
-///     trusts. The Stirling URL carries `?fileUrl=<encoded>` which
-///     Stirling-PDF accepts on its viewer entry; if a particular
-///     Stirling version doesn't auto-load, the user lands on the
-///     Stirling UI with the URL one paste away.
+///   - We use the same `index.php/f/<fileid>` deep link the Office
+///     viewer uses; Files routes the fileid to its registered
+///     handler, which for `.pdf` is Nextcloud's built-in PDF
+///     viewer.
 ///
 /// On `pdf_close_attachment` (or the startup sweep) the temp file
-/// is DAV-DELETED, which atomically invalidates the public-share
-/// token so the URL stops resolving the moment the viewer window
-/// closes — no manual share-revoke step needed.
+/// is DAV-DELETED so the viewer URL stops resolving once the
+/// viewer window closes.
 #[tauri::command]
 async fn pdf_open_attachment(
     nc_id: String,
     filename: String,
     data: Vec<u8>,
     content_type: Option<String>,
-    settings: State<'_, SharedSettings>,
 ) -> Result<PdfOpenResult, NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
@@ -742,53 +721,15 @@ async fn pdf_open_attachment(
     )
     .await?;
 
-    // Stirling URL is read once up front so a settings edit
-    // mid-render still snaps to the value at click-time. Trim
-    // trailing slashes defensively — users routinely paste them
-    // from a browser address bar.
-    let stirling_url = {
-        let s = settings.read().await;
-        s.stirling_pdf_url
-            .as_ref()
-            .map(|u| u.trim().trim_end_matches('/').to_string())
-            .filter(|u| !u.is_empty())
-    };
-
-    let url = match stirling_url {
-        Some(stirling) => {
-            // Mint an anonymous share so Stirling's server can
-            // fetch the bytes without our app password. The share
-            // dies the moment we DELETE the temp file on close —
-            // same lifetime as the viewer window.
-            let share = nimbus_nextcloud::create_public_share(
-                &account.server_url,
-                &account.username,
-                &app_password,
-                &temp_path,
-                None,
-            )
-            .await?;
-            // Append `/download` so Stirling fetches the raw bytes
-            // rather than the share's HTML preview page.
-            let download_url = format!("{}/download", share.url.trim_end_matches('/'));
-            format!(
-                "{}/?fileUrl={}",
-                stirling,
-                percent_encode_query(&download_url)
-            )
-        }
-        None => {
-            let file_id = nimbus_nextcloud::propfind_fileid(
-                &account.server_url,
-                &account.username,
-                &app_password,
-                &temp_path,
-            )
-            .await?;
-            let server = account.server_url.trim_end_matches('/');
-            format!("{server}/index.php/f/{file_id}")
-        }
-    };
+    let file_id = nimbus_nextcloud::propfind_fileid(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &temp_path,
+    )
+    .await?;
+    let server = account.server_url.trim_end_matches('/');
+    let url = format!("{server}/index.php/f/{file_id}");
 
     Ok(PdfOpenResult { url, temp_path })
 }
@@ -866,6 +807,80 @@ async fn office_sweep_temp(nc_id: String) -> Result<u32, NimbusError> {
         tracing::info!("office_sweep_temp: cleaned {swept} stale file(s)");
     }
     Ok(swept)
+}
+
+/// Open an attachment in its OS-default app so the user can print
+/// it from there with the app's own print dialog. Used by the
+/// "🖨 Open to print…" entry in the attachment dropdown.
+///
+/// Why this shape: the *generic* OS print dialog (Windows'
+/// `PrintDialog`, the WinForms printer chooser) is just a printer
+/// picker — it doesn't show the file, and it relies on each
+/// file type's `PrintTo` verb being registered (Edge doesn't
+/// register PrintTo for PDFs, so calling it for `.pdf` from a
+/// fresh Windows install silently fails). The webview-rendered
+/// Chromium print preview is brittle inside Tauri's sandbox.
+///
+/// What works reliably: open the file in its default handler
+/// (Edge / Acrobat for PDF, Word for `.docx`, Photos for images,
+/// Notepad for text, etc.) and let the user press **Ctrl/Cmd-P**.
+/// Each app's own print dialog shows a real preview of the file
+/// alongside the printer chooser — strictly better UX than the
+/// generic OS dialog. The trade-off is one extra keystroke,
+/// which the menu label calls out so the user expects it.
+///
+/// The temp file is kept for 10 minutes so the user has time
+/// to actually print before we clean up.
+#[tauri::command]
+async fn print_attachment(file_name: String, bytes: Vec<u8>) -> Result<(), NimbusError> {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!("nimbus-print-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| NimbusError::Other(format!("create print temp dir: {e}")))?;
+
+    // Strip path separators / NUL from the filename so the spooler
+    // sees a flat name in our temp dir, not a path traversal.
+    let safe_name: String = file_name
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | '\0' => '_',
+            _ => c,
+        })
+        .collect();
+    let safe_name = if safe_name.trim().is_empty() {
+        "attachment".to_string()
+    } else {
+        safe_name
+    };
+    let mut path = dir.clone();
+    path.push(&safe_name);
+    std::fs::write(&path, &bytes)
+        .map_err(|e| NimbusError::Other(format!("write print temp file: {e}")))?;
+
+    // `open::that_detached` is the cross-platform "default verb"
+    // launcher: ShellExecute open on Windows, `open` on macOS,
+    // `xdg-open` (and friends) on Linux. `_detached` so we don't
+    // hold a child handle the user could orphan by closing Nimbus.
+    if let Err(e) = open::that_detached(&path) {
+        let _ = std::fs::remove_dir_all(&dir);
+        return Err(NimbusError::Other(format!(
+            "failed to open '{}' for printing: {e}",
+            path.display()
+        )));
+    }
+
+    let cleanup_dir = dir;
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_secs(600)).await;
+        if let Err(e) = tokio::fs::remove_dir_all(&cleanup_dir).await {
+            tracing::debug!(
+                "print_attachment cleanup: failed to remove {}: {e}",
+                cleanup_dir.display()
+            );
+        }
+    });
+
+    Ok(())
 }
 
 // ── Nextcloud Talk ──────────────────────────────────────────────
@@ -4096,6 +4111,7 @@ fn main() {
             office_sweep_temp,
             pdf_open_attachment,
             pdf_close_attachment,
+            print_attachment,
             save_bytes_to_path,
             sync_nextcloud_contacts,
             get_contacts_sync_status,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -192,6 +192,29 @@
     }
   }
 
+  /** Best-effort startup cleanup for the Office viewer's temp area
+   *  on every connected Nextcloud. If Nimbus crashed mid-edit, or
+   *  `office_close_attachment` errored on the way out last session,
+   *  the user's `/Nimbus Mail/temp` folder accumulates orphan
+   *  uploads. The Rust sweeper scopes by mtime so a still-open
+   *  edit window in a parallel Nimbus instance doesn't get its
+   *  file pulled out from under it. Failures are logged and
+   *  swallowed — no toast, no UI block. */
+  async function sweepNextcloudTempFiles() {
+    try {
+      const accounts = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      for (const a of accounts) {
+        try {
+          await invoke('office_sweep_temp', { ncId: a.id })
+        } catch (e) {
+          console.warn('office_sweep_temp failed for', a.id, e)
+        }
+      }
+    } catch (e) {
+      console.warn('sweepNextcloudTempFiles: get_nextcloud_accounts failed', e)
+    }
+  }
+
   function shouldNotify(): boolean {
     return (
       notificationsGranted && (appPrefs?.notifications_enabled ?? true)
@@ -255,6 +278,7 @@
   $effect(() => {
     loadAppPrefs()
     bootstrapNotifications()
+    void sweepNextcloudTempFiles()
 
     let unlistenNewMail: UnlistenFn | null = null
     let unlistenCompose: UnlistenFn | null = null

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -29,6 +29,24 @@
     jmap_url?: string | null
     signature?: string | null
     folder_icons?: FolderIconRule[]
+    /** Per-account TLS trust list. Each entry is a leaf cert the
+     *  user has explicitly trusted via the AccountSetup wizard or
+     *  the Re-trust button below. Round-tripped through
+     *  `update_account` whenever the trust list changes (e.g.
+     *  after a server cert renewal). */
+    trusted_certs?: TrustedCert[]
+    folder_icon_overrides?: Record<string, string>
+  }
+
+  interface TrustedCert {
+    /** DER bytes as a JSON byte-array — matches the Rust
+     *  `Vec<u8>` serialisation. */
+    der: number[]
+    /** SHA-256 fingerprint, lowercase hex with `:` separators. */
+    sha256: string
+    host: string
+    /** Unix epoch seconds when the cert was trusted. */
+    added_at: number
   }
 
   // ── Props ───────────────────────────────────────────────────
@@ -164,6 +182,92 @@
     } catch (e: any) {
       error = typeof e === 'string' ? e : e?.message ?? 'Failed to remove account'
     }
+  }
+
+  // ── TLS re-trust flow ───────────────────────────────────────
+  //
+  // The AccountSetup wizard already trusts a self-signed leaf at
+  // the moment the account is added, but the trust list is frozen
+  // after that. When the user's mail server rotates its cert
+  // (Let's-Encrypt-style renewals on a self-signed CA, manual
+  // re-issuance, etc.) every IMAP/SMTP connect bombs with
+  // "invalid peer certificate: UnknownIssuer" and there's no in-
+  // app way to recover — the user's stuck reading nothing.
+  //
+  // This pair of helpers re-runs the same probe-and-trust dance
+  // the wizard uses, against an account that already exists. The
+  // probe is unverified-TLS (matches `nimbus_imap::
+  // probe_server_certificate`), the user sees the leaf's SHA-256
+  // fingerprint before committing, and the new cert is appended to
+  // `account.trusted_certs` via `update_account`.
+
+  /** Probed cert awaiting confirmation. `null` = no flow open. */
+  let trustPrompt = $state<{
+    account: Account
+    sha256: string
+    der: number[]
+  } | null>(null)
+  let trustBusy = $state(false)
+  let trustError = $state('')
+
+  interface ProbedCert {
+    der: number[]
+    sha256: string
+  }
+
+  async function startRetrust(account: Account) {
+    trustError = ''
+    trustBusy = true
+    try {
+      const probed = await invoke<ProbedCert>('probe_server_certificate', {
+        host: account.imap_host,
+        port: account.imap_port,
+      })
+      trustPrompt = {
+        account,
+        sha256: probed.sha256,
+        der: probed.der,
+      }
+    } catch (e: any) {
+      trustError = typeof e === 'string' ? e : e?.message ?? 'Failed to probe server certificate'
+    } finally {
+      trustBusy = false
+    }
+  }
+
+  async function commitRetrust() {
+    if (!trustPrompt || trustBusy) return
+    trustBusy = true
+    trustError = ''
+    try {
+      // Append the new cert to the account's trust list. We don't
+      // dedupe — `nimbus_core::tls::build_client_config` happily
+      // accepts duplicates, and an exact-match dupe is harmless.
+      // Anything else (cert renewed under same CN, server moved
+      // hosts, …) is a *new* entry the user explicitly wants.
+      const next: TrustedCert = {
+        der: trustPrompt.der,
+        sha256: trustPrompt.sha256,
+        host: trustPrompt.account.imap_host,
+        added_at: Math.floor(Date.now() / 1000),
+      }
+      const updated: Account = {
+        ...trustPrompt.account,
+        trusted_certs: [...(trustPrompt.account.trusted_certs ?? []), next],
+      }
+      await invoke('update_account', { account: updated })
+      trustPrompt = null
+      await loadAccounts()
+    } catch (e: any) {
+      trustError = typeof e === 'string' ? e : e?.message ?? 'Failed to update account'
+    } finally {
+      trustBusy = false
+    }
+  }
+
+  function cancelRetrust() {
+    trustPrompt = null
+    trustError = ''
   }
 
   // ── Signature editing ───────────────────────────────────────
@@ -453,12 +557,22 @@
                   {/if}
                 </div>
               </div>
-              <button
-                class="btn btn-sm preset-outlined-error-500"
-                onclick={() => removeAccount(account.id, account.email)}
-              >
-                Remove
-              </button>
+              <div class="flex flex-col items-end gap-1">
+                <button
+                  class="btn btn-sm preset-outlined-surface-500 text-xs"
+                  disabled={trustBusy}
+                  title="Probe the IMAP server's current TLS certificate and add it to this account's trust list. Use after a server cert renewal if connections start failing with 'invalid peer certificate / UnknownIssuer'."
+                  onclick={() => void startRetrust(account)}
+                >
+                  {trustBusy ? '…' : '🔒 Trust server cert'}
+                </button>
+                <button
+                  class="btn btn-sm preset-outlined-error-500"
+                  onclick={() => removeAccount(account.id, account.email)}
+                >
+                  Remove
+                </button>
+              </div>
             </div>
 
             <div class="mt-4 pt-4 border-t border-surface-200 dark:border-surface-700">
@@ -565,3 +679,63 @@
     </div>
   </div>
 </div>
+
+<!-- TLS re-trust confirm. Shown after `startRetrust` probes the
+     IMAP host and captures a leaf cert. The user sees the SHA-256
+     so they can compare against what they expected (matches the
+     fingerprint Nextcloud / Let's Encrypt / their CA prints) before
+     trusting it. -->
+{#if trustPrompt}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget && !trustBusy) cancelRetrust() }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-md max-w-full p-5">
+      <h3 class="text-base font-semibold mb-1">Trust this server certificate?</h3>
+      <p class="text-xs text-surface-500 mb-3">
+        For <span class="font-medium text-surface-700 dark:text-surface-300">{trustPrompt.account.email}</span>
+        on <span class="font-mono">{trustPrompt.account.imap_host}:{trustPrompt.account.imap_port}</span>.
+        Compare the SHA-256 against what your server admin (or Nextcloud's
+        <em>Personal → Security</em> page) shows before clicking Trust.
+      </p>
+
+      <div class="text-xs text-surface-500 mb-1">SHA-256 fingerprint</div>
+      <p class="font-mono text-xs wrap-break-word p-2 rounded bg-surface-100 dark:bg-surface-800 mb-3">
+        {trustPrompt.sha256}
+      </p>
+
+      {#if trustError}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{trustError}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500"
+          disabled={trustBusy}
+          onclick={cancelRetrust}
+        >Cancel</button>
+        <button
+          class="btn preset-filled-primary-500"
+          disabled={trustBusy}
+          onclick={() => void commitRetrust()}
+        >{trustBusy ? 'Trusting…' : 'Trust'}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- Standalone error surface for the probe path — fires when
+     `startRetrust` itself errored (no modal opens) so the user
+     still sees what went wrong. -->
+{#if trustError && !trustPrompt}
+  <div class="fixed bottom-4 right-4 z-50 max-w-sm bg-red-500/95 text-white text-sm rounded-md shadow-lg px-3 py-2">
+    {trustError}
+    <button
+      class="ml-2 underline"
+      onclick={() => (trustError = '')}
+    >Dismiss</button>
+  </div>
+{/if}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -60,6 +60,10 @@
     start_minimized: boolean
     theme_name: string
     theme_mode: ThemeMode
+    /** Optional Stirling-PDF base URL. When set, PDF attachments
+     *  open in this instance's embedded viewer; when empty, they
+     *  open in Nextcloud's built-in PDF viewer. */
+    stirling_pdf_url: string | null
   }
 
   let appSettings = $state<AppSettings>({
@@ -70,6 +74,7 @@
     start_minimized: false,
     theme_name: 'cerberus',
     theme_mode: 'system',
+    stirling_pdf_url: null,
   })
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
@@ -337,6 +342,30 @@
             onchange={scheduleSave}
           />
           <span>Start minimized to tray</span>
+        </label>
+
+        <!-- Stirling-PDF integration (Issue #65). Empty / blank
+             value falls back to Nextcloud's built-in PDF viewer
+             on PDF attachment clicks. Two-way bound through a
+             tiny `||`-coalesce so the JSON `null` from Rust
+             round-trips to an empty input cleanly. -->
+        <label class="flex flex-col gap-1">
+          <span>Stirling-PDF server URL (optional)</span>
+          <input
+            type="url"
+            placeholder="https://pdf.example.com"
+            class="input text-sm py-1 px-2"
+            value={appSettings.stirling_pdf_url ?? ''}
+            oninput={(e) => {
+              const v = (e.currentTarget as HTMLInputElement).value.trim()
+              appSettings.stirling_pdf_url = v ? v : null
+            }}
+            onchange={scheduleSave}
+          />
+          <span class="text-xs text-surface-500">
+            When set, PDF attachments open in this Stirling-PDF instance instead
+            of Nextcloud's built-in viewer.
+          </span>
         </label>
       </div>
     </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -78,10 +78,6 @@
     start_minimized: boolean
     theme_name: string
     theme_mode: ThemeMode
-    /** Optional Stirling-PDF base URL. When set, PDF attachments
-     *  open in this instance's embedded viewer; when empty, they
-     *  open in Nextcloud's built-in PDF viewer. */
-    stirling_pdf_url: string | null
   }
 
   let appSettings = $state<AppSettings>({
@@ -92,7 +88,6 @@
     start_minimized: false,
     theme_name: 'cerberus',
     theme_mode: 'system',
-    stirling_pdf_url: null,
   })
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
@@ -196,24 +191,31 @@
   //
   // This pair of helpers re-runs the same probe-and-trust dance
   // the wizard uses, against an account that already exists. The
-  // probe is unverified-TLS (matches `nimbus_imap::
-  // probe_server_certificate`), the user sees the leaf's SHA-256
-  // fingerprint before committing, and the new cert is appended to
-  // `account.trusted_certs` via `update_account`.
+  // probe captures the *full chain* (leaf + intermediates) the
+  // server is currently presenting, the user reviews each
+  // fingerprint, and on confirm every cert in the chain is
+  // appended to `account.trusted_certs`. Trusting the whole chain
+  // (not just the leaf) means a future leaf reissue under the
+  // same intermediate, or a server that reorders certs on the
+  // wire, still resolves through the verifier's chain-walk
+  // matcher without dropping the user back into this prompt.
 
-  /** Probed cert awaiting confirmation. `null` = no flow open. */
-  let trustPrompt = $state<{
-    account: Account
-    sha256: string
-    der: number[]
-  } | null>(null)
-  let trustBusy = $state(false)
-  let trustError = $state('')
-
-  interface ProbedCert {
+  interface ProbedCertEntry {
     der: number[]
     sha256: string
   }
+  interface ProbedCert {
+    chain: ProbedCertEntry[]
+    host: string
+  }
+
+  /** Probed chain awaiting confirmation. `null` = no flow open. */
+  let trustPrompt = $state<{
+    account: Account
+    chain: ProbedCertEntry[]
+  } | null>(null)
+  let trustBusy = $state(false)
+  let trustError = $state('')
 
   async function startRetrust(account: Account) {
     trustError = ''
@@ -225,8 +227,7 @@
       })
       trustPrompt = {
         account,
-        sha256: probed.sha256,
-        der: probed.der,
+        chain: probed.chain,
       }
     } catch (e: any) {
       trustError = typeof e === 'string' ? e : e?.message ?? 'Failed to probe server certificate'
@@ -240,20 +241,22 @@
     trustBusy = true
     trustError = ''
     try {
-      // Append the new cert to the account's trust list. We don't
-      // dedupe — `nimbus_core::tls::build_client_config` happily
-      // accepts duplicates, and an exact-match dupe is harmless.
-      // Anything else (cert renewed under same CN, server moved
-      // hosts, …) is a *new* entry the user explicitly wants.
-      const next: TrustedCert = {
-        der: trustPrompt.der,
-        sha256: trustPrompt.sha256,
-        host: trustPrompt.account.imap_host,
-        added_at: Math.floor(Date.now() / 1000),
-      }
+      // Append every cert in the probed chain to the account's
+      // trust list. We don't dedupe — `nimbus_core::tls::
+      // build_client_config` happily accepts duplicates, and an
+      // exact-match dupe is harmless. Anything else (cert renewed
+      // under same CN, server moved hosts, …) is a *new* entry
+      // the user explicitly wants.
+      const addedAt = Math.floor(Date.now() / 1000)
+      const additions: TrustedCert[] = trustPrompt.chain.map((entry) => ({
+        der: entry.der,
+        sha256: entry.sha256,
+        host: trustPrompt!.account.imap_host,
+        added_at: addedAt,
+      }))
       const updated: Account = {
         ...trustPrompt.account,
-        trusted_certs: [...(trustPrompt.account.trusted_certs ?? []), next],
+        trusted_certs: [...(trustPrompt.account.trusted_certs ?? []), ...additions],
       }
       await invoke('update_account', { account: updated })
       trustPrompt = null
@@ -446,30 +449,6 @@
             onchange={scheduleSave}
           />
           <span>Start minimized to tray</span>
-        </label>
-
-        <!-- Stirling-PDF integration (Issue #65). Empty / blank
-             value falls back to Nextcloud's built-in PDF viewer
-             on PDF attachment clicks. Two-way bound through a
-             tiny `||`-coalesce so the JSON `null` from Rust
-             round-trips to an empty input cleanly. -->
-        <label class="flex flex-col gap-1">
-          <span>Stirling-PDF server URL (optional)</span>
-          <input
-            type="url"
-            placeholder="https://pdf.example.com"
-            class="input text-sm py-1 px-2"
-            value={appSettings.stirling_pdf_url ?? ''}
-            oninput={(e) => {
-              const v = (e.currentTarget as HTMLInputElement).value.trim()
-              appSettings.stirling_pdf_url = v ? v : null
-            }}
-            onchange={scheduleSave}
-          />
-          <span class="text-xs text-surface-500">
-            When set, PDF attachments open in this Stirling-PDF instance instead
-            of Nextcloud's built-in viewer.
-          </span>
         </label>
       </div>
     </div>
@@ -702,10 +681,20 @@
         <em>Personal → Security</em> page) shows before clicking Trust.
       </p>
 
-      <div class="text-xs text-surface-500 mb-1">SHA-256 fingerprint</div>
-      <p class="font-mono text-xs wrap-break-word p-2 rounded bg-surface-100 dark:bg-surface-800 mb-3">
-        {trustPrompt.sha256}
-      </p>
+      <div class="text-xs text-surface-500 mb-1">
+        SHA-256 fingerprint{trustPrompt.chain.length === 1 ? '' : 's'}
+        ({trustPrompt.chain.length === 1
+          ? 'leaf'
+          : `leaf + ${trustPrompt.chain.length - 1} intermediate${trustPrompt.chain.length === 2 ? '' : 's'}`})
+      </div>
+      <ul class="font-mono text-xs wrap-break-word p-2 rounded bg-surface-100 dark:bg-surface-800 mb-3 space-y-1">
+        {#each trustPrompt.chain as entry, i (entry.sha256)}
+          <li>
+            <span class="text-surface-500">{i === 0 ? 'leaf:' : `int${i}:`}</span>
+            {entry.sha256}
+          </li>
+        {/each}
+      </ul>
 
       {#if trustError}
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{trustError}</p>

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -132,16 +132,24 @@
   // ── TLS-trust prompt state ─────────────────────────────────
   // When test_connection fails because the IMAP server's cert
   // can't be validated, we show a prompt that lets the user trust
-  // the cert and retry. The flow:
+  // the chain and retry. The flow:
   //   1. submit() catches the cert error from test_connection
-  //   2. invoke probe_server_certificate to capture the leaf cert
-  //   3. show ProbedCert details + "Trust this server" button
-  //   4. user confirms → trustedCerts gets the cert → retry submit
+  //   2. invoke probe_server_certificate to capture the full chain
+  //   3. show fingerprints + "Trust this server" button
+  //   4. user confirms → every cert in the chain gets added to
+  //      trustedCerts → retry submit
   // The list rides through to add_account so the saved account
   // remembers the trust decision and uses it on future connects.
-  interface ProbedCert {
+  // Trusting the whole chain (not just the leaf) means a leaf
+  // reissue under the same intermediate, or a server that
+  // reorders its chain, doesn't drop the user back into this
+  // prompt.
+  interface ProbedCertEntry {
     der: number[]
     sha256: string
+  }
+  interface ProbedCert {
+    chain: ProbedCertEntry[]
     host: string
   }
   /** Full Rust `TrustedCert` shape — what `test_connection` and
@@ -190,14 +198,20 @@
 
   function trustPendingCert() {
     if (!pendingCert) return
-    // Promote `ProbedCert` → `TrustedCert` by stamping the trust
-    // timestamp here. The retried `test_connection` and the
-    // eventual `add_account` both deserialize this as the full
-    // Rust `TrustedCert` struct, so the shape has to match.
-    trustedCerts = [
-      ...trustedCerts,
-      { ...pendingCert, added_at: Math.floor(Date.now() / 1000) },
-    ]
+    // Promote every cert in the probed chain → `TrustedCert`. We
+    // trust the whole chain, not just the leaf, so a server that
+    // reorders the chain on a future connect (or reissues the leaf
+    // under the same intermediate) still validates without
+    // re-prompting the user.
+    const addedAt = Math.floor(Date.now() / 1000)
+    const host = pendingCert.host
+    const additions: TrustedCert[] = pendingCert.chain.map((entry) => ({
+      der: entry.der,
+      sha256: entry.sha256,
+      host,
+      added_at: addedAt,
+    }))
+    trustedCerts = [...trustedCerts, ...additions]
     pendingCert = null
     void submit()
   }
@@ -442,10 +456,20 @@
             with your server's actual certificate before trusting.
           </p>
           <p class="text-xs mb-1"><span class="text-surface-500">Host:</span> <span class="font-mono">{pendingCert.host}</span></p>
-          <p class="text-xs mb-3 break-all">
-            <span class="text-surface-500">SHA-256:</span>
-            <span class="font-mono">{pendingCert.sha256}</span>
-          </p>
+          <div class="text-xs mb-3">
+            <p class="text-surface-500 mb-1">
+              SHA-256 fingerprint{pendingCert.chain.length === 1 ? '' : 's'}
+              ({pendingCert.chain.length === 1 ? 'leaf' : `leaf + ${pendingCert.chain.length - 1} intermediate${pendingCert.chain.length === 2 ? '' : 's'}`}):
+            </p>
+            <ul class="space-y-1">
+              {#each pendingCert.chain as entry, i (entry.sha256)}
+                <li class="font-mono break-all">
+                  <span class="text-surface-500">{i === 0 ? 'leaf:' : `int${i}:`}</span>
+                  {entry.sha256}
+                </li>
+              {/each}
+            </ul>
+          </div>
           <div class="flex gap-2">
             <button
               type="button"

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -57,6 +57,11 @@
   let attaching = $state(false)
   let sharing = $state(false)
 
+  // Same password-prompt shape as NextcloudFilePicker — see commit
+  // notes there. Snapshot the selection at click time so toggling
+  // the file tree behind the modal can't change what gets shared.
+  let sharePrompt = $state<{ paths: string[]; password: string } | null>(null)
+
   let selectedFileCount = $derived.by(() => {
     let n = 0
     for (const e of entries) if (!e.is_dir && selected.has(e.path)) n++
@@ -109,21 +114,34 @@
       open Compose with them rendered into the body as a "Shared via
       Nextcloud" block — same shape Compose already produces when the
       share button inside the picker is used. */
-  async function sendAsLink() {
+  function sendAsLink() {
     if (selected.size === 0) return
+    sharePrompt = { paths: Array.from(selected), password: '' }
+    error = ''
+  }
+
+  /** Mint the share links with the password the user picked
+      (empty = unprotected, omitted from the OCS form on the Rust
+      side) and hand them off to Compose. Same error shape as the
+      previous one-click flow. */
+  async function commitShare() {
+    if (!sharePrompt) return
+    const { paths, password } = sharePrompt
     sharing = true
     error = ''
     try {
-      const paths = Array.from(selected)
+      const pw = password.trim() ? password : null
       const links = await Promise.all(
         paths.map(async (p) => {
           const url = await invoke<string>('create_nextcloud_share', {
             ncId: accountId,
             path: p,
+            password: pw,
           })
           return { filename: basename(p), url }
         }),
       )
+      sharePrompt = null
       oncompose({ nextcloudLinks: links })
     } catch (e) {
       error = formatError(e) || 'Failed to create share link(s)'
@@ -211,3 +229,65 @@
     {/if}
   </div>
 </div>
+
+<!-- Password prompt for the public share link. Same UX as the
+     equivalent modal inside NextcloudFilePicker — Enter / "Create
+     with password" gates the share, blank input + "Share without
+     password" preserves the previous one-click flow. -->
+{#if sharePrompt}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget && !sharing) sharePrompt = null }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+      <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
+      <p class="text-xs text-surface-500 mb-3">
+        {sharePrompt.paths.length === 1
+          ? 'Anyone with the link can open the file.'
+          : `Anyone with each link can open ${sharePrompt.paths.length} files.`}
+        Setting a password gates the recipient behind it; leave it empty
+        to share without one.
+      </p>
+
+      <label class="block text-xs text-surface-500 mb-1" for="files-share-pw">Password (optional)</label>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        id="files-share-pw"
+        type="password"
+        class="input w-full text-sm px-2 py-1.5 rounded-md mb-3"
+        placeholder="Leave blank for no password"
+        bind:value={sharePrompt.password}
+        disabled={sharing}
+        autofocus
+        onkeydown={(e) => {
+          if (e.key === 'Enter') { e.preventDefault(); void commitShare() }
+          else if (e.key === 'Escape' && !sharing) { e.preventDefault(); sharePrompt = null }
+        }}
+      />
+
+      {#if error}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500"
+          disabled={sharing}
+          onclick={() => (sharePrompt = null)}
+        >Cancel</button>
+        <button
+          class="btn preset-filled-primary-500"
+          disabled={sharing}
+          onclick={() => void commitShare()}
+        >
+          {#if sharing}Sharing…
+          {:else if sharePrompt.password.trim()}Create with password
+          {:else}Share without password{/if}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -24,6 +24,10 @@
      * without retransmitting the rest of the message.
      */
     part_id: number
+    /** RFC 2392 Content-ID — present on attachments referenced inline
+     *  via `<a href="cid:…">` in the body. Used to route those
+     *  anchor clicks to the right attachment in `attachmentClicked`. */
+    content_id?: string | null
   }
 
   interface Email {
@@ -206,6 +210,22 @@
         if (!href) return
         const existing = a.getAttribute('title')
         a.setAttribute('title', existing ? `${existing} — ${href}` : href)
+
+        // Mark `cid:` anchors so the click interceptor below can
+        // find them quickly (no need to re-parse hrefs every click).
+        // Stripping leading angle brackets just in case the sender
+        // pasted them; mail-parser already strips them on the
+        // attachment side, so casing-only mismatches are the only
+        // resolution failure mode left.
+        if (href.toLowerCase().startsWith('cid:')) {
+          const cid = href.slice(4).trim().replace(/^<|>$/g, '')
+          a.setAttribute('data-nimbus-cid', cid)
+          // Default browser behaviour on `cid:` is "navigate this
+          // frame to a non-existent URL". Pin the anchor to "do
+          // nothing on its own" so clicks fall through to our
+          // listener cleanly.
+          a.setAttribute('target', '_self')
+        }
       })
       // `documentElement.outerHTML` gives us a full `<html>…</html>`,
       // which is exactly what `srcdoc` wants. If parsing somehow gives
@@ -222,6 +242,64 @@
   let bodyHtmlWithTooltips = $derived(
     email?.body_html ? addLinkTooltips(email.body_html) : '',
   )
+
+  // ── cid: anchor click interception ──────────────────────────
+  //
+  // The body iframe runs with `sandbox="allow-same-origin"` so the
+  // parent can read its `contentDocument` (scripts inside the
+  // iframe still can't run — `allow-scripts` is NOT set). We
+  // delegate clicks at the document level: any anchor carrying a
+  // `data-nimbus-cid` attribute (added by `addLinkTooltips`) gets
+  // its default behaviour preventDefault'd, the cid is matched
+  // against the message's attachment list, and the result is
+  // dispatched through `attachmentClicked` — the same single
+  // entry point the Office / PDF viewers (issue #65 follow-up
+  // commits) will branch into.
+  let bodyIframe: HTMLIFrameElement | undefined = $state()
+
+  function onIframeLoad() {
+    const doc = bodyIframe?.contentDocument
+    if (!doc) return
+    // Re-attach on every load so iframe re-creation (new message)
+    // wires the listener fresh. The previous frame's document is
+    // garbage-collected with its window so there's nothing to
+    // detach.
+    doc.addEventListener('click', onBodyClick, true)
+  }
+
+  function onBodyClick(e: Event) {
+    const target = e.target as HTMLElement | null
+    if (!target) return
+    const anchor = target.closest('a[data-nimbus-cid]') as HTMLAnchorElement | null
+    if (!anchor) return
+    e.preventDefault()
+    e.stopPropagation()
+    const cid = anchor.getAttribute('data-nimbus-cid') ?? ''
+    if (!cid || !email) return
+    const att = email.attachments.find(
+      (a) =>
+        a.content_id != null &&
+        a.content_id.toLowerCase() === cid.toLowerCase(),
+    )
+    if (!att) {
+      console.warn(
+        `MailView: cid:${cid} clicked but no matching attachment in this message`,
+      )
+      return
+    }
+    void attachmentClicked(att)
+  }
+
+  /** Single dispatch point for any user-driven attachment open
+   *  request (currently: cid:-anchor clicks; the attachment-tray
+   *  buttons keep their explicit Download / Save-to-NC handlers).
+   *  Upcoming commits in issue #65 branch on `att.content_type` to
+   *  open Office / PDF viewers; for now we fall back to the same
+   *  download flow the tray uses so a click on a cid: link does
+   *  something useful instead of silently failing. */
+  async function attachmentClicked(att: EmailAttachment) {
+    await downloadAttachment(att)
+  }
 
   // ---------------------------------------------------------------------
   // Attachments — download to disk or save into a Nextcloud folder.
@@ -532,11 +610,17 @@
           allow-* tokens) disables scripts, form submission, same-origin,
           and top-navigation — so even malicious mail can't attack the app.
         -->
+        <!-- `allow-same-origin` (without `allow-scripts`!) lets the
+             parent read the iframe's `contentDocument` so we can
+             attach the cid:-click listener. Author scripts still
+             can't run because `allow-scripts` isn't on the list. -->
         <iframe
+          bind:this={bodyIframe}
           title="Message body"
           class="w-full h-full border-0 bg-white"
-          sandbox=""
+          sandbox="allow-same-origin"
           srcdoc={bodyHtmlWithTooltips}
+          onload={onIframeLoad}
         ></iframe>
       {:else}
         <p class="text-sm text-surface-500">(This message has no visible body.)</p>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -290,15 +290,124 @@
     void attachmentClicked(att)
   }
 
+  /** MIME types Nextcloud Office (Collabora) opens in-browser via
+   *  the `index.php/f/<id>` deep link. Plain `text/*` is NOT in
+   *  the list — those open more cheaply in our existing reading
+   *  pane and routing them through Office for view-only is overkill.
+   *  When the type is missing / generic (`application/octet-stream`,
+   *  common on incoming mail) we fall back to a filename-extension
+   *  check below. */
+  const OFFICE_MIME_TYPES = new Set([
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.oasis.opendocument.text',
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/vnd.oasis.opendocument.presentation',
+    'application/msword',
+    'application/vnd.ms-excel',
+    'application/vnd.ms-powerpoint',
+    'text/csv',
+  ])
+  const OFFICE_EXTENSIONS = new Set([
+    'docx', 'xlsx', 'pptx', 'odt', 'ods', 'odp',
+    'doc', 'xls', 'ppt', 'csv',
+  ])
+
+  function isOfficeAttachment(att: EmailAttachment): boolean {
+    if (OFFICE_MIME_TYPES.has(att.content_type)) return true
+    const dot = att.filename.lastIndexOf('.')
+    if (dot < 0) return false
+    return OFFICE_EXTENSIONS.has(att.filename.slice(dot + 1).toLowerCase())
+  }
+
   /** Single dispatch point for any user-driven attachment open
    *  request (currently: cid:-anchor clicks; the attachment-tray
    *  buttons keep their explicit Download / Save-to-NC handlers).
-   *  Upcoming commits in issue #65 branch on `att.content_type` to
-   *  open Office / PDF viewers; for now we fall back to the same
-   *  download flow the tray uses so a click on a cid: link does
-   *  something useful instead of silently failing. */
+   *  Branches by content type: Office docs → upload-to-NC + open
+   *  in a fresh webview window via Collabora; everything else
+   *  falls through to the same download flow the tray uses. */
   async function attachmentClicked(att: EmailAttachment) {
+    if (isOfficeAttachment(att)) {
+      await openInOfficeViewer(att)
+      return
+    }
     await downloadAttachment(att)
+  }
+
+  /** Upload `att` to the user's first connected Nextcloud, ask the
+   *  backend for the deep-link URL, and open it in a fresh webview
+   *  window. On window close we DELETE the temp file so the user's
+   *  Nextcloud doesn't accumulate every attachment they've ever
+   *  previewed.
+   *
+   *  Multi-Nextcloud support is intentionally simple here: pick the
+   *  first connected account. The Settings UI will let users choose
+   *  a default once we have more than one user with two NCs. */
+  async function openInOfficeViewer(att: EmailAttachment) {
+    if (!email || uid == null) return
+    setBusy(att.part_id, true)
+    try {
+      const ncAccounts = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      if (ncAccounts.length === 0) {
+        error =
+          'Connect a Nextcloud account in Settings to open Office files in the embedded viewer.'
+        return
+      }
+      const ncId = ncAccounts[0].id
+
+      // Pull the bytes — `download_email_attachment` re-fetches the
+      // raw MIME body and decodes the matching part. Fast on a
+      // cached message, a single IMAP round-trip otherwise.
+      const bytes = await invoke<number[]>('download_email_attachment', {
+        accountId: email.account_id,
+        folder: email.folder,
+        uid,
+        partId: att.part_id,
+      })
+
+      const result = await invoke<{ url: string; tempPath: string }>(
+        'office_open_attachment',
+        {
+          ncId,
+          filename: att.filename,
+          data: bytes,
+          contentType: att.content_type || null,
+        },
+      )
+
+      // Open in a top-level Tauri webview window. Each viewer gets
+      // a unique label so multiple attachments can be open at once
+      // without colliding. The `tauri://destroyed` listener fires
+      // exactly once per window — we use it to expunge the temp
+      // file from the user's Nextcloud.
+      const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow')
+      const label = `office-${crypto.randomUUID().replaceAll('-', '')}`
+      const win = new WebviewWindow(label, {
+        url: result.url,
+        title: att.filename,
+        width: 1200,
+        height: 800,
+      })
+      // Attach the cleanup listener BEFORE awaiting create — the
+      // window emits `tauri://destroyed` once it's gone, and on a
+      // fast close we'd otherwise miss the event. Errors are
+      // swallowed; the startup sweeper picks up any orphans.
+      void win.once('tauri://destroyed', async () => {
+        try {
+          await invoke('office_close_attachment', {
+            ncId,
+            tempPath: result.tempPath,
+          })
+        } catch (e) {
+          console.warn('office_close_attachment failed:', e)
+        }
+      })
+    } catch (e) {
+      error = formatError(e) || 'Failed to open in Office'
+    } finally {
+      setBusy(att.part_id, false)
+    }
   }
 
   // ---------------------------------------------------------------------
@@ -576,6 +685,20 @@
               <span class="font-medium truncate max-w-60" title={att.filename}>{att.filename}</span>
               {#if att.size != null}
                 <span class="text-xs text-surface-500">{formatAttSize(att.size)}</span>
+              {/if}
+              {#if isOfficeAttachment(att)}
+                <!-- Office-compatible attachment → click opens
+                     directly in an embedded Collabora window. The
+                     download / Save-to-NC paths are still one click
+                     away below. -->
+                <button
+                  class="btn btn-sm preset-filled-primary-500 text-xs"
+                  disabled={busy}
+                  onclick={() => openInOfficeViewer(att)}
+                  title="Open in Nextcloud Office (Collabora)"
+                >
+                  {busy ? '…' : '📝 Open in Office'}
+                </button>
               {/if}
               <button
                 class="btn btn-sm preset-outlined-surface-500 text-xs"

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -331,8 +331,8 @@
    *  buttons keep their explicit Download / Save-to-NC handlers).
    *  Branches by content type:
    *    - Office docs → upload-to-NC + open in a Collabora window
-   *    - PDFs → upload-to-NC + Stirling-PDF if configured, else
-   *      Nextcloud's built-in PDF viewer
+   *    - PDFs → upload-to-NC + open in Nextcloud's built-in PDF
+   *      viewer
    *    - everything else → fall through to download */
   async function attachmentClicked(att: EmailAttachment) {
     if (isOfficeAttachment(att)) {
@@ -421,11 +421,12 @@
     }
   }
 
-  /** PDF mirror of `openInOfficeViewer`. The backend command
-   *  decides between Stirling-PDF (if a URL is configured in
-   *  Settings) and Nextcloud's built-in PDF viewer; the frontend
-   *  just opens whichever URL it returns and registers the same
-   *  close-cleanup hook. */
+  /** PDF mirror of `openInOfficeViewer`. The backend uploads the
+   *  bytes to a temp folder on the user's Nextcloud and returns a
+   *  deep link into Nextcloud's built-in PDF viewer; the frontend
+   *  opens that URL in a Tauri window and registers the same
+   *  close-cleanup hook (DAV-deletes the temp file when the
+   *  window is destroyed). */
   async function openInPdfViewer(att: EmailAttachment) {
     if (!email || uid == null) return
     setBusy(att.part_id, true)
@@ -580,6 +581,67 @@
    */
   function startSaveToNextcloud(att: EmailAttachment) {
     savingAttachment = att
+  }
+
+  /** Pull bytes for the attachment and hand them to the backend's
+   *  `print_attachment`, which writes the file to OS temp and
+   *  opens it with the user's default app for that file type
+   *  (Word for .docx, Edge / Acrobat for .pdf, Photos for images,
+   *  Notepad for text, etc.). The user then hits Ctrl/Cmd-P from
+   *  inside that app to get the system printer-chooser dialog. */
+  async function printAttachment(att: EmailAttachment) {
+    if (!email || uid == null) return
+    setBusy(att.part_id, true)
+    try {
+      const bytes = await invoke<number[]>('download_email_attachment', {
+        accountId: email.account_id,
+        folder: email.folder,
+        uid,
+        partId: att.part_id,
+      })
+      await invoke('print_attachment', {
+        fileName: att.filename,
+        bytes,
+      })
+    } catch (e) {
+      error = formatError(e) || 'Failed to print attachment'
+    } finally {
+      setBusy(att.part_id, false)
+    }
+  }
+
+  /** Copy the attachment filename to the clipboard. Useful when the
+   *  user wants to paste it into another app (e.g. as a reference
+   *  in a Talk message) without saving the file first. */
+  async function copyFilename(att: EmailAttachment) {
+    try {
+      await navigator.clipboard.writeText(att.filename)
+    } catch (e) {
+      console.warn('clipboard write failed', e)
+    }
+  }
+
+  // ── Per-attachment action menu (Outlook-style chevron dropdown) ──
+  // One menu open at a time, keyed by `part_id`. `null` = closed.
+  // Anchor + position are captured at click time so the popup floats
+  // next to the row that owns it without needing a portal.
+  let openMenuFor = $state<number | null>(null)
+
+  function toggleMenu(att: EmailAttachment) {
+    openMenuFor = openMenuFor === att.part_id ? null : att.part_id
+  }
+  function closeMenu() {
+    openMenuFor = null
+  }
+
+  /** Click handler that runs an action and closes the menu in one
+   *  go. `void`-wraps async handlers so the inline onclick stays
+   *  synchronous (Svelte warns otherwise). */
+  function runAndClose(fn: () => void | Promise<void>) {
+    return () => {
+      closeMenu()
+      void fn()
+    }
   }
 
   async function onSavePicked(ncId: string, folderPath: string) {
@@ -750,17 +812,23 @@
         <ul class="flex flex-wrap gap-2">
           {#each email.attachments as att (att.part_id)}
             {@const busy = busyParts.has(att.part_id)}
-            <li class="flex items-center gap-2 px-3 py-1.5 rounded-md bg-surface-100 dark:bg-surface-800 text-sm">
+            {@const isOffice = isOfficeAttachment(att)}
+            {@const isPdf = isPdfAttachment(att)}
+            {@const menuOpen = openMenuFor === att.part_id}
+            <li class="relative flex items-center gap-2 pl-3 pr-1 py-1.5 rounded-md bg-surface-100 dark:bg-surface-800 text-sm">
               <span class="text-base">{attachmentIcon(att)}</span>
               <span class="font-medium truncate max-w-60" title={att.filename}>{att.filename}</span>
               {#if att.size != null}
                 <span class="text-xs text-surface-500">{formatAttSize(att.size)}</span>
               {/if}
-              {#if isOfficeAttachment(att)}
-                <!-- Office-compatible attachment → click opens
-                     directly in an embedded Collabora window. The
-                     download / Save-to-NC paths are still one click
-                     away below. -->
+
+              <!-- Primary action — picks the most natural open
+                   verb for the attachment type. Same as a click on
+                   the chip itself; the dropdown to the right
+                   exposes everything else (Print, Download, Save
+                   to NC, Copy filename). Mirrors Outlook's
+                   "click = open, ▾ = more". -->
+              {#if isOffice}
                 <button
                   class="btn btn-sm preset-filled-primary-500 text-xs"
                   disabled={busy}
@@ -769,32 +837,90 @@
                 >
                   {busy ? '…' : '📝 Open in Office'}
                 </button>
-              {:else if isPdfAttachment(att)}
+              {:else if isPdf}
                 <button
                   class="btn btn-sm preset-filled-primary-500 text-xs"
                   disabled={busy}
                   onclick={() => openInPdfViewer(att)}
-                  title="Open in the embedded PDF viewer (Stirling-PDF if configured, otherwise Nextcloud's built-in)"
+                  title="Open in Nextcloud's built-in PDF viewer"
                 >
                   {busy ? '…' : '📄 Open PDF'}
                 </button>
+              {:else}
+                <button
+                  class="btn btn-sm preset-filled-primary-500 text-xs"
+                  disabled={busy}
+                  onclick={() => downloadAttachment(att)}
+                  title="Download to your computer"
+                >
+                  {busy ? '…' : '⬇ Download'}
+                </button>
               {/if}
+
+              <!-- Chevron toggle. Sits flush against the primary
+                   button so they read as one pill with a split
+                   click target. -->
               <button
-                class="btn btn-sm preset-outlined-surface-500 text-xs"
+                class="btn btn-sm preset-outlined-surface-500 text-xs px-2"
                 disabled={busy}
-                onclick={() => downloadAttachment(att)}
-                title="Download to your computer"
-              >
-                {busy ? '…' : '⬇ Download'}
-              </button>
-              <button
-                class="btn btn-sm preset-outlined-primary-500 text-xs"
-                disabled={busy}
-                onclick={() => startSaveToNextcloud(att)}
-                title="Save this attachment to a folder in your Nextcloud"
-              >
-                {busy ? '…' : '☁ Save to Nextcloud'}
-              </button>
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                aria-label="More attachment actions"
+                onclick={() => toggleMenu(att)}
+                title="More actions"
+              >▾</button>
+
+              {#if menuOpen}
+                <!-- Click-outside catcher. Sits behind the menu so
+                     anywhere outside dismisses, but the menu itself
+                     (z-50) stays above and receives clicks. -->
+                <button
+                  type="button"
+                  class="fixed inset-0 z-40 cursor-default"
+                  aria-label="Close menu"
+                  onclick={closeMenu}
+                ></button>
+                <div
+                  role="menu"
+                  class="absolute right-0 top-full mt-1 z-50 min-w-52 rounded-md shadow-lg border border-surface-300 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 py-1 text-sm"
+                >
+                  {#if isOffice}
+                    <button
+                      role="menuitem"
+                      class="block w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
+                      onclick={runAndClose(() => openInOfficeViewer(att))}
+                    >📝 Open in Office</button>
+                  {:else if isPdf}
+                    <button
+                      role="menuitem"
+                      class="block w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
+                      onclick={runAndClose(() => openInPdfViewer(att))}
+                    >📄 Open PDF</button>
+                  {/if}
+                  <button
+                    role="menuitem"
+                    class="block w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
+                    onclick={runAndClose(() => printAttachment(att))}
+                    title="Open this attachment in its default desktop app (Ctrl/Cmd-P there to print)"
+                  >🖥 Open in Desktop App</button>
+                  <button
+                    role="menuitem"
+                    class="block w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
+                    onclick={runAndClose(() => downloadAttachment(att))}
+                  >⬇ Save to disk…</button>
+                  <button
+                    role="menuitem"
+                    class="block w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
+                    onclick={runAndClose(() => startSaveToNextcloud(att))}
+                  >☁ Save to Nextcloud…</button>
+                  <div class="my-1 border-t border-surface-200 dark:border-surface-700"></div>
+                  <button
+                    role="menuitem"
+                    class="block w-full text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
+                    onclick={runAndClose(() => copyFilename(att))}
+                  >📋 Copy filename</button>
+                </div>
+              {/if}
             </li>
           {/each}
         </ul>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -321,15 +321,26 @@
     return OFFICE_EXTENSIONS.has(att.filename.slice(dot + 1).toLowerCase())
   }
 
+  function isPdfAttachment(att: EmailAttachment): boolean {
+    if (att.content_type === 'application/pdf') return true
+    return att.filename.toLowerCase().endsWith('.pdf')
+  }
+
   /** Single dispatch point for any user-driven attachment open
    *  request (currently: cid:-anchor clicks; the attachment-tray
    *  buttons keep their explicit Download / Save-to-NC handlers).
-   *  Branches by content type: Office docs → upload-to-NC + open
-   *  in a fresh webview window via Collabora; everything else
-   *  falls through to the same download flow the tray uses. */
+   *  Branches by content type:
+   *    - Office docs → upload-to-NC + open in a Collabora window
+   *    - PDFs → upload-to-NC + Stirling-PDF if configured, else
+   *      Nextcloud's built-in PDF viewer
+   *    - everything else → fall through to download */
   async function attachmentClicked(att: EmailAttachment) {
     if (isOfficeAttachment(att)) {
       await openInOfficeViewer(att)
+      return
+    }
+    if (isPdfAttachment(att)) {
+      await openInPdfViewer(att)
       return
     }
     await downloadAttachment(att)
@@ -405,6 +416,65 @@
       })
     } catch (e) {
       error = formatError(e) || 'Failed to open in Office'
+    } finally {
+      setBusy(att.part_id, false)
+    }
+  }
+
+  /** PDF mirror of `openInOfficeViewer`. The backend command
+   *  decides between Stirling-PDF (if a URL is configured in
+   *  Settings) and Nextcloud's built-in PDF viewer; the frontend
+   *  just opens whichever URL it returns and registers the same
+   *  close-cleanup hook. */
+  async function openInPdfViewer(att: EmailAttachment) {
+    if (!email || uid == null) return
+    setBusy(att.part_id, true)
+    try {
+      const ncAccounts = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      if (ncAccounts.length === 0) {
+        error =
+          'Connect a Nextcloud account in Settings to open PDFs in the embedded viewer.'
+        return
+      }
+      const ncId = ncAccounts[0].id
+
+      const bytes = await invoke<number[]>('download_email_attachment', {
+        accountId: email.account_id,
+        folder: email.folder,
+        uid,
+        partId: att.part_id,
+      })
+
+      const result = await invoke<{ url: string; tempPath: string }>(
+        'pdf_open_attachment',
+        {
+          ncId,
+          filename: att.filename,
+          data: bytes,
+          contentType: att.content_type || null,
+        },
+      )
+
+      const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow')
+      const label = `pdf-${crypto.randomUUID().replaceAll('-', '')}`
+      const win = new WebviewWindow(label, {
+        url: result.url,
+        title: att.filename,
+        width: 1200,
+        height: 800,
+      })
+      void win.once('tauri://destroyed', async () => {
+        try {
+          await invoke('pdf_close_attachment', {
+            ncId,
+            tempPath: result.tempPath,
+          })
+        } catch (e) {
+          console.warn('pdf_close_attachment failed:', e)
+        }
+      })
+    } catch (e) {
+      error = formatError(e) || 'Failed to open PDF'
     } finally {
       setBusy(att.part_id, false)
     }
@@ -698,6 +768,15 @@
                   title="Open in Nextcloud Office (Collabora)"
                 >
                   {busy ? '…' : '📝 Open in Office'}
+                </button>
+              {:else if isPdfAttachment(att)}
+                <button
+                  class="btn btn-sm preset-filled-primary-500 text-xs"
+                  disabled={busy}
+                  onclick={() => openInPdfViewer(att)}
+                  title="Open in the embedded PDF viewer (Stirling-PDF if configured, otherwise Nextcloud's built-in)"
+                >
+                  {busy ? '…' : '📄 Open PDF'}
                 </button>
               {/if}
               <button

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -69,6 +69,17 @@
   let downloading = $state(false)
   let sharing = $state(false)
 
+  // Password-protect-the-share modal. `null` = the prompt isn't open;
+  // `paths` is the snapshot of selection at the moment the user
+  // clicked "Share as link" so toggling the file tree behind the
+  // modal can't change what gets shared. `password` is the in-flight
+  // input — empty means "no password" (omitted from the OCS request,
+  // which keeps the share open as before).
+  let sharePrompt = $state<{
+    paths: string[]
+    password: string
+  } | null>(null)
+
   // Selection split by entry type. Folders can be shared as public
   // links but not attached as bytes (Nextcloud has no zip-folder
   // endpoint, so there's nothing meaningful to download). The footer
@@ -119,21 +130,39 @@
     }
   }
 
-  async function shareSelected() {
+  /** Open the password prompt instead of jumping straight to OCS.
+      The modal lets the user opt into a password (or skip with
+      Enter / "Share without password") before any link is minted —
+      no way to forget the password gate, no need to delete + recreate
+      a share if the user changes their mind mid-click. */
+  function shareSelected() {
     if (selected.size === 0 || !onlinks) return
+    sharePrompt = { paths: Array.from(selected), password: '' }
+    error = ''
+  }
+
+  /** Run the actual create_nextcloud_share calls with the password
+      the user picked (empty string = no password, omitted from the
+      OCS form on the Rust side). Same error-surface as the previous
+      direct flow. */
+  async function commitShare() {
+    if (!sharePrompt || !onlinks) return
+    const { paths, password } = sharePrompt
     sharing = true
     error = ''
     try {
-      const paths = Array.from(selected)
+      const pw = password.trim() ? password : null
       const results = await Promise.all(
         paths.map(async (p) => {
           const url = await invoke<string>('create_nextcloud_share', {
             ncId: accountId,
             path: p,
+            password: pw,
           })
           return { filename: basename(p), url } satisfies ShareLink
         }),
       )
+      sharePrompt = null
       onlinks(results)
       onclose()
     } catch (e) {
@@ -231,3 +260,68 @@
     </footer>
   </div>
 </div>
+
+<!-- Password prompt for the public share link. Layered on top of
+     the picker's own modal (z-70 vs z-60) so dismissing it returns
+     focus to the picker without unmounting the selection. The
+     "Share without password" path commits with an empty password,
+     which the Rust side translates to omitting the OCS `password`
+     param entirely — keeps the previous "no-password share" flow
+     reachable in one click. -->
+{#if sharePrompt}
+  <div
+    class="fixed inset-0 z-70 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget && !sharing) sharePrompt = null }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+      <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
+      <p class="text-xs text-surface-500 mb-3">
+        {sharePrompt.paths.length === 1
+          ? 'Anyone with the link can open the file.'
+          : `Anyone with each link can open ${sharePrompt.paths.length} files.`}
+        Setting a password gates the recipient behind it; leave it empty
+        to share without one.
+      </p>
+
+      <label class="block text-xs text-surface-500 mb-1" for="share-pw">Password (optional)</label>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        id="share-pw"
+        type="password"
+        class="input w-full text-sm px-2 py-1.5 rounded-md mb-3"
+        placeholder="Leave blank for no password"
+        bind:value={sharePrompt.password}
+        disabled={sharing}
+        autofocus
+        onkeydown={(e) => {
+          if (e.key === 'Enter') { e.preventDefault(); void commitShare() }
+          else if (e.key === 'Escape' && !sharing) { e.preventDefault(); sharePrompt = null }
+        }}
+      />
+
+      {#if error}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500"
+          disabled={sharing}
+          onclick={() => (sharePrompt = null)}
+        >Cancel</button>
+        <button
+          class="btn preset-filled-primary-500"
+          disabled={sharing}
+          onclick={() => void commitShare()}
+        >
+          {#if sharing}Sharing…
+          {:else if sharePrompt.password.trim()}Create with password
+          {:else}Share without password{/if}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -150,6 +150,29 @@
         await refreshCalendarsStatus(a.id)
         await loadCalendarsList(a.id)
       }
+      // Background-refresh the capability snapshot for every account
+      // so newly-installed Nextcloud apps (Office, Talk, …) light up
+      // their chip without needing a disconnect / reconnect. Done
+      // *after* the synchronous loads so the panel paints with the
+      // cached chip set immediately and updates in place once the
+      // server replies. Failures are swallowed in Rust — a flaky
+      // network just keeps the previous snapshot.
+      void Promise.all(
+        accounts.map(async (a) => {
+          try {
+            const fresh = await invoke<NextcloudAccount>(
+              'refresh_nextcloud_capabilities',
+              { ncId: a.id },
+            )
+            // Patch the local list in place — Svelte 5 picks up the
+            // new capabilities on the next render. Match by id in
+            // case the user removed an account mid-refresh.
+            accounts = accounts.map((x) => (x.id === fresh.id ? fresh : x))
+          } catch (e) {
+            console.warn('refresh_nextcloud_capabilities failed for', a.id, e)
+          }
+        }),
+      )
     } catch (e) {
       error = formatError(e) || 'Failed to load Nextcloud connections'
     } finally {

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -24,6 +24,11 @@
     files: boolean
     caldav: boolean
     carddav: boolean
+    /** Nextcloud Office (Collabora, app id `richdocuments`).
+     *  When `true` the attachment-click flow can open `.docx` /
+     *  `.odt` / `.xlsx` etc. in an embedded editor; when `false`
+     *  the UI falls back to plain download. */
+    office?: boolean
   }
   interface NextcloudAccount {
     id: string
@@ -364,6 +369,9 @@
                     {/if}
                     {#if acct.capabilities.carddav}
                       <span class="text-xs px-2 py-0.5 rounded-full bg-orange-500/20 text-orange-600 dark:text-orange-300">Contacts</span>
+                    {/if}
+                    {#if acct.capabilities.office}
+                      <span class="text-xs px-2 py-0.5 rounded-full bg-pink-500/20 text-pink-600 dark:text-pink-300">Office</span>
                     {/if}
                   </div>
                 {/if}


### PR DESCRIPTION
Closes #65.

## Summary

Closes the loop on the Nextcloud attachment-polish issue with the embedded Office / PDF viewers, password-protected public shares, capability auto-refresh, cid:-anchor routing, and a fully reworked attachment chip UI. TLS trust handling was overhauled along the way to actually work against renewed self-signed certs.

## What's in here

### Office attachments
- Click an Office-compatible attachment → uploads to a per-session `/Nimbus Mail/temp/` folder on the user's Nextcloud, opens in a new Tauri window pointed at Collabora's `index.php/f/<fileid>` deep link
- Temp file is DAV-deleted on window close; a startup sweeper expunges anything orphaned by a previous crash
- Office capability (`richdocuments`) detected and shown in Settings alongside Files / CalDAV / CardDAV / Talk

### PDF attachments
- Same upload-to-temp + viewer-window pattern, opens in Nextcloud's built-in PDF viewer
- Stirling-PDF integration was attempted but mainline Stirling has no working load-from-URL viewer route, so it's been removed entirely (settings field, models field, code paths)

### Public share links with optional password
- `create_public_share` takes an optional password and sends it on the OCS request
- Non-2xx responses surface the OCS error message instead of a bare HTTP code
- Password-policy errors get a friendly mapper ("Password is too short. Choose at least N characters.")

### Capability detection
- Nextcloud Office (`richdocuments`) added to the capabilities probe
- Settings auto-refreshes capabilities on mount — no manual button

### cid: routing
- HTML body iframe gets `sandbox="allow-same-origin"` so the parent can read `contentDocument`
- cid: anchors are tagged with `data-nimbus-cid` and intercepted; click routes through `attachmentClicked` so an inline reference opens in the same Office/PDF viewer the tray buttons use
- mail-parser `content_id()` captured into `EmailAttachment.content_id` for the matching

### TLS trust (the painful one)
- `probe_server_certificate` now returns the full handshake chain (leaf + intermediates), not just the leaf
- `FingerprintVerifier` walks every cert in the presented chain and matches against trusted fingerprints (canonicalised: lowercased, separator-stripped) so reorder-on-the-wire and leaf reissue under the same intermediate both validate
- `AccountSettings` adds a per-account 🔒 Trust server cert button that re-runs the probe and trusts every cert in the new chain
- Trust modal lists every fingerprint so the user sees what they're trusting

### Attachment chip UI (Outlook-style)
- Each attachment chip now has one primary action button (Open in Office / Open PDF / Download — type-aware) plus a `▾` chevron
- Chevron opens a popover menu: type-specific Open, 🖥 Open in Desktop App, ⬇ Save to disk, ☁ Save to Nextcloud, 📋 Copy filename
- Click-outside dismissal, ARIA `role="menu"` / `aria-expanded` / `aria-haspopup`
- "Open in Desktop App" hands the attachment to its registered handler (Edge / Acrobat for PDF, Word for `.docx`, Photos for images, Notepad for text); user presses Ctrl/Cmd-P inside that app for the full app print dialog with preview + printer chooser

## Test plan

- [ ] Trust button: click on a self-signed-cert account, confirm modal lists leaf + intermediate fingerprints, click Trust, confirm subsequent IMAP/SMTP connects validate
- [ ] Office attachment: click 📝 Open in Office on a `.docx`, confirm Collabora window opens, edit, close, confirm temp file is gone from Nextcloud
- [ ] PDF attachment: click 📄 Open PDF, confirm Nextcloud's PDF viewer opens with the file
- [ ] cid:-anchor: send an HTML mail with an inline image, click the image inline, confirm it opens in a viewer window
- [ ] Public share with password: share a Nextcloud file with a 4-character password, confirm friendly "Password is too short" error
- [ ] Capabilities: open Settings → Nextcloud, confirm richdocuments / Office chip appears for an Office-equipped server, refreshes without a manual button
- [ ] Dropdown: click ▾ on any attachment chip, confirm menu opens, click outside to dismiss, run each menu entry
- [ ] Open in Desktop App: click the menu entry on a PDF, confirm it opens in the OS-default PDF app, Ctrl/Cmd-P inside that app shows the print dialog with preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)