### PR TITLE
feat(#87): inline HTML mail rendering with DOMPurify + remote image blocking

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -33,6 +33,17 @@ pub struct AppSettings {
     /// Whether the UI follows the OS light/dark preference, or
     /// is pinned to one. Applied via `<html data-mode="…">`.
     pub theme_mode: ThemeMode,
+    /// Render HTML email bodies on a forced white canvas.
+    ///
+    /// HTML emails almost always set inline text colours assuming a
+    /// light page background — the dark text becomes unreadable in
+    /// dark mode if we let it render against the app's surface
+    /// colour. With this on (default), the email body wrapper is
+    /// painted white regardless of the app theme. Turn off to let
+    /// the email render against the app's background — useful for
+    /// dark-themed emails or when a sender provides a proper
+    /// dark-mode design.
+    pub mail_html_white_background: bool,
 }
 
 /// Light/dark mode selection. `System` follows the OS preference
@@ -70,6 +81,7 @@ impl Default for AppSettings {
             start_minimized: false,
             theme_name: "cerberus".to_string(),
             theme_mode: ThemeMode::System,
+            mail_html_white_background: true,
         }
     }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -30,6 +30,8 @@
         "@tiptap/pm": "^3.22.3",
         "@tiptap/starter-kit": "^3.22.3",
         "@tiptap/suggestion": "^3.22.4",
+        "@types/dompurify": "^3.0.5",
+        "dompurify": "^3.4.1",
         "svelte-tiptap": "^3.0.1"
       },
       "devDependencies": {
@@ -1456,6 +1458,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2189,6 +2200,15 @@
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
       "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,6 +46,8 @@
     "@tiptap/pm": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",
     "@tiptap/suggestion": "^3.22.4",
+    "@types/dompurify": "^3.0.5",
+    "dompurify": "^3.4.1",
     "svelte-tiptap": "^3.0.1"
   }
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -167,6 +167,7 @@
     start_minimized: boolean
     theme_name: string
     theme_mode: ThemeMode
+    mail_html_white_background: boolean
   }
 
   // Cached settings snapshot — refreshed when the settings command is
@@ -824,6 +825,7 @@
         accountId={selectedMessageAccountId ?? activeAccountId}
         folder={selectedFolder}
         uid={selectedUid}
+        forceWhiteBackground={appPrefs?.mail_html_white_background ?? true}
         onread={onMessageRead}
         onreply={onReply}
         onreplyall={onReplyAll}

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -43,18 +43,28 @@ body {
   max-width: 100%;
   word-break: break-word;
   overflow-wrap: anywhere;
-  /* HTML emails are designed against a white background — senders set
-     dark text colours via inline styles assuming a light page. Forcing
-     a white canvas here keeps GitHub pipeline status banners,
-     newsletter headlines, etc. legible in dark mode. Same approach
-     Gmail / Outlook / Thunderbird / Apple Mail take. */
+}
+
+/* "Always white" mode (default). HTML emails are designed against a white
+   background — senders set dark text colours via inline styles assuming a
+   light page. Forcing a white canvas here keeps GitHub pipeline status
+   banners, newsletter headlines, etc. legible in dark mode. Same approach
+   Gmail / Outlook / Thunderbird / Apple Mail take. The margin + radius
+   carve the white block into a card so it doesn't bleed edge-to-edge into
+   the dark app chrome. */
+.email-html-body--white {
   background: #ffffff;
   color: #1a1a1a;
-  /* Carve the email a visual frame so the white block doesn't bleed
-     into the dark app chrome. */
   border-radius: 6px;
   margin: 1rem;
   padding: 1.5rem;
+}
+
+/* "Use mail's theme" mode. No forced background — inline styles from the
+   email decide. Padding still applied so the body doesn't collide with
+   the surrounding chrome. */
+.email-html-body--native {
+  /* (padding handled via the Tailwind p-6 class on the element) */
 }
 
 .email-html-body table {

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -41,8 +41,10 @@ body {
 .email-html-body {
   /* Prevent a single wide image or table from stretching the pane. */
   max-width: 100%;
-  word-break: break-word;
-  overflow-wrap: anywhere;
+  /* Only break at long-word boundaries (URLs, hashes) — `anywhere`
+     breaks between every character and stacks short headers like
+     "Status" vertically inside narrow table cells. */
+  overflow-wrap: break-word;
 }
 
 /* "Always white" mode (default). HTML emails are designed against a white

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -31,3 +31,35 @@ body {
 #app {
   @apply h-full;
 }
+
+/* ── Email body renderer ─────────────────────────────────────────────── */
+/* Scoped resets for HTML email content injected via {@html}. We can't
+   scope <style> tags from the email (they're stripped by DOMPurify), but
+   inline styles from the email still apply. These rules establish a sane
+   baseline so email tables, images, and links look reasonable without
+   touching the rest of the app. */
+.email-html-body {
+  /* Prevent a single wide image or table from stretching the pane. */
+  max-width: 100%;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+.email-html-body table {
+  border-collapse: collapse;
+  max-width: 100%;
+}
+
+.email-html-body img {
+  max-width: 100%;
+  height: auto;
+}
+
+.email-html-body a {
+  color: oklch(0.627 0.194 258.2); /* blue-500 equivalent */
+  text-decoration: underline;
+}
+
+.email-html-body a:hover {
+  opacity: 0.8;
+}

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -43,6 +43,18 @@ body {
   max-width: 100%;
   word-break: break-word;
   overflow-wrap: anywhere;
+  /* HTML emails are designed against a white background — senders set
+     dark text colours via inline styles assuming a light page. Forcing
+     a white canvas here keeps GitHub pipeline status banners,
+     newsletter headlines, etc. legible in dark mode. Same approach
+     Gmail / Outlook / Thunderbird / Apple Mail take. */
+  background: #ffffff;
+  color: #1a1a1a;
+  /* Carve the email a visual frame so the white block doesn't bleed
+     into the dark app chrome. */
+  border-radius: 6px;
+  margin: 1rem;
+  padding: 1.5rem;
 }
 
 .email-html-body table {

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -78,6 +78,7 @@
     start_minimized: boolean
     theme_name: string
     theme_mode: ThemeMode
+    mail_html_white_background: boolean
   }
 
   let appSettings = $state<AppSettings>({
@@ -88,6 +89,7 @@
     start_minimized: false,
     theme_name: 'cerberus',
     theme_mode: 'system',
+    mail_html_white_background: true,
   })
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
@@ -499,6 +501,39 @@
               </button>
             {/each}
           </div>
+        </div>
+
+        <div>
+          <p class="font-medium mb-2">HTML mail background</p>
+          <div class="flex flex-wrap gap-2">
+            <button
+              type="button"
+              class="btn btn-sm {appSettings.mail_html_white_background
+                ? 'preset-filled-primary-500'
+                : 'preset-outlined-surface-500'}"
+              onclick={() => {
+                appSettings.mail_html_white_background = true
+                scheduleSave()
+              }}
+            >Always white</button>
+            <button
+              type="button"
+              class="btn btn-sm {!appSettings.mail_html_white_background
+                ? 'preset-filled-primary-500'
+                : 'preset-outlined-surface-500'}"
+              onclick={() => {
+                appSettings.mail_html_white_background = false
+                scheduleSave()
+              }}
+            >Use mail's theme</button>
+          </div>
+          <p class="text-xs text-surface-400 mt-1">
+            HTML emails usually assume a white background — "Always white" keeps
+            them readable in dark mode. "Use mail's theme" lets the email render
+            against the app's background, which respects dark-mode-aware emails
+            but can wash out the rest. Each open mail also has its own toggle
+            to override this default.
+          </p>
         </div>
       </div>
     </div>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -125,6 +125,12 @@
         uid: u,
       })
       if (id === accountId && f === folder && u === uid && cached) {
+        // Resolve trust state BEFORE assigning `email`, otherwise the
+        // first render of the message runs with trustedSender=false,
+        // briefly flashes the "Remote images blocked" banner, and only
+        // then settles into the trusted state — looks like a bug for
+        // senders the user has already approved.
+        trustedSender = isSenderTrusted(cached.from)
         email = cached
         loading = false
       }
@@ -142,6 +148,7 @@
         uid: u,
       })
       if (id === accountId && f === folder && u === uid) {
+        trustedSender = isSenderTrusted(fresh.from)
         email = fresh
       }
     } catch (e: any) {
@@ -154,9 +161,6 @@
       loading = false
       refreshing = false
     }
-
-    // Check if this sender is already trusted for image display.
-    if (email?.from) trustedSender = isSenderTrusted(email.from)
 
     // Mark as read — fire-and-forget. The MailList picked up an optimistic
     // cache update from the backend, and onread() lets the parent refresh

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -990,12 +990,14 @@
       </div>
     {/if}
 
-    <!-- Email body -->
+    <!-- Email body. Prefer HTML when present — multipart/alternative
+         senders (GitHub, newsletters, almost everything modern) include
+         a plain-text fallback for clients that can't render HTML, but
+         the HTML is what carries the real formatting (layout, links,
+         brand styles). DOMPurify + remote-image blocking make this
+         safe; we fall back to plain text only when no HTML part exists. -->
     <div class="flex-1 overflow-y-auto">
-      {#if email.body_text}
-        <!-- Prefer plain text: safe, simple, no remote content. -->
-        <pre class="whitespace-pre-wrap font-sans text-sm p-6">{email.body_text}</pre>
-      {:else if email.body_html}
+      {#if email.body_html}
         <!-- Image-blocking banner — only visible when at least one remote
              image was replaced with a placeholder and the user hasn't opted
              in for this message or trusted this sender. -->
@@ -1027,6 +1029,9 @@
         >
           {@html processedHtml.html}
         </div>
+      {:else if email.body_text}
+        <!-- Plain-text fallback for messages without an HTML part. -->
+        <pre class="whitespace-pre-wrap font-sans text-sm p-6">{email.body_text}</pre>
       {:else}
         <p class="text-sm text-surface-500 p-6">(This message has no visible body.)</p>
       {/if}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -4,13 +4,14 @@
    *
    * Given an account + folder + UID, calls `fetch_message` to pull the
    * full message (headers + body) from the IMAP server. Renders plain
-   * text if we have it, otherwise falls back to the HTML body inside a
-   * sandboxed iframe (to keep any remote-content / scripts in the mail
-   * isolated from the app).
+   * text if we have it, otherwise falls back to inline-rendered HTML
+   * sanitized by DOMPurify (scripts and dangerous attributes stripped)
+   * with remote images blocked by default.
    */
 
   import { invoke } from '@tauri-apps/api/core'
   import { save } from '@tauri-apps/plugin-dialog'
+  import DOMPurify from 'dompurify'
   import { formatError } from './errors'
   import NextcloudFilePicker from './NextcloudFilePicker.svelte'
 
@@ -104,6 +105,8 @@
     refreshing = false
     error = ''
     email = null
+    showImagesForMessage = false
+    trustedSender = false
 
     // Cache first — lets the reading pane paint instantly when the user
     // re-opens a previously read message (the common case).
@@ -143,6 +146,9 @@
       loading = false
       refreshing = false
     }
+
+    // Check if this sender is already trusted for image display.
+    if (email?.from) trustedSender = isSenderTrusted(email.from)
 
     // Mark as read — fire-and-forget. The MailList picked up an optimistic
     // cache update from the backend, and onread() lets the parent refresh
@@ -184,110 +190,167 @@
     return new Date(iso).toLocaleString()
   }
 
-  /**
-   * Add a `title` attribute containing the href to every `<a>` in the
-   * message HTML, so hovering over a link reveals its URL as a native
-   * browser tooltip.
-   *
-   * Why we need this: the message body renders inside a `sandbox=""`
-   * iframe, which in most webviews hides the status bar that would
-   * normally show `<a href>` on hover. Without a `title`, users see a
-   * blue underlined phrase with no way to preview where it leads —
-   * which also happens to be an easy phishing surface. Surfacing the
-   * real URL on hover lets the user sanity-check before clicking.
-   *
-   * Implementation: parse the HTML with DOMParser (which treats scripts
-   * as inert text nodes, so it's safe to use on untrusted mail) and
-   * annotate each anchor. If the anchor already carries a `title`, keep
-   * it and append the URL so we don't clobber author-provided tooltips.
-   */
-  function addLinkTooltips(html: string): string {
-    if (!html) return html
+  // ── Per-sender image trust (persisted in localStorage) ──────────────
+  // senders the user has chosen "always show images from" live here.
+  // Key format: ["user@example.com", ...] — lower-cased bare addresses.
+
+  const TRUSTED_SENDERS_KEY = 'nimbus-trusted-senders'
+
+  function getSenderAddress(from: string): string {
+    const m = from.match(/<([^>]+)>/)
+    return (m ? m[1] : from).trim().toLowerCase()
+  }
+
+  function isSenderTrusted(from: string): boolean {
     try {
-      const doc = new DOMParser().parseFromString(html, 'text/html')
+      const raw = localStorage.getItem(TRUSTED_SENDERS_KEY)
+      const list: string[] = raw ? JSON.parse(raw) : []
+      return list.includes(getSenderAddress(from))
+    } catch {
+      return false
+    }
+  }
+
+  function addTrustedSender(from: string) {
+    try {
+      const raw = localStorage.getItem(TRUSTED_SENDERS_KEY)
+      const list: string[] = raw ? JSON.parse(raw) : []
+      const addr = getSenderAddress(from)
+      if (!list.includes(addr)) {
+        list.push(addr)
+        localStorage.setItem(TRUSTED_SENDERS_KEY, JSON.stringify(list))
+      }
+    } catch {
+      console.warn('Failed to persist trusted sender')
+    }
+  }
+
+  // Per-message "Show images" toggle; reset to false on every new message.
+  let showImagesForMessage = $state(false)
+  // True when the sender is in the trusted list (set in load()).
+  let trustedSender = $state(false)
+
+  // ── HTML sanitization + image blocking ───────────────────────────────
+  //
+  // DOMPurify strips scripts, event handlers, and any element that can
+  // execute code or load external resources (iframe, object, form…).
+  // We keep inline styles so newsletter formatting survives, but we
+  // forbid <style> blocks — they can't be easily scoped and could
+  // clobber the app's UI classes. Most real-world HTML email uses
+  // inline styles anyway (Gmail strips <style> too, so senders know).
+  //
+  // After DOMPurify, a second pass with DOMParser:
+  //   • annotates <a href> with a tooltip showing the raw URL (phishing
+  //     guard — the Tauri webview hides the URL bar)
+  //   • marks cid: anchors with data-nimbus-cid for the click handler
+  //   • unless showImages is true, replaces every remote <img src> with
+  //     a transparent 1×1 GIF and stashes the original in
+  //     data-nimbus-blocked-src
+
+  const BLOCKED_IMG_PLACEHOLDER =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
+  function processEmailHtml(
+    html: string,
+    showImages: boolean,
+  ): { html: string; hadBlocked: boolean } {
+    if (!html) return { html: '', hadBlocked: false }
+    try {
+      const clean = DOMPurify.sanitize(html, {
+        FORBID_TAGS: [
+          'script', 'noscript', 'object', 'embed', 'applet',
+          'iframe', 'frame', 'frameset',
+          'form', 'input', 'textarea', 'select', 'button',
+          'base', 'meta', 'link', 'style',
+        ],
+        ADD_ATTR: ['target', 'data-nimbus-cid', 'data-nimbus-blocked-src', 'title'],
+        FORCE_BODY: true,
+      })
+
+      const doc = new DOMParser().parseFromString(clean, 'text/html')
+
+      // Annotate links with tooltip + handle cid: anchors
       doc.querySelectorAll('a[href]').forEach((a) => {
-        const href = a.getAttribute('href') || ''
+        const href = a.getAttribute('href') ?? ''
         if (!href) return
         const existing = a.getAttribute('title')
         a.setAttribute('title', existing ? `${existing} — ${href}` : href)
-
-        // Mark `cid:` anchors so the click interceptor below can
-        // find them quickly (no need to re-parse hrefs every click).
-        // Stripping leading angle brackets just in case the sender
-        // pasted them; mail-parser already strips them on the
-        // attachment side, so casing-only mismatches are the only
-        // resolution failure mode left.
         if (href.toLowerCase().startsWith('cid:')) {
           const cid = href.slice(4).trim().replace(/^<|>$/g, '')
           a.setAttribute('data-nimbus-cid', cid)
-          // Default browser behaviour on `cid:` is "navigate this
-          // frame to a non-existent URL". Pin the anchor to "do
-          // nothing on its own" so clicks fall through to our
-          // listener cleanly.
-          a.setAttribute('target', '_self')
+          // Neutralise default `cid:` navigation; our click handler takes over.
+          a.setAttribute('href', '#')
+        } else {
+          // External links open in the system browser via open_url command.
+          a.setAttribute('target', '_blank')
+          a.setAttribute('rel', 'noopener noreferrer')
         }
       })
-      // `documentElement.outerHTML` gives us a full `<html>…</html>`,
-      // which is exactly what `srcdoc` wants. If parsing somehow gives
-      // us nothing useful, fall back to the original string below.
-      const out = doc.documentElement?.outerHTML
-      return out || html
-    } catch {
-      return html
+
+      // Block remote images unless the user has opted in for this message/sender
+      let hadBlocked = false
+      if (!showImages) {
+        doc.querySelectorAll('img').forEach((img) => {
+          const src = img.getAttribute('src') ?? ''
+          if (src && !src.toLowerCase().startsWith('data:') && !src.toLowerCase().startsWith('cid:')) {
+            hadBlocked = true
+            img.setAttribute('data-nimbus-blocked-src', src)
+            img.setAttribute('src', BLOCKED_IMG_PLACEHOLDER)
+            img.removeAttribute('srcset')
+            const alt = img.getAttribute('alt') ?? ''
+            if (!alt) img.setAttribute('alt', '(blocked image)')
+            img.setAttribute('title', 'Remote image blocked — click "Show images" to load')
+          }
+        })
+      }
+
+      return { html: doc.body.innerHTML, hadBlocked }
+    } catch (e) {
+      console.warn('processEmailHtml failed:', e)
+      return { html: '', hadBlocked: false }
     }
   }
 
-  // Annotated copy of `email.body_html` with link tooltips. Derived so
-  // we recompute only when the message changes, not on every render.
-  let bodyHtmlWithTooltips = $derived(
-    email?.body_html ? addLinkTooltips(email.body_html) : '',
-  )
+  // Recompute whenever the email body, per-message toggle, or trust state changes.
+  let processedHtml = $derived.by(() => {
+    if (!email?.body_html) return { html: '', hadBlocked: false }
+    return processEmailHtml(email.body_html, showImagesForMessage || trustedSender)
+  })
 
-  // ── cid: anchor click interception ──────────────────────────
+  // ── Click handling for the inline HTML body div ───────────────────────
   //
-  // The body iframe runs with `sandbox="allow-same-origin"` so the
-  // parent can read its `contentDocument` (scripts inside the
-  // iframe still can't run — `allow-scripts` is NOT set). We
-  // delegate clicks at the document level: any anchor carrying a
-  // `data-nimbus-cid` attribute (added by `addLinkTooltips`) gets
-  // its default behaviour preventDefault'd, the cid is matched
-  // against the message's attachment list, and the result is
-  // dispatched through `attachmentClicked` — the same single
-  // entry point the Office / PDF viewers (issue #65 follow-up
-  // commits) will branch into.
-  let bodyIframe: HTMLIFrameElement | undefined = $state()
+  // cid: links open the matching attachment (same as before).
+  // External http/https links are routed through the `open_url` Tauri
+  // command so they open in the user's default system browser instead of
+  // navigating inside the app's webview.
 
-  function onIframeLoad() {
-    const doc = bodyIframe?.contentDocument
-    if (!doc) return
-    // Re-attach on every load so iframe re-creation (new message)
-    // wires the listener fresh. The previous frame's document is
-    // garbage-collected with its window so there's nothing to
-    // detach.
-    doc.addEventListener('click', onBodyClick, true)
-  }
-
-  function onBodyClick(e: Event) {
+  function onBodyClick(e: MouseEvent) {
     const target = e.target as HTMLElement | null
     if (!target) return
-    const anchor = target.closest('a[data-nimbus-cid]') as HTMLAnchorElement | null
+    const anchor = target.closest('a') as HTMLAnchorElement | null
     if (!anchor) return
-    e.preventDefault()
-    e.stopPropagation()
-    const cid = anchor.getAttribute('data-nimbus-cid') ?? ''
-    if (!cid || !email) return
-    const att = email.attachments.find(
-      (a) =>
-        a.content_id != null &&
-        a.content_id.toLowerCase() === cid.toLowerCase(),
-    )
-    if (!att) {
-      console.warn(
-        `MailView: cid:${cid} clicked but no matching attachment in this message`,
+
+    const cid = anchor.getAttribute('data-nimbus-cid')
+    if (cid) {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!email) return
+      const att = email.attachments.find(
+        (a) => a.content_id != null && a.content_id.toLowerCase() === cid.toLowerCase(),
       )
+      if (!att) {
+        console.warn(`MailView: cid:${cid} clicked but no matching attachment`)
+        return
+      }
+      void attachmentClicked(att)
       return
     }
-    void attachmentClicked(att)
+
+    const href = anchor.getAttribute('href') ?? ''
+    if (href && href !== '#' && !href.startsWith('javascript:')) {
+      e.preventDefault()
+      void invoke('open_url', { url: href })
+    }
   }
 
   /** MIME types Nextcloud Office (Collabora) opens in-browser via
@@ -928,30 +991,44 @@
     {/if}
 
     <!-- Email body -->
-    <div class="flex-1 overflow-y-auto p-6">
+    <div class="flex-1 overflow-y-auto">
       {#if email.body_text}
         <!-- Prefer plain text: safe, simple, no remote content. -->
-        <pre class="whitespace-pre-wrap font-sans text-sm">{email.body_text}</pre>
+        <pre class="whitespace-pre-wrap font-sans text-sm p-6">{email.body_text}</pre>
       {:else if email.body_html}
-        <!--
-          HTML-only messages go in a sandboxed iframe. `sandbox=""` (no
-          allow-* tokens) disables scripts, form submission, same-origin,
-          and top-navigation — so even malicious mail can't attack the app.
-        -->
-        <!-- `allow-same-origin` (without `allow-scripts`!) lets the
-             parent read the iframe's `contentDocument` so we can
-             attach the cid:-click listener. Author scripts still
-             can't run because `allow-scripts` isn't on the list. -->
-        <iframe
-          bind:this={bodyIframe}
-          title="Message body"
-          class="w-full h-full border-0 bg-white"
-          sandbox="allow-same-origin"
-          srcdoc={bodyHtmlWithTooltips}
-          onload={onIframeLoad}
-        ></iframe>
+        <!-- Image-blocking banner — only visible when at least one remote
+             image was replaced with a placeholder and the user hasn't opted
+             in for this message or trusted this sender. -->
+        {#if processedHtml.hadBlocked && !showImagesForMessage && !trustedSender}
+          <div class="flex flex-wrap items-center gap-3 px-6 py-2 bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-700 text-sm text-amber-800 dark:text-amber-300">
+            <span class="shrink-0">🛡️ Remote images are blocked.</span>
+            <button
+              class="btn btn-sm preset-outlined-surface-500"
+              onclick={() => (showImagesForMessage = true)}
+            >Show images</button>
+            {#if email.from}
+              <button
+                class="btn btn-sm preset-outlined-surface-500"
+                onclick={() => {
+                  addTrustedSender(email!.from)
+                  trustedSender = true
+                }}
+              >Always show from {getSenderAddress(email.from)}</button>
+            {/if}
+          </div>
+        {/if}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <div
+          class="email-html-body p-6 text-sm leading-relaxed overflow-x-auto"
+          role="region"
+          aria-label="Email body"
+          onclick={onBodyClick}
+        >
+          {@html processedHtml.html}
+        </div>
       {:else}
-        <p class="text-sm text-surface-500">(This message has no visible body.)</p>
+        <p class="text-sm text-surface-500 p-6">(This message has no visible body.)</p>
       {/if}
     </div>
   {/if}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -72,6 +72,12 @@
         deleted on the server. The parent clears the selected UID and
         bumps the MailList refresh so the row disappears. */
     onmessageremoved?: () => void
+    /** App-wide default for "render HTML email on a white canvas".
+        When true the body wrapper gets a forced white background and
+        dark text so emails designed for a light page stay readable in
+        dark mode. The user can override per message via a toolbar
+        toggle. */
+    forceWhiteBackground?: boolean
   }
   let {
     accountId,
@@ -85,6 +91,7 @@
     isDraftsFolder = false,
     oneditdraft,
     onmessageremoved,
+    forceWhiteBackground = true,
   }: Props = $props()
 
   let email = $state<Email | null>(null)
@@ -107,6 +114,7 @@
     email = null
     showImagesForMessage = false
     trustedSender = false
+    whiteBackgroundOverride = null
 
     // Cache first — lets the reading pane paint instantly when the user
     // re-opens a previously read message (the common case).
@@ -229,6 +237,14 @@
   let showImagesForMessage = $state(false)
   // True when the sender is in the trusted list (set in load()).
   let trustedSender = $state(false)
+
+  // Per-message override for the white-canvas default. `null` means
+  // "use the app-wide preference"; `true` / `false` flip it just for
+  // the open message. Reset on every new message in load().
+  let whiteBackgroundOverride = $state<boolean | null>(null)
+  let effectiveWhiteBackground = $derived(
+    whiteBackgroundOverride ?? forceWhiteBackground,
+  )
 
   // ── HTML sanitization + image blocking ───────────────────────────────
   //
@@ -852,6 +868,18 @@
         >{email.is_read ? 'Mark unread' : 'Mark read'}</button>
       {/if}
       <div class="flex-1"></div>
+      {#if email.body_html}
+        <!-- Per-message background toggle — flips the white-canvas
+             default just for the open mail. The label always shows
+             where a click will take you, not the current state. -->
+        <button
+          class="btn btn-sm preset-outlined-surface-500"
+          onclick={() => (whiteBackgroundOverride = !effectiveWhiteBackground)}
+          title={effectiveWhiteBackground
+            ? "Switch this mail to the app's theme background"
+            : 'Switch this mail to a white background'}
+        >{effectiveWhiteBackground ? '🎨 Use mail theme' : '📄 White background'}</button>
+      {/if}
       <button
         class="btn btn-sm preset-outlined-surface-500"
         disabled={removing}
@@ -1022,7 +1050,9 @@
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div
-          class="email-html-body text-sm leading-relaxed overflow-x-auto"
+          class="email-html-body text-sm leading-relaxed overflow-x-auto {effectiveWhiteBackground
+            ? 'email-html-body--white'
+            : 'email-html-body--native p-6'}"
           role="region"
           aria-label="Email body"
           onclick={onBodyClick}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1022,7 +1022,7 @@
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <div
-          class="email-html-body p-6 text-sm leading-relaxed overflow-x-auto"
+          class="email-html-body text-sm leading-relaxed overflow-x-auto"
           role="region"
           aria-label="Email body"
           onclick={onBodyClick}


### PR DESCRIPTION
Closes #87

## Summary

- **Replaces sandboxed iframe** with inline `{@html}` rendering — the HTML body now displays directly in the reading pane, inheriting the app's dark mode and text sizing
- **DOMPurify sanitization**: strips `<script>`, `<iframe>`, `<form>`, `<style>`, `<object>`, event attributes, and all other XSS vectors before the content touches the DOM; inline styles are preserved so newsletters look correct
- **Remote image blocking by default**: every external `<img src>` is replaced with a transparent 1×1 GIF; an amber banner appears with two actions:
  - *Show images* — per-message toggle, resets when you open the next message
  - *Always show from sender@example.com* — persists the sender in localStorage so the banner never appears for that address again
- **External links open in system browser** via the existing open_url Tauri command (the old sandbox blocked them completely)
- cid: inline-attachment links continue to work unchanged via the data-nimbus-cid delegated click handler
- **HTML preferred over plain-text fallback** for multipart/alternative messages (matches Gmail/Outlook/Thunderbird/Apple Mail)
- **Forced white canvas by default** so emails designed for a light page stay readable in dark mode
- **New setting** *Settings → Appearance → HTML mail background*: Always white (default) vs Use mail's theme
- **Per-message toolbar toggle** to flip the canvas choice for the open mail only (resets per message)

## Test plan

- [ ] Open an HTML-only email — body renders inline, no iframe
- [ ] Verify the amber "Remote images are blocked" banner appears when the email contains a remote img tag
- [ ] Click *Show images* — banner disappears, images load for this message only; reopen the message to confirm images are blocked again
- [ ] Click *Always show from…* — images load; open a second email from the same sender and confirm the banner never appears (no flicker on first render)
- [ ] Click an external https:// link — opens in the system browser, not inside the Tauri window
- [ ] Click a cid: link (inline attachment) — attachment open/download dialog works as before
- [ ] Open a plain-text-only email — pre path used, no DOMPurify overhead
- [ ] Open a multipart/alternative email (e.g. GitHub notification) — HTML version is rendered, not the plain-text fallback
- [ ] Dark mode + *Always white* setting: GitHub workflow status mails stay readable, "Status" column header reads horizontally
- [ ] Toggle *Use mail's theme* in settings — opens HTML mail without the white canvas
- [ ] Per-mail toolbar toggle (*🎨 Use mail theme* / *📄 White background*) flips just the open mail; opens the next mail with the global default again

🤖 Generated with [Claude Code](https://claude.com/claude-code)