### PR TITLE
feat(#90): center All-mailbox emoji + add 🌐 globe overlay

### DIFF
--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -155,7 +155,7 @@
 
 <aside
   class="w-14 shrink-0 border-r border-surface-200 dark:border-surface-700
-         bg-surface-100 dark:bg-surface-800 flex flex-col items-center py-2 gap-1"
+         bg-surface-100 dark:bg-surface-800 flex flex-col items-center py-2 gap-3"
 >
   <!-- Account avatars. The "All" bubble only appears when the user
        has more than one account — for a single-account setup it's
@@ -174,11 +174,20 @@
       <!-- Inbox glyph matches the Mail rail icon + the "All
            Inboxes" folder entry, so the "this is the aggregate"
            meaning carries across every surface the user sees. The
-           `text-lg` override pushes the emoji up from the parent's
-           `text-xs` (sized for the other avatars' two-letter
-           initials) so it reads at the same visual weight as the
-           nav icons below the divider. -->
-      <span class="text-lg leading-none">&#x1F4E5;</span>
+           wrapper has a fixed 28×28 box so the composite (inbox +
+           🌐 corner badge) sits as one centered unit inside the
+           36×36 bubble — without the explicit size, the badge
+           protrudes outside the wrapper and pulls the visual
+           weight to the bottom-right. -->
+      <span class="relative block w-7 h-7">
+        <!-- The emoji's intrinsic font metrics put extra ascent above
+             the visible glyph, so a flex-centered emoji renders low.
+             A 2px upward translate lands the visible centre on the
+             box's geometric centre across Linux/macOS/Windows emoji
+             fonts. -->
+        <span class="absolute inset-0 flex items-center justify-center text-lg leading-none -translate-y-[6px]">&#x1F4E5;</span>
+        <span class="absolute bottom-0 right-0 text-[0.65rem] leading-none drop-shadow">&#x1F310;</span>
+      </span>
     </button>
   {/if}
   {#each accounts as a (a.id)}

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -680,7 +680,20 @@
         class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm bg-primary-500/10 text-primary-500 font-medium"
         onclick={() => onselectfolder('INBOX')}
       >
-        <span>📥</span>
+        <!-- Fixed-size icon box so the emoji centers consistently
+             regardless of the system font's emoji metrics. The
+             absolute-positioned 🌐 corner badge signals "across all
+             accounts" at a glance — same visual idiom as a notification
+             dot on an app icon. -->
+        <span
+          class="relative inline-flex items-center justify-center w-5 h-5 leading-none shrink-0"
+          aria-hidden="true"
+        >
+          <span class="text-base leading-none">📥</span>
+          <span
+            class="absolute -bottom-1 -right-1 text-[0.65rem] leading-none drop-shadow"
+          >🌐</span>
+        </span>
         <span class="flex-1 text-left truncate">All Inboxes</span>
         {#if unifiedUnread > 0}
           <span class="badge preset-filled-primary-500 text-xs">{unifiedUnread}</span>


### PR DESCRIPTION
Closes #90

## Summary

Visual polish for the All-mailbox surface in two places:

**Sidebar — \"All Inboxes\" row**
- 📥 inbox glyph wrapped in a fixed 20×20 centered box for consistent column alignment
- 🌐 globe overlay sits in the bottom-right corner of the inbox

**IconRail — \"All\" bubble** (only renders when ≥ 2 accounts configured)
- 📥 inbox sits in a fixed 28×28 box centered inside the 36×36 bubble (without an explicit box, the globe overlay pulled the whole composite to the bottom-right)
- 🌐 globe pinned to the box's bottom-right corner so the wrapper has predictable bounds
- 6px upward translate on the inbox compensates for emoji font ascent padding so the visible glyph lands on the bubble's geometric centre

**Spacing fix**
- IconRail vertical gap bumped from `gap-1` (4px) to `gap-3` (12px). The active-account ring (`ring-2` + `ring-offset-2`) extends 4px past the bubble on each side, so the previous gap caused selection rings to touch/overlap when an account was active.

## Test plan

- [ ] Configure 2+ accounts and verify the All bubble appears in the IconRail with the inbox+globe icon centered in the bubble
- [ ] Click between accounts and confirm the active-account ring no longer overlaps the adjacent bubbles
- [ ] Switch to unified mode — sidebar's \"All Inboxes\" row shows the inbox+globe icon
- [ ] Single-account setup: All bubble is hidden in the IconRail (gating unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)