### PR TITLE
feat(#100): themed accent + tint to lift unread mail rows

### DIFF
--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -240,11 +240,21 @@
       <div class="p-6 text-center text-sm text-surface-500">No messages in {folder}.</div>
     {:else}
       {#each envelopes as env (`${env.account_id}:${env.uid}`)}
+        {@const selected = selectedUid === env.uid && (!unified || selectedUid === env.uid)}
+        <!-- Unread visual treatment: a 3px themed accent strip on the
+             leading edge plus a subtle primary tint on the row.  The
+             border is always present (transparent when read) so rows
+             never reflow between states.  Selection wins over the
+             unread tint for the background colour, but both states
+             can co-exist on the accent strip. -->
         <button
-          class="w-full text-left px-4 py-3 border-b border-surface-100 dark:border-surface-800 transition-colors
-            {selectedUid === env.uid && (!unified || selectedUid === env.uid)
+          class="w-full text-left pl-3 pr-4 py-3 border-b border-l-[3px] border-surface-100 dark:border-surface-800 transition-colors
+            {!env.is_read ? 'border-l-primary-500' : 'border-l-transparent'}
+            {selected
               ? 'bg-primary-500/10'
-              : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
+              : !env.is_read
+                ? 'bg-primary-500/[0.04] dark:bg-primary-500/[0.07] hover:bg-primary-500/10'
+                : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
           onclick={() => onselect(env.uid, unified ? env.account_id : undefined)}
           oncontextmenu={(e) => openContextMenu(e, env)}
         >
@@ -252,7 +262,7 @@
             <span class="text-sm {!env.is_read ? 'font-semibold' : 'font-normal'} truncate pr-2">
               {env.from || '(unknown sender)'}
             </span>
-            <span class="text-xs text-surface-500 shrink-0">{formatDate(env.date)}</span>
+            <span class="text-xs {!env.is_read ? 'text-primary-500 font-medium' : 'text-surface-500'} shrink-0">{formatDate(env.date)}</span>
           </div>
           <p class="text-sm {!env.is_read ? 'font-medium' : ''} truncate">
             {env.subject || '(no subject)'}


### PR DESCRIPTION
Closes #100

## Summary

Unread mail rows in the list were carrying their state via font weight only, which is easy to miss when skimming. This adds a clear themed signal that picks up whichever Skeleton theme is active.

- **3px primary-coloured accent strip** on the row's leading edge — always 3px wide (transparent when read), so the row never reflows between states.
- **Subtle primary tint** on the row background (4% light / 7% dark) for unread + non-selected rows. Sits beneath the 10% selection tint so a selected unread row still clearly reads as selected.
- **Date in primary colour + medium weight** on unread rows, tying the corner of the row to the accent strip.

Everything keys off Skeleton's `primary-500`, so cerberus / modern / pine / rose / vintage each render with their own accent — no per-theme styling needed.

## Test plan

- [ ] Open an inbox with a mix of read + unread mail; unread rows show the 3px accent strip and tinted background, read rows do not
- [ ] Click an unread row to select it — accent strip stays, background flips to the heavier selection tint, font weight remains
- [ ] Mark a row as read (toolbar or right-click menu) — accent strip + tint clear; layout doesn't jump
- [ ] Mark a read row as unread — accent strip + tint reappear instantly
- [ ] Switch themes (cerberus → modern → pine → rose → vintage) — accent picks up each theme's primary colour automatically
- [ ] Light + dark mode: tint remains subtle but visible, doesn't fight selection state in either mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)