### PR TITLE
feat(#99): auto-advance to the next mail after delete / archive

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -44,6 +44,13 @@ pub struct AppSettings {
     /// dark-themed emails or when a sender provides a proper
     /// dark-mode design.
     pub mail_html_white_background: bool,
+    /// After delete / archive, automatically open the row directly
+    /// below the removed message (or above, if it was the last one).
+    /// Default `true` — matches Gmail / Outlook / Thunderbird /
+    /// Apple Mail's triage behaviour.  Turn off to fall back to the
+    /// previous behaviour where the reading pane goes blank after
+    /// every delete.
+    pub auto_advance_after_remove: bool,
 }
 
 /// Light/dark mode selection. `System` follows the OS preference
@@ -79,6 +86,7 @@ impl Default for AppSettings {
             theme_name: "cerberus".to_string(),
             theme_mode: ThemeMode::System,
             mail_html_white_background: true,
+            auto_advance_after_remove: true,
         }
     }
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -98,6 +98,25 @@
   // Bumped to force child lists to re-fetch (manual refresh, mark-as-read).
   let refreshToken = $state(0)
 
+  // Bindable mirror of MailList's currently-rendered envelope rows.
+  // Used by the auto-advance-after-delete flow (#99) to pick the
+  // UID of the row directly below the one we just removed without
+  // having to re-implement the cache fetch up here.  Shape mirrors
+  // MailList's local `EmailEnvelope` interface — we only ever read
+  // `uid` / `account_id` here, but the bind requires the full
+  // shape to type-check both sides.
+  type MailListEnvelope = {
+    uid: number
+    folder: string
+    from: string
+    subject: string
+    date: string
+    is_read: boolean
+    is_starred: boolean
+    account_id: string
+  }
+  let mailListEnvelopes = $state<MailListEnvelope[]>([])
+
   // ── Search state ────────────────────────────────────────────
   // `searchQuery` drives the mail-list column: non-empty query OR
   // any active filter swaps MailList out for SearchResults.
@@ -174,6 +193,7 @@
     theme_name: string
     theme_mode: ThemeMode
     mail_html_white_background: boolean
+    auto_advance_after_remove: boolean
   }
 
   // Cached settings snapshot — refreshed when the settings command is
@@ -465,12 +485,36 @@
   }
 
   /** The currently shown message has been archived or deleted on the
-   *  server. Drop the selection so the reading pane returns to the
-   *  "pick a message" placeholder, and bump `refreshToken` so MailList
-   *  + Sidebar re-query the server and the row disappears. */
-  function onMessageRemoved() {
-    selectedUid = null
-    selectedMessageAccountId = null
+   *  server.  Auto-advances the reading pane to the row directly
+   *  below the removed one (or the row above when the removed row
+   *  was last) so triage flows don't bounce back to the empty
+   *  "pick a message" placeholder after every delete / archive
+   *  click.  Falls back to clearing the pane when the list is now
+   *  empty, when we can't find the removed UID in the current
+   *  rendered list, or when the user has explicitly opted out via
+   *  `appPrefs.auto_advance_after_remove`. */
+  function onMessageRemoved(removedUid: number) {
+    let nextUid: number | null = null
+    let nextAccountId: string | null = null
+
+    if (appPrefs?.auto_advance_after_remove ?? true) {
+      const idx = mailListEnvelopes.findIndex((e) => e.uid === removedUid)
+      if (idx >= 0) {
+        // Visually the list is sorted newest-first, so the row
+        // "below" the current one is `idx + 1` (older message).
+        // When the removed row was at the bottom, we step up to
+        // `idx - 1` instead, matching what every mainstream client
+        // does after deleting the oldest visible mail.
+        const next = mailListEnvelopes[idx + 1] ?? mailListEnvelopes[idx - 1]
+        if (next) {
+          nextUid = next.uid
+          nextAccountId = next.account_id || null
+        }
+      }
+    }
+
+    selectedUid = nextUid
+    selectedMessageAccountId = nextAccountId
     refreshToken++
   }
 
@@ -851,6 +895,7 @@
               selectedUid={selectedUid}
               refreshToken={refreshToken}
               onselect={selectMessage}
+              bind:envelopes={mailListEnvelopes}
             />
           {/if}
         </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -79,6 +79,7 @@
     theme_name: string
     theme_mode: ThemeMode
     mail_html_white_background: boolean
+    auto_advance_after_remove: boolean
   }
 
   let appSettings = $state<AppSettings>({
@@ -90,6 +91,7 @@
     theme_name: 'cerberus',
     theme_mode: 'system',
     mail_html_white_background: true,
+    auto_advance_after_remove: true,
   })
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
@@ -451,6 +453,16 @@
             onchange={scheduleSave}
           />
           <span>Start minimized to tray</span>
+        </label>
+
+        <label class="flex items-center gap-2">
+          <input
+            type="checkbox"
+            class="checkbox"
+            bind:checked={appSettings.auto_advance_after_remove}
+            onchange={scheduleSave}
+          />
+          <span>After delete / archive, open the next message automatically</span>
         </label>
       </div>
     </div>

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -54,6 +54,11 @@
         can route the open-message action to the right account. In
         single-account mode it's omitted (the active account is implicit). */
     onselect: (uid: number, accountId?: string) => void
+    /** Bindable mirror of the rendered envelope list.  Lets the
+        parent peek at "what's currently shown" without re-fetching —
+        used by the auto-advance-after-delete logic to pick the next
+        UID below the removed row. */
+    envelopes?: EmailEnvelope[]
   }
   let {
     accounts = [],
@@ -63,6 +68,7 @@
     selectedUid,
     refreshToken = 0,
     onselect,
+    envelopes = $bindable([]),
   }: Props = $props()
 
   /** Short label for the per-row account chip in unified mode. We
@@ -83,7 +89,6 @@
   // `refreshing` stays true while the network call is still in flight
   // after the cache has rendered, so the UI can show a subtle hint
   // without blanking the list.
-  let envelopes = $state<EmailEnvelope[]>([])
   let loading = $state(true)
   let refreshing = $state(false)
   let error = $state('')

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -69,9 +69,11 @@
         from the "Edit" button inside the drafts toolbar. */
     oneditdraft?: (mail: Email) => void
     /** Fires after the message has been successfully archived or
-        deleted on the server. The parent clears the selected UID and
-        bumps the MailList refresh so the row disappears. */
-    onmessageremoved?: () => void
+        deleted on the server.  The removed UID is passed back so the
+        parent can compute the "next" message to open (auto-advance
+        behaviour) instead of forcing the user back to the empty
+        reading-pane state. */
+    onmessageremoved?: (removedUid: number) => void
     /** App-wide default for "render HTML email on a white canvas".
         When true the body wrapper gets a forced white background and
         dark text so emails designed for a light page stay readable in
@@ -778,7 +780,7 @@
         folder: email.folder,
         uid,
       })
-      onmessageremoved?.()
+      onmessageremoved?.(uid)
     } catch (e) {
       error = formatError(e) || 'Failed to archive'
     } finally {
@@ -798,7 +800,7 @@
         folder: email.folder,
         uid,
       })
-      onmessageremoved?.()
+      onmessageremoved?.(uid)
     } catch (e) {
       error = formatError(e) || 'Failed to delete'
     } finally {


### PR DESCRIPTION
Closes #99

## Summary

Removing the open mail used to dump the user back to the empty "pick a message" placeholder. For triage flows where you want to blast through a stack of mail, every delete or archive click required a follow-up click on the next row. Now the reading pane jumps straight to the row directly below the removed one (or the row above when the removed row was last) — same pattern Gmail / Outlook / Thunderbird / Apple Mail use.

**Wiring**

- `MailView.svelte`: `onmessageremoved` callback now passes the removed UID up.
- `MailList.svelte`: the local envelope list is now a `$bindable` prop. Parent can peek at "what's currently shown" without re-fetching, to compute the next-row UID.
- `App.svelte`: binds `mailListEnvelopes`, looks up the removed UID's index, picks `idx + 1` (older neighbour) — falling back to `idx - 1` for the last-row case — and routes `selectedUid` / `selectedMessageAccountId` to that row. When the list is empty or the removed UID isn't on screen, the pane returns to blank as before.

**Opt-out setting**

New `auto_advance_after_remove` field on `AppSettings` (default `true`), exposed in *Settings → General* as a checkbox: `"After delete / archive, open the next message automatically"`. Users who liked the old blank-pane behaviour can flip it off; existing settings files keep parsing thanks to the struct's `#[serde(default)]`.

## Test plan

- [ ] Open an inbox with several messages, click on one mid-list, archive it — the row below opens automatically
- [ ] Same flow with delete — same auto-advance
- [ ] Remove the bottom-most row — the row above opens (no row below to advance to)
- [ ] Remove the only remaining row — pane goes blank ("Select a message to read.")
- [ ] Toggle off *"After delete / archive, open the next message automatically"* in settings — delete/archive now leaves the pane blank as before
- [ ] Unified-inbox mode: archiving a row from one account opens the next row regardless of which account it belongs to (the bind passes `account_id` through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)