### PR TITLE
feat(#86): Talk room lifecycle — defer invites, delete orphans, above-sig join link

### DIFF
--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -29,5 +29,6 @@ pub use files::{
 };
 pub use shares::{PublicShare, create_public_share, update_share_label};
 pub use talk::{
-    ParticipantSource, RoomType, TalkRoom, add_participant, create_room, list_rooms, rename_room,
+    ParticipantSource, RoomType, TalkRoom, add_participant, create_room, delete_room, list_rooms,
+    rename_room,
 };

--- a/crates/nimbus-nextcloud/src/talk.rs
+++ b/crates/nimbus-nextcloud/src/talk.rs
@@ -333,6 +333,39 @@ pub async fn rename_room(
     Ok(())
 }
 
+/// Delete a Talk room.  Used by Compose's "discard draft" flow
+/// (#86): rooms minted at compose-time get torn down when the user
+/// cancels the draft so the Nextcloud Talk list doesn't accumulate
+/// orphaned empty rooms.  The endpoint is the same `DELETE
+/// /room/{token}` the Talk web UI hits when the moderator clicks
+/// "Delete conversation".
+pub async fn delete_room(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    room_token: &str,
+) -> Result<(), NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}/ocs/v2.php/apps/spreed/api/v4/room/{room_token}?format=json");
+
+    tracing::debug!("DELETE {url}");
+    let http = client::build()?;
+    let resp = http
+        .delete(&url)
+        .header("OCS-APIRequest", "true")
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("talk delete request failed: {e}")))?;
+
+    // Talk returns the (now-deleted) room shape on success and an
+    // OCS error envelope on failure; we just need the meta-level
+    // success check `ocs_text` provides.
+    let _ = ocs_text(resp, "talk delete room").await?;
+    Ok(())
+}
+
 // ── HTTP / parsing helpers ─────────────────────────────────────
 
 /// Centralise the auth-failure / non-2xx handling so the three call

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1101,6 +1101,54 @@ async fn add_talk_participant(
     .await
 }
 
+/// Batched add — invite a whole list of participants on a single
+/// auth handshake.  Used by Compose's deferred-invite flow (#86):
+/// we create the Talk room empty at compose-time and only invite
+/// the recipients once `Send` actually goes out, so a discarded
+/// draft doesn't leave a room full of strangers in the recipient's
+/// Talk list.  Sequential (not parallel) so the first failure halts
+/// the batch and surfaces as a single error.
+#[tauri::command]
+async fn add_talk_participants(
+    nc_id: String,
+    room_token: String,
+    participants: Vec<nimbus_nextcloud::ParticipantSource>,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    for p in &participants {
+        nimbus_nextcloud::add_participant(
+            &account.server_url,
+            &account.username,
+            &app_password,
+            &room_token,
+            p,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Tear down a Talk room (#86).  Compose's `cancel` flow calls this
+/// whenever the user discards a draft that minted a room earlier
+/// in the session — without it, the room would dangle empty in the
+/// user's Talk list with no context.
+#[tauri::command]
+async fn delete_talk_room(
+    nc_id: String,
+    room_token: String,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::delete_room(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &room_token,
+    )
+    .await
+}
+
 /// Rename an existing Talk room. Used by the Compose "Add Event"
 /// flow to keep the auto-created Talk room's name in sync with the
 /// final event title once the user saves the event.
@@ -4429,6 +4477,8 @@ fn main() {
             create_nextcloud_directory,
             list_talk_rooms,
             create_talk_room,
+            add_talk_participants,
+            delete_talk_room,
             add_talk_participant,
             rename_talk_room,
             upload_to_nextcloud,

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1023,26 +1023,32 @@
         },
       })
       // Flush deferred Talk-room invites (#86).  The room was minted
-      // empty at compose-time; here we invite everyone who's *currently*
-      // on To / Cc / Bcc — derived from the live recipient fields
-      // rather than a modal-time snapshot, because the user can
-      // (a) leave the modal's participant box blank and add
+      // empty at compose-time; here we invite everyone who's
+      // *currently* on To / Cc — derived from the live recipient
+      // fields rather than a modal-time snapshot, because the user
+      // can (a) leave the modal's participant box blank and add
       // recipients afterward, or (b) edit the recipient list between
-      // creating the room and clicking Send.  Either way the rule
-      // "Talk participants = mail recipients at send time" is what
-      // matches the user's mental model.
+      // creating the room and clicking Send.
       //
-      // Failures here are non-fatal — recipients have the link in the
-      // body and can still join — but we surface the error so the
-      // user knows to add invites manually.  Clear `talkRoomToken`
-      // unconditionally so a follow-up discard doesn't try to delete
-      // a now-active room.
+      // **Bcc is deliberately excluded.**  A blind-carbon recipient
+      // exists precisely so other recipients don't see them; routing
+      // their address into a shared Talk room would unmask them to
+      // every other invitee, which would be a privacy regression.
+      // The Bcc'd person still gets the email with the join URL in
+      // the body, so they can join the room as a visitor if they
+      // want to — they just don't get explicitly invited.
+      //
+      // Failures here are non-fatal — invited recipients have the
+      // link in the body and can still join — but we surface the
+      // error so the user knows to add invites manually.  Clear
+      // `talkRoomToken` unconditionally so a follow-up discard
+      // doesn't try to delete a now-active room.
       if (talkRoomToken) {
         const ncId = ncAccountId
         const room = talkRoomToken
         const seen = new Set<string>()
         const participantsToAdd: { kind: 'email'; value: string }[] = []
-        for (const raw of [...splitAddrs(to), ...splitAddrs(cc), ...splitAddrs(bcc)]) {
+        for (const raw of [...splitAddrs(to), ...splitAddrs(cc)]) {
           const addr = bareAddr(raw)
           if (!addr) continue
           const key = addr.toLowerCase()

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -411,9 +411,16 @@
       the room after the event is saved. */
   let talkRoomToken: string | null = null
   /** Lower-cased bare addresses we've already POSTed to Talk's
-      participant endpoint, so the post-save sync skips them. Includes
-      the participants we passed at room-creation time. */
+      participant endpoint, so the post-save sync skips them. */
   const talkRoomParticipants = new Set<string>()
+  /** Bare addresses the user wants invited to the Talk room but we
+      haven't POSTed yet (#86: defer until Send so a discarded draft
+      doesn't leak invites).  Compose accumulates these from the
+      modal / silent-create flows; `send()` calls
+      `add_talk_participants` for the lot once the mail actually
+      sends.  `cancel()` ignores them — the room itself gets
+      DELETEd so any pending invites are moot. */
+  let pendingTalkParticipants = $state<string[]>([])
   /** Whether the "Join the Talk room" body block has been appended
       yet. The Talk button injects immediately; the Add-Event auto-
       create defers injection until the event is saved. */
@@ -452,8 +459,13 @@
 
   /** Append the "Join the Talk room" body block once. Used by both
       the immediate-injection path (Talk button) and the deferred path
-      (Add-Event auto-create → injected on event save). The flag keeps
-      callers from accidentally duplicating the block. */
+      (Add-Event auto-create → injected on event save).  The flag
+      keeps callers from accidentally duplicating the block.
+
+      When the active account has a signature appended, the block goes
+      *above* the signature so the join URL reads as part of the
+      message rather than as a postscript after the "-- " delimiter
+      (which most clients render as quote-y / hide on reply). */
   function injectTalkBlock(link: { name: string; url: string }) {
     if (talkLinkInjected) return
     const esc = (s: string) =>
@@ -461,25 +473,49 @@
     const block =
       `<p><strong>Join the Talk room:</strong></p>` +
       `<p>💬 <a href="${link.url}">${esc(link.name)}</a></p>`
-    editorApi?.appendHtml(block)
+
+    // Splice above the signature when one's been auto-inserted and
+    // the user hasn't typed past it.  We re-set the editor HTML
+    // because the underlying editor doesn't expose an "insert
+    // before substring" primitive.
+    if (
+      insertedSignatureHtml
+      && bodyHtml.endsWith(insertedSignatureHtml)
+      && editorApi
+    ) {
+      const without = bodyHtml.slice(0, bodyHtml.length - insertedSignatureHtml.length)
+      const replaced = without + block + insertedSignatureHtml
+      editorApi.setHtml(replaced)
+      bodyHtml = replaced
+    } else {
+      editorApi?.appendHtml(block)
+    }
     talkLinkInjected = true
   }
 
   function onTalkRoomCreated(room: TalkRoom, participants: string[]) {
     createdTalkLink = { name: room.display_name, url: room.web_url }
     talkRoomToken = room.token
+    // The modal is mounted with `deferParticipants={true}`, so the
+    // Talk room itself was minted empty.  Stash the entered list
+    // here; `send()` POSTs them to Talk once the mail actually goes
+    // out.  Cancel-as-discard wipes the room (and these invites
+    // along with it), so `pendingTalkParticipants` is the audit
+    // trail for "what we said we'd invite".
     for (const p of participants) {
       const k = bareAddr(p).toLowerCase()
-      if (k) talkRoomParticipants.add(k)
+      if (k && !talkRoomParticipants.has(k)) {
+        pendingTalkParticipants = [...pendingTalkParticipants, p]
+      }
     }
     // Keep the mail recipients in sync with the Talk invite: any
     // address the user typed into the modal that wasn't already on
     // To/Cc/Bcc gets added to To.
     mergeIntoRecipients(participants)
-    // The Talk button is itself a "share this room now" gesture, so
-    // inject the body block immediately. The Add-Event auto-create
-    // path deliberately bypasses this callback (it uses
-    // `createTalkRoomSilently`) so its block can be deferred.
+    // Talk button is a "share this room now" gesture so the body
+    // block goes in immediately.  The Add-Event auto-create path
+    // bypasses this callback (uses `createTalkRoomSilently`) so its
+    // block can be deferred until the event is saved.
     injectTalkBlock(createdTalkLink)
   }
 
@@ -510,11 +546,20 @@
       // when the user hasn't set a subject yet — they can rename in
       // Nextcloud later.
       roomName: subject.trim() || '(meeting)',
-      participants: dedupd,
+      // #86: defer participant invites until Send.  The room is
+      // minted empty here; the recipient list rides along in
+      // `pendingTalkParticipants` so `send()` can flush the lot once
+      // the mail actually goes out.
+      participants: [],
     })
     createdTalkLink = { name: room.display_name, url: room.web_url }
     talkRoomToken = room.token
-    for (const p of dedupd) talkRoomParticipants.add(p.value.toLowerCase())
+    for (const p of dedupd) {
+      const k = p.value.toLowerCase()
+      if (!talkRoomParticipants.has(k) && !pendingTalkParticipants.some((x) => bareAddr(x).toLowerCase() === k)) {
+        pendingTalkParticipants = [...pendingTalkParticipants, p.value]
+      }
+    }
   }
 
   async function openEventEditor() {
@@ -977,6 +1022,44 @@
           attachments,
         },
       })
+      // Flush deferred Talk-room invites (#86).  The room was minted
+      // empty at compose-time so a discarded draft could be cleaned
+      // up without spamming recipients; now that the mail has gone
+      // out for real, post the invite list to Talk.  A failure here
+      // is non-fatal — the recipients have the link in the body and
+      // can still join the room as visitors — but we surface it so
+      // the user knows to add invites manually if needed.  Clear
+      // both the pending list and `talkRoomToken` so a follow-up
+      // discard doesn't try to delete a now-active room.
+      if (talkRoomToken && pendingTalkParticipants.length > 0) {
+        const ncId = ncAccountId
+        const room = talkRoomToken
+        const participantsToAdd = pendingTalkParticipants
+          .map((p) => bareAddr(p))
+          .filter((p) => p && !talkRoomParticipants.has(p.toLowerCase()))
+          .map((value) => ({ kind: 'email' as const, value }))
+        if (ncId && participantsToAdd.length > 0) {
+          try {
+            await invoke('add_talk_participants', {
+              ncId,
+              roomToken: room,
+              participants: participantsToAdd,
+            })
+            for (const p of participantsToAdd) {
+              talkRoomParticipants.add(p.value.toLowerCase())
+            }
+          } catch (e) {
+            console.warn('add_talk_participants after send failed', e)
+            error = `Sent, but Talk invites couldn't be delivered: ${formatError(e)}`
+          }
+        }
+      }
+      pendingTalkParticipants = []
+      // Mail sent successfully — the room is now "live" so cancel /
+      // close should NOT delete it.  Drop the token to disarm the
+      // delete-on-discard path.
+      talkRoomToken = null
+
       // Clean up the server-side draft we opened from (if any) so
       // the user doesn't end up with a "sent" copy in Sent AND the
       // unfinished draft still sitting in Drafts. A failure here is
@@ -1035,6 +1118,23 @@
   function cancel() {
     // No local persistence — if the user wants to resume later they
     // need to click "Save draft" first (which APPENDs to IMAP Drafts).
+    //
+    // Clean up any Talk room minted during this draft (#86).  The
+    // room was created empty (deferred invites), so a DELETE is
+    // safe — no recipients will see a "you've been removed" notice.
+    // If the user already pressed Send, `talkRoomToken` was nulled
+    // out in `send()`, so the room is left alone.
+    if (talkRoomToken && ncAccountId) {
+      const ncId = ncAccountId
+      const room = talkRoomToken
+      // Fire-and-forget: a failure here is annoying (orphan room in
+      // Nextcloud) but not worth blocking the close on.  The user
+      // can clean it up from Talk manually.
+      invoke('delete_talk_room', { ncId, roomToken: room }).catch((e) => {
+        console.warn('delete_talk_room on cancel failed', e)
+      })
+      talkRoomToken = null
+    }
     onclose()
   }
 
@@ -1301,6 +1401,7 @@
     ncId={ncAccountId}
     initialName={subject}
     initialParticipants={recipients()}
+    deferParticipants={true}
     onclose={() => (showTalkModal = false)}
     oncreated={onTalkRoomCreated}
   />

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1023,21 +1023,33 @@
         },
       })
       // Flush deferred Talk-room invites (#86).  The room was minted
-      // empty at compose-time so a discarded draft could be cleaned
-      // up without spamming recipients; now that the mail has gone
-      // out for real, post the invite list to Talk.  A failure here
-      // is non-fatal — the recipients have the link in the body and
-      // can still join the room as visitors — but we surface it so
-      // the user knows to add invites manually if needed.  Clear
-      // both the pending list and `talkRoomToken` so a follow-up
-      // discard doesn't try to delete a now-active room.
-      if (talkRoomToken && pendingTalkParticipants.length > 0) {
+      // empty at compose-time; here we invite everyone who's *currently*
+      // on To / Cc / Bcc — derived from the live recipient fields
+      // rather than a modal-time snapshot, because the user can
+      // (a) leave the modal's participant box blank and add
+      // recipients afterward, or (b) edit the recipient list between
+      // creating the room and clicking Send.  Either way the rule
+      // "Talk participants = mail recipients at send time" is what
+      // matches the user's mental model.
+      //
+      // Failures here are non-fatal — recipients have the link in the
+      // body and can still join — but we surface the error so the
+      // user knows to add invites manually.  Clear `talkRoomToken`
+      // unconditionally so a follow-up discard doesn't try to delete
+      // a now-active room.
+      if (talkRoomToken) {
         const ncId = ncAccountId
         const room = talkRoomToken
-        const participantsToAdd = pendingTalkParticipants
-          .map((p) => bareAddr(p))
-          .filter((p) => p && !talkRoomParticipants.has(p.toLowerCase()))
-          .map((value) => ({ kind: 'email' as const, value }))
+        const seen = new Set<string>()
+        const participantsToAdd: { kind: 'email'; value: string }[] = []
+        for (const raw of [...splitAddrs(to), ...splitAddrs(cc), ...splitAddrs(bcc)]) {
+          const addr = bareAddr(raw)
+          if (!addr) continue
+          const key = addr.toLowerCase()
+          if (seen.has(key) || talkRoomParticipants.has(key)) continue
+          seen.add(key)
+          participantsToAdd.push({ kind: 'email', value: addr })
+        }
         if (ncId && participantsToAdd.length > 0) {
           try {
             await invoke('add_talk_participants', {

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -496,6 +496,17 @@
   function onTalkRoomCreated(room: TalkRoom, participants: string[]) {
     createdTalkLink = { name: room.display_name, url: room.web_url }
     talkRoomToken = room.token
+    // Subject ↔ Talk-room name sync.  The modal pre-fills its
+    // "Room name" field from `subject` already, so the
+    // subject-filled-first case lands correctly server-side.  When
+    // the user opened the modal with an empty subject and typed a
+    // room name there, copy it back into the subject so the
+    // outgoing mail isn't subject-less.  We only auto-fill — we
+    // never overwrite a subject the user already typed (that would
+    // clobber a deliberate "subject != room name" choice).
+    if (!subject.trim() && room.display_name.trim()) {
+      subject = room.display_name
+    }
     // The modal is mounted with `deferParticipants={true}`, so the
     // Talk room itself was minted empty.  Stash the entered list
     // here; `send()` POSTs them to Talk once the mail actually goes

--- a/ui/src/lib/CreateTalkRoomModal.svelte
+++ b/ui/src/lib/CreateTalkRoomModal.svelte
@@ -45,6 +45,17 @@
      * sees the bare address.
      */
     initialParticipants?: string[]
+    /**
+     * Compose's draft-lifecycle flow (#86) creates the room empty and
+     * defers the actual invite calls to `Send` — so a discarded
+     * draft can DELETE the room cleanly without ever having spammed
+     * recipients.  In that mode the Talk room is minted with zero
+     * participants here; the parsed address list still flows up via
+     * `oncreated` so the caller can hold onto it for later.  Defaults
+     * to `false` (immediate-add behaviour, matching the Talk-button
+     * use case in MailView).
+     */
+    deferParticipants?: boolean
     onclose: () => void
     /**
      * Fires once the room is created. Carries the freshly minted room
@@ -55,7 +66,14 @@
      */
     oncreated: (room: TalkRoom, participantEmails: string[]) => void
   }
-  const { ncId, initialName = '', initialParticipants = [], onclose, oncreated }: Props = $props()
+  const {
+    ncId,
+    initialName = '',
+    initialParticipants = [],
+    deferParticipants = false,
+    onclose,
+    oncreated,
+  }: Props = $props()
 
   // svelte-ignore state_referenced_locally
   let roomName = $state(initialName)
@@ -104,10 +122,14 @@
     creating = true
     try {
       const participants = buildParticipants()
+      // In deferred mode (Compose's flow), mint the room empty and
+      // hand the parsed list up to the caller — they'll add invites
+      // once the mail actually sends, so discarding the draft can
+      // tear the empty room down with no surprised recipients.
       const room = await invoke<TalkRoom>('create_talk_room', {
         ncId,
         roomName: name,
-        participants,
+        participants: deferParticipants ? [] : participants,
       })
       oncreated(room, participants.map((p) => p.value))
       onclose()


### PR DESCRIPTION
Closes #86

## Summary

Four items from the Talk-room follow-up checklist; three needed code, one was already covered.

### Defer participant invites until Send
The Talk room is now minted **empty** at compose-time. Recipient invites get POSTed only after `send_email` succeeds. A discarded draft no longer leaves recipients staring at a stray Talk room with no email context.

- \`CreateTalkRoomModal\` gains a \`deferParticipants\` prop. When \`true\` (Compose's flow) the create call goes out with \`participants: []\`; the parsed list still flows up to the caller via \`oncreated\`. MailView's "Talk" button keeps the immediate-add behaviour by leaving the prop unset.
- \`Compose\` accumulates everything the user typed into the modal (and everything the Add-Event silent-create pulls in) in a \`pendingTalkParticipants\` state. \`send()\` fires a single batched \`add_talk_participants\` call once the mail goes out.

### Delete orphan rooms on cancel
\`cancel()\` calls \`delete_talk_room\` when there's a \`talkRoomToken\` from the current session. \`send()\` nulls the token on success so a "send then close" sequence doesn't tear the freshly-active room down.

### Insert join-link above the signature
The "Join the Talk room:" block was being \`appendHtml\`'d to the end of the editor — *after* any auto-inserted account signature. \`injectTalkBlock\` now splices the block in just before the recorded \`insertedSignatureHtml\` when the body still ends with it (and falls back to \`appendHtml\` when the user has typed past the sig).

### Open Talk links via the OS handler — already done
External link clicks in \`MailView\` route through the \`open_url\` Tauri command, which delegates to the \`open\` crate, which on every platform invokes the OS's registered URL handler. Talk desktop app installed → it picks up the click; otherwise the default browser opens the link. Verified no Talk-specific webview path exists in the codebase.

## Backend additions

- \`nimbus_nextcloud::delete_room\` + \`delete_talk_room\` Tauri command (DELETE \`/ocs/v2.php/apps/spreed/api/v4/room/{token}\`)
- \`add_talk_participants\` Tauri command — sequential \`add_participant\` over a list, single auth handshake

## Test plan

- [ ] Click the Talk button in Compose, fill in participants, **cancel** → in Nextcloud's Talk list, no orphan room appears
- [ ] Same flow, **send** → mail is delivered; recipients get Talk invites; the room shows up in their Talk list with the right name
- [ ] Use Add Event in Compose (silent-create flow), fill recipients, **cancel** → orphan room is deleted
- [ ] Open the freshly-sent Talk room → \`talkRoomParticipants\` is correctly populated server-side
- [ ] Compose with a configured signature → the "Join the Talk room:" block lands *above* the \`-- \` separator, not after it
- [ ] Compose without a signature → block lands at the end of the body (back-compat)
- [ ] Click a Talk URL inside a received mail's body → opens in the registered OS handler (Talk desktop app or default browser), not in a Tauri webview
- [ ] MailView's "Talk" button (creating a Talk room from an existing thread) still adds participants immediately (\`deferParticipants\` only flips for the Compose mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)