### PR TITLE
feat(#103): unified Compose toolbar (Send moves to top-right)

### DIFF
--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -198,6 +198,12 @@
       icon: '📎',
       content: attachTabContent,
     },
+    {
+      id: 'meetings',
+      label: 'Meetings',
+      icon: '💬',
+      content: meetingsTabContent,
+    },
   ])
 
   /** Shares minted from this Compose during the current draft.
@@ -1362,9 +1368,9 @@
   primary actions in the ribbon header").
 -->
 
-<!-- Attach tab panel — same `.rt-btn` styling the editor's panels
-     use so the Attach tab is visually indistinguishable from a
-     built-in tab. -->
+<!-- Attach tab panel — local + Nextcloud file pickers.  Same
+     `.rt-btn` styling the editor's panels use so each Compose tab
+     reads as visually indistinguishable from a built-in. -->
 {#snippet attachTabContent()}
   <label class="rt-btn cursor-pointer" title="Attach a file from your computer">
     <span class="rt-btn-icon">📎</span>
@@ -1378,8 +1384,14 @@
     onclick={() => (showNcPicker = true)}
   >
     <span class="rt-btn-icon">☁️</span>
-    <span class="rt-btn-label">Files</span>
+    <span class="rt-btn-label">NC Files</span>
   </button>
+{/snippet}
+
+<!-- Meetings tab panel — Nextcloud Talk + calendar-event creation.
+     Split out from Attach so picking a meeting feature isn't
+     buried in a "files" context. -->
+{#snippet meetingsTabContent()}
   <button
     type="button"
     class="rt-btn"

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -21,6 +21,7 @@
   import RichTextEditor, {
     type EditorApi,
     type ContactSuggestion,
+    type ExtraTab,
   } from './RichTextEditor.svelte'
   import AddressAutocomplete from './AddressAutocomplete.svelte'
   import NextcloudFilePicker, { type ShareLink } from './NextcloudFilePicker.svelte'
@@ -185,6 +186,19 @@
       ? `${prefix}${recipients}`
       : `${prefix}${recipients.slice(0, max - prefix.length - 1)}…`
   })
+
+  /** Extra tabs we contribute to the editor's ribbon (#103
+   *  follow-up).  Wrapped in a `$derived` because the snippet
+   *  symbols aren't bound until after the template has parsed —
+   *  declaring this as a plain `let` would capture `undefined`. */
+  let composeExtraTabs = $derived<ExtraTab[]>([
+    {
+      id: 'attach',
+      label: 'Attach',
+      icon: '📎',
+      content: attachTabContent,
+    },
+  ])
 
   /** Shares minted from this Compose during the current draft.
    *  We hold onto each one's `id` + `ncId` so when the recipient
@@ -1315,7 +1329,8 @@
           attachmentsForRef={attachments
             .filter((a): a is Attachment & { content_id: string } => !!a.content_id)
             .map((a) => ({ content_id: a.content_id, filename: a.filename }))}
-          actionsTrailing={composeActions}
+          actionsTrailing={sendActions}
+          extraTabs={composeExtraTabs}
         />
       </div>
 
@@ -1338,46 +1353,45 @@
 {/snippet}
 
 <!--
-  Compose's contribution to the unified toolbar (#103).  Lives at
-  the right edge of `RichTextEditor`'s toolbar row via the
-  `actionsTrailing` snippet prop.  Two visual groups:
-
-    - **Attach & share** — paperclip / Nextcloud / Talk / Event.
-    - **Send actions** — Save draft, Send (primary), Discard.
-
-  Buttons are icon + tiny stacked label so the row stays compact
-  while still being scannable.  Send is the primary-filled button
-  and lives last in the row so it has the same visual weight as
-  every other "primary action top-right" the rest of the app uses.
+  Compose's contribution to the editor's tab strip + tab-content
+  area (#103).  We register an "Attach" tab so Attach / Files /
+  Talk / Event live alongside the editor's Format / Insert /
+  Layout tabs in the same ribbon, AND a tab-strip-trailing snippet
+  for the Save / Discard / Send actions which stay visible
+  regardless of which tab is open (matching Outlook's "always-on
+  primary actions in the ribbon header").
 -->
-{#snippet composeActions()}
-  <!-- Attach & share group -->
-  <label class="ctb" title="Attach a file from your computer">
-    <span class="ctb-icon">📎</span>
-    <span class="ctb-label">Attach</span>
+
+<!-- Attach tab panel — same `.rt-btn` styling the editor's panels
+     use so the Attach tab is visually indistinguishable from a
+     built-in tab. -->
+{#snippet attachTabContent()}
+  <label class="rt-btn cursor-pointer" title="Attach a file from your computer">
+    <span class="rt-btn-icon">📎</span>
+    <span class="rt-btn-label">Attach</span>
     <input type="file" multiple class="hidden" onchange={onPickFiles} />
   </label>
   <button
     type="button"
-    class="ctb"
+    class="rt-btn"
     title="Attach a file or link from Nextcloud"
     onclick={() => (showNcPicker = true)}
   >
-    <span class="ctb-icon">☁️</span>
-    <span class="ctb-label">Files</span>
+    <span class="rt-btn-icon">☁️</span>
+    <span class="rt-btn-label">Files</span>
   </button>
   <button
     type="button"
-    class="ctb"
+    class="rt-btn"
     title="Create a Nextcloud Talk room with the current recipients"
     onclick={openTalkModal}
   >
-    <span class="ctb-icon">💬</span>
-    <span class="ctb-label">Talk</span>
+    <span class="rt-btn-icon">💬</span>
+    <span class="rt-btn-label">Talk</span>
   </button>
   <button
     type="button"
-    class="ctb"
+    class="rt-btn"
     disabled={openingEvent}
     title={
       createdTalkLink
@@ -1386,13 +1400,15 @@
     }
     onclick={openEventEditor}
   >
-    <span class="ctb-icon">{openingEvent ? '⏳' : '📅'}</span>
-    <span class="ctb-label">{openingEvent ? 'Creating…' : 'Event'}</span>
+    <span class="rt-btn-icon">{openingEvent ? '⏳' : '📅'}</span>
+    <span class="rt-btn-label">{openingEvent ? 'Creating…' : 'Event'}</span>
   </button>
+{/snippet}
 
-  <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-  <!-- Send actions group -->
+<!-- Always-visible Save / Discard / Send actions in the tab-strip
+     trailing slot.  Compact (`.ctb`) so they fit alongside the tab
+     buttons.  Send is primary-filled and rightmost. -->
+{#snippet sendActions()}
   <button
     type="button"
     class="ctb"
@@ -1401,7 +1417,7 @@
     onclick={saveDraft}
   >
     <span class="ctb-icon">💾</span>
-    <span class="ctb-label">Save draft</span>
+    <span class="ctb-label">Save</span>
   </button>
   <button
     type="button"

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1298,7 +1298,12 @@
       </div>
 
       <!-- `flex-1 min-h-0` makes this the stretchy slot in the body
-           column; the editor inside uses `h-full` to fill it. -->
+           column; the editor inside uses `h-full` to fill it.
+
+           The trailing-actions snippet hands the editor toolbar
+           our Attach / Talk / Files / Send / Save Draft / Discard
+           buttons so they share one toolbar row with the rich-text
+           controls instead of living in a separate footer (#103). -->
       <div class="flex-1 min-h-0 flex flex-col">
         <RichTextEditor
           content={bodyHtml}
@@ -1310,6 +1315,7 @@
           attachmentsForRef={attachments
             .filter((a): a is Attachment & { content_id: string } => !!a.content_id)
             .map((a) => ({ content_id: a.content_id, filename: a.filename }))}
+          actionsTrailing={composeActions}
         />
       </div>
 
@@ -1329,46 +1335,94 @@
       {/if}
     </div>
 
-    <!-- Footer with wrap-on-narrow. Primary actions (Send + the
-         attach / NC / Talk / event buttons) stay left-aligned and
-         reflow onto a second row when the modal is narrow — the
-         `flex-wrap` is what keeps "Creating Talk room…" from
-         pushing Cancel off the edge on smaller widths. Cancel is
-         pinned to the trailing edge by the `ml-auto` spacer so the
-         user always has a consistent escape hatch. -->
-    <footer class="px-5 py-3 border-t border-surface-200 dark:border-surface-700 flex flex-wrap items-center gap-2">
-      <button class="btn preset-filled-primary-500" disabled={sending} onclick={send}>
-        {sending ? 'Sending…' : 'Send'}
-      </button>
-      <label class="btn preset-outlined-surface-500 cursor-pointer">
-        📎 Attach
-        <input type="file" multiple class="hidden" onchange={onPickFiles} />
-      </label>
-      <button
-        type="button"
-        class="btn preset-outlined-surface-500"
-        onclick={() => (showNcPicker = true)}
-      >☁️ From Nextcloud</button>
-      <button
-        type="button"
-        class="btn preset-outlined-surface-500"
-        title="Create a Nextcloud Talk room with the current recipients and add the join link to this email"
-        onclick={openTalkModal}
-      >💬 Talk room</button>
-      <button
-        type="button"
-        class="btn preset-outlined-surface-500"
-        disabled={openingEvent}
-        title={
-          createdTalkLink
-            ? 'Create a calendar event with the current recipients as attendees (existing Talk link prefilled)'
-            : 'Create a Talk room and a calendar event with the current recipients — the Talk link is added to the event URL and the email body'
-        }
-        onclick={openEventEditor}
-      >{openingEvent ? (createdTalkLink ? 'Loading…' : 'Creating Talk room…') : '📅 Add event'}</button>
-      <button class="btn preset-outlined-surface-500" disabled={sending} onclick={saveDraft}>Save draft</button>
-      <button class="btn preset-outlined-surface-500 ml-auto" onclick={cancel}>Cancel</button>
-    </footer>
+{/snippet}
+
+<!--
+  Compose's contribution to the unified toolbar (#103).  Lives at
+  the right edge of `RichTextEditor`'s toolbar row via the
+  `actionsTrailing` snippet prop.  Two visual groups:
+
+    - **Attach & share** — paperclip / Nextcloud / Talk / Event.
+    - **Send actions** — Save draft, Send (primary), Discard.
+
+  Buttons are icon + tiny stacked label so the row stays compact
+  while still being scannable.  Send is the primary-filled button
+  and lives last in the row so it has the same visual weight as
+  every other "primary action top-right" the rest of the app uses.
+-->
+{#snippet composeActions()}
+  <!-- Attach & share group -->
+  <label class="ctb" title="Attach a file from your computer">
+    <span class="ctb-icon">📎</span>
+    <span class="ctb-label">Attach</span>
+    <input type="file" multiple class="hidden" onchange={onPickFiles} />
+  </label>
+  <button
+    type="button"
+    class="ctb"
+    title="Attach a file or link from Nextcloud"
+    onclick={() => (showNcPicker = true)}
+  >
+    <span class="ctb-icon">☁️</span>
+    <span class="ctb-label">Files</span>
+  </button>
+  <button
+    type="button"
+    class="ctb"
+    title="Create a Nextcloud Talk room with the current recipients"
+    onclick={openTalkModal}
+  >
+    <span class="ctb-icon">💬</span>
+    <span class="ctb-label">Talk</span>
+  </button>
+  <button
+    type="button"
+    class="ctb"
+    disabled={openingEvent}
+    title={
+      createdTalkLink
+        ? 'Create a calendar event with the current recipients (existing Talk link prefilled)'
+        : 'Create a Talk room + calendar event with the current recipients'
+    }
+    onclick={openEventEditor}
+  >
+    <span class="ctb-icon">{openingEvent ? '⏳' : '📅'}</span>
+    <span class="ctb-label">{openingEvent ? 'Creating…' : 'Event'}</span>
+  </button>
+
+  <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+
+  <!-- Send actions group -->
+  <button
+    type="button"
+    class="ctb"
+    disabled={sending}
+    title="Save the current draft to the Drafts folder"
+    onclick={saveDraft}
+  >
+    <span class="ctb-icon">💾</span>
+    <span class="ctb-label">Save draft</span>
+  </button>
+  <button
+    type="button"
+    class="ctb ctb-danger"
+    disabled={sending}
+    title="Discard this draft and close the window"
+    onclick={cancel}
+  >
+    <span class="ctb-icon">🗑</span>
+    <span class="ctb-label">Discard</span>
+  </button>
+  <button
+    type="button"
+    class="ctb ctb-primary"
+    disabled={sending}
+    title="Send the message"
+    onclick={send}
+  >
+    <span class="ctb-icon">📤</span>
+    <span class="ctb-label">{sending ? 'Sending…' : 'Send'}</span>
+  </button>
 {/snippet}
 
 {#if showNcPicker}
@@ -1445,3 +1499,55 @@
     onsaved={onEventSaved}
   />
 {/if}
+
+<style>
+  /* Compose-toolbar buttons (#103).  Stacked icon + tiny label so
+     each action stays compact in the unified toolbar row.  The
+     `:global` is needed because these buttons render inside the
+     RichTextEditor's `actionsTrailing` snippet — Svelte scopes
+     parent styles to the parent's DOM, but snippet contents land
+     in the child component's tree.  Variants:
+       - `.ctb-primary` — the Send button (filled primary).
+       - `.ctb-danger`  — the Discard button (red on hover). */
+  :global(.ctb) {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.05rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.375rem;
+    line-height: 1;
+    color: inherit;
+    cursor: pointer;
+    transition: background-color 100ms ease, color 100ms ease;
+  }
+  :global(.ctb:hover:not(:disabled)) {
+    background: rgb(0 0 0 / 0.06);
+  }
+  :global([data-mode='dark'] .ctb:hover:not(:disabled)) {
+    background: rgb(255 255 255 / 0.08);
+  }
+  :global(.ctb:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  :global(.ctb-icon) {
+    font-size: 1rem;
+  }
+  :global(.ctb-label) {
+    font-size: 0.625rem;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  :global(.ctb-primary) {
+    color: white;
+    background: var(--color-primary-500, #3b82f6);
+  }
+  :global(.ctb-primary:hover:not(:disabled)) {
+    background: var(--color-primary-600, #2563eb);
+  }
+  :global(.ctb-danger:hover:not(:disabled)) {
+    color: rgb(239 68 68);
+    background: rgb(239 68 68 / 0.12);
+  }
+</style>

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -417,7 +417,28 @@
       Highlight.configure({ multicolor: true }),
       Table.configure({ resizable: true }),
       TableRow,
-      TableCell,
+      // Extend TableCell with a backgroundColor attribute so the
+      // toolbar's cell-colour picker has somewhere to write.  The
+      // attr round-trips via inline `style="background-color: …"`,
+      // which every mail client renders correctly without needing
+      // a class-based stylesheet on the recipient side.
+      TableCell.extend({
+        addAttributes() {
+          return {
+            ...this.parent?.(),
+            backgroundColor: {
+              default: null,
+              parseHTML: (el: HTMLElement) =>
+                el.style.backgroundColor || null,
+              renderHTML: (attrs: Record<string, unknown>) => {
+                const c = attrs.backgroundColor
+                if (!c) return {}
+                return { style: `background-color: ${c}` }
+              },
+            },
+          }
+        },
+      }),
       TableHeader,
       // ── `@` contact mention ────────────────────────────────
       // Renamed from the default `mention` so it can coexist with
@@ -813,9 +834,59 @@
   let tableHoverCols = $state(0)
   const TABLE_GRID = 8  // 8x8 picker like Outlook
 
+  /** Selection (cursor position) snapshotted when the user opens
+   *  the table picker.  We restore it before inserting so the
+   *  table lands where the user's cursor was, not wherever Tiptap
+   *  thinks the focus moved to during the dropdown interaction. */
+  let savedTableSelection: { from: number; to: number } | null = null
+
+  function openTablePicker() {
+    if ($editor) {
+      const sel = $editor.state.selection
+      savedTableSelection = { from: sel.from, to: sel.to }
+    }
+    showTablePicker = !showTablePicker
+  }
+
   function insertTable(rows: number, cols: number) {
-    cmd().insertTable({ rows, cols, withHeaderRow: true }).run()
+    if (savedTableSelection) {
+      cmd()
+        .setTextSelection(savedTableSelection)
+        .insertTable({ rows, cols, withHeaderRow: true })
+        .run()
+    } else {
+      cmd().insertTable({ rows, cols, withHeaderRow: true }).run()
+    }
+    savedTableSelection = null
     showTablePicker = false
+  }
+
+  // ── Table editing actions (#103 follow-up) ─────────────────────
+  // Thin wrappers around Tiptap's table commands.  The toolbar
+  // disables them when the cursor isn't inside a table, so calling
+  // them in that state would no-op anyway — but keeping the chain
+  // explicit means future "is the cursor in a header row?" checks
+  // can branch here without each call site reimplementing it.
+  function tblAddRowAbove() { cmd().addRowBefore().run() }
+  function tblAddRowBelow() { cmd().addRowAfter().run() }
+  function tblAddColLeft()  { cmd().addColumnBefore().run() }
+  function tblAddColRight() { cmd().addColumnAfter().run() }
+  function tblDeleteRow()   { cmd().deleteRow().run() }
+  function tblDeleteCol()   { cmd().deleteColumn().run() }
+  function tblDelete()      { cmd().deleteTable().run() }
+  function tblSetCellColor(e: Event) {
+    const color = (e.target as HTMLInputElement).value
+    cmd().setCellAttribute('backgroundColor', color).run()
+  }
+  function tblClearCellColor() {
+    cmd().setCellAttribute('backgroundColor', null).run()
+  }
+
+  /** Reactive: is the cursor currently inside a table?  Drives the
+   *  enabled/disabled state of the table-edit buttons in the
+   *  Insert tab. */
+  function tableActive(): boolean {
+    return !!$editor?.isActive('table')
   }
 
   // ── Ribbon tab + emoji-picker state (#103 follow-up) ──────────
@@ -851,6 +922,25 @@
     cmd().insertContent(e).run()
     showEmojiPicker = false
   }
+
+  // Click-outside dismissal for the emoji popup.  The popup itself
+  // stops propagation on its own click handler, so any click that
+  // reaches `document` originated outside it.  We delay the install
+  // by one tick (`setTimeout(0)`) so the click that *opened* the
+  // popup doesn't immediately close it.  Same idiom would work for
+  // the other popups (font / table) but the user only flagged the
+  // emoji picker — keeping scope tight.
+  $effect(() => {
+    if (!showEmojiPicker) return
+    const close = () => (showEmojiPicker = false)
+    const handle = setTimeout(() => {
+      window.addEventListener('click', close)
+    }, 0)
+    return () => {
+      clearTimeout(handle)
+      window.removeEventListener('click', close)
+    }
+  })
 
   /** Strip every mark + collapse the current block down to the
    *  default paragraph node.  Outlook's "Clear formatting" button. */
@@ -962,11 +1052,15 @@
     transition: background 0.1s, color 0.1s;
     position: relative;
   }
-  :global(.rt-btn:hover) {
+  :global(.rt-btn:hover:not(:disabled)) {
     background: var(--color-surface-200);
   }
-  :global([data-mode='dark'] .rt-btn:hover) {
+  :global([data-mode='dark'] .rt-btn:hover:not(:disabled)) {
     background: var(--color-surface-700);
+  }
+  :global(.rt-btn:disabled) {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
   :global(.rt-btn-icon) {
     font-size: 1.125rem;
@@ -1268,7 +1362,7 @@
 
         <!-- Table picker -->
         <div class="relative inline-block">
-          <button class="rt-btn" title="Insert table" onclick={() => (showTablePicker = !showTablePicker)}>
+          <button class="rt-btn" title="Insert table at cursor" onclick={openTablePicker}>
             <span class="rt-btn-icon">▦</span>
             <span class="rt-btn-label">Table</span>
           </button>
@@ -1337,6 +1431,56 @@
             </div>
           {/if}
         </div>
+
+        <span class="rt-divider"></span>
+
+        <!-- Table editing tools — visible always, but disabled when
+             the cursor isn't inside a table.  Sits in the Insert
+             tab next to the table-creation picker so the user
+             reaches for one ribbon section regardless of whether
+             they're creating or editing.  Background-colour input
+             writes to a custom `backgroundColor` attribute on the
+             cell (TableCell extension above) which renders as
+             inline `style="background-color: …"` for cross-client
+             email compatibility. -->
+        {@const tblOn = tableActive()}
+        <button class="rt-btn" title="Add row above" disabled={!tblOn} onclick={tblAddRowAbove}>
+          <span class="rt-btn-icon">⤴︎</span>
+          <span class="rt-btn-label">Row above</span>
+        </button>
+        <button class="rt-btn" title="Add row below" disabled={!tblOn} onclick={tblAddRowBelow}>
+          <span class="rt-btn-icon">⤵︎</span>
+          <span class="rt-btn-label">Row below</span>
+        </button>
+        <button class="rt-btn" title="Add column left" disabled={!tblOn} onclick={tblAddColLeft}>
+          <span class="rt-btn-icon">⇤</span>
+          <span class="rt-btn-label">Col left</span>
+        </button>
+        <button class="rt-btn" title="Add column right" disabled={!tblOn} onclick={tblAddColRight}>
+          <span class="rt-btn-icon">⇥</span>
+          <span class="rt-btn-label">Col right</span>
+        </button>
+        <button class="rt-btn" title="Delete current row" disabled={!tblOn} onclick={tblDeleteRow}>
+          <span class="rt-btn-icon">−↔</span>
+          <span class="rt-btn-label">Del row</span>
+        </button>
+        <button class="rt-btn" title="Delete current column" disabled={!tblOn} onclick={tblDeleteCol}>
+          <span class="rt-btn-icon">−↕</span>
+          <span class="rt-btn-label">Del col</span>
+        </button>
+        <label class="rt-btn cursor-pointer" title="Cell background colour" class:opacity-50={!tblOn}>
+          <span class="rt-btn-icon">🎨</span>
+          <span class="rt-btn-label">Cell colour</span>
+          <input type="color" class="w-0 h-0 opacity-0 absolute" disabled={!tblOn} onchange={tblSetCellColor} />
+        </label>
+        <button class="rt-btn" title="Clear cell background colour" disabled={!tblOn} onclick={tblClearCellColor}>
+          <span class="rt-btn-icon">⌫</span>
+          <span class="rt-btn-label">Clear fill</span>
+        </button>
+        <button class="rt-btn" title="Delete entire table" disabled={!tblOn} onclick={tblDelete}>
+          <span class="rt-btn-icon">🗑</span>
+          <span class="rt-btn-label">Del table</span>
+        </button>
       {:else if activeTab === 'layout'}
         <!-- Headings -->
         <button class="rt-btn {active('heading', { level: 1 })}" title="Heading 1" onclick={() => toggleHeading(1)}>

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -88,6 +88,14 @@
      *  no separate event needed when the parent's attachments
      *  change. */
     attachmentsForRef?: AttachmentRef[]
+    /** Caller-provided actions appended to the right side of the
+     *  toolbar (#103).  Compose uses this to colocate the
+     *  Attach / Talk / Files / Send / Save Draft / Discard buttons
+     *  with the rich-text controls so the user has one toolbar
+     *  instead of a top-row + bottom-footer split.  When omitted
+     *  the toolbar ends at the rich-text group, which is what
+     *  every other future embedder gets by default. */
+    actionsTrailing?: import('svelte').Snippet
   }
 
   /** A row in the `@` contact picker. */
@@ -121,6 +129,7 @@
     oncontactquery,
     oncontactpicked,
     attachmentsForRef = [],
+    actionsTrailing,
   }: Props = $props()
 
   // \u2500\u2500 Inline `@` and `/` picker state \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -1114,6 +1123,18 @@
     <button class="tb" title="Redo (Ctrl+Y)" onclick={() => doRedo()}>
       &#x21AA;
     </button>
+
+    <!-- Trailing actions slot — Compose injects Attach / Talk /
+         Files + Send / Save Draft / Discard here so they share
+         the toolbar row with the rich-text controls (#103).  The
+         leading `ml-auto` separator pushes the snippet against
+         the right edge of the toolbar so editor controls and
+         caller actions visibly read as left-half / right-half. -->
+    {#if actionsTrailing}
+      <span class="ml-auto"></span>
+      <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+      {@render actionsTrailing()}
+    {/if}
   </div>
 
   <!-- Editor area. `flex-1 min-h-0` lets it shrink/grow with the

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -89,13 +89,39 @@
      *  change. */
     attachmentsForRef?: AttachmentRef[]
     /** Caller-provided actions appended to the right side of the
-     *  toolbar (#103).  Compose uses this to colocate the
-     *  Attach / Talk / Files / Send / Save Draft / Discard buttons
-     *  with the rich-text controls so the user has one toolbar
-     *  instead of a top-row + bottom-footer split.  When omitted
-     *  the toolbar ends at the rich-text group, which is what
-     *  every other future embedder gets by default. */
+     *  toolbar (#103).  Compose uses this to colocate the Save /
+     *  Discard / Send buttons with the rich-text controls so the
+     *  user has one toolbar instead of a top-row + bottom-footer
+     *  split.  When omitted the tab strip ends at the trailing
+     *  divider, which is what every future embedder without send-
+     *  style actions gets by default. */
     actionsTrailing?: import('svelte').Snippet
+    /** Extra tabs the embedder wants to add to the toolbar (#103
+     *  follow-up).  Compose contributes a single "Attach" tab so
+     *  Attach / NC Files / Talk / Event live in the same ribbon as
+     *  the rich-text controls.  Each entry is `{ id, label, icon,
+     *  content }` — `content` is rendered as the panel below the
+     *  tab strip when the tab is active.  Empty / omitted → no
+     *  extra tabs. */
+    extraTabs?: ExtraTab[]
+  }
+
+  /** Embedder-provided tab spec.  Mirrors the ribbon tabs the
+   *  editor renders by default but lets a parent like Compose add
+   *  Compose-only actions (Attach / Files / Talk / Event) into the
+   *  same tab strip as Format / Insert / Layout. */
+  export interface ExtraTab {
+    /** Stable id used as the `activeTab` value when this tab is
+     *  selected.  Avoid collisions with the built-in tab ids
+     *  (`'format' | 'insert' | 'layout'`). */
+    id: string
+    /** Tab strip label, e.g. "Attach". */
+    label: string
+    /** Optional emoji / icon shown left of the label in the strip. */
+    icon?: string
+    /** Panel contents — rendered below the tab strip when this tab
+     *  is the active one. */
+    content: import('svelte').Snippet
   }
 
   /** A row in the `@` contact picker. */
@@ -130,6 +156,7 @@
     oncontactpicked,
     attachmentsForRef = [],
     actionsTrailing,
+    extraTabs = [],
   }: Props = $props()
 
   // \u2500\u2500 Inline `@` and `/` picker state \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -791,6 +818,46 @@
     showTablePicker = false
   }
 
+  // ── Ribbon tab + emoji-picker state (#103 follow-up) ──────────
+  // The toolbar is split into Outlook-style tabs.  `activeTab`
+  // drives which panel is rendered below the tab strip; values
+  // beyond the built-in three come from the embedder's
+  // `extraTabs` prop (Compose contributes "attach").
+  type BuiltinTab = 'format' | 'insert' | 'layout'
+  let activeTab = $state<BuiltinTab | string>('format')
+
+  let showEmojiPicker = $state(false)
+
+  /** Curated set the emoji popup shows.  Keeping this small and
+   *  hand-picked beats a full-Unicode picker for the email-compose
+   *  use case — most users want a familiar handful, and the popup
+   *  fits in one screen of grid without paging. */
+  const EMOJI_SET = [
+    '😀','😃','😄','😁','😆','😅','😂','🤣',
+    '😊','😇','🙂','🙃','😉','😌','😍','🥰',
+    '😘','😋','😛','😝','😜','🤪','😎','🤓',
+    '🥳','😏','😒','😔','😢','😭','😤','😡',
+    '😱','😳','🥵','🥶','😴','🤔','🤨','🙄',
+    '👍','👎','👌','✌️','🤞','🤟','🤘','👏',
+    '🙌','🤝','🙏','💪','✍️','👈','👉','👆',
+    '❤️','🧡','💛','💚','💙','💜','🤎','🖤',
+    '💔','❣️','💕','💖','💯','✅','❌','⚠️',
+    '❓','❗','💡','🎉','🎊','⭐','🌟','✨',
+    '🔥','💥','📌','📎','📋','📝','📅','🕐',
+    '🔔','📞','📧','📤','📥','💾','🗑','📁',
+  ]
+
+  function insertEmoji(e: string) {
+    cmd().insertContent(e).run()
+    showEmojiPicker = false
+  }
+
+  /** Strip every mark + collapse the current block down to the
+   *  default paragraph node.  Outlook's "Clear formatting" button. */
+  function clearFormatting() {
+    cmd().unsetAllMarks().clearNodes().run()
+  }
+
   function setColor(e: Event) {
     const color = (e.target as HTMLInputElement).value
     cmd().setColor(color).run()
@@ -802,7 +869,9 @@
   }
 
   // Reactive "is active" helpers for styling toolbar buttons.
-  const ACTIVE_CLS = 'bg-surface-300 dark:bg-surface-600'
+  // Returns the `is-active` class which `.rt-btn` (panel buttons)
+  // and `.tb` (compact buttons) both pick up via `:global` rules.
+  const ACTIVE_CLS = 'is-active'
 
   function active(name: string, attrs?: Record<string, unknown>): string {
     return $editor?.isActive(name, attrs) ? ACTIVE_CLS : ''
@@ -814,7 +883,10 @@
 </script>
 
 <style>
-  /* Toolbar buttons — small, consistent touch targets. */
+  /* Compact toolbar buttons — used by the tab strip's undo/redo +
+     embedder-supplied trailing actions where vertical space is
+     scarce.  Same idiom as before; the ribbon's panel buttons get
+     `.rt-btn` styling instead. */
   .tb {
     display: inline-flex;
     align-items: center;
@@ -835,6 +907,99 @@
   }
   :global(.dark) .tb:hover {
     background: var(--color-surface-700);
+  }
+  .tb.is-active {
+    background: var(--color-surface-300);
+  }
+  :global(.dark) .tb.is-active {
+    background: var(--color-surface-600);
+  }
+
+  /* ── Ribbon-style tab strip (#103 follow-up) ─────────────────── */
+
+  /* Tab buttons.  Rounded-top chip with a primary-colour underline
+     when active, matching Outlook Web's ribbon tabs. */
+  :global(.rt-tab) {
+    padding: 0.45rem 1rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+    line-height: 1;
+    transition: background 0.1s, border-color 0.1s, color 0.1s;
+  }
+  :global(.rt-tab:hover) {
+    background: var(--color-surface-200);
+  }
+  :global([data-mode='dark'] .rt-tab:hover) {
+    background: var(--color-surface-700);
+  }
+  :global(.rt-tab-active) {
+    color: var(--color-primary-500);
+    border-bottom-color: var(--color-primary-500);
+  }
+
+  /* Panel buttons — large stacked icon-above-label.  Outlook-Web
+     ribbon proportions: ~50px tall, 24px icon, 11px label. */
+  :global(.rt-btn) {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.125rem;
+    min-width: 3.25rem;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.375rem;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    transition: background 0.1s, color 0.1s;
+    position: relative;
+  }
+  :global(.rt-btn:hover) {
+    background: var(--color-surface-200);
+  }
+  :global([data-mode='dark'] .rt-btn:hover) {
+    background: var(--color-surface-700);
+  }
+  :global(.rt-btn-icon) {
+    font-size: 1.125rem;
+    line-height: 1;
+    height: 1.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  :global(.rt-btn-label) {
+    font-size: 0.6875rem;
+    line-height: 1;
+    white-space: nowrap;
+  }
+  :global(.rt-btn-wide) {
+    min-width: 6rem;
+  }
+  :global(.rt-btn.is-active) {
+    background: rgb(from var(--color-primary-500) r g b / 0.15);
+    color: var(--color-primary-500);
+  }
+
+  /* Vertical rule between sub-groups inside a panel. */
+  :global(.rt-divider) {
+    display: inline-block;
+    width: 1px;
+    height: 2.25rem;
+    background: var(--color-surface-300);
+    margin: 0 0.375rem;
+    align-self: center;
+  }
+  :global([data-mode='dark'] .rt-divider) {
+    background: var(--color-surface-600);
   }
   /* Tiptap editor chrome — keep the editing area clean and consistent
      with the rest of the app. */
@@ -942,199 +1107,297 @@
      block parent too — `h-full` is simply ignored and the editor falls
      back to its intrinsic 200 px minimum. -->
 <div class="h-full flex flex-col min-h-0">
-  <!-- Toolbar -->
-  <div class="flex flex-wrap items-center gap-0.5 px-2 py-1.5 border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 text-sm">
-    <!-- Font family picker — dropdown because 6 named families
-         wouldn't fit as individual toolbar buttons. The trigger
-         label tracks the font at the cursor: `currentFontLabel`
-         reads Tiptap's active textStyle attrs via `$editor`, which
-         re-emits on every transaction, so the button reflects
-         moves through text of different faces in real time.
-         Clicking outside closes the menu (see global listener
-         inside the `$effect` below). -->
-    <div class="relative inline-block">
+  <!-- ── Ribbon: tab strip + active panel (#103) ───────────────────
+       Outlook-style two-row toolbar.  Top row holds the tab labels
+       on the left, undo/redo + the embedder's send actions on the
+       right.  Bottom row renders the active tab's panel — bigger
+       icon-above-label buttons for a less flat, more discoverable
+       look than the previous single-row layout. -->
+  <div class="border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800">
+    <!-- Tab strip -->
+    <div class="flex items-stretch gap-0 px-2 pt-0.5" role="tablist">
       <button
         type="button"
-        class="tb"
-        title="Font family"
-        onclick={() => (showFontPicker = !showFontPicker)}
-      >
-        {currentFontLabel()} ▾
-      </button>
-      {#if showFontPicker}
-        <div
-          class="absolute z-20 mt-1 min-w-40 rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-md py-1"
-          role="menu"
-          tabindex="-1"
-          onclick={(e) => e.stopPropagation()}
-          onkeydown={(e) => e.key === 'Escape' && (showFontPicker = false)}
-        >
-          {#each FONT_FAMILIES as f (f.label)}
-            <button
-              type="button"
-              class="w-full text-left px-3 py-1 text-sm hover:bg-surface-200 dark:hover:bg-surface-800"
-              style={f.css ? `font-family: ${f.css};` : ''}
-              onclick={() => setFont(f.css)}
-            >{f.label}</button>
-          {/each}
-        </div>
-      {/if}
-    </div>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Text style group -->
-    <button class="tb {active('bold')}" title="Bold" onclick={() => $editor?.chain().focus().toggleBold().run()}>
-      <strong>B</strong>
-    </button>
-    <button class="tb {active('italic')}" title="Italic" onclick={() => $editor?.chain().focus().toggleItalic().run()}>
-      <em>I</em>
-    </button>
-    <button class="tb {active('underline')}" title="Underline" onclick={() => $editor?.chain().focus().toggleUnderline().run()}>
-      <u>U</u>
-    </button>
-    <button class="tb {active('strike')}" title="Strikethrough" onclick={() => $editor?.chain().focus().toggleStrike().run()}>
-      <s>S</s>
-    </button>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Headings -->
-    <button class="tb {active('heading', { level: 1 })}" title="Heading 1" onclick={() => toggleHeading(1)}>
-      H1
-    </button>
-    <button class="tb {active('heading', { level: 2 })}" title="Heading 2" onclick={() => toggleHeading(2)}>
-      H2
-    </button>
-    <button class="tb {active('heading', { level: 3 })}" title="Heading 3" onclick={() => toggleHeading(3)}>
-      H3
-    </button>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Lists -->
-    <button class="tb {active('bulletList')}" title="Bullet list" onclick={() => $editor?.chain().focus().toggleBulletList().run()}>
-      &#8226; List
-    </button>
-    <button class="tb {active('orderedList')}" title="Numbered list" onclick={() => $editor?.chain().focus().toggleOrderedList().run()}>
-      1. List
-    </button>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Alignment -->
-    <button class="tb {activeAttrs({ textAlign: 'left' })}" title="Align left" onclick={() => $editor?.chain().focus().setTextAlign('left').run()}>
-      &#x2261;L
-    </button>
-    <button class="tb {activeAttrs({ textAlign: 'center' })}" title="Align center" onclick={() => $editor?.chain().focus().setTextAlign('center').run()}>
-      &#x2261;C
-    </button>
-    <button class="tb {activeAttrs({ textAlign: 'right' })}" title="Align right" onclick={() => $editor?.chain().focus().setTextAlign('right').run()}>
-      &#x2261;R
-    </button>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Colors -->
-    <label class="tb cursor-pointer" title="Text color">
-      A
-      <input type="color" class="w-0 h-0 opacity-0 absolute" onchange={setColor} />
-    </label>
-    <label class="tb cursor-pointer" title="Highlight color">
-      <span class="bg-yellow-200 px-0.5 rounded-sm">H</span>
-      <input type="color" value="#fde68a" class="w-0 h-0 opacity-0 absolute" onchange={setHighlight} />
-    </label>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Insert group -->
-    <button class="tb {active('link')}" title="Insert link" onclick={setLink}>
-      Link
-    </button>
-
-    <!-- Image: two entry points. "Image" picks a local file and
-         embeds it as a data URL. "NC" opens the parent's Nextcloud
-         file picker (via `onrequestncimage`) so the user can drop
-         in a file they already have on their Nextcloud without
-         saving it locally first — consistent with how attachments
-         work in the Compose toolbar. Falls back to a URL prompt if
-         the embedder didn't wire up the Nextcloud callback. -->
-    <div class="relative inline-block">
-      <button class="tb" title="Insert image from local file" onclick={() => addImageFromFile()}>
-        Image
-      </button>
+        role="tab"
+        aria-selected={activeTab === 'format'}
+        class="rt-tab"
+        class:rt-tab-active={activeTab === 'format'}
+        onclick={() => (activeTab = 'format')}
+      >Format</button>
       <button
-        class="tb text-[10px]"
-        title={onrequestncimage ? 'Insert image from Nextcloud' : 'Insert image from URL'}
-        onclick={() => addImageFromNcOrUrl()}
-      >
-        {onrequestncimage ? 'NC' : 'URL'}
-      </button>
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'insert'}
+        class="rt-tab"
+        class:rt-tab-active={activeTab === 'insert'}
+        onclick={() => (activeTab = 'insert')}
+      >Insert</button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={activeTab === 'layout'}
+        class="rt-tab"
+        class:rt-tab-active={activeTab === 'layout'}
+        onclick={() => (activeTab = 'layout')}
+      >Layout</button>
+      {#each extraTabs as t (t.id)}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === t.id}
+          class="rt-tab"
+          class:rt-tab-active={activeTab === t.id}
+          onclick={() => (activeTab = t.id)}
+        >
+          {#if t.icon}<span class="mr-1">{t.icon}</span>{/if}{t.label}
+        </button>
+      {/each}
+
+      <!-- Top-right: undo/redo + caller's send-side actions.  Lives
+           in the tab strip rather than inside any panel because the
+           user expects Send + Save + Undo to be reachable
+           regardless of which tab is open. -->
+      <div class="ml-auto flex items-center gap-1 px-1">
+        <button class="tb" title="Undo (Ctrl+Z)" onclick={() => doUndo()}>↩</button>
+        <button class="tb" title="Redo (Ctrl+Y)" onclick={() => doRedo()}>↪</button>
+        {#if actionsTrailing}
+          <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
+          {@render actionsTrailing()}
+        {/if}
+      </div>
     </div>
 
-    <!-- Table: Outlook-style grid picker -->
-    <div class="relative inline-block">
-      <button class="tb" title="Insert table" onclick={() => (showTablePicker = !showTablePicker)}>
-        Table
-      </button>
-      {#if showTablePicker}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          class="absolute left-0 top-full mt-1 z-50 p-2 bg-white dark:bg-surface-800 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg"
-          onmouseleave={() => { tableHoverRows = 0; tableHoverCols = 0 }}
-        >
-          <div class="text-xs text-surface-500 mb-1 text-center">
-            {tableHoverRows > 0 ? `${tableHoverRows} × ${tableHoverCols}` : 'Pick size'}
-          </div>
-          <div class="grid gap-0.5" style="grid-template-columns: repeat({TABLE_GRID}, 1fr)">
-            {#each { length: TABLE_GRID } as _, r}
-              {#each { length: TABLE_GRID } as _, c}
+    <!-- Tab panel — flex row of large stacked-icon buttons.  Each
+         tab's content lives behind its own `{#if}` so swapping tabs
+         doesn't carry hidden DOM.  Dividers split logical sub-
+         groups within a panel for scannability. -->
+    <div class="flex flex-wrap items-center gap-0.5 px-2 py-1.5 min-h-[3rem]">
+      {#if activeTab === 'format'}
+        <!-- Font family — wider trigger, dropdown menu. -->
+        <div class="relative inline-block">
+          <button
+            type="button"
+            class="rt-btn rt-btn-wide"
+            title="Font family"
+            onclick={() => (showFontPicker = !showFontPicker)}
+          >
+            <span class="rt-btn-icon" aria-hidden="true">𝐀</span>
+            <span class="rt-btn-label">{currentFontLabel()} ▾</span>
+          </button>
+          {#if showFontPicker}
+            <div
+              class="absolute z-20 mt-1 min-w-44 rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-md py-1"
+              role="menu"
+              tabindex="-1"
+              onclick={(e) => e.stopPropagation()}
+              onkeydown={(e) => e.key === 'Escape' && (showFontPicker = false)}
+            >
+              {#each FONT_FAMILIES as f (f.label)}
                 <button
                   type="button"
-                  aria-label="{r + 1} × {c + 1} table"
-                  class="w-4 h-4 border rounded-sm cursor-pointer transition-colors
-                    {r < tableHoverRows && c < tableHoverCols
-                      ? 'bg-primary-500/40 border-primary-500'
-                      : 'bg-surface-100 dark:bg-surface-700 border-surface-300 dark:border-surface-600'}"
-                  onmouseenter={() => { tableHoverRows = r + 1; tableHoverCols = c + 1 }}
-                  onclick={() => insertTable(r + 1, c + 1)}
-                  tabindex="-1"
-                ></button>
+                  class="w-full text-left px-3 py-1.5 text-sm hover:bg-surface-200 dark:hover:bg-surface-800"
+                  style={f.css ? `font-family: ${f.css};` : ''}
+                  onclick={() => setFont(f.css)}
+                >{f.label}</button>
               {/each}
-            {/each}
-          </div>
+            </div>
+          {/if}
         </div>
+
+        <span class="rt-divider"></span>
+
+        <!-- Text style -->
+        <button class="rt-btn {active('bold')}" title="Bold (Ctrl+B)" onclick={() => $editor?.chain().focus().toggleBold().run()}>
+          <span class="rt-btn-icon"><strong>B</strong></span>
+          <span class="rt-btn-label">Bold</span>
+        </button>
+        <button class="rt-btn {active('italic')}" title="Italic (Ctrl+I)" onclick={() => $editor?.chain().focus().toggleItalic().run()}>
+          <span class="rt-btn-icon"><em>I</em></span>
+          <span class="rt-btn-label">Italic</span>
+        </button>
+        <button class="rt-btn {active('underline')}" title="Underline (Ctrl+U)" onclick={() => $editor?.chain().focus().toggleUnderline().run()}>
+          <span class="rt-btn-icon"><u>U</u></span>
+          <span class="rt-btn-label">Underline</span>
+        </button>
+        <button class="rt-btn {active('strike')}" title="Strikethrough" onclick={() => $editor?.chain().focus().toggleStrike().run()}>
+          <span class="rt-btn-icon"><s>S</s></span>
+          <span class="rt-btn-label">Strike</span>
+        </button>
+
+        <span class="rt-divider"></span>
+
+        <!-- Colors -->
+        <label class="rt-btn cursor-pointer" title="Text color">
+          <span class="rt-btn-icon" style="border-bottom: 3px solid currentColor;">A</span>
+          <span class="rt-btn-label">Color</span>
+          <input type="color" class="w-0 h-0 opacity-0 absolute" onchange={setColor} />
+        </label>
+        <label class="rt-btn cursor-pointer" title="Highlight color">
+          <span class="rt-btn-icon"><span class="bg-yellow-200 dark:bg-yellow-300 px-0.5 rounded-sm text-surface-900">H</span></span>
+          <span class="rt-btn-label">Highlight</span>
+          <input type="color" value="#fde68a" class="w-0 h-0 opacity-0 absolute" onchange={setHighlight} />
+        </label>
+
+        <span class="rt-divider"></span>
+
+        <!-- Clear formatting — strips marks AND collapses to plain
+             paragraph (matches Outlook's "Clear all formatting"). -->
+        <button class="rt-btn" title="Clear all formatting" onclick={clearFormatting}>
+          <span class="rt-btn-icon">🧹</span>
+          <span class="rt-btn-label">Clear</span>
+        </button>
+      {:else if activeTab === 'insert'}
+        <button class="rt-btn {active('link')}" title="Insert link" onclick={setLink}>
+          <span class="rt-btn-icon">🔗</span>
+          <span class="rt-btn-label">Link</span>
+        </button>
+        <button class="rt-btn" title="Insert image from local file" onclick={() => addImageFromFile()}>
+          <span class="rt-btn-icon">🖼️</span>
+          <span class="rt-btn-label">Image</span>
+        </button>
+        <button
+          class="rt-btn"
+          title={onrequestncimage ? 'Insert image from Nextcloud' : 'Insert image from URL'}
+          onclick={() => addImageFromNcOrUrl()}
+        >
+          <span class="rt-btn-icon">{onrequestncimage ? '☁️' : '🌐'}</span>
+          <span class="rt-btn-label">{onrequestncimage ? 'NC image' : 'From URL'}</span>
+        </button>
+
+        <span class="rt-divider"></span>
+
+        <!-- Table picker -->
+        <div class="relative inline-block">
+          <button class="rt-btn" title="Insert table" onclick={() => (showTablePicker = !showTablePicker)}>
+            <span class="rt-btn-icon">▦</span>
+            <span class="rt-btn-label">Table</span>
+          </button>
+          {#if showTablePicker}
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="absolute left-0 top-full mt-1 z-50 p-2 bg-white dark:bg-surface-800 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg"
+              onmouseleave={() => { tableHoverRows = 0; tableHoverCols = 0 }}
+            >
+              <div class="text-xs text-surface-500 mb-1 text-center">
+                {tableHoverRows > 0 ? `${tableHoverRows} × ${tableHoverCols}` : 'Pick size'}
+              </div>
+              <div class="grid gap-0.5" style="grid-template-columns: repeat({TABLE_GRID}, 1fr)">
+                {#each { length: TABLE_GRID } as _, r}
+                  {#each { length: TABLE_GRID } as _, c}
+                    <button
+                      type="button"
+                      aria-label="{r + 1} × {c + 1} table"
+                      class="w-4 h-4 border rounded-sm cursor-pointer transition-colors
+                        {r < tableHoverRows && c < tableHoverCols
+                          ? 'bg-primary-500/40 border-primary-500'
+                          : 'bg-surface-100 dark:bg-surface-700 border-surface-300 dark:border-surface-600'}"
+                      onmouseenter={() => { tableHoverRows = r + 1; tableHoverCols = c + 1 }}
+                      onclick={() => insertTable(r + 1, c + 1)}
+                      tabindex="-1"
+                    ></button>
+                  {/each}
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+
+        <button class="rt-btn" title="Horizontal rule" onclick={() => cmd().setHorizontalRule().run()}>
+          <span class="rt-btn-icon">―</span>
+          <span class="rt-btn-label">HR</span>
+        </button>
+
+        <span class="rt-divider"></span>
+
+        <!-- Emoji picker — popup grid of curated emojis (#103
+             follow-up).  Click outside or pick an emoji to dismiss. -->
+        <div class="relative inline-block">
+          <button class="rt-btn" title="Insert emoji" onclick={() => (showEmojiPicker = !showEmojiPicker)}>
+            <span class="rt-btn-icon">😀</span>
+            <span class="rt-btn-label">Emoji</span>
+          </button>
+          {#if showEmojiPicker}
+            <div
+              class="absolute left-0 top-full mt-1 z-50 p-2 bg-surface-50 dark:bg-surface-900 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg w-72"
+              role="menu"
+              tabindex="-1"
+              onclick={(e) => e.stopPropagation()}
+              onkeydown={(e) => e.key === 'Escape' && (showEmojiPicker = false)}
+            >
+              <div class="grid grid-cols-8 gap-0.5 max-h-72 overflow-y-auto">
+                {#each EMOJI_SET as e}
+                  <button
+                    type="button"
+                    class="w-8 h-8 flex items-center justify-center text-lg rounded-md hover:bg-surface-200 dark:hover:bg-surface-800"
+                    title={e}
+                    onclick={() => insertEmoji(e)}
+                  >{e}</button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      {:else if activeTab === 'layout'}
+        <!-- Headings -->
+        <button class="rt-btn {active('heading', { level: 1 })}" title="Heading 1" onclick={() => toggleHeading(1)}>
+          <span class="rt-btn-icon">H₁</span>
+          <span class="rt-btn-label">Heading 1</span>
+        </button>
+        <button class="rt-btn {active('heading', { level: 2 })}" title="Heading 2" onclick={() => toggleHeading(2)}>
+          <span class="rt-btn-icon">H₂</span>
+          <span class="rt-btn-label">Heading 2</span>
+        </button>
+        <button class="rt-btn {active('heading', { level: 3 })}" title="Heading 3" onclick={() => toggleHeading(3)}>
+          <span class="rt-btn-icon">H₃</span>
+          <span class="rt-btn-label">Heading 3</span>
+        </button>
+
+        <span class="rt-divider"></span>
+
+        <!-- Lists -->
+        <button class="rt-btn {active('bulletList')}" title="Bullet list" onclick={() => $editor?.chain().focus().toggleBulletList().run()}>
+          <span class="rt-btn-icon">•</span>
+          <span class="rt-btn-label">Bullets</span>
+        </button>
+        <button class="rt-btn {active('orderedList')}" title="Numbered list" onclick={() => $editor?.chain().focus().toggleOrderedList().run()}>
+          <span class="rt-btn-icon">1.</span>
+          <span class="rt-btn-label">Numbered</span>
+        </button>
+
+        <span class="rt-divider"></span>
+
+        <!-- Alignment -->
+        <button class="rt-btn {activeAttrs({ textAlign: 'left' })}" title="Align left" onclick={() => $editor?.chain().focus().setTextAlign('left').run()}>
+          <span class="rt-btn-icon">⇤</span>
+          <span class="rt-btn-label">Left</span>
+        </button>
+        <button class="rt-btn {activeAttrs({ textAlign: 'center' })}" title="Align center" onclick={() => $editor?.chain().focus().setTextAlign('center').run()}>
+          <span class="rt-btn-icon">≡</span>
+          <span class="rt-btn-label">Center</span>
+        </button>
+        <button class="rt-btn {activeAttrs({ textAlign: 'right' })}" title="Align right" onclick={() => $editor?.chain().focus().setTextAlign('right').run()}>
+          <span class="rt-btn-icon">⇥</span>
+          <span class="rt-btn-label">Right</span>
+        </button>
+        <button class="rt-btn {activeAttrs({ textAlign: 'justify' })}" title="Justify" onclick={() => $editor?.chain().focus().setTextAlign('justify').run()}>
+          <span class="rt-btn-icon">☰</span>
+          <span class="rt-btn-label">Justify</span>
+        </button>
+
+        <span class="rt-divider"></span>
+
+        <button class="rt-btn {active('blockquote')}" title="Blockquote" onclick={() => cmd().toggleBlockquote().run()}>
+          <span class="rt-btn-icon">❝</span>
+          <span class="rt-btn-label">Quote</span>
+        </button>
+      {:else}
+        {#each extraTabs as t (t.id)}
+          {#if activeTab === t.id}
+            {@render t.content()}
+          {/if}
+        {/each}
       {/if}
     </div>
-
-    <button class="tb" title="Horizontal rule" onclick={() => cmd().setHorizontalRule().run()}>
-      &#x2015;
-    </button>
-    <button class="tb {active('blockquote')}" title="Blockquote" onclick={() => cmd().toggleBlockquote().run()}>
-      &#x201C;
-    </button>
-
-    <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-
-    <!-- Undo / Redo -->
-    <button class="tb" title="Undo (Ctrl+Z)" onclick={() => doUndo()}>
-      &#x21A9;
-    </button>
-    <button class="tb" title="Redo (Ctrl+Y)" onclick={() => doRedo()}>
-      &#x21AA;
-    </button>
-
-    <!-- Trailing actions slot — Compose injects Attach / Talk /
-         Files + Send / Save Draft / Discard here so they share
-         the toolbar row with the rich-text controls (#103).  The
-         leading `ml-auto` separator pushes the snippet against
-         the right edge of the toolbar so editor controls and
-         caller actions visibly read as left-half / right-half. -->
-    {#if actionsTrailing}
-      <span class="ml-auto"></span>
-      <span class="w-px h-5 bg-surface-300 dark:bg-surface-600 mx-1"></span>
-      {@render actionsTrailing()}
-    {/if}
   </div>
 
   <!-- Editor area. `flex-1 min-h-0` lets it shrink/grow with the


### PR DESCRIPTION
Closes #103

## Summary

Compose carried two horizontal action surfaces — the RichTextEditor's format toolbar at the top of the body, and a separate footer row at the bottom with Send / Attach / Talk / Event / etc. As more tools landed the footer was getting close to wrapping, and the user had to look in two places for "what can I do here".

Collapse them into **one bar at the top**, matching the Outlook-Web ribbon idea (no actual ribbon tabs — flat single row with visual dividers between groups).

## Changes

- **\`RichTextEditor\`** gains an \`actionsTrailing?: Snippet\` prop. When present, the editor's toolbar appends \`ml-auto\` + a divider + the snippet contents to the right side of its row, so editor controls and embedder actions read as left-half / right-half.
- **\`Compose\`** declares a \`composeActions\` snippet with two groups separated by a vertical divider:
  - **Attach & share** — Attach / Files / Talk / Event
  - **Send actions** — Save draft / Discard / Send (primary-filled, last in row)
- The bottom \`<footer>\` is **gone**. Cancel renamed to "Discard" with a red-on-hover variant so the destructive action reads as such.

## Visual

Each action button is a stacked **icon + tiny label** (\`flex-direction: column\`, 0.625rem label) — same idiom Outlook Web uses. Compact enough to fit alongside the rich-text controls without wrapping at typical Compose widths. \`:global\` CSS because the snippet renders inside \`RichTextEditor\`'s DOM subtree.

## Design decisions worth noting

- **Single row, no tabs** — issue says "Outlook ribbon but flat (no actual ribbon tabs)". Hiding actions behind tabs would slow the user down.
- **Send at top-right, not bottom** — agreed with the user to standardise on top-right primary-action across the app (matches the icon rail / ribbon-style direction the rest of Nimbus is heading; matches Gmail compose, Linear, Slack composer). Bottom-aligned send fights that consistency.
- **Responsive collapse / label-when-room** — explicit follow-up. The user's note: *"we have to iterate on this part anyway because we have to check the look and feel"*. This PR lays the structural foundation; behaviour tuning lands separately.

## Test plan

- [ ] Open Compose — one toolbar at the top with format/block/insert (left) and Attach/Talk/Files/Event + SaveDraft/Discard/Send (right), separated by vertical dividers
- [ ] Click Send → mail goes out as before
- [ ] Click Save draft → draft saved as before
- [ ] Click Discard → modal closes, Talk-room cleanup runs (#86) if a room was created
- [ ] Click Attach → file picker opens
- [ ] Click Files → Nextcloud picker opens
- [ ] Click Talk → Talk-room modal opens
- [ ] Click Event → calendar event editor opens
- [ ] Confirm no bottom footer remains; the body is taller than before because the footer space is now gone
- [ ] Resize the modal narrow — the toolbar wraps onto multiple rows (responsive collapse comes in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)