### PR TITLE
Event UI redesign + modern date/time/select pickers (#128, #126)

### DIFF
--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -30,7 +30,7 @@ pub use files::{
 };
 pub use shares::{PublicShare, create_public_share, update_share_label};
 pub use talk::{
-    ParticipantSource, RoomType, TalkRoom, add_participant, create_room, delete_room, list_rooms,
-    rename_room, set_room_public,
+    CreateRoomOptions, ParticipantSource, RoomType, TalkRoom, add_participant, create_room,
+    delete_room, list_rooms, rename_room, set_room_public,
 };
 pub use user::{NextcloudUserMatch, NextcloudUserProfile, fetch_current_user, find_user_by_email};

--- a/crates/nimbus-nextcloud/src/talk.rs
+++ b/crates/nimbus-nextcloud/src/talk.rs
@@ -219,36 +219,51 @@ pub async fn list_rooms(
 /// finish the join in the browser. The room itself is preserved on the
 /// server — leaving an empty room dangling is better than rolling back
 /// and silently dropping a working room the user can still use.
-// `room_type_override`: `2` = group/private (only invited NC
-// users can join), `3` = public (anyone with the URL joins as
-// guest).  `None` falls back to group/private — the
-// Compose-side "create Talk room" flow's behaviour.  Event-bound
-// rooms pass `Some(3)` so externals invited to the event can
-// click through the calendar link without an NC login.
+/// Optional knobs to `create_room` that group together cleanly
+/// — bundling them keeps the call signature within clippy's
+/// `too_many_arguments` ceiling and clarifies that they're all
+/// "tweaks for event-bound rooms" rather than required params.
+///
+/// `room_type`: `2` = group/private (only invited NC users can
+/// join), `3` = public (anyone with the URL joins as guest).
+/// `None` falls back to group/private — the Compose-side
+/// "create Talk room" flow's behaviour.  Event-bound rooms pass
+/// `Some(3)` so externals invited to the event can click
+/// through the calendar link without an NC login.
+///
+/// `object_type` + `object_id` mirror Nextcloud Calendar's
+/// "Make it a Talk conversation" tagging — pass
+/// `Some("event")` and a unique id (typically `crypto.randomUUID()`)
+/// to have Talk's UI categorise the room as a meeting room.
+#[derive(Debug, Default)]
+pub struct CreateRoomOptions<'a> {
+    pub room_type: Option<u8>,
+    pub object_type: Option<&'a str>,
+    pub object_id: Option<&'a str>,
+}
+
 pub async fn create_room(
     server_url: &str,
     username: &str,
     app_password: &str,
     room_name: &str,
     participants: &[ParticipantSource],
-    object_type: Option<&str>,
-    object_id: Option<&str>,
-    room_type_override: Option<u8>,
+    options: CreateRoomOptions<'_>,
 ) -> Result<TalkRoom, NimbusError> {
     let server = client::normalize_server_url(server_url);
     let url = format!("{server}/ocs/v2.php/apps/spreed/api/v4/room?format=json");
 
     tracing::debug!("POST {url} (room_name={room_name:?})");
     let http = client::build()?;
-    let room_type = room_type_override.unwrap_or(ROOM_TYPE_GROUP).to_string();
+    let room_type = options.room_type.unwrap_or(ROOM_TYPE_GROUP).to_string();
     let mut form: Vec<(&str, &str)> = vec![
         ("roomType", room_type.as_str()),
         ("roomName", room_name),
     ];
-    if let Some(t) = object_type {
+    if let Some(t) = options.object_type {
         form.push(("objectType", t));
     }
-    if let Some(id) = object_id {
+    if let Some(id) = options.object_id {
         form.push(("objectId", id));
     }
     let resp = http

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -454,6 +454,35 @@ async fn refresh_nextcloud_capabilities(nc_id: String) -> Result<NextcloudAccoun
     Ok(account)
 }
 
+/// Fetch the configured email address of the Nextcloud user owning
+/// the given account. This is the same `email` field NC's Mail
+/// Provider keys against for iMIP, so it's the right value to use as
+/// `ORGANIZER` / CHAIR in calendar invites — making the calendar's
+/// owning NC identity (not the user's first IMAP account) drive the
+/// organizer line in the editor's attendee list.
+///
+/// Returns `None` when the user hasn't set an email in Personal info
+/// or when the OCS lookup fails — caller should fall back to a
+/// reasonable default (e.g. the first mail account).
+#[tauri::command]
+async fn get_nextcloud_user_email(nc_id: String) -> Result<Option<String>, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    match nimbus_nextcloud::user::fetch_current_user(
+        &account.server_url,
+        &account.username,
+        &app_password,
+    )
+    .await
+    {
+        Ok(profile) => Ok(profile.email),
+        Err(e) => {
+            tracing::warn!("get_nextcloud_user_email for {nc_id}: {e}");
+            Ok(None)
+        }
+    }
+}
+
 /// Remove a Nextcloud connection and its stored app password.
 ///
 /// Does **not** attempt to revoke the app password on the server —
@@ -1090,9 +1119,11 @@ async fn create_talk_room(
         &app_password,
         &room_name,
         &participants,
-        object_type.as_deref(),
-        object_id.as_deref(),
-        room_type,
+        nimbus_nextcloud::CreateRoomOptions {
+            room_type,
+            object_type: object_type.as_deref(),
+            object_id: object_id.as_deref(),
+        },
     )
     .await
 }
@@ -2632,7 +2663,6 @@ fn parse_event_invite(bytes: Vec<u8>) -> Result<InviteSummary, NimbusError> {
 /// the line as a single token after the colon (REQUEST / REPLY /
 /// CANCEL / etc.); we just normalise to upper case so JS-side
 /// equality checks don't have to be case-insensitive.
-
 fn extract_calendar_method(ics: &str) -> Option<String> {
     for line in ics.lines() {
         let trimmed = line.trim();
@@ -3042,14 +3072,13 @@ async fn get_event_partstat_for_user(
     // CalDAV client without waiting for the background-sync
     // interval.  Best-effort: a sync failure leaves the cache
     // as-is and we return the locally-known state.
-    if let Some((_, cal_path)) = cache.get_calendar_server_path(&handle.calendar_id)? {
-        if let Err(e) =
+    if let Some((_, cal_path)) = cache.get_calendar_server_path(&handle.calendar_id)?
+        && let Err(e) =
             refresh_calendar_cache(&cache, &handle.nextcloud_account_id, &cal_path).await
-        {
-            tracing::warn!(
-                "RSVP badge: pre-read calendar sync failed (continuing with stale cache): {e}"
-            );
-        }
+    {
+        tracing::warn!(
+            "RSVP badge: pre-read calendar sync failed (continuing with stale cache): {e}"
+        );
     }
     let Some(handle) = cache.get_event_server_handle(&event_id)? else {
         return Ok(None);
@@ -5390,6 +5419,7 @@ fn main() {
             poll_nextcloud_login,
             get_nextcloud_accounts,
             refresh_nextcloud_capabilities,
+            get_nextcloud_user_email,
             remove_nextcloud_account,
             open_url,
             list_nextcloud_files,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -657,6 +657,18 @@
   }
   const isDraftsFolder = $derived(isDraftsFolderName(selectedFolder))
 
+  /** Same heuristic for the Sent folder — used to suppress the
+   *  RSVP card on outbound invites the user themselves sent
+   *  (you don't reply to your own meeting requests).  Same
+   *  caveat as the Drafts hint: name-based until the backend
+   *  surfaces `\Sent` special-use through the API. */
+  const SENT_NAME_HINTS = ['sent', 'sent items', 'gesendet', 'envoyés', 'envoyes', 'inviati', 'enviados']
+  function isSentFolderName(name: string): boolean {
+    const lower = name.toLowerCase()
+    return SENT_NAME_HINTS.some((h) => lower.includes(h))
+  }
+  const isSentFolder = $derived(isSentFolderName(selectedFolder))
+
   /** Open a draft from the Drafts folder back in Compose for editing.
    *  Mirrors the reply/forward entry points but additionally:
    *    - downloads every attachment's bytes so the user can re-send
@@ -945,6 +957,7 @@
         onforward={onForward}
         oncreatetalk={onCreateTalkFromMail}
         isDraftsFolder={isDraftsFolder}
+        isSentFolder={isSentFolder}
         oneditdraft={onEditDraft}
         onmessageremoved={onMessageRemoved}
       />

--- a/ui/src/lib/CalendarInviteCard.svelte
+++ b/ui/src/lib/CalendarInviteCard.svelte
@@ -67,6 +67,27 @@
     color: string | null
     last_synced_at: string | null
     hidden?: boolean
+    /** Layer-2 visibility — set from the calendar sidebar's
+     *  swatch toggle.  Muted calendars stay in the picker
+     *  (the user might still want to drop the accepted event
+     *  there), but their events are excluded from the day
+     *  preview so the "what's already on my day" view matches
+     *  what the user actually has visible in CalendarView. */
+    muted?: boolean
+  }
+  /** Slim mirror of the Rust `CalendarEvent` — we only consume
+   *  the fields needed to lay the preview out (id for calendar
+   *  lookup + key, start/end for positioning, summary for the
+   *  hover title). */
+  interface PreviewEvent {
+    id: string
+    summary: string
+    start: string
+    end: string
+    /** Attendee list — used to detect the current user's
+     *  PARTSTAT so we can render existing events with the
+     *  same tentative/declined treatment as the agenda grid. */
+    attendees?: InviteAttendee[] | null
   }
   let calendars = $state<CalendarRow[]>([])
   let selectedCalendarId = $state<string | null>(null)
@@ -80,6 +101,305 @@
    *  matching account for; backend falls back to NC profile
    *  email + mail-account list. */
   let attendeeHint = $state<string | null>(null)
+
+  /** Lower-cased email addresses identifying the current user.
+   *  Loaded from the configured mail accounts on mount and
+   *  used to find the user's own ATTENDEE row in any preview
+   *  event so we can apply the same tentative / declined
+   *  visuals the agenda grid uses. */
+  let userIdentities = $state<Set<string>>(new Set())
+  $effect(() => {
+    void invoke<{ email: string }[]>('get_accounts')
+      .then((rows) => {
+        const set = new Set<string>()
+        for (const r of rows) if (r.email) set.add(r.email.toLowerCase())
+        userIdentities = set
+      })
+      .catch(() => {})
+  })
+
+  /** Return the user's PARTSTAT on an existing preview event,
+   *  or `null` if the event has no attendee row matching the
+   *  user — matches the semantics of CalendarView's
+   *  `userPartstatIs`. */
+  function userPartstatOn(ev: PreviewEvent): string | null {
+    if (userIdentities.size === 0) return null
+    for (const a of ev.attendees ?? []) {
+      if (userIdentities.has(a.email.toLowerCase())) {
+        return (a.status ?? '').toUpperCase() || null
+      }
+    }
+    return null
+  }
+
+  // ── "More info" details panel ──────────────────────────────
+  // Expanded view: read-only attendee chips + a one-day mini
+  // preview showing what else is on the user's calendar(s) for
+  // the proposed slot.  Loaded lazily on first expand so the
+  // card stays cheap when the user just wants to Accept and
+  // move on.
+  let detailsOpen = $state(false)
+  let previewLoading = $state(false)
+  let previewError = $state('')
+  /** Currently-displayed day in the preview.  Initialised to
+   *  the invite's local day on first open; the prev/next day
+   *  arrows mutate this without changing the invite itself. */
+  let previewDate = $state<Date>(new Date(invite.start))
+  /** Events keyed by `YYYY-MM-DD` so navigating back to a
+   *  previously-loaded day is instant — IPC + expansion only
+   *  hits the cache the first time the user lands on a date. */
+  let previewEventsByDate = $state<Map<string, PreviewEvent[]>>(new Map())
+  function dayKey(d: Date): string {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }
+  let previewEvents = $derived(previewEventsByDate.get(dayKey(previewDate)) ?? [])
+  let previewLoaded = $derived(previewEventsByDate.has(dayKey(previewDate)))
+
+  /** Map calendar id → row, for colour + display-name lookup
+   *  in the preview block.  `eventCalendarId(ev.id)` recovers
+   *  the calendar id from the composite event id. */
+  const calendarsById = $derived.by(() => {
+    const m = new Map<string, CalendarRow>()
+    for (const c of calendars) m.set(c.id, c)
+    return m
+  })
+  function eventCalendarId(id: string): string {
+    return id.split('::').slice(0, 2).join('::')
+  }
+
+  async function loadPreviewForDate(d: Date) {
+    const key = dayKey(d)
+    if (previewEventsByDate.has(key) || previewLoading) return
+    previewLoading = true
+    previewError = ''
+    try {
+      const dayStart = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+      const dayEnd = new Date(dayStart)
+      dayEnd.setDate(dayEnd.getDate() + 1)
+      const activeIds = calendars
+        .filter((c) => !c.hidden && !c.muted)
+        .map((c) => c.id)
+      const ev =
+        activeIds.length === 0
+          ? []
+          : await invoke<PreviewEvent[]>('get_cached_events', {
+              calendarIds: activeIds,
+              rangeStart: dayStart.toISOString(),
+              rangeEnd: dayEnd.toISOString(),
+            })
+      // Re-bind so Svelte's reactivity picks up the new entry.
+      const next = new Map(previewEventsByDate)
+      next.set(key, ev)
+      previewEventsByDate = next
+    } catch (e) {
+      previewError = formatError(e) || 'Failed to load calendar preview'
+    } finally {
+      previewLoading = false
+    }
+  }
+
+  function toggleDetails() {
+    detailsOpen = !detailsOpen
+    if (detailsOpen && !previewLoaded) void loadPreviewForDate(previewDate)
+  }
+  function shiftPreviewDay(deltaDays: number) {
+    const next = new Date(
+      previewDate.getFullYear(),
+      previewDate.getMonth(),
+      previewDate.getDate() + deltaDays,
+    )
+    previewDate = next
+    if (!previewEventsByDate.has(dayKey(next))) void loadPreviewForDate(next)
+  }
+
+  // ── Mini day-grid layout ───────────────────────────────────
+  // Full 24-hour grid, vertically scrollable.  The viewport caps
+  // height at ~9 hours so the panel stays compact, and on first
+  // expand we auto-scroll the proposed slot near the top of the
+  // viewport — keeps overlapping events visible without forcing
+  // the user to hunt for the meeting in question.
+  const HOUR_PX = 32
+  const PREVIEW_VIEWPORT_PX = 280
+  const PREVIEW_TOTAL_PX = 24 * HOUR_PX
+
+  /** Local-midnight of the currently-displayed day. */
+  let previewDayStart = $derived(
+    new Date(
+      previewDate.getFullYear(),
+      previewDate.getMonth(),
+      previewDate.getDate(),
+    ),
+  )
+  let previewDayEnd = $derived.by(() => {
+    const d = new Date(previewDayStart)
+    d.setDate(d.getDate() + 1)
+    return d
+  })
+  function minutesFromDayStart(iso: string, dayStart: Date): number {
+    return (new Date(iso).getTime() - dayStart.getTime()) / 60000
+  }
+  /** Top + height (px) on the full-day axis, clamped to the
+   *  visible 24h window of `previewDayStart`.  Events that
+   *  spill in from the previous day clamp to top:0, and events
+   *  that bleed past midnight clamp to the bottom — instead of
+   *  silently dropping. */
+  function blockGeometry(
+    startISO: string,
+    endISO: string,
+  ): { top: number; height: number } | null {
+    const s = Math.max(0, minutesFromDayStart(startISO, previewDayStart))
+    const e = Math.min(
+      24 * 60,
+      minutesFromDayStart(endISO, previewDayStart),
+    )
+    if (e <= s) return null
+    return {
+      top: (s / 60) * HOUR_PX,
+      height: ((e - s) / 60) * HOUR_PX,
+    }
+  }
+  /** True iff the invite's slot intersects the day currently
+   *  being previewed.  When the user has navigated to a
+   *  different day with the arrows, the proposed slot is
+   *  hidden because it doesn't belong on that day. */
+  let proposedOnPreviewedDay = $derived.by(() => {
+    const start = new Date(invite.start).getTime()
+    const end = new Date(invite.end).getTime()
+    return (
+      end > previewDayStart.getTime() && start < previewDayEnd.getTime()
+    )
+  })
+
+  /** Localised "Wed, Apr 29" label for the day currently
+   *  shown in the preview — drives the centre label between
+   *  the prev/next day arrows. */
+  let previewDayLabel = $derived(
+    previewDate.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+    }),
+  )
+
+  // Auto-scroll the preview to the proposed slot the first time
+  // the user opens the details panel, then once again whenever
+  // they navigate to a different invite (different uid).  Avoids
+  // both (a) opening on the 00:00–08:00 dead zone and (b)
+  // re-snapping if the user manually scrolls within the panel.
+  let previewScrollEl: HTMLDivElement | undefined = $state()
+  // Track the (uid, day) pair we last auto-scrolled for so
+  // arrow-day-navigation re-centers the viewport on the new
+  // day's "interesting hours" (proposed slot if present, else
+  // 08:00 as a sensible default), but doesn't fight the user
+  // if they manually scroll within a day.
+  let lastScrollKey = $state<string | null>(null)
+  $effect(() => {
+    if (!detailsOpen) {
+      lastScrollKey = null
+      return
+    }
+    if (!previewScrollEl) return
+    const key = `${invite.uid}|${dayKey(previewDate)}`
+    if (lastScrollKey === key) return
+    let targetMin: number
+    if (proposedOnPreviewedDay) {
+      targetMin = Math.max(
+        0,
+        minutesFromDayStart(invite.start, previewDayStart),
+      )
+    } else {
+      targetMin = 8 * 60
+    }
+    const target = Math.max(0, (targetMin / 60) * HOUR_PX - HOUR_PX)
+    previewScrollEl.scrollTop = target
+    lastScrollKey = key
+  })
+
+  /** Display name preference for an attendee chip: CN if given,
+   *  else the local-part of the email so a list of bare emails
+   *  doesn't fill the panel with redundant "@domain" suffixes. */
+  function attendeeName(a: InviteAttendee): string {
+    if (a.common_name && a.common_name.trim()) return a.common_name.trim()
+    const at = a.email.indexOf('@')
+    return at > 0 ? a.email.slice(0, at) : a.email
+  }
+  /** `HH:MM` from an ISO timestamp, in local time — matches the
+   *  display the rest of the card uses for `timeRange`. */
+  function fmtClock(iso: string): string {
+    return new Date(iso).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }
+  let proposedRangeLabel = $derived(`${fmtClock(invite.start)}–${fmtClock(invite.end)}`)
+
+  /** Build an inline style string for an existing event block
+   *  using the calendar's identity colour, mirroring the
+   *  agenda grid's `.ev-block` palette so the previews share
+   *  visual language with the main calendar.  Inline (not
+   *  scoped CSS) to keep the styling immune to compound-class
+   *  scoping edge cases. */
+  function existingEventStyle(colour: string, status: string | null): string {
+    const c = colour
+    const s = (status ?? '').toUpperCase()
+    if (s === 'DECLINED') {
+      return [
+        `background: transparent`,
+        `border: 1.5px solid ${c}`,
+        `color: ${c}`,
+        `text-decoration: line-through`,
+        `opacity: 0.85`,
+      ].join('; ')
+    }
+    const base = [
+      `background-color: color-mix(in srgb, ${c} 22%, transparent)`,
+      `border: 1px solid color-mix(in srgb, ${c} 45%, transparent)`,
+      `box-shadow: inset 3px 0 0 0 ${c}`,
+      `color: ${c}`,
+      `padding-left: 8px`,
+    ]
+    if (s === 'TENTATIVE') {
+      base.push(
+        `background-image: repeating-linear-gradient(45deg, transparent 0, transparent 6px, color-mix(in srgb, ${c} 35%, transparent) 6px, color-mix(in srgb, ${c} 35%, transparent) 8px)`,
+      )
+    }
+    return base.join('; ')
+  }
+
+  /** Recover the bare VEVENT UID from a composite calendar
+   *  event id (`{nc_id}::{cal_path}::{uid}` or
+   *  `{…}::{uid}::occ::{epoch}`).  Used to detect whether the
+   *  proposed invite already lives on one of the user's
+   *  calendars. */
+  function eventUid(id: string): string {
+    const parts = id.split('::')
+    return parts[2] ?? ''
+  }
+  /** When the proposed event is *already* on a visible
+   *  calendar (e.g. the user accepted earlier), pull that row
+   *  out of the preview list so we can render the proposed
+   *  slot in its real calendar colour + PARTSTAT visual
+   *  instead of the generic "primary outline" placeholder. */
+  let matchedExistingEvent = $derived(
+    previewEvents.find((ev) => eventUid(ev.id) === invite.uid) ?? null,
+  )
+  let proposedExistsInCalendar = $derived(matchedExistingEvent !== null)
+  let proposedCalendarColor = $derived(
+    matchedExistingEvent
+      ? (calendarsById.get(eventCalendarId(matchedExistingEvent.id))?.color ?? '#2bb0ed')
+      : null,
+  )
+
+  /** Emoji indicator for an attendee's PARTSTAT — matches the
+   *  same alphabet used by the RSVP dropdown in EventEditor so
+   *  the visual language carries across the app. */
+  function attendeeStatusEmoji(a: InviteAttendee): string {
+    const s = (a.status ?? 'NEEDS-ACTION').toUpperCase()
+    if (s === 'ACCEPTED') return '✅'
+    if (s === 'DECLINED') return '❌'
+    if (s === 'TENTATIVE') return '❓'
+    return '❔'
+  }
 
   // Fetch calendars + the user's default-calendar setting on
   // mount.  Both go through Tauri.  We don't gate the card on
@@ -485,6 +805,10 @@
     <p class="text-xs text-red-500 mt-2">{error}</p>
   {/if}
 
+  <!-- RSVP action area — placed above the "More info" /
+       day-preview block so the answer affordance stays at the
+       top of the card and the user can reply without scrolling
+       past the (optional, expandable) details panel. -->
   {#if isCancel}
     <!-- CANCEL flavour.  The organiser dropped the meeting; we
          offer a single button to remove the local copy.  Once
@@ -571,5 +895,221 @@
       </button>
     </div>
   {/if}
+
+  <!-- "More info" toggle.  Cheap to render closed — the
+       attendee chip list and the day-preview grid only mount
+       when the user opens the panel, and the events for the
+       grid are fetched lazily on first expand. -->
+  <button
+    type="button"
+    class="mt-2 inline-flex items-center gap-1 text-xs text-primary-600 dark:text-primary-300 hover:text-primary-700 dark:hover:text-primary-200"
+    onclick={toggleDetails}
+    aria-expanded={detailsOpen}
+  >
+    <span class="transition-transform inline-block {detailsOpen ? 'rotate-90' : ''}">▸</span>
+    {detailsOpen ? 'Hide details' : 'More info'}
+  </button>
+
+  {#if detailsOpen}
+    <div class="mt-3 pt-3 border-t border-surface-300/40 dark:border-surface-600/40 space-y-3">
+      <!-- Attendee chips — read-only mirror of EventEditor's
+           chip list, but stripped of the photo + edit affordances
+           so the panel stays compact.  Status dot encodes the
+           PARTSTAT at a glance: green=accepted, amber=tentative,
+           red=declined, grey=no response. -->
+      {#if invite.attendees.length > 0}
+        <div>
+          <div class="text-[10px] uppercase tracking-wider text-surface-500 mb-1.5">
+            Attendees ({invite.attendees.length})
+          </div>
+          <div class="flex flex-wrap gap-1.5">
+            {#each invite.attendees as a (a.email)}
+              <span
+                class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs bg-surface-200 dark:bg-surface-700"
+                title={a.email + (a.status ? ` — ${a.status.toLowerCase()}` : '')}
+              >
+                <span class="text-[11px] leading-none shrink-0" aria-hidden="true">{attendeeStatusEmoji(a)}</span>
+                <span class="truncate max-w-[180px]">{attendeeName(a)}</span>
+              </span>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
+      <!-- Day preview grid.  Full 24h axis with even hour-row
+           spacing (CSS grid), scrollable, with prev/next-day
+           arrows around a centred date label.  Events render on
+           top via an absolutely-positioned overlay so they can
+           span arbitrary minutes inside an hour cell. -->
+      <div>
+        <div class="text-[10px] uppercase tracking-wider text-surface-500 mb-1.5">Your day</div>
+        <!-- Day navigation: ◀ <date> ▶ — keeps the date as the
+             visual anchor between the arrows so the user reads
+             a clear "where am I" line at a glance. -->
+        <div class="flex items-center justify-center gap-2 mb-2 text-xs">
+          <button
+            type="button"
+            class="w-7 h-7 rounded-md flex items-center justify-center border border-surface-300 dark:border-surface-600 bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-700 hover:border-surface-400 dark:hover:border-surface-500 transition-colors"
+            aria-label="Previous day"
+            title="Previous day"
+            onclick={() => shiftPreviewDay(-1)}
+          >‹</button>
+          <span class="font-medium text-surface-700 dark:text-surface-200 min-w-[120px] text-center">
+            {previewDayLabel}
+          </span>
+          <button
+            type="button"
+            class="w-7 h-7 rounded-md flex items-center justify-center border border-surface-300 dark:border-surface-600 bg-surface-100 dark:bg-surface-800 text-surface-600 dark:text-surface-300 hover:bg-surface-200 dark:hover:bg-surface-700 hover:border-surface-400 dark:hover:border-surface-500 transition-colors"
+            aria-label="Next day"
+            title="Next day"
+            onclick={() => shiftPreviewDay(1)}
+          >›</button>
+        </div>
+
+        {#if previewLoading && !previewLoaded}
+          <p class="text-xs text-surface-500 italic">Loading…</p>
+        {:else if previewError}
+          <p class="text-xs text-red-500">{previewError}</p>
+        {:else}
+          {@const proposedGeom = proposedOnPreviewedDay ? blockGeometry(invite.start, invite.end) : null}
+          <div
+            bind:this={previewScrollEl}
+            class="relative rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50/60 dark:bg-surface-900/40 overflow-y-auto"
+            style="max-height: {PREVIEW_VIEWPORT_PX}px;"
+          >
+            <!-- Hour rows: 24 fixed-height grid rows guarantee
+                 perfectly even spacing regardless of how the
+                 absolute event overlay paints on top of them. -->
+            <div
+              class="relative grid"
+              style="grid-template-rows: repeat(24, {HOUR_PX}px); height: {PREVIEW_TOTAL_PX}px;"
+            >
+              {#each Array.from({ length: 24 }, (_, i) => i) as h (h)}
+                <div class="border-t border-surface-200/70 dark:border-surface-700/70 relative">
+                  <span class="absolute left-1 top-0.5 text-[9px] text-surface-400 leading-none">
+                    {String(h).padStart(2, '0')}:00
+                  </span>
+                </div>
+              {/each}
+
+              <!-- Event overlay layer: absolute children
+                   positioned against the grid container above. -->
+              <div class="absolute inset-0 pointer-events-none">
+                <!-- Existing events on the left half.  Each
+                     block carries the start–end time inline in
+                     the top-right corner if it's tall enough
+                     (≥28px), and always exposes the times via
+                     the hover tooltip. -->
+                {#each previewEvents as ev (ev.id)}
+                  {#if eventUid(ev.id) !== invite.uid}
+                    {@const g = blockGeometry(ev.start, ev.end)}
+                    {#if g}
+                      {@const cal = calendarsById.get(eventCalendarId(ev.id))}
+                      {@const colour = cal?.color ?? '#2bb0ed'}
+                      {@const range = `${fmtClock(ev.start)}–${fmtClock(ev.end)}`}
+                      {@const showInline = g.height >= 28}
+                      {@const partstat = userPartstatOn(ev)}
+                      <div
+                        class="absolute rounded-sm text-[10px] overflow-hidden pointer-events-auto"
+                        style="left: 36px; right: 50%; top: {g.top}px; height: {g.height}px; {existingEventStyle(colour, partstat)}"
+                        title={`${ev.summary || '(no title)'} — ${range}${cal ? ` · ${cal.display_name}` : ''}${partstat && partstat !== 'ACCEPTED' ? ` (${partstat.toLowerCase()})` : ''}`}
+                      >
+                        {#if showInline}
+                          <div class="truncate font-medium leading-tight pr-10">{ev.summary || '(no title)'}</div>
+                          <span
+                            class="absolute top-0.5 right-1 text-[9px] font-mono tabular-nums leading-none text-surface-500 dark:text-surface-400"
+                          >{range}</span>
+                        {:else}
+                          <div class="truncate leading-tight">{ev.summary || '(no title)'}</div>
+                        {/if}
+                      </div>
+                    {/if}
+                  {/if}
+                {/each}
+
+                <!-- Proposed event on the right half.  Inline
+                     styles only — no compound scoped classes —
+                     so the box is guaranteed to render with a
+                     visible border + fill regardless of CSS
+                     scoping quirks.  Two flavours:
+                     - already-on-calendar → calendar-coloured
+                       fill (or stripes / declined-border per
+                       the user's PARTSTAT)
+                     - not-on-calendar → primary dashed border
+                       + light primary tint to signal "what you
+                       would be adding". -->
+                {#if proposedGeom}
+                  {@const tooltip = proposedExistsInCalendar
+                    ? `${invite.summary || '(untitled)'} — from this invite (already on your calendar, ${respondedAs ? respondedAs.toLowerCase() : 'accepted'})`
+                    : `${invite.summary || '(untitled)'} — proposed`}
+                  {@const showInlineProp = proposedGeom.height >= 28}
+                  {#if proposedExistsInCalendar}
+                    {@const c = proposedCalendarColor ?? '#2bb0ed'}
+                    <!-- Existing-on-calendar branch: render in
+                         the matched calendar's identity colour
+                         (transparent fill + bordered + accent
+                         bar) and stamp an "✉ Invite" pill in the
+                         top-right corner so the user can
+                         immediately tell *this is the meeting
+                         the email is about*, distinguishing it
+                         from any neighbouring event in the same
+                         calendar. -->
+                    <div
+                      class="absolute rounded-sm text-[10px] font-medium overflow-hidden pointer-events-auto ring-2 ring-primary-500/70"
+                      style="left: 50%; right: 4px; top: {proposedGeom.top}px; height: {proposedGeom.height}px; {existingEventStyle(c, respondedAs)}"
+                      title={tooltip}
+                    >
+                      {#if showInlineProp}
+                        <div class="truncate leading-tight pr-10">{invite.summary || '(untitled)'}</div>
+                        <span
+                          class="absolute top-0.5 right-1 text-[9px] font-mono tabular-nums leading-none text-surface-500 dark:text-surface-400"
+                        >{proposedRangeLabel}</span>
+                      {:else}
+                        <div class="truncate leading-tight">{invite.summary || '(untitled)'}</div>
+                      {/if}
+                      <!-- Invite badge — primary-tinted, sits at
+                           the bottom-right so it doesn't clash
+                           with the time pill on tall blocks and
+                           still surfaces on short ones. -->
+                      <span
+                        class="absolute bottom-0 right-0 text-[8px] uppercase tracking-wider font-bold px-1 py-px rounded-tl bg-primary-500 text-white leading-none"
+                        title="Matches this invite"
+                      >✉ invite</span>
+                    </div>
+                  {:else}
+                    <!-- Not-on-calendar branch: dashed primary
+                         border + light primary tint signals
+                         "this is what you would be adding". -->
+                    <div
+                      class="absolute rounded-sm text-[10px] font-medium border-2 border-dashed border-primary-500 bg-primary-500/15 text-primary-900 dark:text-primary-100 overflow-hidden pointer-events-auto"
+                      style="left: 50%; right: 4px; top: {proposedGeom.top}px; height: {proposedGeom.height}px;"
+                      title={tooltip}
+                    >
+                      {#if showInlineProp}
+                        <div class="truncate leading-tight px-1 pr-10">{invite.summary || '(untitled)'}</div>
+                        <span
+                          class="absolute top-0.5 right-1 text-[9px] font-mono tabular-nums leading-none text-surface-500 dark:text-surface-400"
+                        >{proposedRangeLabel}</span>
+                      {:else}
+                        <div class="truncate leading-tight px-1">{invite.summary || '(untitled)'}</div>
+                      {/if}
+                    </div>
+                  {/if}
+                {/if}
+
+                {#if previewEvents.length === 0 && previewLoaded && !proposedGeom}
+                  <div class="absolute inset-0 flex items-center justify-center text-[11px] text-surface-400 italic">
+                    Nothing on this day
+                  </div>
+                {/if}
+              </div>
+            </div>
+          </div>
+        {/if}
+      </div>
+    </div>
+  {/if}
+
 </div>
 {/if}
+

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -33,6 +33,7 @@
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
   import EventEditor, { type SavedEvent } from './EventEditor.svelte'
+  import Select from './Select.svelte'
 
   interface Props {
     onclose: () => void
@@ -129,6 +130,18 @@
 
   // Current navigation focus: the Monday of the visible week.
   let currentWeekStart = $state<Date>(startOfWeek(new Date()))
+  // Live "now" — drives the today-column current-time line and
+  // the gray "past" overlay on today.  Ticked every 30s; cheap
+  // because Svelte 5's reactivity only re-renders the dependent
+  // overlay/line, not the whole grid.
+  let now = $state(new Date())
+  $effect(() => {
+    const id = setInterval(() => {
+      now = new Date()
+    }, 30_000)
+    return () => clearInterval(id)
+  })
+  const nowMinutes = $derived(now.getHours() * 60 + now.getMinutes())
   // What range of data we currently have fetched. Tracked so week
   // nav can tell whether it's crossing into uncached territory and
   // trigger an extension.
@@ -144,6 +157,47 @@
   /** Calendars shown in the sidebar: everything not hidden by Settings
    *  (Layer 1). The muted flag (Layer 2) only affects event rendering. */
   const sidebarCalendars = $derived(calendars.filter((c) => !c.hidden))
+
+  /** Pretty hostname extracted from a Nextcloud `server_url`,
+   *  e.g. "https://cloud.example.com/" → "cloud.example.com".
+   *  Falls back to the raw URL on parse failure so the user
+   *  always sees *something* identifying the server. */
+  function ncHostname(serverUrl: string): string {
+    try {
+      return new URL(serverUrl).host
+    } catch {
+      return serverUrl
+    }
+  }
+  /** Sidebar calendars grouped by their owning NC account, in
+   *  the order the accounts were configured.  Each group gets a
+   *  divider + hostname header so users with multiple servers
+   *  can tell at a glance which calendars belong where. */
+  const sidebarGroups = $derived.by(() => {
+    const byNc = new Map<string, CalendarSummary[]>()
+    for (const c of sidebarCalendars) {
+      const list = byNc.get(c.nextcloud_account_id) ?? []
+      list.push(c)
+      byNc.set(c.nextcloud_account_id, list)
+    }
+    const out: { ncId: string; label: string; calendars: CalendarSummary[] }[] = []
+    // Walk `accounts` first so the visual order matches the
+    // Settings list; fall back to insertion order for any
+    // calendar whose account isn't in `accounts` yet (still
+    // loading).
+    const seen = new Set<string>()
+    for (const a of accounts) {
+      const list = byNc.get(a.id)
+      if (!list) continue
+      out.push({ ncId: a.id, label: ncHostname(a.server_url), calendars: list })
+      seen.add(a.id)
+    }
+    for (const [ncId, list] of byNc) {
+      if (seen.has(ncId)) continue
+      out.push({ ncId, label: ncId, calendars: list })
+    }
+    return out
+  })
   /** Calendars whose events paint on the grid: sidebar calendars that
    *  are also not muted (Layer 2). */
   const visibleCalendars = $derived(sidebarCalendars.filter((c) => !c.muted))
@@ -219,6 +273,22 @@
       document.removeEventListener('mousedown', onDocMouseDown)
       document.removeEventListener('keydown', onDocKey)
     }
+  })
+
+  // Esc dismisses the "New calendar" modal — same UX shortcut as
+  // the EventEditor.  Skip if the account-picker dropdown is open
+  // (its own listbox handles Esc to close just the dropdown).
+  $effect(() => {
+    if (!newCalendarForm) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      if (document.querySelector('[role="listbox"]')) return
+      e.preventDefault()
+      newCalendarForm = null
+      calendarOpError = ''
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
   })
 
   /** Refresh the calendar list + events from the cache after a
@@ -1067,7 +1137,19 @@
           >+</button>
         </div>
         <ul class="space-y-1">
-          {#each sidebarCalendars as c (c.id)}
+          {#each sidebarGroups as g, gi (g.ncId)}
+            <!-- NC account divider + hostname header.  Skipped
+                 above the very first group so the list doesn't
+                 start with an empty divider line. -->
+            <li class="pt-2 {gi === 0 ? '' : 'border-t border-surface-200 dark:border-surface-700 mt-2'}">
+              <div
+                class="px-1 pb-1 text-[10px] uppercase tracking-wider text-surface-500 truncate"
+                title={g.label}
+              >
+                {g.label}
+              </div>
+            </li>
+            {#each g.calendars as c (c.id)}
             <li>
               {#if renamingCalendarId === c.id}
                 <div class="flex items-center gap-2 px-2 py-1">
@@ -1115,6 +1197,7 @@
                 </div>
               {/if}
             </li>
+            {/each}
           {/each}
           {#if sidebarCalendars.length === 0 && calendars.length > 0}
             <li class="px-2 py-1 text-xs text-surface-500">
@@ -1236,6 +1319,7 @@
                  24-hour axis without interfering with each other. -->
             {#each weekBuckets as b (b.dayKey)}
               {@const overlay = dragOverlay(b)}
+              {@const todayCol = isToday(b.date)}
               <div
                 class="relative border-l border-surface-200 dark:border-surface-700 cursor-crosshair select-none"
                 class:bg-surface-100={isPast(b.date)}
@@ -1246,13 +1330,44 @@
                 onmouseleave={onDayMouseLeave}
                 role="presentation"
               >
-                <!-- Hour gridlines — pure visual rhythm. -->
+                <!-- Today: gray out the portion of the day that has
+                     already happened, matching the full-column
+                     background applied to past days.  Painted
+                     *before* the gridlines so the hour rules still
+                     show through it.  Pointer-events-none so the
+                     user can still click-drag to create events in
+                     the past part of today (they may want to log
+                     something they just did). -->
+                {#if todayCol}
+                  <div
+                    class="absolute left-0 right-0 top-0 bg-surface-100 dark:bg-surface-800 pointer-events-none"
+                    style="height: {nowMinutes * PX_PER_MINUTE}px;"
+                  ></div>
+                {/if}
+
+                <!-- Hour gridlines — pure visual rhythm.  Drawn
+                     after the past-today overlay so the lines run
+                     uninterrupted across the full 24 hours and the
+                     greyed and ungreyed halves of today match. -->
                 {#each Array.from({ length: 24 }, (_, i) => i) as h}
                   <div
                     class="absolute left-0 right-0 border-t border-surface-200/60 dark:border-surface-700/60"
                     style="top: {h * HOUR_HEIGHT_PX}px;"
                   ></div>
                 {/each}
+
+                {#if todayCol}
+                  <!-- Current-time line. Red-500 + small leading
+                       dot for an Outlook/Apple-Calendar-style
+                       indicator the eye picks up immediately. -->
+                  <div
+                    class="absolute left-0 right-0 z-20 pointer-events-none"
+                    style="top: {nowMinutes * PX_PER_MINUTE}px;"
+                  >
+                    <div class="absolute -left-1 -top-1 w-2 h-2 rounded-full bg-red-500"></div>
+                    <div class="border-t border-red-500"></div>
+                  </div>
+                {/if}
 
                 <!-- In-progress drag overlay — translucent rectangle
                      that follows the pointer between mousedown and
@@ -1408,18 +1523,24 @@
     <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
       <h3 class="text-base font-semibold mb-3">New calendar</h3>
 
+      <!-- Account picker: only meaningful with more than one
+           connected NC account.  Hidden when there's a single
+           account (the form's `ncId` is already pre-seeded with
+           it on open). -->
       {#if accounts.length > 1}
         <label class="block text-xs text-surface-500 mb-1" for="new-cal-account">Nextcloud account</label>
-        <select
-          id="new-cal-account"
-          class="select w-full text-sm px-2 py-1.5 rounded-md mb-3"
-          bind:value={newCalendarForm.ncId}
-          disabled={calendarOpBusy}
-        >
-          {#each accounts as a (a.id)}
-            <option value={a.id}>{a.display_name || a.username}</option>
-          {/each}
-        </select>
+        <div class="mb-3">
+          <Select
+            id="new-cal-account"
+            ariaLabel="Nextcloud account"
+            bind:value={newCalendarForm.ncId}
+            disabled={calendarOpBusy}
+            options={accounts.map((a) => ({
+              value: a.id,
+              label: `${a.display_name || a.username} — ${ncHostname(a.server_url)}`,
+            }))}
+          />
+        </div>
       {/if}
 
       <label class="block text-xs text-surface-500 mb-1" for="new-cal-name">Name</label>

--- a/ui/src/lib/DateField.svelte
+++ b/ui/src/lib/DateField.svelte
@@ -1,0 +1,279 @@
+<script lang="ts">
+  /**
+   * DateField — calendar-popover date picker (#126).
+   *
+   * A reusable date input that replaces the native
+   * `<input type="date">`.  The native control varies wildly
+   * across browsers and platforms (Chromium on Linux ships a
+   * particularly minimal one), so we render a custom popover
+   * matching Outlook's calendar-grid style.  Locale-formatted
+   * display, prev/next month arrows, current-day highlight,
+   * outside-click + Escape to close, arrow-key navigation
+   * inside the grid.
+   *
+   * Value is `YYYY-MM-DD` so it round-trips through the
+   * existing date helpers in EventEditor unchanged.
+   */
+
+  import { onMount } from 'svelte'
+
+  let {
+    value = $bindable(''),
+    id,
+    ariaLabel,
+  }: {
+    value?: string
+    id?: string
+    ariaLabel?: string
+  } = $props()
+
+  // Popover open / close.  Closing snaps the focused-month
+  // view back to the selected date so reopening doesn't keep
+  // the user on a month they were just browsing.
+  let open = $state(false)
+  let anchor: HTMLDivElement | undefined = $state()
+
+  /** Parse `YYYY-MM-DD` to a `Date` (local-zone calendar
+   *  date).  Returns today on bad / empty input. */
+  function parseDate(s: string): Date {
+    if (!s) return new Date()
+    const [y, m, d] = s.split('-').map((p) => parseInt(p, 10))
+    if (!y || !m || !d) return new Date()
+    return new Date(y, m - 1, d)
+  }
+  /** Format `Date` → `YYYY-MM-DD` (local-zone). */
+  function formatISO(d: Date): string {
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+  }
+  /** Localised display: "Apr 28, 2026". */
+  function formatDisplay(s: string): string {
+    if (!s) return ''
+    const d = parseDate(s)
+    return d.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+  function sameDay(a: Date, b: Date): boolean {
+    return (
+      a.getFullYear() === b.getFullYear() &&
+      a.getMonth() === b.getMonth() &&
+      a.getDate() === b.getDate()
+    )
+  }
+
+  /** Currently-displayed month — driven by the prev/next
+   *  arrows.  Initialised to the value's month so the popover
+   *  opens centred on the current selection. */
+  // svelte-ignore state_referenced_locally
+  let view = $state(monthStart(parseDate(value)))
+  function monthStart(d: Date): Date {
+    return new Date(d.getFullYear(), d.getMonth(), 1)
+  }
+  // Keep the view in sync when the bound value changes
+  // externally (e.g. reset by the parent on form open).
+  $effect(() => {
+    if (!open) view = monthStart(parseDate(value))
+  })
+
+  /** 6-week grid of `Date`s for the current view month.
+   *  First row may include trailing days of the previous
+   *  month; last row may spill into the next.  Always 42
+   *  cells so the popover height never jumps as the user
+   *  navigates between 28-, 30-, and 31-day months. */
+  let grid = $derived.by(() => {
+    const first = new Date(view.getFullYear(), view.getMonth(), 1)
+    // RFC: week starts on Monday for our locale; getDay() 0=Sun → shift.
+    const offset = (first.getDay() + 6) % 7
+    const start = new Date(first)
+    start.setDate(1 - offset)
+    const cells: Date[] = []
+    for (let i = 0; i < 42; i++) {
+      const d = new Date(start)
+      d.setDate(start.getDate() + i)
+      cells.push(d)
+    }
+    return cells
+  })
+
+  let today = new Date()
+  let selected = $derived(parseDate(value))
+
+  function pick(d: Date) {
+    value = formatISO(d)
+    open = false
+  }
+  function prevMonth() {
+    view = new Date(view.getFullYear(), view.getMonth() - 1, 1)
+  }
+  function nextMonth() {
+    view = new Date(view.getFullYear(), view.getMonth() + 1, 1)
+  }
+  function goToday() {
+    pick(new Date())
+  }
+
+  // Outside-click + Escape close.  Bound at mount so we don't
+  // leak listeners on hot-reload.
+  onMount(() => {
+    function onKey(e: KeyboardEvent) {
+      if (!open) return
+      if (e.key === 'Escape') {
+        open = false
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        const d = new Date(selected)
+        d.setDate(d.getDate() - 1)
+        value = formatISO(d)
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        const d = new Date(selected)
+        d.setDate(d.getDate() + 1)
+        value = formatISO(d)
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        const d = new Date(selected)
+        d.setDate(d.getDate() - 7)
+        value = formatISO(d)
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        const d = new Date(selected)
+        d.setDate(d.getDate() + 7)
+        value = formatISO(d)
+      } else if (e.key === 'Enter') {
+        open = false
+      }
+    }
+    function onClick(e: MouseEvent) {
+      if (!open || !anchor) return
+      if (!anchor.contains(e.target as Node)) open = false
+    }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onClick)
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.removeEventListener('mousedown', onClick)
+    }
+  })
+
+  // Locale-aware month + weekday labels.  Computed once per
+  // view change so we don't reformat on every grid cell.
+  let monthLabel = $derived(
+    view.toLocaleDateString(undefined, { month: 'long', year: 'numeric' }),
+  )
+  // Mon … Sun — generated from a fixed reference week so the
+  // labels match whatever the browser's locale renders.
+  let weekdayLabels = $derived.by(() => {
+    // 2024-01-01 was a Monday.
+    const ref = new Date(2024, 0, 1)
+    const out: string[] = []
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(ref)
+      d.setDate(ref.getDate() + i)
+      out.push(d.toLocaleDateString(undefined, { weekday: 'short' }))
+    }
+    return out
+  })
+</script>
+
+<div class="relative" bind:this={anchor}>
+  <button
+    type="button"
+    {id}
+    aria-label={ariaLabel}
+    aria-haspopup="dialog"
+    aria-expanded={open}
+    class="input w-full px-3 py-2 text-sm rounded-md text-left flex items-center justify-between gap-2"
+    onclick={() => (open = !open)}
+  >
+    <span class={value ? '' : 'text-surface-400'}>
+      {value ? formatDisplay(value) : 'Pick a date'}
+    </span>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="w-4 h-4 text-surface-500 shrink-0"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4M8 2v4M3 10h18" />
+    </svg>
+  </button>
+
+  {#if open}
+    <div
+      class="absolute z-50 mt-1 w-[280px] rounded-md border border-surface-300 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg p-3"
+      role="dialog"
+      aria-label="Pick a date"
+    >
+      <!-- Header: prev | month-year label | next -->
+      <div class="flex items-center justify-between mb-2">
+        <button
+          type="button"
+          class="btn btn-sm preset-tonal-surface w-8 h-8 p-0"
+          aria-label="Previous month"
+          onclick={prevMonth}
+        >‹</button>
+        <span class="text-sm font-medium">{monthLabel}</span>
+        <button
+          type="button"
+          class="btn btn-sm preset-tonal-surface w-8 h-8 p-0"
+          aria-label="Next month"
+          onclick={nextMonth}
+        >›</button>
+      </div>
+
+      <!-- Weekday header row (Mon-first). -->
+      <div class="grid grid-cols-7 gap-0.5 mb-1">
+        {#each weekdayLabels as wd (wd)}
+          <div class="text-[10px] uppercase tracking-wide text-surface-500 text-center py-1">
+            {wd}
+          </div>
+        {/each}
+      </div>
+
+      <!-- 6×7 grid.  Out-of-month days stay clickable but
+           dimmed so the user can drag selection across month
+           boundaries without breaking flow. -->
+      <div class="grid grid-cols-7 gap-0.5">
+        {#each grid as d (d.getTime())}
+          {@const inMonth = d.getMonth() === view.getMonth()}
+          {@const isToday = sameDay(d, today)}
+          {@const isSelected = sameDay(d, selected)}
+          <button
+            type="button"
+            class="text-sm h-8 rounded-md flex items-center justify-center {isSelected
+              ? 'bg-primary-500 text-white font-semibold'
+              : isToday
+                ? 'border border-primary-500 text-primary-500'
+                : inMonth
+                  ? 'hover:bg-surface-200 dark:hover:bg-surface-800'
+                  : 'text-surface-400 hover:bg-surface-200 dark:hover:bg-surface-800'}"
+            onclick={() => pick(d)}
+          >
+            {d.getDate()}
+          </button>
+        {/each}
+      </div>
+
+      <!-- Footer: Today shortcut.  Clear button is
+           deliberately omitted — the field is required for
+           events, so giving the user a button to wipe it would
+           just produce form-validation errors on save. -->
+      <div class="flex justify-end mt-2">
+        <button
+          type="button"
+          class="btn btn-sm preset-tonal-primary"
+          onclick={goToday}
+        >Today</button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -34,6 +34,9 @@
 
   import { convertFileSrc, invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import DateField from './DateField.svelte'
+  import TimeField from './TimeField.svelte'
+  import Select from './Select.svelte'
 
   // ── Types (kept local; these mirror the Rust models) ──────────
   interface EventAttendee {
@@ -159,6 +162,31 @@
     return draft?.calendarId ?? calendars[0]?.id ?? ''
   }
 
+  // Close on Escape.  We attach to `document` so the key works
+  // regardless of where focus is — including inside DateField /
+  // TimeField / Select inputs.  Inner popovers (calendar grid,
+  // time slots, dropdown listbox, attendee suggestions) render a
+  // listbox or labelled dialog while open; if any of those exist,
+  // their own Escape handler should close just the popover, so
+  // we bail out and let them handle it instead of dismissing the
+  // whole editor.
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (
+        document.querySelector(
+          '[role="listbox"], [role="dialog"][aria-label="Pick a date"]',
+        )
+      ) {
+        return
+      }
+      e.preventDefault()
+      onclose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
   // Async-load the default-calendar setting and switch to it if the
   // user hasn't manually changed the picker yet.  In create-mode
   // this is the single biggest UX nicety — Nick's "primary"
@@ -181,20 +209,22 @@
   // svelte-ignore state_referenced_locally
   let allDay = $state(initialAllDay)
 
-  // datetime-local inputs work in the user's local timezone — the
-  // value shape is `YYYY-MM-DDTHH:MM` with no offset. We seed from the
-  // event/draft (which carry UTC instants) and convert back to UTC at
-  // save time. For all-day events we keep the date-only state in
-  // `startDate` / `endDate` and let the save path fold them into
-  // 00:00:00Z / 23:59:59Z.
+  // Date and time are kept as separate strings (#126) — one
+  // `YYYY-MM-DD` and one `HH:MM` per endpoint — so we can render
+  // a proper split picker that matches the mockup (#128).  We
+  // seed from the event/draft (which carry UTC instants), but
+  // surface them in the user's *local* zone so the inputs read
+  // naturally; the save path combines + converts back to UTC.
+  // For all-day events the date-only state is what matters and
+  // the save path folds them into 00:00:00Z / 23:59:59Z.
   // svelte-ignore state_referenced_locally
-  let startLocal = $state(toLocalInput(initialStart()))
+  let startDate = $state(toLocalDateInput(initialStart()))
   // svelte-ignore state_referenced_locally
-  let endLocal = $state(toLocalInput(initialEnd()))
+  let startTime = $state(toLocalTimeInput(initialStart()))
   // svelte-ignore state_referenced_locally
-  let startDate = $state(toDateInput(initialStart()))
+  let endDate = $state(toLocalDateInput(initialEnd()))
   // svelte-ignore state_referenced_locally
-  let endDate = $state(toDateInput(initialEnd()))
+  let endTime = $state(toLocalTimeInput(initialEnd()))
 
   // ── Attendees ─────────────────────────────────────────────
   // Three role-bucketed lists drive the chip-row UI; the input
@@ -224,6 +254,93 @@
   let chairAttendees = $state<EventAttendee[]>(
     event ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'CHAIR') : [],
   )
+
+  /** Lower-cased addresses we consider "the user" — the union
+   *  of every configured mail-account email.  Used by the RSVP
+   *  dropdown to find the user's own ATTENDEE row in edit
+   *  mode (when the user is invited to someone else's event)
+   *  so they can change their response inline.  Loaded once
+   *  on mount; an empty set just hides the RSVP dropdown
+   *  (no harm done — the inbox card remains the canonical
+   *  RSVP surface). */
+  let userIdentities = $state<Set<string>>(new Set())
+  $effect(() => {
+    void invoke<{ email: string }[]>('get_accounts')
+      .then((rows) => {
+        const set = new Set<string>()
+        for (const a of rows) if (a.email) set.add(a.email.toLowerCase())
+        userIdentities = set
+      })
+      .catch(() => {})
+  })
+
+  /** Email of the Nextcloud user that owns the *currently
+   *  selected* calendar.  This is the address NC's Mail Provider
+   *  uses for iMIP, so it's the correct ORGANIZER for events
+   *  saved into that calendar.  Refetched whenever the calendar
+   *  picker changes (the user may have multiple NC servers
+   *  configured with different emails). */
+  let organizerEmail = $state<string | null>(null)
+  // Cache by nc_id so swapping calendars doesn't re-hit OCS.
+  const organizerCache = new Map<string, string | null>()
+  $effect(() => {
+    const cal = calendars.find((c) => c.id === calendarId)
+    if (!cal) {
+      organizerEmail = null
+      return
+    }
+    const ncId = cal.nextcloud_account_id
+    if (organizerCache.has(ncId)) {
+      organizerEmail = organizerCache.get(ncId) ?? null
+      return
+    }
+    void invoke<string | null>('get_nextcloud_user_email', { ncId })
+      .then((email) => {
+        organizerCache.set(ncId, email ?? null)
+        // Only apply if the user hasn't switched calendars while
+        // the OCS round-trip was in flight.
+        const current = calendars.find((c) => c.id === calendarId)
+        if (current?.nextcloud_account_id === ncId) {
+          organizerEmail = email ?? null
+        }
+      })
+      .catch(() => {
+        organizerCache.set(ncId, null)
+      })
+  })
+
+  // In create mode, auto-add the NC user (calendar owner) as
+  // CHAIR (organizer) once their email is known.  Skip if
+  // they're already in any bucket — e.g. seeded from the
+  // originating email's To/Cc, or already added on a previous
+  // calendar switch.
+  $effect(() => {
+    if (mode !== 'create') return
+    if (!organizerEmail) return
+    const me = organizerEmail.toLowerCase()
+    const present = [...requiredAttendees, ...optionalAttendees, ...chairAttendees]
+      .some((a) => a.email.toLowerCase() === me)
+    if (present) return
+    chairAttendees = [
+      ...chairAttendees,
+      { email: organizerEmail, role: 'CHAIR', status: 'ACCEPTED' },
+    ]
+  })
+  /** The user's own ATTENDEE row in this event (if any).  When
+   *  set, the RSVP dropdown surfaces and is bound to its
+   *  PARTSTAT; on save, `update_calendar_event` rewrites the
+   *  body with whatever the user picked.  Searches all three
+   *  buckets so it works for users who were typed as Hosts /
+   *  Required / Optional. */
+  let myAttendee = $derived.by(() => {
+    if (mode !== 'edit') return null
+    if (userIdentities.size === 0) return null
+    const all = [...requiredAttendees, ...optionalAttendees, ...chairAttendees]
+    for (const a of all) {
+      if (userIdentities.has(a.email.toLowerCase())) return a
+    }
+    return null
+  })
 
   // One pending input per role.  Each commits to its bucket on
   // Enter / comma / blur.  Datalist suggestions come from the
@@ -565,24 +682,27 @@
   }
 
   // ── datetime / date helpers ─────────────────────────────────
-  /** `Date` → `YYYY-MM-DDTHH:MM` in the user's local zone. */
-  function toLocalInput(d: Date): string {
+  /** `Date` → `YYYY-MM-DD` in the user's *local* zone (split-
+   *  picker date half).  Note this is local-zone unlike the
+   *  earlier all-day-only `toDateInput` helper which was UTC-
+   *  based — both timed and all-day flows now go through the
+   *  same date string and the save path interprets it
+   *  appropriately. */
+  function toLocalDateInput(d: Date): string {
     const pad = (n: number) => String(n).padStart(2, '0')
-    return (
-      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
-      `T${pad(d.getHours())}:${pad(d.getMinutes())}`
-    )
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
   }
-  /** `Date` → `YYYY-MM-DD` in UTC (matches the all-day storage shape). */
-  function toDateInput(d: Date): string {
+  /** `Date` → `HH:MM` in the user's local zone. */
+  function toLocalTimeInput(d: Date): string {
     const pad = (n: number) => String(n).padStart(2, '0')
-    return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`
   }
-  /** `YYYY-MM-DDTHH:MM` (local) → ISO string in UTC. */
-  function fromLocalInput(s: string): Date {
-    // The browser parses `T`-separated strings without an offset as
-    // local time, so this is the inverse of `toLocalInput`.
-    return new Date(s)
+  /** Combine a local `YYYY-MM-DD` + `HH:MM` into a `Date`. */
+  function fromLocalSplit(date: string, time: string): Date {
+    // Browsers parse `YYYY-MM-DDTHH:MM` (no offset) as local
+    // time, then the Date constructor stores it as UTC under
+    // the hood.  Save-path callers then `.toISOString()` it.
+    return new Date(`${date}T${time || '00:00'}`)
   }
   /** `YYYY-MM-DD` (treated as a UTC calendar date) → midnight UTC. */
   function dateInputToUtcMidnight(s: string): Date {
@@ -593,23 +713,15 @@
     return new Date(`${s}T23:59:59.999Z`)
   }
 
-  // When the user toggles all-day, keep the visible inputs sane: copy
-  // the timed value over to the date-only field on the way in, and
-  // restore a sensible 1-hour timed window on the way out.
+  // When the user toggles all-day, keep the visible inputs sane:
+  // turning it on, the date stays; turning it off, restore a
+  // sensible 09:00 → 10:00 window in local time.
   function onToggleAllDay() {
-    if (allDay) {
-      const s = fromLocalInput(startLocal)
-      const e = fromLocalInput(endLocal)
-      startDate = toDateInput(s)
-      endDate = toDateInput(e)
-    } else {
-      const s = dateInputToUtcMidnight(startDate)
-      const out = new Date(s)
-      out.setHours(9, 0, 0, 0)
-      const end = new Date(out)
-      end.setHours(end.getHours() + 1)
-      startLocal = toLocalInput(out)
-      endLocal = toLocalInput(end)
+    if (!allDay) {
+      // Just turned timed: reset times to a 09:00 → 10:00 slot
+      // on the same date.
+      if (!startTime) startTime = '09:00'
+      if (!endTime) endTime = '10:00'
     }
   }
 
@@ -816,10 +928,10 @@
   function buildInput() {
     const start = allDay
       ? dateInputToUtcMidnight(startDate)
-      : fromLocalInput(startLocal)
+      : fromLocalSplit(startDate, startTime)
     const end = allDay
       ? dateInputToUtcEndOfDay(endDate)
-      : fromLocalInput(endLocal)
+      : fromLocalSplit(endDate, endTime)
     return {
       summary: summary.trim(),
       description: description.trim() ? description.trim() : null,
@@ -933,340 +1045,427 @@
       <h2 class="text-base font-semibold shrink-0">
         {mode === 'create' ? 'New event' : 'Edit event'}
       </h2>
-      <div class="flex items-center gap-2">
-        <!-- Talk meeting shortcut.  Mints a fresh Nextcloud Talk
-             room on the calendar's parent NC account and writes
-             its URL into the event's LOCATION field — same path
-             Nextcloud Calendar's "Make it a Talk conversation"
-             button uses, which is what NC's Calendar UI keys off
-             to render the "Join Talk" affordance.  Disabled
-             before a calendar is picked. -->
-        <button
-          type="button"
-          class="btn btn-sm preset-outlined-primary-500 whitespace-nowrap"
-          disabled={creatingTalkRoom || !calendarId}
-          title="Create a Nextcloud Talk room and use its link as the location"
-          onclick={() => void addTalkLink()}
-        >
-          {creatingTalkRoom ? 'Creating…' : '💬 Talk meeting'}
-        </button>
-        <button
-          class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100"
-          onclick={onclose}
-          aria-label="Close"
-        >✕</button>
-      </div>
+      <button
+        class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100"
+        onclick={onclose}
+        aria-label="Close"
+      >✕</button>
     </header>
 
     <div class="flex-1 overflow-y-auto p-5 space-y-3">
+      <!-- Row 1 — Title spans the row alongside the calendar
+           dropdown (mockup #128).  Title gets the lion's share
+           of the width; calendar picker tucks into a fixed
+           240px column on the right so long calendar names
+           don't squeeze the title to nothing.  In edit mode the
+           calendar is read-only (moving an event between
+           calendars is a separate flow). -->
       <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-summary">Title</label>
         <input
           id="event-summary"
           class="input flex-1 px-3 py-2 text-sm rounded-md"
           bind:value={summary}
-          placeholder="Event title"
+          placeholder="Title of the event"
+          aria-label="Title"
         />
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-calendar">Calendar</label>
         {#if mode === 'create'}
-          <select
-            id="event-calendar"
-            class="select flex-1 px-3 py-2 text-sm rounded-md"
-            bind:value={calendarId}
-          >
-            {#each calendars as c (c.id)}
-              <option value={c.id}>{c.display_name}</option>
-            {/each}
-          </select>
+          <div class="w-60">
+            <Select
+              id="event-calendar"
+              ariaLabel="Calendar"
+              bind:value={calendarId}
+              options={calendars.map((c) => ({ value: c.id, label: c.display_name }))}
+              placeholder="Select calendar"
+            />
+          </div>
         {:else}
-          <span class="flex-1 px-3 py-2 text-sm text-surface-600 dark:text-surface-300">
+          <span class="w-60 px-3 py-2 text-sm text-surface-600 dark:text-surface-300 truncate" title={currentCalendarLabel()}>
             {currentCalendarLabel()}
           </span>
         {/if}
       </div>
 
+      <!-- Row 2 — Status dropdowns: RSVP (only in edit mode and
+           only when the user is themselves an attendee) and
+           Show-as (always).  Mockup positions these together so
+           the user can adjust both without navigating away. -->
       <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-allday">All day</label>
+        {#if myAttendee}
+          <div class="w-44">
+            <Select
+              id="event-rsvp"
+              ariaLabel="Your response (RSVP)"
+              value={(myAttendee.status ?? 'NEEDS-ACTION').toUpperCase()}
+              options={[
+                { value: 'NEEDS-ACTION', label: '❔ No response' },
+                { value: 'ACCEPTED', label: '✅ Accepted' },
+                { value: 'TENTATIVE', label: '❓ Tentative' },
+                { value: 'DECLINED', label: '❌ Declined' },
+              ]}
+              onchange={(v) => {
+                const target = myAttendee
+                if (!target) return
+                target.status = v
+                requiredAttendees = [...requiredAttendees]
+                optionalAttendees = [...optionalAttendees]
+                chairAttendees = [...chairAttendees]
+              }}
+            />
+          </div>
+        {/if}
+        <div class="w-44">
+          <Select
+            id="event-transp"
+            ariaLabel="Show as (busy / free)"
+            bind:value={transparency}
+            options={[
+              { value: 'OPAQUE', label: 'Busy' },
+              { value: 'TRANSPARENT', label: 'Free' },
+            ]}
+          />
+        </div>
+        <div class="flex-1">
+          <Select
+            id="event-reminder"
+            ariaLabel="Reminder"
+            bind:value={reminderChoice}
+            options={[
+              { value: 'none', label: 'No reminder' },
+              { value: '5', label: '5 minutes before' },
+              { value: '15', label: '15 minutes before' },
+              { value: '30', label: '30 minutes before' },
+              { value: '60', label: '1 hour before' },
+              { value: '1440', label: '1 day before' },
+              ...(reminderChoice === 'custom'
+                ? [{ value: 'custom' as const, label: 'Custom (preserved from server)' }]
+                : []),
+            ]}
+          />
+        </div>
+      </div>
+
+      <!-- All-day toggle on its own thin row above the
+           date/time grid so Start and End sit symmetrically
+           on the row beneath it. -->
+      <label class="flex items-center gap-2 text-xs text-surface-600 dark:text-surface-300">
         <input
-          id="event-allday"
           type="checkbox"
           class="checkbox"
           bind:checked={allDay}
           onchange={onToggleAllDay}
         />
+        All-day event
+      </label>
+
+      <!-- Symmetric Start ↔ End row.  Two equal columns, each
+           with its own date + (optional) time field.  When
+           `allDay` is on the time fields collapse and the
+           dates take the full column width.  Custom DateField
+           / TimeField components (#126) replace the native
+           HTML5 inputs — the native pickers vary too much
+           across platforms / browsers and don't match
+           Outlook's "calendar grid + slot list" UX the issue
+           asks for. -->
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <span class="text-xs text-surface-500 mb-1 block">Start</span>
+          <div class="flex items-center gap-2">
+            <div class="flex-1 min-w-0">
+              <DateField
+                id="event-start-date"
+                ariaLabel="Start date"
+                bind:value={startDate}
+              />
+            </div>
+            {#if !allDay}
+              <div class="w-28">
+                <TimeField
+                  id="event-start-time"
+                  ariaLabel="Start time"
+                  bind:value={startTime}
+                />
+              </div>
+            {/if}
+          </div>
+        </div>
+        <div>
+          <span class="text-xs text-surface-500 mb-1 block">End</span>
+          <div class="flex items-center gap-2">
+            <div class="flex-1 min-w-0">
+              <DateField
+                id="event-end-date"
+                ariaLabel="End date"
+                bind:value={endDate}
+              />
+            </div>
+            {#if !allDay}
+              <div class="w-28">
+                <TimeField
+                  id="event-end-time"
+                  ariaLabel="End time"
+                  bind:value={endTime}
+                />
+              </div>
+            {/if}
+          </div>
+        </div>
       </div>
 
+      <!-- Row 5 — Location + Talk meeting shortcut.  Talk
+           button mints a Nextcloud Talk room and writes its
+           URL into LOCATION (matches NC Calendar's "Make it a
+           Talk conversation" flow); the URL replaces whatever
+           was typed when the field is empty, otherwise it
+           appends to DESCRIPTION (handled in `addTalkLink`). -->
       <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-start">Starts</label>
-        {#if allDay}
-          <input
-            id="event-start"
-            type="date"
-            class="input flex-1 px-3 py-2 text-sm rounded-md"
-            bind:value={startDate}
-          />
-        {:else}
-          <input
-            id="event-start"
-            type="datetime-local"
-            class="input flex-1 px-3 py-2 text-sm rounded-md"
-            bind:value={startLocal}
-          />
-        {/if}
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-end">Ends</label>
-        {#if allDay}
-          <input
-            id="event-end"
-            type="date"
-            class="input flex-1 px-3 py-2 text-sm rounded-md"
-            bind:value={endDate}
-          />
-        {:else}
-          <input
-            id="event-end"
-            type="datetime-local"
-            class="input flex-1 px-3 py-2 text-sm rounded-md"
-            bind:value={endLocal}
-          />
-        {/if}
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-location">Location</label>
         <input
           id="event-location"
           class="input flex-1 px-3 py-2 text-sm rounded-md"
           bind:value={location}
-          placeholder="Address, room, link…"
+          placeholder="Location"
+          aria-label="Location"
         />
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-transp">Show as</label>
-        <select
-          id="event-transp"
-          class="select flex-1 px-3 py-2 text-sm rounded-md"
-          bind:value={transparency}
+        <button
+          type="button"
+          class="btn btn-sm preset-outlined-primary-500 whitespace-nowrap"
+          disabled={creatingTalkRoom || !calendarId}
+          title="Create a Nextcloud Talk room and use its link"
+          onclick={() => void addTalkLink()}
         >
-          <option value="OPAQUE">Busy</option>
-          <option value="TRANSPARENT">Free</option>
-        </select>
+          {creatingTalkRoom ? 'Creating…' : '💬 Talk meeting'}
+        </button>
       </div>
 
-      <div class="flex items-center gap-2">
-        <label class="text-xs w-20 text-surface-500" for="event-reminder">Reminder</label>
-        <select
-          id="event-reminder"
-          class="select flex-1 px-3 py-2 text-sm rounded-md"
-          bind:value={reminderChoice}
-        >
-          <option value="none">None</option>
-          <option value="5">5 minutes before</option>
-          <option value="15">15 minutes before</option>
-          <option value="30">30 minutes before</option>
-          <option value="60">1 hour before</option>
-          <option value="1440">1 day before</option>
-          {#if reminderChoice === 'custom'}
-            <option value="custom">Custom (preserved from server)</option>
-          {/if}
-        </select>
+      <!-- Row 6 — Description.  Tall by default — the mockup
+           shows it occupying the bulk of the form's middle. -->
+      <div>
+        <textarea
+          id="event-description"
+          class="textarea w-full px-3 py-2 text-sm rounded-md min-h-[140px]"
+          bind:value={description}
+          placeholder="Description"
+          aria-label="Description"
+        ></textarea>
       </div>
 
-      <!-- Per-role attendee section.  Each role gets its own row:
-           a chip list of already-added participants (large chips
-           with the CardDAV photo when known, and a × remove
-           button) above an input that adds new ones.  Each input
-           drives its own debounced `search_contacts` dropdown —
-           same plumbing AddressAutocomplete uses on Compose,
-           adapted so a click adds the contact straight into the
-           bucket instead of into a comma-separated string. -->
+      <!-- Attendee section, split into two halves per the
+           mockup (#128):
+             1. Three full-width inputs at the top — one for
+                each role (Hosts / Required / Optional) — so
+                adding people is a clean type-and-press flow
+                without chips elbowing into the input row.
+             2. Below the section separator, the chip lists
+                grouped under role headers, only rendered when
+                there's something in the bucket so the editor
+                stays compact for personal events with no
+                attendees.
+           Each input still drives its own debounced
+           `search_contacts` dropdown with photo previews. -->
 
-      {#snippet attendeeRow(label: string, role: Role, list: EventAttendee[], placeholder: string)}
-        <div class="flex items-start gap-2">
-          <div class="text-xs w-20 text-surface-500 pt-2">{label}</div>
-          <div class="flex-1 min-w-0">
-            {#if list.length > 0}
-              <div class="flex flex-wrap gap-2 mb-2">
-                {#each list as a (a.email)}
-                  {@const c = contactsByEmail.get(a.email.toLowerCase())}
-                  {@const photo = photoUrl(c)}
-                  <span class="inline-flex items-center gap-2 pl-1 pr-2 py-1 rounded-full text-sm bg-surface-200 dark:bg-surface-700 max-w-full">
-                    {#if photo}
-                      <img
-                        src={photo}
-                        alt=""
-                        loading="lazy"
-                        class="w-7 h-7 rounded-full object-cover flex-shrink-0"
-                      />
-                    {:else}
-                      <div class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-600 flex items-center justify-center text-[11px] font-semibold flex-shrink-0">
-                        {initials(chipLabel(a))}
-                      </div>
-                    {/if}
-                    <span class="flex flex-col min-w-0">
-                      <span class="flex items-center gap-1.5 max-w-[260px]">
-                        <span class="truncate leading-tight font-medium" title={a.email}>{chipLabel(a)}</span>
-                        {#if isInternal(a.email)}
-                          <!-- Tag for NC-internal users — set when
-                               `find_nextcloud_user_by_email` returns
-                               a hit.  Drives the participant-add flow
-                               (internals go in as `users` source) and
-                               the room-visibility downgrade (private
-                               when *every* attendee is internal). -->
-                          <span
-                            class="text-[9px] uppercase tracking-wide font-semibold px-1 py-px rounded bg-primary-500/20 text-primary-700 dark:text-primary-300 leading-tight shrink-0"
-                            title="Nextcloud user on this server"
-                          >internal</span>
-                        {/if}
-                      </span>
-                      {#if a.status && a.status.toUpperCase() !== 'NEEDS-ACTION'}
-                        <span class="text-[10px] uppercase tracking-wide text-surface-500 leading-tight" title="Response status">
-                          {a.status.toLowerCase()}
-                        </span>
-                      {:else if c && c.organization}
-                        <span class="text-[11px] text-surface-500 leading-tight truncate max-w-[220px]">{c.organization}</span>
-                      {/if}
-                    </span>
-                    <button
-                      type="button"
-                      class="text-surface-500 hover:text-red-500 ml-1 text-base leading-none"
-                      title="Remove"
-                      aria-label={`Remove ${a.email}`}
-                      onclick={() => removeAttendee(role, a.email)}
-                    >×</button>
-                  </span>
-                {/each}
-              </div>
-            {/if}
-            <div class="relative">
-              <input
-                type="text"
-                class="input w-full px-3 py-2 text-sm rounded-md"
-                {placeholder}
-                autocomplete="off"
-                value={role === 'REQ-PARTICIPANT'
+      {#snippet attendeeInput(role: Role, placeholder: string)}
+        <div class="relative">
+          <!-- Leading person icon — same visual vocabulary as
+               the trailing icons on DateField/TimeField.  Sits
+               inside the input's left padding so the placeholder
+               text doesn't overlap. -->
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="w-4 h-4 text-surface-500 absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+          <input
+            type="text"
+            class="input w-full pl-9 pr-3 py-2 text-sm rounded-md"
+            {placeholder}
+            autocomplete="off"
+            value={role === 'REQ-PARTICIPANT'
+              ? requiredInput
+              : role === 'OPT-PARTICIPANT'
+                ? optionalInput
+                : chairInput}
+            oninput={(e) => {
+              const v = (e.currentTarget as HTMLInputElement).value
+              if (role === 'REQ-PARTICIPANT') requiredInput = v
+              else if (role === 'OPT-PARTICIPANT') optionalInput = v
+              else chairInput = v
+              activeSuggestionRole = role
+              runSuggestionSearch(role, v)
+            }}
+            onfocus={() => {
+              activeSuggestionRole = role
+              const v =
+                role === 'REQ-PARTICIPANT'
                   ? requiredInput
                   : role === 'OPT-PARTICIPANT'
                     ? optionalInput
-                    : chairInput}
-                oninput={(e) => {
-                  const v = (e.currentTarget as HTMLInputElement).value
-                  if (role === 'REQ-PARTICIPANT') requiredInput = v
-                  else if (role === 'OPT-PARTICIPANT') optionalInput = v
-                  else chairInput = v
-                  activeSuggestionRole = role
-                  runSuggestionSearch(role, v)
-                }}
-                onfocus={() => {
-                  activeSuggestionRole = role
-                  const v =
-                    role === 'REQ-PARTICIPANT'
-                      ? requiredInput
-                      : role === 'OPT-PARTICIPANT'
-                        ? optionalInput
-                        : chairInput
-                  if (v.trim().length >= 2) runSuggestionSearch(role, v)
-                }}
-                onblur={() => {
-                  // Defer the close so a click on a suggestion
-                  // can fire its onmousedown handler first.
-                  setTimeout(() => {
-                    if (activeSuggestionRole === role) {
-                      activeSuggestionRole = null
-                      dropdownSuggestions = []
-                    }
-                    commitInput(role)
-                  }, 120)
-                }}
-                onkeydown={(e) => {
-                  const open = activeSuggestionRole === role && dropdownSuggestions.length > 0
-                  if (open && e.key === 'ArrowDown') {
+                    : chairInput
+              if (v.trim().length >= 2) runSuggestionSearch(role, v)
+            }}
+            onblur={() => {
+              setTimeout(() => {
+                if (activeSuggestionRole === role) {
+                  activeSuggestionRole = null
+                  dropdownSuggestions = []
+                }
+                commitInput(role)
+              }, 120)
+            }}
+            onkeydown={(e) => {
+              const open = activeSuggestionRole === role && dropdownSuggestions.length > 0
+              if (open && e.key === 'ArrowDown') {
+                e.preventDefault()
+                activeIndex = (activeIndex + 1) % dropdownSuggestions.length
+              } else if (open && e.key === 'ArrowUp') {
+                e.preventDefault()
+                activeIndex =
+                  (activeIndex - 1 + dropdownSuggestions.length) %
+                  dropdownSuggestions.length
+              } else if (open && (e.key === 'Enter' || e.key === 'Tab')) {
+                e.preventDefault()
+                pickSuggestion(role, dropdownSuggestions[activeIndex])
+              } else if (e.key === 'Enter' || e.key === ',') {
+                e.preventDefault()
+                commitInput(role)
+              } else if (e.key === 'Escape') {
+                activeSuggestionRole = null
+                dropdownSuggestions = []
+              }
+            }}
+          />
+          {#if activeSuggestionRole === role && dropdownSuggestions.length > 0}
+            <ul
+              class="absolute left-0 right-0 top-full mt-1 z-50 max-h-72 overflow-y-auto bg-surface-50 dark:bg-surface-900 border border-surface-300 dark:border-surface-700 rounded-md shadow-lg"
+              role="listbox"
+            >
+              {#each dropdownSuggestions as c, i (c.id)}
+                {@const url = photoUrl(c)}
+                <li
+                  role="option"
+                  aria-selected={i === activeIndex}
+                  class="flex items-center gap-3 px-3 py-2 cursor-pointer text-sm {i === activeIndex
+                    ? 'bg-primary-500/15'
+                    : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
+                  onmousedown={(e) => {
                     e.preventDefault()
-                    activeIndex = (activeIndex + 1) % dropdownSuggestions.length
-                  } else if (open && e.key === 'ArrowUp') {
-                    e.preventDefault()
-                    activeIndex =
-                      (activeIndex - 1 + dropdownSuggestions.length) %
-                      dropdownSuggestions.length
-                  } else if (open && (e.key === 'Enter' || e.key === 'Tab')) {
-                    e.preventDefault()
-                    pickSuggestion(role, dropdownSuggestions[activeIndex])
-                  } else if (e.key === 'Enter' || e.key === ',') {
-                    e.preventDefault()
-                    commitInput(role)
-                  } else if (e.key === 'Escape') {
-                    activeSuggestionRole = null
-                    dropdownSuggestions = []
-                  }
-                }}
-              />
-
-              {#if activeSuggestionRole === role && dropdownSuggestions.length > 0}
-                <ul
-                  class="absolute left-0 right-0 top-full mt-1 z-50 max-h-72 overflow-y-auto bg-surface-50 dark:bg-surface-900 border border-surface-300 dark:border-surface-700 rounded-md shadow-lg"
-                  role="listbox"
+                    pickSuggestion(role, c)
+                  }}
+                  onmouseenter={() => (activeIndex = i)}
                 >
-                  {#each dropdownSuggestions as c, i (c.id)}
-                    {@const url = photoUrl(c)}
-                    <li
-                      role="option"
-                      aria-selected={i === activeIndex}
-                      class="flex items-center gap-3 px-3 py-2 cursor-pointer text-sm {i === activeIndex
-                        ? 'bg-primary-500/15'
-                        : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
-                      onmousedown={(e) => {
-                        e.preventDefault()
-                        pickSuggestion(role, c)
-                      }}
-                      onmouseenter={() => (activeIndex = i)}
-                    >
-                      {#if url}
-                        <img
-                          src={url}
-                          alt=""
-                          loading="lazy"
-                          class="w-8 h-8 rounded-full object-cover flex-shrink-0"
-                        />
-                      {:else}
-                        <div class="w-8 h-8 rounded-full bg-surface-300 dark:bg-surface-700 flex items-center justify-center text-xs font-semibold flex-shrink-0">
-                          {initials(c.display_name)}
-                        </div>
-                      {/if}
-                      <div class="flex-1 min-w-0">
-                        <p class="font-medium truncate">{c.display_name}</p>
-                        <p class="text-xs text-surface-500 truncate">
-                          {primaryEmail(c)}
-                          {#if c.organization}· {c.organization}{/if}
-                        </p>
-                      </div>
-                    </li>
-                  {/each}
-                </ul>
-              {/if}
-            </div>
-          </div>
+                  {#if url}
+                    <img
+                      src={url}
+                      alt=""
+                      loading="lazy"
+                      class="w-8 h-8 rounded-full object-cover flex-shrink-0"
+                    />
+                  {:else}
+                    <div class="w-8 h-8 rounded-full bg-surface-300 dark:bg-surface-700 flex items-center justify-center text-xs font-semibold flex-shrink-0">
+                      {initials(c.display_name)}
+                    </div>
+                  {/if}
+                  <div class="flex-1 min-w-0">
+                    <p class="font-medium truncate">{c.display_name}</p>
+                    <p class="text-xs text-surface-500 truncate">
+                      {primaryEmail(c)}
+                      {#if c.organization}· {c.organization}{/if}
+                    </p>
+                  </div>
+                </li>
+              {/each}
+            </ul>
+          {/if}
         </div>
       {/snippet}
 
-      {@render attendeeRow('Required', 'REQ-PARTICIPANT', requiredAttendees, 'alice@example.com')}
-      {@render attendeeRow('Optional', 'OPT-PARTICIPANT', optionalAttendees, 'bob@example.com')}
-      {@render attendeeRow('Chair', 'CHAIR', chairAttendees, 'meeting host (usually one)')}
+      {#snippet chipList(label: string, role: Role, list: EventAttendee[])}
+        {#if list.length > 0}
+          <div>
+            <div class="border-t border-surface-200 dark:border-surface-700 pt-3 mb-2">
+              <span class="text-xs uppercase tracking-wide text-surface-500">{label}</span>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              {#each list as a (a.email)}
+                {@const c = contactsByEmail.get(a.email.toLowerCase())}
+                {@const photo = photoUrl(c)}
+                <span class="inline-flex items-center gap-2 pl-1 pr-2 py-1 rounded-full text-sm bg-surface-200 dark:bg-surface-700 max-w-full">
+                  {#if photo}
+                    <img
+                      src={photo}
+                      alt=""
+                      loading="lazy"
+                      class="w-7 h-7 rounded-full object-cover flex-shrink-0"
+                    />
+                  {:else}
+                    <div class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-600 flex items-center justify-center text-[11px] font-semibold flex-shrink-0">
+                      {initials(chipLabel(a))}
+                    </div>
+                  {/if}
+                  <span class="flex flex-col min-w-0">
+                    <span class="flex items-center gap-1.5 max-w-[260px]">
+                      <span class="truncate leading-tight font-medium" title={a.email}>{chipLabel(a)}</span>
+                      {#if isInternal(a.email)}
+                        <span
+                          class="text-[9px] uppercase tracking-wide font-semibold px-1 py-px rounded bg-primary-500/20 text-primary-700 dark:text-primary-300 leading-tight shrink-0"
+                          title="Nextcloud user on this server"
+                        >internal</span>
+                      {/if}
+                    </span>
+                    {#if userIdentities.has(a.email.toLowerCase()) && (a.role ?? '').toUpperCase() === 'CHAIR'}
+                      <!-- The user's own CHAIR row is the
+                           organizer.  Override whatever PARTSTAT
+                           it carries (typically auto-set to
+                           ACCEPTED) with the more meaningful
+                           "Organizer" label, so the user doesn't
+                           see themselves as just another
+                           "accepted" guest.  All other CHAIRs
+                           (co-hosts) keep their response status. -->
+                      <span class="text-[10px] uppercase tracking-wide text-primary-600 dark:text-primary-300 leading-tight" title="You are the organizer">
+                        organizer
+                      </span>
+                    {:else if a.status && a.status.toUpperCase() !== 'NEEDS-ACTION'}
+                      <span class="text-[10px] uppercase tracking-wide text-surface-500 leading-tight" title="Response status">
+                        {a.status.toLowerCase()}
+                      </span>
+                    {:else if c && c.organization}
+                      <span class="text-[11px] text-surface-500 leading-tight truncate max-w-[220px]">{c.organization}</span>
+                    {/if}
+                  </span>
+                  <button
+                    type="button"
+                    class="text-surface-500 hover:text-red-500 ml-1 text-base leading-none"
+                    title="Remove"
+                    aria-label={`Remove ${a.email}`}
+                    onclick={() => removeAttendee(role, a.email)}
+                  >×</button>
+                </span>
+              {/each}
+            </div>
+          </div>
+        {/if}
+      {/snippet}
 
-      <div class="flex items-start gap-2">
-        <label class="text-xs w-20 text-surface-500 pt-2" for="event-description">Notes</label>
-        <textarea
-          id="event-description"
-          class="textarea flex-1 px-3 py-2 text-sm rounded-md min-h-[120px]"
-          bind:value={description}
-          placeholder="Description, agenda, notes…"
-        ></textarea>
-      </div>
+      <!-- Three input rows, one per role.  Order matches the
+           mockup: Hosts (CHAIR) → Required → Optional. -->
+      {@render attendeeInput('CHAIR', 'Hosts attendees')}
+      {@render attendeeInput('REQ-PARTICIPANT', 'Required attendees')}
+      {@render attendeeInput('OPT-PARTICIPANT', 'Optional attendees')}
+
+      <!-- Section separator + the chip lists grouped by role.
+           Each header is faint until there's content under it,
+           and `chipList` short-circuits empty buckets so the
+           card collapses cleanly for unattended events. -->
+      {@render chipList('Hosts', 'CHAIR', chairAttendees)}
+      {@render chipList('Required', 'REQ-PARTICIPANT', requiredAttendees)}
+      {@render chipList('Optional', 'OPT-PARTICIPANT', optionalAttendees)}
 
       {#if error}
         <p class="text-sm text-red-500">{error}</p>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -68,6 +68,12 @@
         cluster to a single "Edit" action, because Reply-to-a-draft
         doesn't model anything useful. */
     isDraftsFolder?: boolean
+    /** True when the currently selected folder is the account's
+        Sent mailbox.  Used to suppress the iMIP RSVP card for
+        invites the user themselves sent — you don't reply to your
+        own meeting requests, and showing Accept/Decline on a
+        message in Sent is misleading. */
+    isSentFolder?: boolean
     /** Open the shown draft back in Compose for editing. Fires only
         from the "Edit" button inside the drafts toolbar. */
     oneditdraft?: (mail: Email) => void
@@ -99,6 +105,7 @@
     onforward,
     oncreatetalk,
     isDraftsFolder = false,
+    isSentFolder = false,
     oneditdraft,
     onmessageremoved,
     inStandaloneWindow = false,
@@ -1067,7 +1074,7 @@
     <!-- Calendar invite (#58 / iMIP).  Mounted above the
          attachment list so the user reaches for Accept / Decline
          before scanning the rest of the message body. -->
-    {#if invite}
+    {#if invite && !isSentFolder}
       <div class="px-6 pt-3">
         <CalendarInviteCard
           invite={invite}

--- a/ui/src/lib/Select.svelte
+++ b/ui/src/lib/Select.svelte
@@ -1,0 +1,205 @@
+<script lang="ts" generics="T extends string | number | null">
+  /**
+   * Select — custom popover dropdown (#128).
+   *
+   * Replaces the native `<select>` element for fields that
+   * need a more modern look.  Native selects render the
+   * platform's system dropdown which clashes badly with the
+   * rest of the editor (especially on Linux Chromium).  This
+   * component matches the styling vocabulary of `DateField`
+   * and `TimeField`: a button face, a popover anchored below,
+   * hover / selected highlights with the primary colour, and
+   * keyboard navigation (Arrow Up/Down, Enter, Escape).
+   *
+   * Generic over the option `value` so the same component can
+   * back string-keyed selects (calendar id, RSVP partstat,
+   * show-as) and number-keyed ones (reminder minutes-before)
+   * without coercing through `string`.
+   */
+
+  import { onMount } from 'svelte'
+
+  type Option<V> = { value: V; label: string }
+
+  let {
+    value = $bindable(),
+    options,
+    placeholder = '',
+    id,
+    ariaLabel,
+    disabled = false,
+    onchange,
+  }: {
+    value: T
+    options: Option<T>[]
+    placeholder?: string
+    id?: string
+    ariaLabel?: string
+    disabled?: boolean
+    /** Optional callback fired when the user picks an option.
+     *  Useful when the parent doesn't want to use `bind:value`
+     *  (e.g. the value is a derived view of some other state
+     *  and needs custom write-back logic). */
+    onchange?: (v: T) => void
+  } = $props()
+
+  let open = $state(false)
+  let anchor: HTMLDivElement | undefined = $state()
+  let listEl: HTMLUListElement | undefined = $state()
+  /** Index of the option highlighted by keyboard nav.  Resets
+   *  to the currently-selected value on open so the cursor
+   *  starts on something familiar. */
+  let activeIndex = $state(0)
+
+  let selectedOption = $derived(options.find((o) => o.value === value))
+  let displayLabel = $derived(selectedOption?.label ?? placeholder)
+
+  function pick(opt: Option<T>) {
+    value = opt.value
+    open = false
+    onchange?.(opt.value)
+  }
+
+  function toggle() {
+    if (disabled) return
+    if (!open) {
+      activeIndex = Math.max(
+        0,
+        options.findIndex((o) => o.value === value),
+      )
+    }
+    open = !open
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (disabled) return
+    if (!open) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        toggle()
+      }
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      open = false
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      activeIndex = (activeIndex + 1) % options.length
+      ensureVisible()
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      activeIndex = (activeIndex - 1 + options.length) % options.length
+      ensureVisible()
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const opt = options[activeIndex]
+      if (opt) pick(opt)
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      activeIndex = 0
+      ensureVisible()
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      activeIndex = options.length - 1
+      ensureVisible()
+    }
+  }
+
+  /** Scroll the active option into the popover viewport so the
+   *  keyboard cursor doesn't disappear off the bottom on long
+   *  lists (calendar pickers, reminder presets). */
+  function ensureVisible() {
+    queueMicrotask(() => {
+      const li = listEl?.querySelector(`[data-idx="${activeIndex}"]`)
+      if (li instanceof HTMLElement) li.scrollIntoView({ block: 'nearest' })
+    })
+  }
+
+  onMount(() => {
+    function onClick(e: MouseEvent) {
+      if (!open || !anchor) return
+      if (!anchor.contains(e.target as Node)) open = false
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  })
+</script>
+
+<div class="relative" bind:this={anchor}>
+  <button
+    type="button"
+    {id}
+    aria-label={ariaLabel}
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    {disabled}
+    class="input w-full px-3 py-2 text-sm rounded-md text-left flex items-center justify-between gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+    onclick={toggle}
+    onkeydown={onKey}
+  >
+    <span class="truncate {selectedOption ? '' : 'text-surface-400'}">
+      {displayLabel}
+    </span>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="w-4 h-4 text-surface-500 shrink-0 transition-transform {open
+        ? 'rotate-180'
+        : ''}"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  </button>
+
+  {#if open}
+    <ul
+      bind:this={listEl}
+      class="absolute z-50 mt-1 w-full max-h-72 overflow-y-auto rounded-md border border-surface-300 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg"
+      role="listbox"
+    >
+      {#each options as opt, i (`${i}-${String(opt.value)}`)}
+        {@const isSelected = opt.value === value}
+        {@const isActive = i === activeIndex}
+        <li
+          role="option"
+          aria-selected={isSelected}
+          data-idx={i}
+          class="px-3 py-2 text-sm cursor-pointer flex items-center justify-between gap-2 {isSelected
+            ? 'bg-primary-500 text-white'
+            : isActive
+              ? 'bg-primary-500/15'
+              : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
+          onmousedown={(e) => {
+            e.preventDefault()
+            pick(opt)
+          }}
+          onmouseenter={() => (activeIndex = i)}
+        >
+          <span class="truncate">{opt.label}</span>
+          {#if isSelected}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="w-4 h-4 shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/ui/src/lib/TimeField.svelte
+++ b/ui/src/lib/TimeField.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  /**
+   * TimeField — slot-list time picker (#126).
+   *
+   * Replaces the native `<input type="time">` for consistency
+   * with `DateField` and to give users a familiar
+   * Outlook-style 15-minute slot dropdown.  The text input
+   * itself stays editable so power users can type "08:45"
+   * directly without scrolling the list — clicking or focusing
+   * just additionally surfaces the slot picker.  Slots run
+   * 00:00 → 23:45 in 15-minute increments and the dropdown
+   * auto-scrolls to the currently-selected slot on open.
+   *
+   * Value is `HH:MM` so it round-trips through the existing
+   * `fromLocalSplit` helper in EventEditor unchanged.
+   */
+
+  import { onMount, tick } from 'svelte'
+
+  let {
+    value = $bindable(''),
+    id,
+    ariaLabel,
+  }: {
+    value?: string
+    id?: string
+    ariaLabel?: string
+  } = $props()
+
+  let open = $state(false)
+  let anchor: HTMLDivElement | undefined = $state()
+  let listEl: HTMLUListElement | undefined = $state()
+  // Stable id for the combobox / listbox `aria-controls` link.
+  // A counter would also work; uniqueness is what matters.
+  const listId = `timefield-list-${crypto.randomUUID()}`
+
+  /** Pre-computed list of selectable times. 15-min increments
+   *  cover the common meeting cadence (Outlook default).
+   *  Cheap enough to compute once at module load. */
+  const slots = (() => {
+    const out: string[] = []
+    for (let h = 0; h < 24; h++) {
+      for (let m = 0; m < 60; m += 15) {
+        out.push(`${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`)
+      }
+    }
+    return out
+  })()
+
+  function pick(slot: string) {
+    value = slot
+    open = false
+  }
+
+  function onInputKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      open = false
+    } else if (e.key === 'Enter') {
+      open = false
+    } else if (e.key === 'ArrowDown' && !open) {
+      open = true
+    }
+  }
+
+  // Auto-scroll the list to the selected slot when the
+  // popover opens, so the user lands on something familiar
+  // instead of always at 00:00.
+  $effect(() => {
+    if (!open) return
+    void tick().then(() => {
+      const li = listEl?.querySelector(`[data-slot="${value}"]`)
+      if (li instanceof HTMLElement) {
+        li.scrollIntoView({ block: 'center' })
+      }
+    })
+  })
+
+  // Outside-click closes.
+  onMount(() => {
+    function onClick(e: MouseEvent) {
+      if (!open || !anchor) return
+      if (!anchor.contains(e.target as Node)) open = false
+    }
+    document.addEventListener('mousedown', onClick)
+    return () => document.removeEventListener('mousedown', onClick)
+  })
+</script>
+
+<div class="relative" bind:this={anchor}>
+  <input
+    {id}
+    type="text"
+    inputmode="numeric"
+    pattern="[0-9]{'{1,2}'}:[0-9]{'{2}'}"
+    placeholder="HH:MM"
+    aria-label={ariaLabel}
+    aria-haspopup="listbox"
+    role="combobox"
+    aria-expanded={open}
+    aria-controls={listId}
+    autocomplete="off"
+    class="input w-full px-3 py-2 text-sm rounded-md pr-9"
+    bind:value
+    onfocus={() => (open = true)}
+    onclick={() => (open = true)}
+    onkeydown={onInputKey}
+  />
+  <!-- Trailing clock icon — purely decorative, hints that the
+       field is a time picker.  Sits inside the input's
+       padding-right so the value text doesn't overlap. -->
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    class="w-4 h-4 text-surface-500 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 2" />
+  </svg>
+
+  {#if open}
+    <ul
+      id={listId}
+      bind:this={listEl}
+      class="absolute z-50 mt-1 w-full max-h-60 overflow-y-auto rounded-md border border-surface-300 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg"
+      role="listbox"
+    >
+      {#each slots as slot (slot)}
+        <li
+          role="option"
+          aria-selected={slot === value}
+          data-slot={slot}
+          class="px-3 py-1.5 text-sm cursor-pointer {slot === value
+            ? 'bg-primary-500 text-white'
+            : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
+          onmousedown={(e) => {
+            e.preventDefault()
+            pick(slot)
+          }}
+        >
+          {slot}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary

- **#128**: full Event editor restructure to match the mockup — symmetric Start/End row, RSVP + Show-as + reminder row, attendee inputs grouped by role with chip lists, organizer auto-seeded from the owning Nextcloud calendar's identity.
- **#126**: custom DateField (calendar popover), TimeField (15-min slot list), and a generic Select component replacing native dropdowns across EventEditor and CalendarView.
- **Outlook-style "More info" preview** on inbound invites — read-only attendee chips, scrollable 24h day preview with day-nav arrows, events from all active calendars styled like the agenda grid, proposed slot marked with a primary ring + "✉ invite" badge when already on the calendar.
- **CalendarView polish**: sidebar grouped by Nextcloud account with hostname headers, live current-time indicator on today's column, hour rules through the past portion of today, modal Esc-to-close.
- **Mail integration**: RSVP card hidden in the Sent folder, organizer chip label, keyboard niceties (Esc closes editor / new-calendar modal).
- **Clippy clean**: fixed `collapsible_if`, `empty_line_after_doc_comments`, `too_many_arguments` (new `CreateRoomOptions` in nimbus-nextcloud).

## Test plan

- [ ] Create a new event — date/time pickers behave like Outlook, organizer chip says "Organizer" not "Accepted", attendees grouped by Hosts/Required/Optional.
- [ ] Edit an existing event — calendar shown read-only, RSVP dropdown reflects user's PARTSTAT with emoji prefixes.
- [ ] Esc closes EventEditor when no popover is open; closes inner popover otherwise.
- [ ] CalendarView sidebar shows hostname headers per NC account.
- [ ] Today's column has a red current-time line; past portion is gray with hour rules visible.
- [ ] New-calendar `+` modal: account picker shows hostname, Esc closes the modal.
- [ ] Open an inbound iMIP invite → "More info" expands attendee chips + day preview; arrows navigate days; matching meeting on calendar shows ✉ invite badge with primary ring.
- [ ] Open an outbound invite from Sent — RSVP card is suppressed.
- [ ] `cargo clippy --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)