### PR TITLE
Talk: native NC-user invites + RSVP polish (#124)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1129,6 +1129,32 @@ async fn create_talk_room(
     .await
 }
 
+/// Surgical PARTSTAT update for an event already in the user's
+/// cache — the EventEditor's RSVP dropdown lands here when an
+/// attendee changes their response on a meeting that's already
+/// on the calendar.
+///
+/// Why we don't just route this through `update_calendar_event`:
+/// regenerating the VEVENT body from form fields drops X-* lines
+/// and re-orders properties, which Sabre's iTIP broker reads as
+/// a "noisy" diff and silently suppresses the REPLY iMIP.  The
+/// inbox card's `respond_to_invite` already implements the
+/// byte-preserving surgical path; this command is a thin wrapper
+/// that pulls the cached `ics_raw` for an existing event id and
+/// hands it to `respond_to_invite` so the same flow applies.
+#[tauri::command]
+async fn rsvp_existing_event(
+    event_id: String,
+    partstat: String,
+    attendee_hint: Option<String>,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let handle = load_event_handle(&cache, &event_id)?;
+    let calendar_id = handle.calendar_id.clone();
+    let raw_ics = handle.ics_raw.clone();
+    respond_to_invite(calendar_id, raw_ics, partstat, attendee_hint, cache).await
+}
+
 /// Toggle a Talk room's public/private visibility.  Used by
 /// the EventEditor save flow to downgrade a room from public
 /// to private once we've confirmed every attendee is an
@@ -1187,9 +1213,62 @@ async fn find_nextcloud_user_by_email(
     }))
 }
 
+/// Promote an `Email`-source participant to a `User`-source one
+/// whenever the address belongs to a real Nextcloud account on
+/// this server (issue #124).  The internal user lands in the
+/// room as themselves with an in-NC notification instead of
+/// receiving a guest invite link via email — better UX, native
+/// rights, and no second mail in the recipient's inbox.
+///
+/// Lookup is fail-soft: a network blip or an admin-restricted
+/// sharees endpoint falls through to the original `Email`
+/// source so the invite still gets out, just as a guest.  An
+/// in-batch cache (`HashMap<lowercased-addr, ParticipantSource>`)
+/// keeps duplicate addresses across the To/Cc list to a single
+/// OCS round-trip.
+async fn promote_email_to_user_if_internal(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    src: &nimbus_nextcloud::ParticipantSource,
+    cache: &mut std::collections::HashMap<String, nimbus_nextcloud::ParticipantSource>,
+) -> nimbus_nextcloud::ParticipantSource {
+    use nimbus_nextcloud::ParticipantSource;
+    let addr = match src {
+        ParticipantSource::User(_) => return src.clone(),
+        ParticipantSource::Email(a) => a,
+    };
+    let key = addr.to_lowercase();
+    if let Some(hit) = cache.get(&key) {
+        return hit.clone();
+    }
+    let resolved = match nimbus_nextcloud::find_user_by_email(
+        server_url,
+        username,
+        app_password,
+        addr,
+    )
+    .await
+    {
+        Ok(Some(m)) => ParticipantSource::User(m.user_id),
+        Ok(None) => src.clone(),
+        Err(e) => {
+            tracing::warn!(
+                "talk-invite: NC user lookup failed for {addr}: {e}; \
+                 falling back to email guest"
+            );
+            src.clone()
+        }
+    };
+    cache.insert(key, resolved.clone());
+    resolved
+}
+
 /// Add a single participant to an existing Talk room. Exposed so the
 /// UI can grow an "Add participant" affordance later without a
-/// backend round-trip.
+/// backend round-trip.  Email-source participants whose address
+/// matches a Nextcloud user on this server are silently promoted
+/// to `User` source (issue #124).
 #[tauri::command]
 async fn add_talk_participant(
     nc_id: String,
@@ -1198,12 +1277,21 @@ async fn add_talk_participant(
 ) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    let mut cache = std::collections::HashMap::new();
+    let resolved = promote_email_to_user_if_internal(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &participant,
+        &mut cache,
+    )
+    .await;
     nimbus_nextcloud::add_participant(
         &account.server_url,
         &account.username,
         &app_password,
         &room_token,
-        &participant,
+        &resolved,
     )
     .await
 }
@@ -1214,7 +1302,10 @@ async fn add_talk_participant(
 /// the recipients once `Send` actually goes out, so a discarded
 /// draft doesn't leave a room full of strangers in the recipient's
 /// Talk list.  Sequential (not parallel) so the first failure halts
-/// the batch and surfaces as a single error.
+/// the batch and surfaces as a single error.  Email-source entries
+/// whose address matches a Nextcloud user on this server are
+/// promoted to `User` source per issue #124 — internal recipients
+/// join natively, externals still get the email-guest flow.
 #[tauri::command]
 async fn add_talk_participants(
     nc_id: String,
@@ -1223,13 +1314,22 @@ async fn add_talk_participants(
 ) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    let mut cache = std::collections::HashMap::new();
     for p in &participants {
+        let resolved = promote_email_to_user_if_internal(
+            &account.server_url,
+            &account.username,
+            &app_password,
+            p,
+            &mut cache,
+        )
+        .await;
         nimbus_nextcloud::add_participant(
             &account.server_url,
             &account.username,
             &app_password,
             &room_token,
-            p,
+            &resolved,
         )
         .await?;
     }
@@ -5750,6 +5850,7 @@ fn main() {
             create_calendar_event,
             parse_event_invite,
             respond_to_invite,
+            rsvp_existing_event,
             get_rsvp_response,
             get_event_partstat_for_user,
             update_calendar_event,

--- a/ui/src/lib/CalendarInviteCard.svelte
+++ b/ui/src/lib/CalendarInviteCard.svelte
@@ -315,13 +315,41 @@
     lastScrollKey = key
   })
 
-  /** Display name preference for an attendee chip: CN if given,
-   *  else the local-part of the email so a list of bare emails
-   *  doesn't fill the panel with redundant "@domain" suffixes. */
+  /** Display name preference for an attendee chip: "You" when
+   *  the row matches one of the user's configured mail account
+   *  identities (the address the invite landed on), CN if
+   *  given, else the local-part of the email so a list of bare
+   *  emails doesn't fill the panel with redundant "@domain"
+   *  suffixes. */
   function attendeeName(a: InviteAttendee): string {
+    if (userIdentities.has(a.email.toLowerCase())) return 'You'
     if (a.common_name && a.common_name.trim()) return a.common_name.trim()
     const at = a.email.indexOf('@')
     return at > 0 ? a.email.slice(0, at) : a.email
+  }
+
+  /** Optimistic PARTSTAT overrides keyed by lower-cased email,
+   *  applied on top of the static `invite.attendees` snapshot
+   *  so the user's chip flips to their just-picked response
+   *  the moment the RSVP IPC succeeds — without waiting for a
+   *  CalDAV round-trip + resync to land a fresh `invite` prop. */
+  let attendeeStatusOverrides = $state<Map<string, string>>(new Map())
+  function effectiveStatus(a: InviteAttendee): string {
+    // 1) In-session override — set when the user clicks Accept /
+    //    Tentative / Decline.
+    const override = attendeeStatusOverrides.get(a.email.toLowerCase())
+    if (override) return override.toUpperCase()
+    // 2) Persisted PARTSTAT from `respondedAs`, which the mount
+    //    effect hydrates from the cached calendar event (and the
+    //    fallback `rsvp_responses` table).  This keeps the user's
+    //    own chip stamped with their answer when they reopen the
+    //    invite later — without it, the chip would reset to the
+    //    static `invite.attendees` PARTSTAT (typically NEEDS-
+    //    ACTION on the original REQUEST body).
+    if (respondedAs && userIdentities.has(a.email.toLowerCase())) {
+      return respondedAs
+    }
+    return (a.status ?? 'NEEDS-ACTION').toUpperCase()
   }
   /** `HH:MM` from an ISO timestamp, in local time — matches the
    *  display the rest of the card uses for `timeRange`. */
@@ -394,7 +422,7 @@
    *  same alphabet used by the RSVP dropdown in EventEditor so
    *  the visual language carries across the app. */
   function attendeeStatusEmoji(a: InviteAttendee): string {
-    const s = (a.status ?? 'NEEDS-ACTION').toUpperCase()
+    const s = effectiveStatus(a)
     if (s === 'ACCEPTED') return '✅'
     if (s === 'DECLINED') return '❌'
     if (s === 'TENTATIVE') return '❓'
@@ -726,6 +754,32 @@
       })
       respondedAs = partstat
       onresponded?.(partstat)
+      // Optimistically flip the user's row in the attendee chip
+      // strip so the emoji reflects the just-picked response
+      // without waiting for a fresh `invite` prop to land.
+      // Keyed by the resolved attendee email if we have one, else
+      // every userIdentities entry (covers aliases / address
+      // variants so the right row matches whichever address NC
+      // has on the ATTENDEE line).
+      const next = new Map(attendeeStatusOverrides)
+      const targets = attendeeHint
+        ? [attendeeHint.toLowerCase()]
+        : Array.from(userIdentities)
+      for (const t of targets) next.set(t, partstat)
+      attendeeStatusOverrides = next
+      // Drop the per-day events cache so the day preview re-fetches
+      // and immediately reflects the just-recorded RSVP — the
+      // proposed slot's "is this on my calendar?" detection and
+      // the matched event's PARTSTAT visual both depend on
+      // `previewEvents`.  Reset the auto-scroll key so the
+      // viewport snaps back to the proposed slot like a fresh
+      // open (otherwise the user would have to scroll manually
+      // to see the new "✉ invite" treatment land).
+      previewEventsByDate = new Map()
+      lastScrollKey = null
+      if (detailsOpen) {
+        void loadPreviewForDate(previewDate)
+      }
     } catch (e) {
       error = formatError(e) || 'Failed to record RSVP'
     } finally {
@@ -926,7 +980,7 @@
             {#each invite.attendees as a (a.email)}
               <span
                 class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs bg-surface-200 dark:bg-surface-700"
-                title={a.email + (a.status ? ` — ${a.status.toLowerCase()}` : '')}
+                title={a.email + ` — ${effectiveStatus(a).toLowerCase()}`}
               >
                 <span class="text-[11px] leading-none shrink-0" aria-hidden="true">{attendeeStatusEmoji(a)}</span>
                 <span class="truncate max-w-[180px]">{attendeeName(a)}</span>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -432,6 +432,34 @@
       `add_talk_participant` when we sync recipients back into the
       room on Send. */
   let talkRoomToken: string | null = null
+  /** Tracks the room's current public/private state so the
+      after-send sync can downgrade to private without an extra
+      round-trip when every recipient turned out internal. */
+  let talkRoomIsPublic: boolean = false
+  /** In-session cache of "is this address an internal NC user?"
+      so a recipient typed in both To and Cc only costs a single
+      sharees lookup.  `null` value = looked up, no match. */
+  type InternalUserHit = { user_id: string; display_name: string }
+  const internalLookup = new Map<string, InternalUserHit | null>()
+  async function resolveInternal(
+    ncId: string,
+    addr: string,
+  ): Promise<InternalUserHit | null> {
+    const key = addr.toLowerCase()
+    if (internalLookup.has(key)) return internalLookup.get(key) ?? null
+    try {
+      const m = await invoke<InternalUserHit | null>('find_nextcloud_user_by_email', {
+        ncId,
+        email: addr,
+      })
+      internalLookup.set(key, m ?? null)
+      return m ?? null
+    } catch (e) {
+      console.warn('find_nextcloud_user_by_email failed for', addr, e)
+      internalLookup.set(key, null)
+      return null
+    }
+  }
   /** Lower-cased bare addresses we've already POSTed to Talk's
       participant endpoint, so the post-save sync skips them. */
   const talkRoomParticipants = new Set<string>()
@@ -581,9 +609,15 @@
       // `pendingTalkParticipants` so `send()` can flush the lot once
       // the mail actually goes out.
       participants: [],
+      // #124: mint as public so externals can join via the link in
+      // the body.  The send-time sync downgrades to private once we
+      // confirm every recipient is an internal NC user (mirrors
+      // EventEditor's policy — same UX in both surfaces).
+      roomType: 3,
     })
     createdTalkLink = { name: room.display_name, url: room.web_url }
     talkRoomToken = room.token
+    talkRoomIsPublic = true
     for (const p of dedupd) {
       const k = p.value.toLowerCase()
       if (!talkRoomParticipants.has(k) && !pendingTalkParticipants.some((x) => bareAddr(x).toLowerCase() === k)) {
@@ -905,13 +939,62 @@
         const ncId = ncAccountId
         const room = talkRoomToken
         const seen = new Set<string>()
-        const participantsToAdd: { kind: 'email'; value: string }[] = []
+        const participantsToAdd: (
+          | { kind: 'email'; value: string }
+          | { kind: 'user'; value: string }
+        )[] = []
+        // #124: resolve each recipient against the connected NC
+        // server so internal users land in the room as themselves
+        // (`users` source) instead of as email-guests.  Tracks
+        // whether every recipient turned out internal so we can
+        // downgrade the room to private below.
+        let allInternal = true
+        // The sender (Talk-room creator) is implicitly the
+        // room's owner — NC adds them automatically.  Skip any
+        // recipient whose address resolves to *one of the user's
+        // own identities* so the organiser doesn't land in the
+        // room twice (once as the auto-owner, once as a guest).
+        // Sources we consider as "the user":
+        //   - every configured mail-account address (covers the
+        //     "I sent from a different alias than my NC profile"
+        //     case),
+        //   - the NC profile email for the room's owning account
+        //     (Sabre's principal CUA — the canonical "who am I"
+        //     on the server).
+        // Lower-cased and deduped so the lookup is a single Set
+        // hit per recipient.
+        const senderIdentities = new Set<string>()
+        for (const a of accounts) {
+          if (a.email) senderIdentities.add(a.email.toLowerCase())
+        }
+        if (ncAccountId) {
+          try {
+            const profileEmail = await invoke<string | null>(
+              'get_nextcloud_user_email',
+              { ncId: ncAccountId },
+            )
+            if (profileEmail) senderIdentities.add(profileEmail.toLowerCase())
+          } catch (e) {
+            // Soft-fail — we still have the mail-account
+            // identities to filter with.
+            console.warn('get_nextcloud_user_email failed', e)
+          }
+        }
         for (const raw of [...splitAddrs(to), ...splitAddrs(cc)]) {
           const addr = bareAddr(raw)
           if (!addr) continue
           const key = addr.toLowerCase()
           if (seen.has(key) || talkRoomParticipants.has(key)) continue
+          if (senderIdentities.has(key)) continue
           seen.add(key)
+          if (ncId) {
+            const match = await resolveInternal(ncId, addr)
+            if (match) {
+              participantsToAdd.push({ kind: 'user', value: match.user_id })
+              continue
+            }
+            allInternal = false
+          }
           participantsToAdd.push({ kind: 'email', value: addr })
         }
         if (ncId && participantsToAdd.length > 0) {
@@ -927,6 +1010,22 @@
           } catch (e) {
             console.warn('add_talk_participants after send failed', e)
             error = `Sent, but Talk invites couldn't be delivered: ${formatError(e)}`
+          }
+          // Downgrade to private when every invited recipient is
+          // internal — the externals-only public-link affordance is
+          // moot at that point and matching EventEditor's policy
+          // keeps the two surfaces' Talk-room behaviour consistent.
+          if (allInternal && talkRoomIsPublic) {
+            try {
+              await invoke('set_talk_room_public', {
+                ncId,
+                roomToken: room,
+                public: false,
+              })
+              talkRoomIsPublic = false
+            } catch (e) {
+              console.warn('set_talk_room_public(false) failed', e)
+            }
           }
         }
       }

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -328,10 +328,8 @@
   })
   /** The user's own ATTENDEE row in this event (if any).  When
    *  set, the RSVP dropdown surfaces and is bound to its
-   *  PARTSTAT; on save, `update_calendar_event` rewrites the
-   *  body with whatever the user picked.  Searches all three
-   *  buckets so it works for users who were typed as Hosts /
-   *  Required / Optional. */
+   *  PARTSTAT.  Searches all three buckets so it works for
+   *  users who were typed as Hosts / Required / Optional. */
   let myAttendee = $derived.by(() => {
     if (mode !== 'edit') return null
     if (userIdentities.size === 0) return null
@@ -340,6 +338,33 @@
       if (userIdentities.has(a.email.toLowerCase())) return a
     }
     return null
+  })
+
+  /** PARTSTAT the user's own ATTENDEE row carried when the
+   *  editor opened — captured once from the original `event`
+   *  prop so the save flow can detect "did the user change
+   *  their RSVP?" without depending on `myAttendee`'s mutable
+   *  bucket-array reactivity.  Stays `null` for create mode and
+   *  for edit-mode events where the user isn't an attendee. */
+  // svelte-ignore state_referenced_locally
+  let originalUserPartstat = $state<string | null>(deriveOriginalUserPartstat())
+  function deriveOriginalUserPartstat(): string | null {
+    if (mode !== 'edit' || !event) return null
+    for (const a of event.attendees ?? []) {
+      // userIdentities may not be populated yet on first paint;
+      // we re-resolve once it lands via the effect below.
+      if (userIdentities.has(a.email.toLowerCase())) {
+        return (a.status ?? 'NEEDS-ACTION').toUpperCase()
+      }
+    }
+    return null
+  }
+  // userIdentities loads async — re-derive once it's known so the
+  // change detection has the right baseline.
+  $effect(() => {
+    if (originalUserPartstat !== null) return
+    if (userIdentities.size === 0) return
+    originalUserPartstat = deriveOriginalUserPartstat()
   })
 
   // One pending input per role.  Each commits to its bucket on
@@ -620,9 +645,14 @@
     }
   }
 
-  /** Render an attendee for the chip label — prefers display
-   *  name when present, otherwise the email. */
+  /** Render an attendee for the chip label.  When the row's
+   *  email matches one of the user's configured mail-account
+   *  identities, render "You" — that's the address the invite
+   *  landed on, and the user reads "You" much faster than their
+   *  own email at a glance.  Otherwise prefer the CN, falling
+   *  back to the bare email. */
   function chipLabel(a: EventAttendee): string {
+    if (userIdentities.has(a.email.toLowerCase())) return 'You'
     if (a.common_name && a.common_name.trim() && a.common_name !== a.email) {
       return a.common_name
     }
@@ -788,6 +818,17 @@
     const cal = calendars.find((c) => c.id === calendarId)
     if (!cal) return
     const ncId = cal.nextcloud_account_id
+
+    // Drop the user's own ATTENDEE row before talking to Talk —
+    // they're already the room's auto-owner (NC adds the
+    // creator), and the EventEditor auto-seeds the user as a
+    // CHAIR (organiser) on every new event since #128.  Without
+    // this filter that CHAIR row would land in the room a second
+    // time as either a `users` participant or — if the lookup
+    // misses — a `Email` guest with the user's own address.
+    attendees = attendees.filter(
+      (a) => !userIdentities.has(a.email.toLowerCase()),
+    )
 
     // Fill any gaps in `internalLookup` synchronously here so
     // the room-type decision is based on the *full* answer set
@@ -993,10 +1034,37 @@
           attendees: input.attendees.map((a) => a.email),
         })
       } else if (event) {
-        await invoke('update_calendar_event', {
-          eventId: event.id,
-          input,
-        })
+        // RSVP-only fast path: when the user is themselves an
+        // attendee and changed their PARTSTAT, route the update
+        // through the dedicated surgical IPC.  That preserves
+        // the cached body byte-for-byte (just flipping the user's
+        // ATTENDEE PARTSTAT and stamping SCHEDULE-FORCE-SEND=
+        // REPLY) so Sabre's iTIP broker classifies the diff as a
+        // genuine RSVP and dispatches the REPLY iMIP.  Going
+        // through `update_calendar_event` would regenerate the
+        // body from form fields and the broker silently swallows
+        // the iMIP — issue #124 / regression from #128.
+        const newPartstat = (myAttendee?.status ?? 'NEEDS-ACTION').toUpperCase()
+        const partstatChanged =
+          myAttendee !== null &&
+          originalUserPartstat !== null &&
+          newPartstat !== originalUserPartstat
+        if (partstatChanged) {
+          await invoke('rsvp_existing_event', {
+            eventId: event.id,
+            partstat: newPartstat,
+            attendeeHint: myAttendee?.email ?? null,
+          })
+          // Pin the new baseline so a subsequent save in the same
+          // session doesn't try to fire another surgical RSVP for
+          // a PARTSTAT that already landed.
+          originalUserPartstat = newPartstat
+        } else {
+          await invoke('update_calendar_event', {
+            eventId: event.id,
+            input,
+          })
+        }
         onsaved()
       }
 


### PR DESCRIPTION
## Summary

- **Backend resolver** ([main.rs](nimbus-mail/src-tauri/src/main.rs)) — `add_talk_participant` / `add_talk_participants` now run every `Email`-source entry through the NC sharees endpoint and promote hits to `User(id)` so internal recipients land in the room as themselves with native NC notifications. In-batch HashMap cache; fail-soft fallback to email guest.
- **Compose flow** ([Compose.svelte](nimbus-mail/ui/src/lib/Compose.svelte)) — mints the Talk room as public, resolves each To/Cc address up-front, tags participants user/email, downgrades the room to private when everyone turns out internal. Filters out the organiser's own identity (every configured mail account + NC profile email) so they're not added as a guest on top of being the room's auto-owner.
- **EventEditor** ([EventEditor.svelte](nimbus-mail/ui/src/lib/EventEditor.svelte)) — `syncTalkParticipants` drops the user's own ATTENDEE row before posting. Chip labels render "You" for the user's row.
- **RSVP regression fix** — the new RSVP dropdown introduced in #128 routed through `update_calendar_event`, which regenerates the VEVENT body and breaks Sabre's iTIP "minimal PARTSTAT diff" classification → no REPLY iMIP. New `rsvp_existing_event` IPC wraps the existing `respond_to_invite` surgical path; the editor now calls it when only the user's PARTSTAT changed. NC fires the REPLY mail again.
- **Inbox card polish** ([CalendarInviteCard.svelte](nimbus-mail/ui/src/lib/CalendarInviteCard.svelte)) — after RSVP, optimistic emoji on the user's chip, cache wipe + auto-scroll reset on the day preview so the "✉ invite" treatment lands instantly. `effectiveStatus()` falls back to `respondedAs` so reopening the invite still shows the user's stored answer. "You" label for the user's own row.

## Test plan

- [ ] Compose with a mix of NC-user + external recipients, hit Add Talk, send → internal users join as themselves in Talk; externals get the email-guest invite; the organiser is not in the participant list.
- [ ] Compose with all-internal recipients → room is automatically downgraded to private after send.
- [ ] Compose where one of the recipients is one of the user's other mail accounts (alias) → that recipient is filtered out (no self-invite as guest).
- [ ] Create event with a Talk room + invite NC users + externals → same outcome on the EventEditor side; user's own CHAIR row not posted to Talk.
- [ ] Open an inbound invite, hit Accept → preview re-focuses on the proposed slot, "✉ invite" badge appears, user's chip emoji flips to ✅, organiser receives a REPLY iMIP.
- [ ] Edit an existing event you accepted as TENTATIVE, change RSVP via the dropdown to ACCEPTED, save → organiser receives the REPLY iMIP (the regression).
- [ ] Reopen the inbox invite later → user's chip still shows the recorded answer.

Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)