### PR TITLE
Account sidebar polish: unread badges, emoji avatars, reorder, sender name (#115)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -158,6 +158,29 @@ pub struct Account {
     /// silently apply to another.
     #[serde(default)]
     pub trusted_certs: Vec<TrustedCert>,
+    /// Optional emoji chosen by the user to render in the
+    /// IconRail's account avatar in place of the initials
+    /// bubble (issue #115).  Free-form string so a future
+    /// "use a contact photo" path can drop into the same slot
+    /// without a schema change; the UI treats anything
+    /// non-empty as the emoji and falls back to initials when
+    /// `None`.
+    #[serde(default)]
+    pub emoji: Option<String>,
+    /// Display order in the IconRail's account avatar list
+    /// (issue #115).  Lower values render first; ties break on
+    /// `id` so the order is stable across re-renders.  Defaults
+    /// to `0` for back-compat — new accounts inherit `0` and
+    /// new sort assignments run on top of that.
+    #[serde(default)]
+    pub sort_order: i32,
+    /// Human's full name for the From: header (issue #115),
+    /// e.g. `"Nick Schlecker"`.  Separate from `display_name`
+    /// (which is the account *label* — "Work", "Personal").
+    /// `None` falls back to `display_name`, preserving the
+    /// pre-115 behaviour for users who haven't set it.
+    #[serde(default)]
+    pub person_name: Option<String>,
 }
 
 /// One TLS leaf certificate the user has chosen to trust for an

--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -69,7 +69,8 @@ fn read_all(cache: &Cache) -> Result<Vec<Account>, NimbusError> {
             "SELECT id, display_name, email, imap_host, imap_port,
                     smtp_host, smtp_port, use_jmap, jmap_url, signature,
                     folder_icons_json, trusted_certs_json,
-                    folder_icon_overrides_json
+                    folder_icon_overrides_json,
+                    emoji, sort_order, person_name
              FROM accounts
              ORDER BY rowid",
         )
@@ -109,6 +110,9 @@ fn row_to_account(r: &rusqlite::Row<'_>) -> rusqlite::Result<Account> {
         folder_icons,
         trusted_certs,
         folder_icon_overrides,
+        emoji: r.get(13)?,
+        sort_order: r.get::<_, i64>(14)? as i32,
+        person_name: r.get(15)?,
     })
 }
 
@@ -143,8 +147,10 @@ fn insert_one(cache: &Cache, account: &Account) -> Result<(), NimbusError> {
             (id, display_name, email, imap_host, imap_port,
              smtp_host, smtp_port, use_jmap, jmap_url, signature,
              folder_icons_json, trusted_certs_json,
-             folder_icon_overrides_json, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+             folder_icon_overrides_json, created_at,
+             emoji, sort_order, person_name)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                 ?15, ?16, ?17)",
         params![
             account.id,
             account.display_name,
@@ -160,6 +166,9 @@ fn insert_one(cache: &Cache, account: &Account) -> Result<(), NimbusError> {
             trusted_certs_json,
             folder_icon_overrides_json,
             chrono::Utc::now().timestamp(),
+            account.emoji,
+            account.sort_order as i64,
+            account.person_name,
         ],
     )
     .map_err(|e| NimbusError::Storage(format!("insert account: {e}")))?;
@@ -206,7 +215,10 @@ pub fn update_account(cache: &Cache, updated: Account) -> Result<(), NimbusError
                  signature                  = ?10,
                  folder_icons_json          = ?11,
                  trusted_certs_json         = ?12,
-                 folder_icon_overrides_json = ?13
+                 folder_icon_overrides_json = ?13,
+                 emoji                      = ?14,
+                 sort_order                 = ?15,
+                 person_name                = ?16
              WHERE id = ?1",
             params![
                 updated.id,
@@ -222,6 +234,9 @@ pub fn update_account(cache: &Cache, updated: Account) -> Result<(), NimbusError
                 folder_icons_json,
                 trusted_certs_json,
                 folder_icon_overrides_json,
+                updated.emoji,
+                updated.sort_order as i64,
+                updated.person_name,
             ],
         )
         .map_err(|e| NimbusError::Storage(format!("update account: {e}")))?;
@@ -341,6 +356,9 @@ mod tests {
             folder_icons: Vec::new(),
             trusted_certs: Vec::new(),
             folder_icon_overrides: Default::default(),
+            emoji: None,
+            sort_order: 0,
+            person_name: None,
         }
     }
 

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -706,6 +706,36 @@ impl Cache {
         Ok(count as u32)
     }
 
+    /// Per-account unread INBOX count, keyed by `account_id`
+    /// (issue #115).  Used by the IconRail to paint a red badge
+    /// on the avatar of each account that has new mail.
+    /// Accounts with zero unread messages are *omitted* from the
+    /// map so the caller can `?? 0` without the row showing up
+    /// as "0 unread" in the UI.
+    pub fn unread_counts_by_account(
+        &self,
+    ) -> Result<std::collections::HashMap<String, u32>, CacheError> {
+        let conn = self.pool.get()?;
+        let mut stmt = conn.prepare(
+            "SELECT account_id, COUNT(*) FROM messages
+             WHERE folder = 'INBOX' AND is_read = 0
+             GROUP BY account_id",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            let id: String = r.get(0)?;
+            let n: i64 = r.get(1)?;
+            Ok((id, n as u32))
+        })?;
+        let mut out = std::collections::HashMap::new();
+        for r in rows {
+            let (id, n) = r?;
+            if n > 0 {
+                out.insert(id, n);
+            }
+        }
+        Ok(out)
+    }
+
     // ── Message bodies ──────────────────────────────────────────
 
     /// Upsert a cached message body alongside its envelope.

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -640,6 +640,24 @@ const MIGRATIONS: &[&str] = &[
         cancelled_at  INTEGER NOT NULL
     );
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v15 → v16: account UI polish (Issue #115).
+    //
+    // - `emoji` — optional avatar emoji shown in the IconRail in
+    //   place of the initials bubble.  NULL falls back to initials.
+    // - `sort_order` — display rank in the IconRail / Settings.
+    //   Lower values render first; ties break on `id`.  Defaults to
+    //   `0` so existing rows keep their insertion order until the
+    //   user reorders.
+    // - `person_name` — human's full name for the From: header,
+    //   separate from `display_name` (the account label).  NULL
+    //   falls back to `display_name`, preserving pre-#115 behaviour.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE accounts ADD COLUMN emoji TEXT;
+    ALTER TABLE accounts ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE accounts ADD COLUMN person_name TEXT;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5212,6 +5212,30 @@ fn refresh_unread_badge(app: &AppHandle) {
     if let Err(e) = app.emit("unread-count-updated", total) {
         tracing::warn!("failed to emit unread-count-updated: {e}");
     }
+    // Issue #115: also push the per-account split so the
+    // IconRail can paint a red badge on each account's avatar
+    // without doing its own poll.  Soft-fails — the global
+    // count above is still informative even if this query
+    // bombs.
+    match app.state::<Cache>().unread_counts_by_account() {
+        Ok(by_acc) => {
+            if let Err(e) = app.emit("unread-count-by-account-updated", &by_acc) {
+                tracing::warn!("failed to emit unread-count-by-account-updated: {e}");
+            }
+        }
+        Err(e) => tracing::warn!("unread_counts_by_account failed: {e}"),
+    }
+}
+
+/// Per-account unread INBOX count map, keyed by account id.
+/// Used by the IconRail on mount to paint per-avatar badges
+/// before the next `unread-count-by-account-updated` event
+/// fires (those only land on poll completion).
+#[tauri::command]
+fn get_unread_counts_by_account(
+    cache: State<'_, Cache>,
+) -> Result<std::collections::HashMap<String, u32>, NimbusError> {
+    cache.unread_counts_by_account().map_err(Into::into)
 }
 
 // ── Talk-join reminders (issue #123) ──────────────────────────
@@ -5865,6 +5889,7 @@ fn main() {
             check_mail_now,
             dismiss_talk_reminder,
             get_total_unread,
+            get_unread_counts_by_account,
             show_main_window_cmd,
             quit_app,
         ])

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -36,6 +36,12 @@
      *  after a server cert renewal). */
     trusted_certs?: TrustedCert[]
     folder_icon_overrides?: Record<string, string>
+    /** Optional emoji avatar for the IconRail (#115). */
+    emoji?: string | null
+    /** Display order in the IconRail; lower = top. */
+    sort_order?: number
+    /** Human's full name for outbound From: header (#115). */
+    person_name?: string | null
   }
 
   interface TrustedCert {
@@ -370,6 +376,65 @@
     }
   })
 
+  /** Persist the emoji avatar (#115).  Empty string clears it
+   *  back to the initials fallback in the IconRail. */
+  async function onEmojiChange(account: Account, raw: string) {
+    const next = raw.trim() || null
+    account.emoji = next
+    try {
+      await invoke('update_account', { account: { ...account, emoji: next } })
+    } catch (e) {
+      console.warn('failed to save account emoji', e)
+    }
+  }
+
+  /** Persist the sender (person) name (#115). */
+  async function onPersonNameChange(account: Account, raw: string) {
+    const next = raw.trim() || null
+    account.person_name = next
+    try {
+      await invoke('update_account', {
+        account: { ...account, person_name: next },
+      })
+    } catch (e) {
+      console.warn('failed to save sender name', e)
+    }
+  }
+
+  /** Swap places with the next/previous account in the
+   *  display-order ranking.  Re-numbers the affected pair so
+   *  ties don't accumulate over time, and updates the local
+   *  state immediately so the UI reorders without waiting on
+   *  the round-trip. */
+  async function moveAccount(account: Account, delta: -1 | 1) {
+    const sorted = [...accounts].sort((a, b) => {
+      const ao = a.sort_order ?? 0
+      const bo = b.sort_order ?? 0
+      if (ao !== bo) return ao - bo
+      return a.id.localeCompare(b.id)
+    })
+    const idx = sorted.findIndex((a) => a.id === account.id)
+    const target = idx + delta
+    if (target < 0 || target >= sorted.length) return
+    const other = sorted[target]
+    // Re-rank from 0 so ties accumulated from older saves get
+    // cleaned up.  Cheap — typical user has 1-3 accounts.
+    sorted[idx] = other
+    sorted[target] = account
+    for (let i = 0; i < sorted.length; i++) {
+      const a = sorted[i]
+      if ((a.sort_order ?? 0) !== i) {
+        a.sort_order = i
+        try {
+          await invoke('update_account', { account: { ...a, sort_order: i } })
+        } catch (e) {
+          console.warn('failed to save account sort order', e)
+        }
+      }
+    }
+    accounts = [...sorted]
+  }
+
   async function persistIcons(account: Account, rules: FolderIconRule[]) {
     iconSaveStatus[account.id] = 'saving'
     account.folder_icons = rules
@@ -643,20 +708,51 @@
       </div>
 
     {:else}
-      <!-- Account list -->
+      <!-- Account list — sorted by `sort_order` (#115) so the
+           order in this panel matches the IconRail. -->
+      {@const sortedRows = [...accounts].sort((a, b) => {
+        const ao = a.sort_order ?? 0
+        const bo = b.sort_order ?? 0
+        if (ao !== bo) return ao - bo
+        return a.id.localeCompare(b.id)
+      })}
       <div class="space-y-4">
-        {#each accounts as account (account.id)}
+        {#each sortedRows as account, accountIdx (account.id)}
           <div class="card p-4 bg-surface-100 dark:bg-surface-800 rounded-lg">
             <div class="flex items-start justify-between">
-              <div>
-                <p class="font-semibold">{account.display_name}</p>
-                <p class="text-sm text-surface-500">{account.email}</p>
-                <div class="text-xs text-surface-400 mt-2 space-y-0.5">
-                  <p>IMAP: {account.imap_host}:{account.imap_port}</p>
-                  <p>SMTP: {account.smtp_host}:{account.smtp_port}</p>
-                  {#if account.use_jmap}
-                    <p class="text-primary-500">JMAP enabled</p>
-                  {/if}
+              <div class="flex items-start gap-3">
+                <!-- Reorder handle: ▲ / ▼ swap places with the
+                     neighbouring row.  The sort_order field is
+                     persisted via update_account so the IconRail
+                     picks up the new order on its next render. -->
+                <div class="flex flex-col gap-1 mt-1">
+                  <button
+                    type="button"
+                    class="w-5 h-5 flex items-center justify-center rounded text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700 disabled:opacity-30"
+                    disabled={accountIdx === 0}
+                    title="Move up"
+                    aria-label="Move account up"
+                    onclick={() => void moveAccount(account, -1)}
+                  >▲</button>
+                  <button
+                    type="button"
+                    class="w-5 h-5 flex items-center justify-center rounded text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700 disabled:opacity-30"
+                    disabled={accountIdx === sortedRows.length - 1}
+                    title="Move down"
+                    aria-label="Move account down"
+                    onclick={() => void moveAccount(account, 1)}
+                  >▼</button>
+                </div>
+                <div>
+                  <p class="font-semibold">{account.display_name}</p>
+                  <p class="text-sm text-surface-500">{account.email}</p>
+                  <div class="text-xs text-surface-400 mt-2 space-y-0.5">
+                    <p>IMAP: {account.imap_host}:{account.imap_port}</p>
+                    <p>SMTP: {account.smtp_host}:{account.smtp_port}</p>
+                    {#if account.use_jmap}
+                      <p class="text-primary-500">JMAP enabled</p>
+                    {/if}
+                  </div>
                 </div>
               </div>
               <div class="flex flex-col items-end gap-1">
@@ -676,6 +772,34 @@
                 </button>
               </div>
             </div>
+
+            <!-- Identity fields: emoji avatar + person name (#115). -->
+            <div class="mt-4 pt-4 border-t border-surface-200 dark:border-surface-700 grid grid-cols-[auto_1fr] gap-3 items-center">
+              <label class="text-sm font-medium" for="emoji-{account.id}">Avatar emoji</label>
+              <input
+                id="emoji-{account.id}"
+                type="text"
+                maxlength="4"
+                placeholder="📨"
+                value={account.emoji ?? ''}
+                onchange={(e) => void onEmojiChange(account, (e.currentTarget as HTMLInputElement).value)}
+                class="input text-lg text-center w-16 px-2 py-1 rounded-md"
+                aria-label="Account emoji avatar"
+              />
+              <label class="text-sm font-medium" for="person-{account.id}">Sender name</label>
+              <input
+                id="person-{account.id}"
+                type="text"
+                placeholder={account.display_name}
+                value={account.person_name ?? ''}
+                onchange={(e) => void onPersonNameChange(account, (e.currentTarget as HTMLInputElement).value)}
+                class="input flex-1 text-sm px-3 py-1 rounded-md"
+                aria-label="Sender display name"
+              />
+            </div>
+            <p class="text-xs text-surface-400 mt-1 ml-1">
+              The sender name appears as <code>"Name" &lt;email&gt;</code> on outgoing mail. Defaults to the account name when empty.
+            </p>
 
             <div class="mt-4 pt-4 border-t border-surface-200 dark:border-surface-700">
               <div class="flex items-center justify-between mb-1">

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -40,6 +40,11 @@
     display_name: string
     email: string
     signature?: string | null
+    /** Optional human's full name for outbound From: (#115).
+     *  When set, outgoing mail goes out as
+     *  `"Person Name" <email>`; when null we fall back to the
+     *  account's display_name. */
+    person_name?: string | null
   }
   /** Slim calendar summary — matches the Rust `CalendarSummary` Tauri
       return shape. We pass the full list to `EventEditor` so the user
@@ -140,6 +145,21 @@
     accounts.find((a) => a.id === fromAccountId) ?? accounts[0],
   )
   const fromAddress = $derived(fromAccount?.email ?? '')
+  /** RFC-5322 From: header value, including the human's full
+   *  name when set on the account.  Falls back to the bare
+   *  email when neither `person_name` nor `display_name` is
+   *  populated.  Quotes the name to keep characters like
+   *  commas / periods from breaking the header parser on the
+   *  receiving side. */
+  const fromHeader = $derived.by(() => {
+    if (!fromAccount) return fromAddress
+    const name = (fromAccount.person_name ?? fromAccount.display_name ?? '').trim()
+    if (!name) return fromAddress
+    // Escape any internal quotes so the surrounding pair stays
+    // balanced even if the user typed a `"` in their name.
+    const escaped = name.replace(/"/g, '\\"')
+    return `"${escaped}" <${fromAddress}>`
+  })
 
   // ── Form state ──────────────────────────────────────────────
   // Seeded from `initial` (reply / forward / "share this file" entry
@@ -650,7 +670,7 @@
       await invoke('save_draft', {
         accountId: src?.accountId ?? fromAccountId,
         email: {
-          from: fromAddress,
+          from: fromHeader,
           to: splitAddrs(to),
           cc: splitAddrs(cc),
           bcc: splitAddrs(bcc),
@@ -903,7 +923,7 @@
       await invoke('send_email', {
         accountId: fromAccountId,
         email: {
-          from: fromAddress,
+          from: fromHeader,
           to: toList,
           cc: splitAddrs(cc),
           bcc: splitAddrs(bcc),
@@ -1210,7 +1230,7 @@
           </select>
         {:else}
           <span id="compose-from" class="text-sm text-surface-700 dark:text-surface-300">
-            {fromAccount?.display_name || ''} &lt;{fromAddress}&gt;
+            {(fromAccount?.person_name ?? fromAccount?.display_name) || ''} &lt;{fromAddress}&gt;
           </span>
         {/if}
       </div>

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -29,12 +29,18 @@
    */
 
   import { invoke } from '@tauri-apps/api/core'
+  import { listen, type UnlistenFn } from '@tauri-apps/api/event'
   import { onDestroy } from 'svelte'
 
   interface Account {
     id: string
     display_name: string
     email: string
+    /** Optional emoji avatar (issue #115) — replaces the
+     *  initials bubble when set. */
+    emoji?: string | null
+    /** Display order for the rail; lower values render first. */
+    sort_order?: number
   }
 
   interface TalkRoomSummary {
@@ -88,6 +94,54 @@
     if (parts.length === 1) return parts[0][0].toUpperCase()
     return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
   }
+
+  /** Accounts sorted by `sort_order` (#115) so the rail honours
+   *  the user's chosen ordering — `id` ties keep the order
+   *  stable when two rows share the same sort_order. */
+  const sortedAccounts = $derived(
+    [...accounts].sort((a, b) => {
+      const ao = a.sort_order ?? 0
+      const bo = b.sort_order ?? 0
+      if (ao !== bo) return ao - bo
+      return a.id.localeCompare(b.id)
+    }),
+  )
+
+  // ── Per-account unread badges (#115) ────────────────────────
+  // The Rust side emits `unread-count-by-account-updated` after
+  // every poll, carrying a HashMap<accountId, count>.  We seed
+  // the state once on mount via `get_unread_counts_by_account`
+  // so the badge paints immediately, then keep it live with the
+  // event subscription.
+  let unreadByAccount = $state<Record<string, number>>({})
+  $effect(() => {
+    void invoke<Record<string, number>>('get_unread_counts_by_account')
+      .then((m) => (unreadByAccount = m))
+      .catch((e) => console.warn('get_unread_counts_by_account failed', e))
+    let unlisten: UnlistenFn | null = null
+    void listen<Record<string, number>>(
+      'unread-count-by-account-updated',
+      (e) => {
+        unreadByAccount = e.payload ?? {}
+      },
+    )
+      .then((fn) => (unlisten = fn))
+      .catch((e) =>
+        console.warn('listen unread-count-by-account-updated failed', e),
+      )
+    return () => {
+      if (unlisten) unlisten()
+    }
+  })
+  function unreadFor(id: string): number {
+    return unreadByAccount[id] ?? 0
+  }
+  /** Sum of every account's unread count — drives the "All
+   *  inboxes" bubble's badge so the unified view also shows a
+   *  single aggregate red dot when anything's pending. */
+  const totalUnread = $derived(
+    Object.values(unreadByAccount).reduce((a, b) => a + b, 0),
+  )
 
   // ── Talk unread badge ───────────────────────────────────────
   // Polls the first configured Nextcloud account every 30s and
@@ -162,7 +216,7 @@
        chrome with no distinct behaviour. -->
   {#if accounts.length > 1}
     <button
-      class="w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
+      class="relative w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
              transition-colors
              {unified
                ? 'bg-primary-500 text-white ring-2 ring-offset-2 ring-offset-surface-100 dark:ring-offset-surface-800 ring-primary-500'
@@ -188,21 +242,42 @@
         <span class="absolute inset-0 flex items-center justify-center text-lg leading-none -translate-y-[6px]">&#x1F4E5;</span>
         <span class="absolute bottom-0 right-0 text-[0.65rem] leading-none drop-shadow">&#x1F310;</span>
       </span>
+      {#if totalUnread > 0}
+        <span
+          class="absolute -top-0.5 -right-0.5 min-w-4 h-4 px-1 text-[10px] rounded-full bg-red-500 text-white flex items-center justify-center font-semibold ring-2 ring-surface-100 dark:ring-surface-800"
+          title={`${totalUnread} unread across all inboxes`}
+        >{totalUnread > 99 ? '99+' : totalUnread}</span>
+      {/if}
     </button>
   {/if}
-  {#each accounts as a (a.id)}
+  {#each sortedAccounts as a (a.id)}
     {@const active = !unified && accountId === a.id}
+    {@const unread = unreadFor(a.id)}
     <button
-      class="w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
+      class="relative w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
              transition-colors
              {active
                ? 'bg-primary-500 text-white ring-2 ring-offset-2 ring-offset-surface-100 dark:ring-offset-surface-800 ring-primary-500'
                : 'bg-surface-300 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-400 dark:hover:bg-surface-600'}"
-      title="{a.display_name || a.email}"
+      title={`${a.display_name || a.email}${unread > 0 ? ` — ${unread} unread` : ''}`}
       aria-label="Switch to {a.display_name || a.email}"
       onclick={() => onselectaccount(a.id)}
     >
-      {initials(a)}
+      {#if a.emoji && a.emoji.trim()}
+        <span class="text-lg leading-none">{a.emoji}</span>
+      {:else}
+        {initials(a)}
+      {/if}
+      {#if unread > 0}
+        <!-- Red unread badge (#115).  Pinned top-right and
+             ringed in the rail's surface colour so the badge
+             reads cleanly over both light and dark themes
+             without doubling as part of the avatar bubble's
+             outline. -->
+        <span
+          class="absolute -top-0.5 -right-0.5 min-w-4 h-4 px-1 text-[10px] rounded-full bg-red-500 text-white flex items-center justify-center font-semibold ring-2 ring-surface-100 dark:ring-surface-800"
+        >{unread > 99 ? '99+' : unread}</span>
+      {/if}
     </button>
   {/each}
 


### PR DESCRIPTION
## Summary

All four items from #115:

1. **Red unread badge** on each IconRail account avatar (and on the All-inboxes bubble) — backed by a new `unread_counts_by_account` cache method + `unread-count-by-account-updated` event so the badge refreshes live with every poll.
2. **Emoji avatar** replaces the initials bubble when set on the account; falls back to initials when empty.
3. **Reorderable accounts** via ▲/▼ handles in Settings; persisted as `sort_order` and respected by the IconRail's sort.
4. **Sender name** on the account (separate from the account label) used to build `\"Person Name\" <email>` in the From: header on send and save-draft. Empty falls back to `display_name`.

## Storage

- v15 → v16 migration adds `emoji`, `sort_order`, `person_name` columns to `accounts`. `row_to_account` / `insert_one` / `update_account` and the in-memory test fixture all carry the new fields.

## Test plan

- [ ] Send some unread mail to one of the accounts → red corner pill lights on that avatar; aggregate badge updates on the All-inboxes bubble. Mark as read → badge disappears.
- [ ] Set an emoji in Settings → avatar bubble shows the emoji.
- [ ] Reorder via ▲/▼ → IconRail order matches Settings on next render; reload app → order persists.
- [ ] Set a sender name in Settings → outbound mail's From: header is `\"Sender\" <email>`; recipients see the person name.
- [ ] Empty sender name → falls back to the account's display_name (pre-115 behaviour).

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)