### PR TITLE
feat(#67): Nextcloud Notes integration

### DIFF
--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -18,6 +18,7 @@ pub mod auth;
 pub mod capabilities;
 pub mod client;
 pub mod files;
+pub mod notes;
 pub mod shares;
 pub mod talk;
 pub mod user;
@@ -27,6 +28,9 @@ pub use capabilities::fetch_capabilities;
 pub use files::{
     FileEntry, create_directory, delete_path, download_file, list_directory, propfind_fileid,
     upload_file,
+};
+pub use notes::{
+    NewNote, Note, NoteUpdate, create_note, delete_note, get_note, list_notes, update_note,
 };
 pub use shares::{PublicShare, create_public_share, update_share_label};
 pub use talk::{

--- a/crates/nimbus-nextcloud/src/notes.rs
+++ b/crates/nimbus-nextcloud/src/notes.rs
@@ -1,0 +1,281 @@
+//! Nextcloud Notes integration — list / get / create / update / delete
+//! markdown notes via the Notes app's REST API.
+//!
+//! # Endpoint shape
+//!
+//! Unlike Talk and Files, Notes lives outside OCS. Every call hits
+//! `/index.php/apps/notes/api/v1/notes` with HTTP Basic auth and
+//! plain JSON in / out — no `OCS-APIRequest` header, no two-level
+//! `ocs.data` envelope, just the resource itself.
+//!
+//! Auth is the same app-password Basic auth Talk and Files use; the
+//! caller pulls it from the keychain and hands it in.
+//!
+//! # MVP scope (issue #67)
+//!
+//! - [`list_notes`] — fetch every note the user has access to.
+//! - [`get_note`] — fetch a single note by id (used after the list to
+//!   pull the body, since list responses include it but a fresh fetch
+//!   guarantees the latest etag for the upcoming PUT).
+//! - [`create_note`] — POST a brand-new note.
+//! - [`update_note`] — PUT title / content / category changes.
+//! - [`delete_note`] — drop a note.
+//!
+//! Categories and the `favorite` flag round-trip cleanly but the UI
+//! doesn't surface them in this slice — they're carried so a future
+//! iteration can add filtering / pinning without a wire-format change.
+
+use serde::{Deserialize, Serialize};
+
+use nimbus_core::NimbusError;
+
+use crate::client;
+
+/// One note as the UI cares about it. Mirrors the Notes app's JSON
+/// shape exactly so we can serde the wire format straight in / out
+/// without an intermediate `Wire*` struct (the Talk / Shares modules
+/// need the wire-vs-domain split because OCS wraps everything; Notes
+/// doesn't, so the extra type would be pure ceremony).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Note {
+    /// Server-assigned id. `0` on a fresh local draft before
+    /// `create_note` returns — the server stamps the real id.
+    pub id: u64,
+    /// Optimistic-concurrency token. Sent back on `update_note` via
+    /// the `If-Match` header; the server rejects the PUT with `412`
+    /// if another client has saved in the meantime.
+    #[serde(default)]
+    pub etag: String,
+    /// Unix epoch seconds of the last modification.
+    #[serde(default)]
+    pub modified: i64,
+    /// Note title — derived by the server from the first line of
+    /// `content` if the client doesn't set it explicitly. We mirror
+    /// the server's behaviour by sending an empty title on create
+    /// and letting it auto-fill, but `update_note` accepts a
+    /// caller-supplied override.
+    #[serde(default)]
+    pub title: String,
+    /// Folder-style grouping (e.g. `"Work/Meetings"`). Empty string
+    /// = uncategorized. Round-trips cleanly even though the current
+    /// UI ignores it.
+    #[serde(default)]
+    pub category: String,
+    /// Markdown body. The Notes web UI renders this with its own
+    /// markdown pipeline; Nimbus shows it plain in the MVP and lets
+    /// markdown round-trip through the editor.
+    #[serde(default)]
+    pub content: String,
+    /// User-pinned flag. Round-trips but isn't surfaced in the MVP.
+    #[serde(default)]
+    pub favorite: bool,
+}
+
+/// Body of a `create_note` POST. Separate from `Note` so callers
+/// don't have to invent an `id` / `etag` / `modified` for a note
+/// that doesn't exist yet — the server fills those in on the
+/// response.
+#[derive(Debug, Clone, Serialize)]
+pub struct NewNote<'a> {
+    pub title: &'a str,
+    pub content: &'a str,
+    pub category: &'a str,
+}
+
+/// Body of an `update_note` PUT. Each field is optional — the
+/// server only touches the ones we send, so a category-only edit
+/// doesn't have to round-trip the whole note. The Notes app
+/// accepts these field names verbatim under
+/// `PUT /apps/notes/api/v1/notes/{id}`.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct NoteUpdate<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub category: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub favorite: Option<bool>,
+}
+
+/// Path prefix shared by every Notes endpoint. Pulled out as a const
+/// so the URL shape lives in one place — if Notes ever ships a v2
+/// (currently no signs of it) we change this constant.
+const NOTES_BASE: &str = "/index.php/apps/notes/api/v1/notes";
+
+/// List every note the current user has access to. Returns an empty
+/// list (not an error) when the user has no notes yet — that's the
+/// "first launch of NotesView" state the UI's empty placeholder
+/// covers.
+pub async fn list_notes(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+) -> Result<Vec<Note>, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}{NOTES_BASE}");
+
+    tracing::debug!("GET {url}");
+    let http = client::build()?;
+    let resp = http
+        .get(&url)
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("notes list request failed: {e}")))?;
+
+    expect_success(&resp, "list notes")?;
+    resp.json::<Vec<Note>>()
+        .await
+        .map_err(|e| NimbusError::Protocol(format!("notes list parse failed: {e}")))
+}
+
+/// Fetch a single note by id. The list response already includes
+/// `content`, so this is mostly used right before `update_note` to
+/// pick up the freshest `etag` and avoid a 412 collision with a
+/// concurrent edit from the web UI.
+pub async fn get_note(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    id: u64,
+) -> Result<Note, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}{NOTES_BASE}/{id}");
+
+    tracing::debug!("GET {url}");
+    let http = client::build()?;
+    let resp = http
+        .get(&url)
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("notes get request failed: {e}")))?;
+
+    expect_success(&resp, "get note")?;
+    resp.json::<Note>()
+        .await
+        .map_err(|e| NimbusError::Protocol(format!("notes get parse failed: {e}")))
+}
+
+/// Create a new note and return the server's freshly-stamped row.
+/// The server derives `title` from the first line of `content` when
+/// `title` is empty — pass `""` to get that auto-fill behaviour, or
+/// a real title to pin one.
+pub async fn create_note(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    note: &NewNote<'_>,
+) -> Result<Note, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}{NOTES_BASE}");
+
+    tracing::debug!("POST {url}");
+    let http = client::build()?;
+    let resp = http
+        .post(&url)
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .json(note)
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("notes create request failed: {e}")))?;
+
+    expect_success(&resp, "create note")?;
+    resp.json::<Note>()
+        .await
+        .map_err(|e| NimbusError::Protocol(format!("notes create parse failed: {e}")))
+}
+
+/// Apply a partial update to an existing note. `etag` is the value
+/// the caller saw on its last `get_note` (or `list_notes`); the
+/// server returns 412 Precondition Failed if another writer has
+/// touched the note in the meantime — the caller should re-fetch
+/// and retry / merge.
+pub async fn update_note(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    id: u64,
+    etag: &str,
+    update: &NoteUpdate<'_>,
+) -> Result<Note, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}{NOTES_BASE}/{id}");
+
+    tracing::debug!("PUT {url}");
+    let http = client::build()?;
+    let mut req = http
+        .put(&url)
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .json(update);
+    if !etag.is_empty() {
+        req = req.header("If-Match", format!("\"{etag}\""));
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("notes update request failed: {e}")))?;
+
+    expect_success(&resp, "update note")?;
+    resp.json::<Note>()
+        .await
+        .map_err(|e| NimbusError::Protocol(format!("notes update parse failed: {e}")))
+}
+
+/// Delete a note by id. Idempotent on the server — deleting a
+/// missing note returns 404, which we propagate as `NotFound` so
+/// the UI can stay quiet on a double-click of the trash button.
+pub async fn delete_note(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    id: u64,
+) -> Result<(), NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let url = format!("{server}{NOTES_BASE}/{id}");
+
+    tracing::debug!("DELETE {url}");
+    let http = client::build()?;
+    let resp = http
+        .delete(&url)
+        .header("Accept", "application/json")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("notes delete request failed: {e}")))?;
+
+    expect_success(&resp, "delete note")?;
+    Ok(())
+}
+
+/// Notes uses regular HTTP status codes (no OCS envelope), so a
+/// non-2xx is a real error — surface a typed variant for the
+/// common cases instead of always tossing the body into a generic
+/// `Protocol` so the UI can react meaningfully (re-auth on 401,
+/// "note not found" on 404, conflict-recovery on 412).
+fn expect_success(resp: &reqwest::Response, op: &str) -> Result<(), NimbusError> {
+    let status = resp.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    Err(match status.as_u16() {
+        401 => NimbusError::Auth(format!("{op}: not authenticated")),
+        403 => NimbusError::Auth(format!("{op}: forbidden")),
+        // No dedicated `NotFound` variant; `Nextcloud` is the
+        // closest fit and surfaces the per-app context cleanly.
+        404 => NimbusError::Nextcloud(format!("{op}: note not found")),
+        // Reuse the same etag-collision variant CalDAV uses so
+        // future "refresh and retry" plumbing in the UI can match
+        // on a single error type across protocols.
+        412 => NimbusError::EtagMismatch(format!(
+            "{op}: note was modified by another client"
+        )),
+        _ => NimbusError::Network(format!("{op}: HTTP {status}")),
+    })
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1377,6 +1377,122 @@ async fn rename_talk_room(
     .await
 }
 
+// ── Nextcloud Notes (issue #67) ────────────────────────────────
+//
+// Five thin commands wrapping `nimbus_nextcloud::notes`. Same
+// shape as the Talk block above: each call loads the chosen NC
+// account + app password and forwards. The Notes API is plain
+// REST under `/index.php/apps/notes/api/v1/notes`, so there's no
+// envelope unpacking — the wire types come straight back.
+//
+// We deliberately don't cache notes locally: the Notes web UI is
+// the canonical editor and we want NotesView to reflect what the
+// user just typed there without a sync-roundtrip dance. Cost is
+// one HTTP call per list-refresh, which is cheap.
+
+/// List every note the connected Nextcloud user can see.
+#[tauri::command]
+async fn list_nextcloud_notes(
+    nc_id: String,
+) -> Result<Vec<nimbus_nextcloud::Note>, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::list_notes(&account.server_url, &account.username, &app_password).await
+}
+
+/// Fetch a single note, primarily to refresh the etag right before
+/// an edit lands so we don't trip a 412 on a note the user looked
+/// at long ago.
+#[tauri::command]
+async fn get_nextcloud_note(
+    nc_id: String,
+    note_id: u64,
+) -> Result<nimbus_nextcloud::Note, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::get_note(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        note_id,
+    )
+    .await
+}
+
+/// Create a new note. Title can be empty — the server derives it
+/// from the first content line in that case, matching the behaviour
+/// of the Notes web UI.
+#[tauri::command]
+async fn create_nextcloud_note(
+    nc_id: String,
+    title: String,
+    content: String,
+    category: String,
+) -> Result<nimbus_nextcloud::Note, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::create_note(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &nimbus_nextcloud::NewNote {
+            title: &title,
+            content: &content,
+            category: &category,
+        },
+    )
+    .await
+}
+
+/// Apply a partial update. Each field is optional — the frontend
+/// sends only the ones the user touched so a category-only edit
+/// doesn't have to round-trip body bytes the user didn't change.
+#[tauri::command]
+async fn update_nextcloud_note(
+    nc_id: String,
+    note_id: u64,
+    etag: String,
+    title: Option<String>,
+    content: Option<String>,
+    category: Option<String>,
+    favorite: Option<bool>,
+) -> Result<nimbus_nextcloud::Note, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::update_note(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        note_id,
+        &etag,
+        &nimbus_nextcloud::NoteUpdate {
+            title: title.as_deref(),
+            content: content.as_deref(),
+            category: category.as_deref(),
+            favorite,
+        },
+    )
+    .await
+}
+
+/// Delete a note. Called by the trash button in NotesView; the
+/// frontend confirms in JS first so we don't need a confirm here.
+#[tauri::command]
+async fn delete_nextcloud_note(
+    nc_id: String,
+    note_id: u64,
+) -> Result<(), NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    nimbus_nextcloud::delete_note(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        note_id,
+    )
+    .await
+}
+
 // ── CardDAV contacts ────────────────────────────────────────────
 //
 // Contact sync is driven from a single entry point: the UI calls
@@ -5844,6 +5960,11 @@ fn main() {
             delete_talk_room,
             add_talk_participant,
             rename_talk_room,
+            list_nextcloud_notes,
+            get_nextcloud_note,
+            create_nextcloud_note,
+            update_nextcloud_note,
+            delete_nextcloud_note,
             upload_to_nextcloud,
             office_open_attachment,
             office_close_attachment,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -29,6 +29,7 @@
   import CalendarView from './lib/CalendarView.svelte'
   import FilesView from './lib/FilesView.svelte'
   import TalkView from './lib/TalkView.svelte'
+  import NotesView from './lib/NotesView.svelte'
   import CreateTalkRoomModal, { type TalkRoom } from './lib/CreateTalkRoomModal.svelte'
   import SearchBar, {
     type SearchScope,
@@ -49,6 +50,7 @@
     | 'calendar'
     | 'files'
     | 'talk'
+    | 'notes'
   let currentView = $state<View>('loading')
 
 
@@ -893,6 +895,67 @@
       talkLink: { name: room.display_name, url: room.web_url },
     })
   }
+
+  /** "Save as note" handler — issue #67's email→note bridge. Builds
+      a markdown body that preserves the headers the user actually
+      cares about (From / To / Date) so the note carries enough
+      context to be useful when read months later. Body source
+      preference: plain text first (already the right shape for
+      markdown), falling back to a stripped HTML body so users on
+      HTML-only senders still get readable note content. */
+  async function onSaveMailAsNote(mail: OpenMail & { body_html?: string | null }) {
+    let ncId = ''
+    try {
+      const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      if (list.length === 0) {
+        alert('Connect a Nextcloud account first (Settings → Nextcloud).')
+        return
+      }
+      ncId = list[0].id
+    } catch (e) {
+      alert(`Failed to load Nextcloud accounts: ${e}`)
+      return
+    }
+
+    const headerLines = [
+      `**From:** ${mail.from}`,
+      mail.to.length ? `**To:** ${mail.to.join(', ')}` : null,
+      mail.cc.length ? `**Cc:** ${mail.cc.join(', ')}` : null,
+      `**Date:** ${new Date(mail.date).toLocaleString()}`,
+    ].filter(Boolean)
+
+    let body = (mail.body_text ?? '').trim()
+    if (!body && mail.body_html) {
+      // Strip tags for the markdown note body — collapsing
+      // whitespace afterwards keeps the result readable when the
+      // sender's HTML had each block on its own line.
+      const tmp = document.createElement('div')
+      tmp.innerHTML = mail.body_html
+      body = (tmp.textContent ?? '').trim()
+    }
+
+    const content = `${headerLines.join('  \n')}\n\n---\n\n${body}`
+    const title = mail.subject || '(no subject)'
+
+    try {
+      await invoke('create_nextcloud_note', {
+        ncId,
+        title,
+        content,
+        category: 'Mail',
+      })
+      // Surface success via the same OS toast path new-mail uses,
+      // when permission's been granted; otherwise fall back to a
+      // plain alert so the user knows the save took.
+      if (notificationsGranted) {
+        fireToast('Saved to Notes', title)
+      } else {
+        alert(`Saved "${title}" to Nextcloud Notes.`)
+      }
+    } catch (e) {
+      alert(`Failed to save note: ${e}`)
+    }
+  }
 </script>
 
 <!-- Loading / Setup both run before the user has an account, so the
@@ -951,6 +1014,10 @@
     {:else if currentView === 'talk'}
       <div class="flex-1 min-w-0">
         <TalkView onclose={goToInbox} oncompose={openCompose} />
+      </div>
+    {:else if currentView === 'notes'}
+      <div class="flex-1 min-w-0">
+        <NotesView onclose={goToInbox} oncompose={openCompose} />
       </div>
     {:else}
       <!-- Mail view: Sidebar (folders) + mail-list column + MailView.
@@ -1015,6 +1082,7 @@
         onreplyall={onReplyAll}
         onforward={onForward}
         oncreatetalk={onCreateTalkFromMail}
+        onsavenote={onSaveMailAsNote}
         isDraftsFolder={isDraftsFolder}
         isSentFolder={isSentFolder}
         oneditdraft={onEditDraft}

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -57,6 +57,7 @@
     | 'calendar'
     | 'files'
     | 'talk'
+    | 'notes'
     | 'settings'
 
   interface Props {
@@ -204,6 +205,7 @@
     { match: 'calendar', label: 'Calendar', icon: '\u{1F4C5}' }, // 📅
     { match: 'files', label: 'Files', icon: '\u{1F4C1}' },       // 📁
     { match: 'talk', label: 'Talk', icon: '\u{1F4AC}' },         // 💬
+    { match: 'notes', label: 'Notes', icon: '\u{1F4DD}' },       // 📝
   ]
 </script>
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -63,6 +63,11 @@
         subject + thread participants. Wired from `App.svelte` so the
         resulting Compose window stacks on top of the inbox view. */
     oncreatetalk?: (mail: Email) => void
+    /** Save the email as a Nextcloud note. The handler in
+        `App.svelte` picks the NC account and POSTs to the Notes
+        API — we just hand over the email so the title/body are
+        sourced consistently with what's currently visible. */
+    onsavenote?: (mail: Email) => void
     /** True when the currently selected folder is the account's
         Drafts mailbox. Swaps the toolbar over from the reply/forward
         cluster to a single "Edit" action, because Reply-to-a-draft
@@ -104,6 +109,7 @@
     onreplyall,
     onforward,
     oncreatetalk,
+    onsavenote,
     isDraftsFolder = false,
     isSentFolder = false,
     oneditdraft,
@@ -1016,6 +1022,13 @@
             onclick={() => email && oncreatetalk?.(email)}
             title="Create a Nextcloud Talk room with the participants of this thread"
           >💬 Talk</button>
+        {/if}
+        {#if onsavenote}
+          <button
+            class="btn btn-sm preset-outlined-primary-500"
+            onclick={() => email && onsavenote?.(email)}
+            title="Save this email as a Nextcloud note"
+          >📝 Save as note</button>
         {/if}
         <button
           class="btn btn-sm preset-outlined-surface-500"

--- a/ui/src/lib/NotesView.svelte
+++ b/ui/src/lib/NotesView.svelte
@@ -1,0 +1,409 @@
+<script lang="ts">
+  /**
+   * NotesView — sidebar-routed full-pane Nextcloud Notes browser + editor.
+   *
+   * Two-column layout: list pane on the left (notes sorted by modified
+   * desc), editor on the right. Same shell as TalkView / FilesView so
+   * the integration views feel coherent.
+   *
+   * # Why no local cache
+   *
+   * Same reason TalkView skips it: the Notes API is cheap, the Notes
+   * web UI is the canonical editor, and reconciling a local copy with
+   * server-side edits via etags is complexity we don't need for the
+   * MVP. We refetch on demand and on a slow background timer.
+   *
+   * # Cross-actions
+   *
+   * `Send as email` opens Compose with the note's title as subject and
+   * the markdown body as the message body — the same `ComposeInitial`
+   * shape every other "share to mail" entry point uses, so the editor
+   * doesn't need a Notes-specific code path.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { onDestroy, onMount } from 'svelte'
+  import { formatError } from './errors'
+  import type { ComposeInitial } from './Compose.svelte'
+
+  interface NextcloudAccount {
+    id: string
+    server_url: string
+    username: string
+    display_name?: string | null
+  }
+
+  /** Mirror of the Rust `nimbus_nextcloud::Note` struct. */
+  interface Note {
+    id: number
+    etag: string
+    modified: number
+    title: string
+    category: string
+    content: string
+    favorite: boolean
+  }
+
+  interface Props {
+    onclose: () => void
+    /** Open Compose with the given prefill (used for "Send as email"). */
+    oncompose: (initial: ComposeInitial) => void
+  }
+  const { onclose, oncompose }: Props = $props()
+
+  // ── State ───────────────────────────────────────────────────
+  let accounts = $state<NextcloudAccount[]>([])
+  let accountId = $state('')
+  let notes = $state<Note[]>([])
+  let loading = $state(false)
+  let error = $state('')
+
+  /** Currently selected note id, or `null` for the empty-state pane.
+      We hold the id (not the row) so the right-pane editor stays
+      bound to the freshest version after a refresh. */
+  let selectedId = $state<number | null>(null)
+  /** Working copy of the selected note's editable fields. Kept
+      separate from the list row so a half-finished edit doesn't
+      pollute the list rendering, and so we can diff against the
+      server copy at save time. */
+  let draftTitle = $state('')
+  let draftContent = $state('')
+  /** etag we last loaded the open note at — sent back on update so
+      the server can reject (412) if a concurrent edit landed. */
+  let draftEtag = $state('')
+  /** "Saving…" / "Saved" / "Save failed" pill status next to the
+      title input. Driven by the debounced auto-save loop. */
+  let saveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
+
+  /** The currently-selected row, looked up at read-time so it stays
+      in sync with the list after a refresh. */
+  const selected = $derived(
+    selectedId == null ? null : notes.find((n) => n.id === selectedId) ?? null,
+  )
+
+  // Periodic refresh — slower than Talk's 30s because notes change
+  // far less often than chat messages. Two minutes keeps the list
+  // fresh enough that a note edited in the web UI shows up before
+  // the user gets confused, without spamming the server.
+  const REFRESH_INTERVAL_MS = 120_000
+  let pollTimer: number | null = null
+
+  onMount(async () => {
+    await loadAccounts()
+  })
+
+  onDestroy(() => {
+    if (pollTimer !== null) window.clearInterval(pollTimer)
+    if (saveTimer !== null) clearTimeout(saveTimer)
+  })
+
+  async function loadAccounts() {
+    try {
+      const list = await invoke<NextcloudAccount[]>('get_nextcloud_accounts')
+      accounts = list
+      if (list.length >= 1 && !accountId) {
+        accountId = list[0].id
+        await refresh()
+        startPolling()
+      }
+    } catch (e) {
+      error = formatError(e) || 'Failed to load Nextcloud accounts'
+    }
+  }
+
+  async function selectAccount(id: string) {
+    accountId = id
+    notes = []
+    selectedId = null
+    await refresh()
+    startPolling()
+  }
+
+  function startPolling() {
+    if (pollTimer !== null) window.clearInterval(pollTimer)
+    pollTimer = window.setInterval(() => {
+      void refresh({ silent: true })
+    }, REFRESH_INTERVAL_MS)
+  }
+
+  async function refresh(opts: { silent?: boolean } = {}) {
+    if (!accountId) return
+    if (!opts.silent) loading = true
+    if (!opts.silent) error = ''
+    try {
+      const list = await invoke<Note[]>('list_nextcloud_notes', { ncId: accountId })
+      // Newest modification on top. Notes with `modified=0` (rare —
+      // would mean the server didn't stamp the field) sort to the
+      // bottom rather than confusing the order.
+      list.sort((a, b) => b.modified - a.modified)
+      notes = list
+      // If the open note is gone (deleted from another client), drop
+      // the editor pane back to its empty state.
+      if (selectedId != null && !list.some((n) => n.id === selectedId)) {
+        selectedId = null
+      }
+    } catch (e) {
+      if (!opts.silent) error = formatError(e) || 'Failed to load notes'
+    } finally {
+      if (!opts.silent) loading = false
+    }
+  }
+
+  function openNote(note: Note) {
+    selectedId = note.id
+    draftTitle = note.title
+    draftContent = note.content
+    draftEtag = note.etag
+    saveStatus = ''
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+  }
+
+  async function newNote() {
+    if (!accountId) return
+    try {
+      // Empty title + content lets the server stamp a real id and
+      // pick "New note" as the title — same default the Notes web
+      // UI uses for its "+ New note" button.
+      const created = await invoke<Note>('create_nextcloud_note', {
+        ncId: accountId,
+        title: '',
+        content: '',
+        category: '',
+      })
+      notes = [created, ...notes]
+      openNote(created)
+    } catch (e) {
+      error = formatError(e) || 'Failed to create note'
+    }
+  }
+
+  async function deleteSelected() {
+    if (!accountId || selectedId == null) return
+    const note = selected
+    if (!note) return
+    const label = note.title.trim() || 'this note'
+    if (!confirm(`Delete ${label}? This cannot be undone.`)) return
+    try {
+      await invoke('delete_nextcloud_note', { ncId: accountId, noteId: note.id })
+      notes = notes.filter((n) => n.id !== note.id)
+      selectedId = null
+      saveStatus = ''
+    } catch (e) {
+      error = formatError(e) || 'Failed to delete note'
+    }
+  }
+
+  // ── Auto-save ───────────────────────────────────────────────
+  // Debounced 800ms — long enough that a fast typist doesn't fire
+  // a request on every keystroke, short enough that the user feels
+  // the save tracking what they typed.
+  let saveTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleSave() {
+    if (selectedId == null || !accountId) return
+    saveStatus = 'saving'
+    if (saveTimer !== null) clearTimeout(saveTimer)
+    saveTimer = setTimeout(saveNow, 800)
+  }
+
+  async function saveNow() {
+    if (selectedId == null || !accountId) return
+    const id = selectedId
+    const titleNow = draftTitle
+    const contentNow = draftContent
+    try {
+      const updated = await invoke<Note>('update_nextcloud_note', {
+        ncId: accountId,
+        noteId: id,
+        etag: draftEtag,
+        title: titleNow,
+        content: contentNow,
+        category: null,
+        favorite: null,
+      })
+      // Splice the freshly-saved row into the list so its updated
+      // modified time floats it back to the top on the next sort.
+      const rest = notes.filter((n) => n.id !== updated.id)
+      notes = [updated, ...rest].sort((a, b) => b.modified - a.modified)
+      // Only refresh the etag — the user may already have typed
+      // more characters since we kicked off the save, and overwriting
+      // their `draftTitle` / `draftContent` would clobber that.
+      if (id === selectedId) draftEtag = updated.etag
+      saveStatus = 'saved'
+      setTimeout(() => {
+        if (saveStatus === 'saved') saveStatus = ''
+      }, 1500)
+    } catch (e) {
+      console.warn('save note failed', e)
+      saveStatus = 'error'
+    }
+  }
+
+  /** "Send as email" action — opens Compose with the note as the
+      seed of a new message. Title becomes the subject; markdown
+      content goes into the body. The body is plain text (the
+      RichTextEditor wraps it in <br>s automatically), which keeps
+      the markdown legible at the receiving end. */
+  function sendAsEmail() {
+    const note = selected
+    if (!note) return
+    oncompose({
+      subject: note.title || '(untitled note)',
+      body: note.content,
+    })
+  }
+
+  function fmtDate(epochSecs: number): string {
+    if (!epochSecs) return ''
+    const d = new Date(epochSecs * 1000)
+    const now = new Date()
+    const sameDay = d.toDateString() === now.toDateString()
+    if (sameDay) {
+      return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    }
+    return d.toLocaleDateString([], { month: 'short', day: 'numeric' })
+  }
+
+  /** Short preview of the note body for the list row — first
+      non-empty line after the title. We strip the title line
+      because it's already shown above the snippet, and an
+      auto-titled note would otherwise echo the same text twice. */
+  function preview(note: Note): string {
+    const lines = note.content.split('\n').map((l) => l.trim()).filter(Boolean)
+    const title = note.title.trim()
+    const body = title && lines[0] === title ? lines.slice(1) : lines
+    return body[0] ?? ''
+  }
+</script>
+
+<div class="h-full flex flex-col bg-surface-50 dark:bg-surface-900">
+  <!-- Header -->
+  <header class="px-4 py-3 border-b border-surface-200 dark:border-surface-700 flex items-center gap-3">
+    <h1 class="text-lg font-semibold flex-1">Notes</h1>
+
+    {#if accounts.length > 1}
+      <select
+        class="select text-sm py-1 px-2 rounded-md"
+        value={accountId}
+        onchange={(e) => selectAccount((e.currentTarget as HTMLSelectElement).value)}
+      >
+        {#each accounts as a (a.id)}
+          <option value={a.id}>{a.display_name || a.username}</option>
+        {/each}
+      </select>
+    {/if}
+
+    <button
+      class="btn btn-sm preset-outlined-surface-500"
+      onclick={() => refresh()}
+      disabled={loading || !accountId}
+      title="Refresh"
+    >
+      &#x21bb;
+    </button>
+    <button
+      class="btn btn-sm preset-filled-primary-500"
+      onclick={newNote}
+      disabled={!accountId}
+    >
+      + New note
+    </button>
+    <button class="btn btn-sm preset-outlined-surface-500" onclick={onclose}>
+      Back
+    </button>
+  </header>
+
+  <!-- Body: list pane | editor pane. Falls back to a single-column
+       message when there's no NC account configured. -->
+  <div class="flex-1 min-h-0 flex">
+    {#if accounts.length === 0 && !loading}
+      <div class="flex-1 flex items-center justify-center text-sm text-surface-500 p-8 text-center">
+        Connect a Nextcloud account first (Settings → Nextcloud) to use Notes.
+      </div>
+    {:else}
+      <!-- List pane -->
+      <div class="w-72 shrink-0 border-r border-surface-200 dark:border-surface-700 overflow-y-auto">
+        {#if loading && notes.length === 0}
+          <div class="p-6 text-center text-sm text-surface-500">Loading…</div>
+        {:else if error && notes.length === 0}
+          <div class="p-4 text-sm text-red-500">{error}</div>
+        {:else if notes.length === 0}
+          <div class="p-6 text-center text-sm text-surface-500">
+            No notes yet. Click <strong>+ New note</strong> to create one.
+          </div>
+        {:else}
+          {#each notes as n (n.id)}
+            <button
+              class="w-full text-left px-4 py-3 border-b border-surface-100 dark:border-surface-800 transition-colors
+                {selectedId === n.id
+                  ? 'bg-primary-500/10'
+                  : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
+              onclick={() => openNote(n)}
+            >
+              <div class="flex items-center justify-between mb-1">
+                <span class="text-sm font-medium truncate pr-2">
+                  {n.title || '(untitled)'}
+                </span>
+                <span class="text-xs text-surface-500 shrink-0">{fmtDate(n.modified)}</span>
+              </div>
+              {#if preview(n)}
+                <p class="text-xs text-surface-500 truncate">{preview(n)}</p>
+              {/if}
+              {#if n.category}
+                <p class="text-[10px] text-surface-400 mt-1 truncate">📂 {n.category}</p>
+              {/if}
+            </button>
+          {/each}
+        {/if}
+      </div>
+
+      <!-- Editor pane -->
+      <div class="flex-1 min-w-0 flex flex-col">
+        {#if !selected}
+          <div class="flex-1 flex items-center justify-center text-sm text-surface-500">
+            Select a note from the list, or create a new one.
+          </div>
+        {:else}
+          <div class="px-5 py-3 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
+            <input
+              class="input flex-1 text-base font-semibold px-3 py-2 rounded-md"
+              placeholder="Title (optional — derived from the first line if empty)"
+              bind:value={draftTitle}
+              oninput={scheduleSave}
+            />
+            {#if saveStatus === 'saving'}
+              <span class="text-xs text-surface-400">Saving…</span>
+            {:else if saveStatus === 'saved'}
+              <span class="text-xs text-success-500">Saved</span>
+            {:else if saveStatus === 'error'}
+              <span class="text-xs text-error-500">Save failed</span>
+            {/if}
+            <button
+              class="btn btn-sm preset-outlined-primary-500"
+              onclick={sendAsEmail}
+              title="Open Compose with this note as the message body"
+            >
+              ✉ Send as email
+            </button>
+            <button
+              class="btn btn-sm preset-outlined-error-500"
+              onclick={deleteSelected}
+            >
+              Delete
+            </button>
+          </div>
+
+          <textarea
+            class="flex-1 resize-none p-5 bg-surface-50 dark:bg-surface-900 outline-none font-mono text-sm leading-relaxed"
+            placeholder="Start writing — markdown is preserved on the server."
+            bind:value={draftContent}
+            oninput={scheduleSave}
+          ></textarea>
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Closes #67. Browse, create, and edit Nextcloud Notes from inside Nimbus Mail, with bidirectional cross-actions between mail and notes.

- **Backend**: new `nimbus-nextcloud::notes` module (list / get / create / update / delete) over the plain JSON REST API at `/index.php/apps/notes/api/v1/notes`. Five thin Tauri commands wrap it.
- **UI**: new `NotesView.svelte` (list pane + editor, multi-NC-account picker, debounced auto-save with etag handling, 2-minute background refresh). New 📝 entry in `IconRail`.
- **Cross-actions**: `📝 Save as note` button in MailView (formats headers as markdown, files under category "Mail"); `✉ Send as email` button in NotesView (uses the same `ComposeInitial` shape as every other share-to-mail entry point).

Notes are intentionally not cached locally for the MVP — the Notes web UI is the canonical editor and the API is cheap. Categories + favorite flag round-trip cleanly but aren't surfaced yet.

## Test plan

- [ ] `cargo tauri dev`, click 📝 in the rail — list populates with existing notes from Nextcloud
- [ ] Click `+ New note` — empty note appears at top, editor opens
- [ ] Type into title + body — "Saving…" pill flips to "Saved" after ~800ms; verify the change appears in the Notes web UI
- [ ] Edit the same note in the web UI, wait ≤2 min — the change shows up in NotesView (or hit refresh for instant)
- [ ] Open a mail, click `📝 Save as note` — confirm a new note appears in the Notes web UI under category "Mail" with `**From:** … **To:** …` header block + body
- [ ] In NotesView click `✉ Send as email` — Compose opens with the note title as subject and content as body
- [ ] With multiple NC accounts: switch via the dropdown — list reloads against the new account
- [ ] Delete a note — confirm dialog appears, note disappears from list and from the web UI

## Out of scope

- Categories / favorite flag UI (round-tripped but not surfaced)
- Local cache + offline edit (deferred — Notes web UI stays canonical for MVP)
- Markdown preview pane (raw markdown editing only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)