### PR TITLE
Allow drag-to-create across existing calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,79 @@ shows which Nextcloud apps are available (Talk, Files, Calendar,
 Contacts). The feature-specific integrations that consume these
 capabilities are tracked in the [Roadmap](#roadmap).
 
+## Contacts, Contact Groups, Mailing Lists, and Teams
+
+Nimbus pulls four distinct concepts together in the Contacts view. They look
+similar — all of them surface as "groups of people" in the UI — but each
+lives in a different system, and knowing which is which makes the picker
+behave the way you expect.
+
+### Addressbooks
+
+CardDAV collections on your Nextcloud server. Each addressbook is a folder of
+vCards; every contact lives in exactly one addressbook (e.g. *Personal*,
+*Work*). The Contacts tab's sidebar lists addressbooks as filters — clicking
+*Personal* narrows the contact list to that collection. New contacts are
+created into an addressbook of your choice.
+
+This is the storage layer — addressbooks are *where* contacts live, not how
+you group them.
+
+### Contact Groups (vCard CATEGORIES)
+
+Tags applied to individual contacts. They are stored as the `CATEGORIES`
+property on each vCard, so they sync through CardDAV automatically and show
+up in Nextcloud as *Kontaktgruppen* and on iOS as *Groups*. A contact can
+belong to many groups, and a contact group can span multiple addressbooks
+(it's a tag, not a folder).
+
+Use these for organising people: *Family*, *Book club*, *D&D party*. The
+sidebar shows them as filters under *Contact Groups*; selecting one shows
+every contact carrying that tag, regardless of addressbook.
+
+### Mailing Lists
+
+A separate concept for *sending* mail to a bundle of people in one go.
+Mailing lists live on the Lists tab and unify three sources behind a single
+list:
+
+1. **Categories with "Use as mailing list" enabled** — every Contact Group
+   automatically gets a mirrored mailing-list row. Toggle it off via the
+   left swatch on the row if you only want it to be an organisational tag.
+   Editable: adding a contact tags their vCard with the category.
+2. **Manual mailing lists** — standalone `KIND:group` vCards that exist
+   purely to bundle email addresses. They sync to Nextcloud as a special
+   "Mailing Lists" Kontaktgruppe so iOS Contacts surfaces them next to
+   your other groups. Fully editable: rename, set an emoji avatar, add /
+   remove members, delete.
+3. **Teams** (read-only) — Nextcloud user groups (OCS) and Circles unified
+   under one section. Membership is managed in Nextcloud itself; Nimbus
+   just expands them when you address one.
+
+Picking a mailing list in the Compose autocomplete (or the event-invite
+attendee picker) expands every member's email address into the recipient
+field. The left swatch on each row toggles whether it appears in the
+autocomplete dropdown — useful for hiding noisy auto-generated groups.
+
+### How they relate
+
+```
+Addressbook (storage)
+   └── Contact (vCard)
+           ├── CATEGORIES: ["Family", "Book club"]   ← Contact Groups
+           └── lives in   ─→ "Mailing Lists" Kontaktgruppe (auto-tag)
+
+Contact Group  ─── mirrored as ──→  Mailing List (category source)
+Manual mailing list (KIND:group vCard)  ──→  Mailing List (manual source)
+Nextcloud user group / Circle           ──→  Mailing List (team source)
+```
+
+Rule of thumb: **addressbooks** decide *where the data lives*, **contact
+groups** decide *how you organise people*, and **mailing lists** decide
+*how you send to them*. Most users will only think about contact groups —
+the mailing-list view exists for finer control over what shows up when
+you're addressing mail.
+
 ## Themes
 
 Nimbus uses [Skeleton UI](https://www.skeleton.dev) for theming. Out of

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ you group them.
 
 Tags applied to individual contacts. They are stored as the `CATEGORIES`
 property on each vCard, so they sync through CardDAV automatically and show
-up in Nextcloud as *Kontaktgruppen* and on iOS as *Groups*. A contact can
+up in Nextcloud as *Contact Groups* and on iOS as *Groups*. A contact can
 belong to many groups, and a contact group can span multiple addressbooks
 (it's a tag, not a folder).
 

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -425,6 +425,11 @@
     dayKey: string
     startMinute: number
     currentMinute: number
+    /** Event id the drag started on top of, if any.  Lets a
+     *  no-movement mouseup fall back to "open this event"
+     *  while still allowing real drags that originate inside
+     *  an event block to create a new draft. */
+    startEventId: string | null
   }
   let drag = $state<DragState | null>(null)
 
@@ -1016,17 +1021,21 @@
   }
 
   function onDayMouseDown(ev: MouseEvent, bucket: WeekBucket) {
-    // Left-click on empty space only. If the user clicked an existing
-    // event block, that block's own click handler runs and stops
-    // propagation — so a missed click here always means "blank area".
     if (ev.button !== 0) return
     const target = ev.currentTarget as HTMLElement
     const rect = target.getBoundingClientRect()
     const minute = pxToMinuteSnapped(ev.clientY - rect.top)
+    // If the press lands inside an event block we still start a
+    // drag — that lets the user sweep across an existing event
+    // to create a new one in the same slot.  The event id is
+    // remembered so a no-movement mouseup falls back to "open
+    // this event" instead of creating a one-hour overlay.
+    const evEl = (ev.target as HTMLElement).closest('[data-event-id]') as HTMLElement | null
     drag = {
       dayKey: bucket.dayKey,
       startMinute: minute,
       currentMinute: minute,
+      startEventId: evEl?.dataset.eventId ?? null,
     }
   }
 
@@ -1044,12 +1053,23 @@
     if (!drag || drag.dayKey !== bucket.dayKey) return
     const a = Math.min(drag.startMinute, drag.currentMinute)
     const b = Math.max(drag.startMinute, drag.currentMinute)
-    // Treat a bare click (no movement) as a 1-hour event starting at
-    // the click point. A real drag uses whatever the user swept,
-    // floored to a 15-minute minimum so a tiny accidental drag still
-    // produces a clickable block in the editor.
+    const moved = b - a >= 15
+    // Click (no movement) on top of an existing event opens it
+    // for editing — preserves the previous "click an event to
+    // open it" affordance now that the event block no longer
+    // swallows mousedown.
+    if (!moved && drag.startEventId) {
+      const id = drag.startEventId
+      drag = null
+      const ev = events.find((e) => e.id === id)
+      if (ev) openEditor(ev)
+      return
+    }
+    // Otherwise: bare click on empty space → 1-hour event,
+    // real drag → swept range.  Either way we open the editor
+    // with a fresh draft.
     const startMinute = a
-    const endMinute = b - a < 15 ? a + 60 : b
+    const endMinute = moved ? b : a + 60
     const start = new Date(bucket.date)
     start.setHours(0, startMinute, 0, 0)
     const end = new Date(bucket.date)
@@ -1447,14 +1467,13 @@
                   {@const meetingUrl = extractMeetingUrl(p.event)}
                   {@const showJoin = !!meetingUrl && inJoinWindow(p.event)}
                   <div
+                    data-event-id={p.event.id}
                     class="ev-block ev-timed absolute rounded-md text-[11px] overflow-hidden px-1.5 py-1 cursor-pointer leading-tight {userTentative(p.event) ? 'ev-tentative' : ''} {userDeclined(p.event) ? 'ev-declined' : ''}"
                     style="--ev-color: {eventColor(p.event)}; top: {p.topPx}px; height: {p.heightPx}px; left: calc({(p.lane / p.laneCount) * 100}% + 2px); width: calc({(1 / p.laneCount) * 100}% - 4px);"
                     title={`${p.event.summary || '(no title)'} — ${fmtTime(p.event.start)}–${fmtTime(p.event.end)}${p.event.location ? ` @ ${p.event.location}` : ''}`}
-                    onmousedown={(ev) => ev.stopPropagation()}
-                    onclick={(ev) => { ev.stopPropagation(); openEditor(p.event) }}
                     role="button"
                     tabindex="0"
-                    onkeydown={(ev) => { if (ev.key === 'Enter') openEditor(p.event) }}
+                    onkeydown={(ev) => { if (ev.key === 'Enter' || ev.key === ' ') { ev.preventDefault(); openEditor(p.event) } }}
                   >
                     <div
                       class="font-medium wrap-break-word"


### PR DESCRIPTION
## Summary
- Pressing on an existing event no longer swallows the drag-to-create gesture, so the user can sweep a new event in a slot that already has something in it.
- Click-on-event to open and hover-for-tooltip both still work — a no-movement mouseup that started on an event opens it instead of creating an overlay.

## Test plan
- [ ] Drag across an existing event in the week grid → new draft opens with the swept range.
- [ ] Click an existing event (no movement) → editor opens for that event.
- [ ] Click an empty slot → 1-hour draft (unchanged).
- [ ] Hover an event → tooltip still shows.
- [ ] Enter / Space on a focused event still opens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)