### PR TITLE
Fix CI on main: rustfmt drift + AccountSettings TS error

### DIFF
--- a/crates/nimbus-caldav/src/discovery.rs
+++ b/crates/nimbus-caldav/src/discovery.rs
@@ -144,10 +144,9 @@ fn parse_response(
                     // match either.
                     loop {
                         match reader.read_event()? {
-                            Event::Empty(e) | Event::Start(e)
-                                if local_name(&e) == "calendar" => {
-                                    is_calendar = true;
-                                }
+                            Event::Empty(e) | Event::Start(e) if local_name(&e) == "calendar" => {
+                                is_calendar = true;
+                            }
                             Event::End(e) if local_name_end(&e) == "resourcetype" => break,
                             Event::Eof => break,
                             _ => {}

--- a/crates/nimbus-caldav/src/expand.rs
+++ b/crates/nimbus-caldav/src/expand.rs
@@ -304,17 +304,31 @@ mod tests {
         );
         // 2026-05-04, 05-11, 05-18, 05-25 → 4 instances in May.
         assert_eq!(out.len(), 4);
-        assert!(out[0].start.date_naive().to_string().starts_with("2026-05-04"));
-        assert!(out[3].start.date_naive().to_string().starts_with("2026-05-25"));
+        assert!(
+            out[0]
+                .start
+                .date_naive()
+                .to_string()
+                .starts_with("2026-05-04")
+        );
+        assert!(
+            out[3]
+                .start
+                .date_naive()
+                .to_string()
+                .starts_with("2026-05-25")
+        );
         // Each synthesised instance preserves duration.
         for inst in &out {
             assert_eq!(inst.end - inst.start, chrono::Duration::hours(1));
             assert!(inst.rrule.is_none(), "occurrence must not carry RRULE");
-            assert!(inst.recurrence_id.is_some(), "occurrence sets recurrence_id");
+            assert!(
+                inst.recurrence_id.is_some(),
+                "occurrence sets recurrence_id"
+            );
         }
         // Distinct ids so the UI's keyed each doesn't dedupe.
-        let ids: std::collections::HashSet<&str> =
-            out.iter().map(|e| e.id.as_str()).collect();
+        let ids: std::collections::HashSet<&str> = out.iter().map(|e| e.id.as_str()).collect();
         assert_eq!(ids.len(), 4);
     }
 
@@ -333,8 +347,8 @@ mod tests {
         );
         assert_eq!(out.len(), 3);
         assert!(
-            !out.iter().any(|ev| ev.start
-                == Utc.with_ymd_and_hms(2026, 5, 11, 9, 0, 0).unwrap()),
+            !out.iter()
+                .any(|ev| ev.start == Utc.with_ymd_and_hms(2026, 5, 11, 9, 0, 0).unwrap()),
             "cancelled instance must not appear"
         );
     }
@@ -448,8 +462,8 @@ mod tests {
         // Two RRULE instances + one RDATE extra.
         assert_eq!(out.len(), 3);
         assert!(
-            out.iter().any(|ev| ev.start
-                == Utc.with_ymd_and_hms(2026, 5, 15, 9, 0, 0).unwrap()),
+            out.iter()
+                .any(|ev| ev.start == Utc.with_ymd_and_hms(2026, 5, 15, 9, 0, 0).unwrap()),
             "RDATE extra must appear"
         );
     }

--- a/crates/nimbus-caldav/src/ical.rs
+++ b/crates/nimbus-caldav/src/ical.rs
@@ -191,9 +191,10 @@ fn attendee_from_property(prop: &Property, value: &str) -> Option<EventAttendee>
 /// that we skip them rather than misinterpret them. Skipped alarms log
 /// a warning and round-trip via `ics_raw` instead of vanishing on PUT.
 fn reminder_from_alarm(alarm: &IcalAlarm) -> Option<EventReminder> {
-    let trigger = alarm.properties.iter().find(|p| {
-        p.name.eq_ignore_ascii_case("TRIGGER")
-    })?;
+    let trigger = alarm
+        .properties
+        .iter()
+        .find(|p| p.name.eq_ignore_ascii_case("TRIGGER"))?;
     let value = trigger.value.as_deref()?;
 
     let is_date_time = property_param(trigger, "VALUE")
@@ -392,9 +393,7 @@ fn parse_datetime_list(prop: &Property, value: &str) -> Result<Vec<DateTime<Utc>
     for item in value.split(',').map(str::trim).filter(|s| !s.is_empty()) {
         let parsed = if is_date_only {
             NaiveDate::parse_from_str(item, "%Y%m%d")
-                .map(|d| {
-                    Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0).expect("midnight is valid"))
-                })
+                .map(|d| Utc.from_utc_datetime(&d.and_hms_opt(0, 0, 0).expect("midnight is valid")))
                 .map_err(|e| format!("DATE list item {item:?}: {e}"))
         } else {
             parse_single_datetime(item, tzid)
@@ -582,8 +581,15 @@ pub fn build_ics_with_method(
         // DTEND for VALUE=DATE is exclusive, so the day after the
         // last-covered day. Our parser snapped end to 23:59:59 of the
         // last day, so step forward one day for the wire format.
-        let exclusive_end = event.end.date_naive().succ_opt().unwrap_or(event.end.date_naive());
-        lines.push(format!("DTEND;VALUE=DATE:{}", exclusive_end.format("%Y%m%d")));
+        let exclusive_end = event
+            .end
+            .date_naive()
+            .succ_opt()
+            .unwrap_or(event.end.date_naive());
+        lines.push(format!(
+            "DTEND;VALUE=DATE:{}",
+            exclusive_end.format("%Y%m%d")
+        ));
     } else {
         lines.push(format!("DTSTART:{}", format_utc_dt(&event.start)));
         lines.push(format!("DTEND:{}", format_utc_dt(&event.end)));
@@ -629,13 +635,14 @@ pub fn build_ics_with_method(
         lines.push(format!("RECURRENCE-ID:{}", format_utc_dt(&rid)));
     }
     if !event.attendees.is_empty()
-        && let Some(email) = organizer_email {
-            let mut params = String::new();
-            if let Some(cn) = organizer_name {
-                params.push_str(&format!(";CN={cn}"));
-            }
-            lines.push(format!("ORGANIZER{params}:mailto:{email}"));
+        && let Some(email) = organizer_email
+    {
+        let mut params = String::new();
+        if let Some(cn) = organizer_name {
+            params.push_str(&format!(";CN={cn}"));
         }
+        lines.push(format!("ORGANIZER{params}:mailto:{email}"));
+    }
     // For iMIP REQUESTs we enrich each ATTENDEE with the params
     // Apple Mail / Outlook need to surface RSVP UI: ROLE,
     // CUTYPE, and especially `RSVP=TRUE` (Apple Mail hides the
@@ -698,8 +705,14 @@ pub fn build_ics_with_method(
 
     for r in &event.reminders {
         lines.push("BEGIN:VALARM".into());
-        lines.push(format!("ACTION:{}", r.action.as_deref().unwrap_or("DISPLAY")));
-        lines.push(format!("TRIGGER:{}", duration_to_trigger(r.trigger_minutes_before)));
+        lines.push(format!(
+            "ACTION:{}",
+            r.action.as_deref().unwrap_or("DISPLAY")
+        ));
+        lines.push(format!(
+            "TRIGGER:{}",
+            duration_to_trigger(r.trigger_minutes_before)
+        ));
         lines.push(format!("DESCRIPTION:{}", escape_text(&event.summary)));
         lines.push("END:VALARM".into());
     }
@@ -906,8 +919,12 @@ fn split_params(head: &str) -> Vec<String> {
 fn is_all_day_window(start: DateTime<Utc>, end: DateTime<Utc>) -> bool {
     let s = start.time();
     let e = end.time();
-    s.hour() == 0 && s.minute() == 0 && s.second() == 0
-        && e.hour() == 23 && e.minute() == 59 && e.second() == 59
+    s.hour() == 0
+        && s.minute() == 0
+        && s.second() == 0
+        && e.hour() == 23
+        && e.minute() == 59
+        && e.second() == 59
 }
 
 fn format_utc_dt(dt: &DateTime<Utc>) -> String {

--- a/crates/nimbus-caldav/src/lib.rs
+++ b/crates/nimbus-caldav/src/lib.rs
@@ -36,6 +36,4 @@ pub use discovery::{Calendar, list_calendars};
 pub use expand::expand_event;
 pub use ical::{build_ics, parse_ics};
 pub use sync::{CalendarSyncDelta, RawEvent, sync_calendar};
-pub use write::{
-    WriteOutcome, create_event, delete_event, delete_event_silent, update_event,
-};
+pub use write::{WriteOutcome, create_event, delete_event, delete_event_silent, update_event};

--- a/crates/nimbus-caldav/src/sync.rs
+++ b/crates/nimbus-caldav/src/sync.rs
@@ -359,7 +359,10 @@ mod tests {
 </d:multistatus>"#;
         let r = parse_sync_collection(xml, "https://cloud.example.com").unwrap();
         assert_eq!(r.changed.len(), 1);
-        assert_eq!(r.changed[0].href, "https://cloud.example.com/dav/cal/e1.ics");
+        assert_eq!(
+            r.changed[0].href,
+            "https://cloud.example.com/dav/cal/e1.ics"
+        );
         assert_eq!(r.deleted, vec!["https://cloud.example.com/dav/cal/e2.ics"]);
         assert_eq!(r.new_sync_token.as_deref(), Some("http://nc/ns/sync/55"));
     }

--- a/crates/nimbus-caldav/src/write.rs
+++ b/crates/nimbus-caldav/src/write.rs
@@ -164,8 +164,7 @@ async fn delete_event_inner(
     let status = resp.status();
     if status == StatusCode::PRECONDITION_FAILED {
         return Err(NimbusError::Nextcloud(
-            "event was modified on the server since last sync — refresh and try again"
-                .to_string(),
+            "event was modified on the server since last sync — refresh and try again".to_string(),
         ));
     }
     // 404 is fine — already gone is the state we wanted.

--- a/crates/nimbus-caldav/src/xml_util.rs
+++ b/crates/nimbus-caldav/src/xml_util.rs
@@ -51,10 +51,9 @@ pub fn read_text_until(
         match reader.read_event() {
             Ok(Event::Text(t)) => buf.push_str(&t.unescape().unwrap_or_default()),
             Ok(Event::CData(c)) => buf.push_str(&String::from_utf8_lossy(&c)),
-            Ok(Event::End(end))
-                if local_name_end(&end).eq_ignore_ascii_case(start_local) => {
-                    return Ok(buf);
-                }
+            Ok(Event::End(end)) if local_name_end(&end).eq_ignore_ascii_case(start_local) => {
+                return Ok(buf);
+            }
             Ok(Event::Eof) => return Ok(buf),
             Err(e) => return Err(e),
             _ => {}
@@ -68,17 +67,15 @@ pub fn skip_subtree(reader: &mut Reader<&[u8]>, start_local: &str) -> Result<(),
     let mut depth = 1;
     loop {
         match reader.read_event() {
-            Ok(Event::Start(s))
-                if local_name(&s) == start_local => {
-                    depth += 1;
+            Ok(Event::Start(s)) if local_name(&s) == start_local => {
+                depth += 1;
+            }
+            Ok(Event::End(e)) if local_name_end(&e).eq_ignore_ascii_case(start_local) => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(());
                 }
-            Ok(Event::End(e))
-                if local_name_end(&e).eq_ignore_ascii_case(start_local) => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return Ok(());
-                    }
-                }
+            }
             Ok(Event::Eof) => return Ok(()),
             Err(e) => return Err(e),
             _ => {}

--- a/crates/nimbus-carddav/src/discovery.rs
+++ b/crates/nimbus-carddav/src/discovery.rs
@@ -147,9 +147,10 @@ fn parse_response(
                     loop {
                         match reader.read_event()? {
                             Event::Empty(e) | Event::Start(e)
-                                if local_name(&e) == "addressbook" => {
-                                    is_addressbook = true;
-                                }
+                                if local_name(&e) == "addressbook" =>
+                            {
+                                is_addressbook = true;
+                            }
                             Event::End(e) if local_name_end(&e) == "resourcetype" => break,
                             Event::Eof => break,
                             _ => {}

--- a/crates/nimbus-carddav/src/vcard.rs
+++ b/crates/nimbus-carddav/src/vcard.rs
@@ -619,12 +619,24 @@ mod tests {
             uid: "abc-123".into(),
             display_name: "Alice Example".into(),
             emails: vec![
-                VcardEmail { kind: "home".into(), value: "alice@example.com".into() },
-                VcardEmail { kind: "work".into(), value: "alice@work.com".into() },
+                VcardEmail {
+                    kind: "home".into(),
+                    value: "alice@example.com".into(),
+                },
+                VcardEmail {
+                    kind: "work".into(),
+                    value: "alice@work.com".into(),
+                },
             ],
             phones: vec![
-                VcardPhone { kind: "cell".into(), value: "+1 555 0100".into() },
-                VcardPhone { kind: "work".into(), value: "+1 555 0200".into() },
+                VcardPhone {
+                    kind: "cell".into(),
+                    value: "+1 555 0100".into(),
+                },
+                VcardPhone {
+                    kind: "work".into(),
+                    value: "+1 555 0200".into(),
+                },
             ],
             organization: Some("Example Corp".into()),
             ..Default::default()

--- a/crates/nimbus-carddav/src/xml_util.rs
+++ b/crates/nimbus-carddav/src/xml_util.rs
@@ -69,10 +69,9 @@ pub fn skip_subtree(reader: &mut Reader<&[u8]>, start_local: &str) -> Result<(),
     let mut depth = 1;
     loop {
         match reader.read_event() {
-            Ok(Event::Start(s))
-                if local_name(&s) == start_local => {
-                    depth += 1;
-                }
+            Ok(Event::Start(s)) if local_name(&s) == start_local => {
+                depth += 1;
+            }
             Ok(Event::End(e)) => {
                 let bytes = e.name();
                 let name_bytes = bytes.as_ref();

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -120,7 +120,6 @@ pub enum ThemeMode {
     Dark,
 }
 
-
 impl Default for AppSettings {
     fn default() -> Self {
         Self {

--- a/crates/nimbus-core/src/tls.rs
+++ b/crates/nimbus-core/src/tls.rs
@@ -128,10 +128,13 @@ impl ServerCertVerifier for FingerprintVerifier {
         ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, rustls::Error> {
-        match self
-            .inner
-            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
-        {
+        match self.inner.verify_server_cert(
+            end_entity,
+            intermediates,
+            server_name,
+            ocsp_response,
+            now,
+        ) {
             Ok(v) => Ok(v),
             Err(webpki_err) => {
                 // Walk the entire presented chain — leaf and every
@@ -146,8 +149,9 @@ impl ServerCertVerifier for FingerprintVerifier {
                     .iter()
                     .map(|c| canonicalize_fingerprint(&fingerprint_sha256(c.as_ref())))
                     .collect();
-                let chain_fps: Vec<&String> =
-                    std::iter::once(&leaf_fp).chain(intermediate_fps.iter()).collect();
+                let chain_fps: Vec<&String> = std::iter::once(&leaf_fp)
+                    .chain(intermediate_fps.iter())
+                    .collect();
 
                 let matched = chain_fps
                     .iter()

--- a/crates/nimbus-discovery/src/autoconfig.rs
+++ b/crates/nimbus-discovery/src/autoconfig.rs
@@ -42,9 +42,7 @@ pub async fn discover(domain: &str, email: &str) -> Result<DiscoveredAccount, Di
 
     let candidates = [
         (
-            format!(
-                "https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}"
-            ),
+            format!("https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}"),
             DiscoverySource::AutoconfigDomain,
         ),
         (

--- a/crates/nimbus-discovery/src/srv.rs
+++ b/crates/nimbus-discovery/src/srv.rs
@@ -51,10 +51,7 @@ pub async fn discover(domain: &str) -> Result<DiscoveredAccount, DiscoveryError>
     // STARTTLS fallback.
     let imap_starttls = lookup_first_srv(&resolver, "_imap._tcp", domain).await;
     let smtp_starttls = lookup_first_srv(&resolver, "_submission._tcp", domain).await;
-    if let (Some(i), Some(s)) = (
-        imap_tls.or(imap_starttls),
-        smtp_tls.or(smtp_starttls),
-    ) {
+    if let (Some(i), Some(s)) = (imap_tls.or(imap_starttls), smtp_tls.or(smtp_starttls)) {
         debug!("SRV: mixed/STARTTLS pair imap={i:?} smtp={s:?}");
         return Ok(DiscoveredAccount {
             imap_host: i.host,
@@ -95,7 +92,10 @@ async fn lookup_first_srv(
                 if host.is_empty() {
                     continue;
                 }
-                let candidate = SrvEndpoint { host, port: r.port() };
+                let candidate = SrvEndpoint {
+                    host,
+                    port: r.port(),
+                };
                 let key = (r.priority(), u16::MAX - r.weight());
                 if best.as_ref().map(|(p, _, _)| key < (*p, 0)).unwrap_or(true) {
                     best = Some((key.0, key.1, candidate));

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -72,10 +72,7 @@ async fn tls_connect(
 /// by walking the entire presented chain anyway. Caller is
 /// responsible for never using this for actual mail traffic — we
 /// drop the connection immediately after the handshake succeeds.
-pub async fn probe_server_certificate(
-    host: &str,
-    port: u16,
-) -> Result<Vec<Vec<u8>>, NimbusError> {
+pub async fn probe_server_certificate(host: &str, port: u16) -> Result<Vec<Vec<u8>>, NimbusError> {
     let addr = format!("{host}:{port}");
     let tcp = TcpStream::connect(&addr)
         .await
@@ -283,11 +280,7 @@ impl ImapClient {
     /// to the new one. That's handled in the caller (`main.rs`)
     /// via `Cache::rename_folder` — this method only drives the
     /// IMAP side.
-    pub async fn rename_folder(
-        &mut self,
-        from: &str,
-        to: &str,
-    ) -> Result<(), NimbusError> {
+    pub async fn rename_folder(&mut self, from: &str, to: &str) -> Result<(), NimbusError> {
         let session = self
             .session
             .as_mut()
@@ -786,9 +779,7 @@ impl ImapClient {
             .attachment(part_id)
             .or_else(|| parsed.parts.get(part_id as usize))
             .ok_or_else(|| {
-                NimbusError::Protocol(format!(
-                    "Message UID {uid} has no part #{part_id}"
-                ))
+                NimbusError::Protocol(format!("Message UID {uid} has no part #{part_id}"))
             })?;
 
         let filename = part
@@ -1172,18 +1163,14 @@ impl ImapClient {
                 // command for another reason). Fall back to plain
                 // EXPUNGE — we only flagged one UID in this session
                 // so the broader command is still targeted enough.
-                tracing::warn!(
-                    "delete_message: UID EXPUNGE failed ({e}), falling back to EXPUNGE"
-                );
+                tracing::warn!("delete_message: UID EXPUNGE failed ({e}), falling back to EXPUNGE");
                 let expunged: Vec<_> = session
                     .expunge()
                     .await
                     .map_err(|e| NimbusError::Protocol(format!("EXPUNGE failed: {e}")))?
                     .try_collect()
                     .await
-                    .map_err(|e| {
-                        NimbusError::Protocol(format!("Failed to read EXPUNGE: {e}"))
-                    })?;
+                    .map_err(|e| NimbusError::Protocol(format!("Failed to read EXPUNGE: {e}")))?;
                 info!(
                     "delete_message: EXPUNGE removed {} message(s) (fallback)",
                     expunged.len()

--- a/crates/nimbus-imap/src/mutf7.rs
+++ b/crates/nimbus-imap/src/mutf7.rs
@@ -31,10 +31,9 @@ use base64::engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig};
 fn engine() -> GeneralPurpose {
     // Unwrap is safe: the alphabet string is a compile-time constant
     // of exactly 64 unique characters, which `Alphabet::new` accepts.
-    let alphabet = Alphabet::new(
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,",
-    )
-    .expect("static IMAP mUTF-7 alphabet is valid");
+    let alphabet =
+        Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+,")
+            .expect("static IMAP mUTF-7 alphabet is valid");
     let config = GeneralPurposeConfig::new()
         .with_encode_padding(false)
         .with_decode_padding_mode(DecodePaddingMode::RequireNone);

--- a/crates/nimbus-nextcloud/src/files.rs
+++ b/crates/nimbus-nextcloud/src/files.rs
@@ -614,10 +614,7 @@ fn parse_multistatus(
     // Prefix of the href we should treat as "our path", so we can
     // strip it and produce user-facing paths relative to the user root.
     // Nextcloud returns hrefs URL-encoded; we match encoded-to-encoded.
-    let user_prefix = format!(
-        "/remote.php/dav/files/{}",
-        encode_path_segment(username)
-    );
+    let user_prefix = format!("/remote.php/dav/files/{}", encode_path_segment(username));
     // Encoded form of the request target under the user root.
     let request_prefix_encoded = encode_path(request_path); // e.g. "/Documents/"
 
@@ -763,14 +760,12 @@ fn resourcetype_is_collection(
     let mut is_collection = false;
     loop {
         match reader.read_event()? {
-            Event::Start(e) | Event::Empty(e)
-                if local_name(&e) == "collection" => {
-                    is_collection = true;
-                }
-            Event::End(e)
-                if local_name_end(&e) == "resourcetype" => {
-                    return Ok(is_collection);
-                }
+            Event::Start(e) | Event::Empty(e) if local_name(&e) == "collection" => {
+                is_collection = true;
+            }
+            Event::End(e) if local_name_end(&e) == "resourcetype" => {
+                return Ok(is_collection);
+            }
             Event::Eof => return Ok(is_collection),
             _ => {}
         }
@@ -805,10 +800,9 @@ fn read_text_until(
         match reader.read_event()? {
             Event::Text(t) => buf.push_str(&t.unescape().unwrap_or_default()),
             Event::CData(c) => buf.push_str(&String::from_utf8_lossy(&c)),
-            Event::End(e)
-                if strip_prefix_lowercase(e.name().as_ref()) == start_local => {
-                    return Ok(buf);
-                }
+            Event::End(e) if strip_prefix_lowercase(e.name().as_ref()) == start_local => {
+                return Ok(buf);
+            }
             Event::Eof => return Ok(buf),
             _ => {}
         }
@@ -823,7 +817,10 @@ mod tests {
 
     #[test]
     fn encodes_path_segments_but_keeps_slashes() {
-        assert_eq!(encode_path("/Documents/Q1 report.pdf"), "/Documents/Q1%20report.pdf");
+        assert_eq!(
+            encode_path("/Documents/Q1 report.pdf"),
+            "/Documents/Q1%20report.pdf"
+        );
         assert_eq!(encode_path("/"), "/");
         assert_eq!(encode_path(""), "");
         // Unicode: ä = 0xC3 0xA4

--- a/crates/nimbus-nextcloud/src/notes.rs
+++ b/crates/nimbus-nextcloud/src/notes.rs
@@ -273,9 +273,7 @@ fn expect_success(resp: &reqwest::Response, op: &str) -> Result<(), NimbusError>
         // Reuse the same etag-collision variant CalDAV uses so
         // future "refresh and retry" plumbing in the UI can match
         // on a single error type across protocols.
-        412 => NimbusError::EtagMismatch(format!(
-            "{op}: note was modified by another client"
-        )),
+        412 => NimbusError::EtagMismatch(format!("{op}: note was modified by another client")),
         _ => NimbusError::Network(format!("{op}: HTTP {status}")),
     })
 }

--- a/crates/nimbus-nextcloud/src/shares.rs
+++ b/crates/nimbus-nextcloud/src/shares.rs
@@ -169,13 +169,15 @@ pub async fn create_public_share(
         ("permissions", &permissions_s),
     ];
     if let Some(pw) = password
-        && !pw.is_empty() {
-            form.push(("password", pw));
-        }
+        && !pw.is_empty()
+    {
+        form.push(("password", pw));
+    }
     if let Some(lbl) = label
-        && !lbl.is_empty() {
-            form.push(("label", lbl));
-        }
+        && !lbl.is_empty()
+    {
+        form.push(("label", lbl));
+    }
 
     let resp = http
         .post(&url)
@@ -251,12 +253,9 @@ fn friendly_share_error(raw: &str) -> String {
     // ("Password needs to be at least N characters long.",
     // "Password is too short", "The password is too short.") so we
     // pull the digits when we can and fall back to a generic floor.
-    if lower.contains("password") && (lower.contains("short") || lower.contains("at least"))
-    {
+    if lower.contains("password") && (lower.contains("short") || lower.contains("at least")) {
         if let Some(min_len) = first_number(raw) {
-            return format!(
-                "Password is too short. Choose at least {min_len} characters."
-            );
+            return format!("Password is too short. Choose at least {min_len} characters.");
         }
         return "Password is too short. Try a longer one.".to_string();
     }
@@ -377,9 +376,8 @@ pub async fn update_share_label(
         return Err(NimbusError::Other("share_id is empty".into()));
     }
     let server = client::normalize_server_url(server_url);
-    let url = format!(
-        "{server}/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}?format=json"
-    );
+    let url =
+        format!("{server}/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}?format=json");
 
     tracing::debug!("PUT {url} for share {share_id} (label len {})", label.len());
 

--- a/crates/nimbus-nextcloud/src/talk.rs
+++ b/crates/nimbus-nextcloud/src/talk.rs
@@ -256,10 +256,8 @@ pub async fn create_room(
     tracing::debug!("POST {url} (room_name={room_name:?})");
     let http = client::build()?;
     let room_type = options.room_type.unwrap_or(ROOM_TYPE_GROUP).to_string();
-    let mut form: Vec<(&str, &str)> = vec![
-        ("roomType", room_type.as_str()),
-        ("roomName", room_name),
-    ];
+    let mut form: Vec<(&str, &str)> =
+        vec![("roomType", room_type.as_str()), ("roomName", room_name)];
     if let Some(t) = options.object_type {
         form.push(("objectType", t));
     }
@@ -466,10 +464,7 @@ async fn ocs_text(resp: reqwest::Response, ctx: &str) -> Result<String, NimbusEr
 /// meaningful error. Mirrors `shares::parse_share_response` — meta is
 /// inspected first because on OCS-level failures `data` may be `[]`,
 /// which would never deserialize into a payload struct.
-fn parse_ocs_data<T: serde::de::DeserializeOwned>(
-    body: &str,
-    ctx: &str,
-) -> Result<T, NimbusError> {
+fn parse_ocs_data<T: serde::de::DeserializeOwned>(body: &str, ctx: &str) -> Result<T, NimbusError> {
     let raw: OcsRaw = serde_json::from_str(body)
         .map_err(|e| NimbusError::Protocol(format!("{ctx} bad JSON: {e}")))?;
 
@@ -534,7 +529,9 @@ mod tests {
         assert_eq!(r0.unread_messages, 4);
         assert!(r0.unread_mention);
 
-        let mapped = rooms[0].clone_for_test().into_room("https://cloud.example.com");
+        let mapped = rooms[0]
+            .clone_for_test()
+            .into_room("https://cloud.example.com");
         assert_eq!(mapped.web_url, "https://cloud.example.com/call/abc123");
         assert_eq!(mapped.room_type, RoomType::Group);
     }
@@ -580,7 +577,10 @@ mod tests {
         match err {
             NimbusError::Nextcloud(msg) => {
                 assert!(msg.contains("403"), "expected status 403 in error: {msg}");
-                assert!(msg.contains("Permission denied"), "expected server msg: {msg}");
+                assert!(
+                    msg.contains("Permission denied"),
+                    "expected server msg: {msg}"
+                );
             }
             other => panic!("expected Nextcloud error, got {other:?}"),
         }

--- a/crates/nimbus-nextcloud/src/user.rs
+++ b/crates/nimbus-nextcloud/src/user.rs
@@ -406,9 +406,7 @@ pub async fn fetch_my_circles(
         .await
         .map_err(|e| NimbusError::Network(format!("circles request failed: {e}")))?;
     let status = resp.status();
-    if status == reqwest::StatusCode::NOT_FOUND
-        || status == reqwest::StatusCode::FORBIDDEN
-    {
+    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
         return Ok(Vec::new());
     }
     if !status.is_success() {
@@ -480,9 +478,7 @@ pub async fn fetch_circle_member_ids(
         .await
         .map_err(|e| NimbusError::Network(format!("circle members request failed: {e}")))?;
     let status = resp.status();
-    if status == reqwest::StatusCode::NOT_FOUND
-        || status == reqwest::StatusCode::FORBIDDEN
-    {
+    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
         return Ok(Vec::new());
     }
     if !status.is_success() {

--- a/crates/nimbus-smtp/src/client.rs
+++ b/crates/nimbus-smtp/src/client.rs
@@ -155,10 +155,7 @@ fn build_tls_params(
 /// the cert isn't visible until after a SMTP greeting + STARTTLS
 /// dance — and in practice the IMAP probe usually surfaces the
 /// same cert (same host), so we let the UI try the IMAP probe first.
-pub async fn probe_server_certificate(
-    host: &str,
-    port: u16,
-) -> Result<Vec<u8>, NimbusError> {
+pub async fn probe_server_certificate(host: &str, port: u16) -> Result<Vec<u8>, NimbusError> {
     let addr = format!("{host}:{port}");
     let tcp = tokio::net::TcpStream::connect(&addr)
         .await
@@ -176,9 +173,7 @@ pub async fn probe_server_certificate(
     let leaf = conn
         .peer_certificates()
         .and_then(|chain| chain.first())
-        .ok_or_else(|| {
-            NimbusError::Protocol(format!("server '{host}' returned no certificate"))
-        })?
+        .ok_or_else(|| NimbusError::Protocol(format!("server '{host}' returned no certificate")))?
         .to_vec();
     Ok(leaf)
 }

--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -54,9 +54,10 @@ pub fn load_accounts(cache: &Cache) -> Result<Vec<Account>, NimbusError> {
     let accounts = read_all(cache)?;
     #[cfg(not(test))]
     if accounts.is_empty()
-        && let Some(imported) = migrate_from_legacy_json(cache)? {
-            return Ok(imported);
-        }
+        && let Some(imported) = migrate_from_legacy_json(cache)?
+    {
+        return Ok(imported);
+    }
     Ok(accounts)
 }
 
@@ -323,10 +324,7 @@ fn migrate_from_legacy_json(cache: &Cache) -> Result<Option<Vec<Account>>, Nimbu
 /// callers can use `?` without sprinkling `.map_err` everywhere.
 fn conn(
     cache: &Cache,
-) -> Result<
-    r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>,
-    NimbusError,
-> {
+) -> Result<r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>, NimbusError> {
     cache
         .pool()
         .get()

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -221,10 +221,7 @@ impl Cache {
         // Prune calendars that vanished server-side. We bind the
         // full server path list as an in-memory temp join so we
         // don't have to build a variadic `NOT IN (...)` clause.
-        tx.execute(
-            "CREATE TEMP TABLE _seen_paths (path TEXT PRIMARY KEY)",
-            [],
-        )?;
+        tx.execute("CREATE TEMP TABLE _seen_paths (path TEXT PRIMARY KEY)", [])?;
         {
             let mut stmt = tx.prepare("INSERT INTO _seen_paths (path) VALUES (?1)")?;
             for r in rows {
@@ -306,11 +303,7 @@ impl Cache {
 
     /// Layer 1 toggle — removes the calendar from the sidebar entirely.
     /// Purely client-side; never touches the server.
-    pub fn set_calendar_hidden(
-        &self,
-        calendar_id: &str,
-        hidden: bool,
-    ) -> Result<(), CacheError> {
+    pub fn set_calendar_hidden(&self, calendar_id: &str, hidden: bool) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
         conn.execute(
             "UPDATE calendars SET hidden = ?2 WHERE id = ?1",
@@ -322,11 +315,7 @@ impl Cache {
     /// Layer 2 toggle — keeps the calendar in the sidebar but hides its
     /// events from the agenda grid. Purely client-side; never touches
     /// the server.
-    pub fn set_calendar_muted(
-        &self,
-        calendar_id: &str,
-        muted: bool,
-    ) -> Result<(), CacheError> {
+    pub fn set_calendar_muted(&self, calendar_id: &str, muted: bool) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
         conn.execute(
             "UPDATE calendars SET muted = ?2 WHERE id = ?1",
@@ -347,10 +336,7 @@ impl Cache {
 
     /// All cached calendars for one Nextcloud account, alphabetised
     /// by display name.
-    pub fn list_calendars(
-        &self,
-        nc_account_id: &str,
-    ) -> Result<Vec<CachedCalendar>, CacheError> {
+    pub fn list_calendars(&self, nc_account_id: &str) -> Result<Vec<CachedCalendar>, CacheError> {
         let conn = self.pool.get()?;
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, path, display_name, color,
@@ -518,10 +504,10 @@ impl Cache {
                     &e.exdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>(),
                 )
                 .unwrap_or_else(|_| "[]".into());
-                let attendees_json = serde_json::to_string(&e.attendees)
-                    .unwrap_or_else(|_| "[]".into());
-                let reminders_json = serde_json::to_string(&e.reminders)
-                    .unwrap_or_else(|_| "[]".into());
+                let attendees_json =
+                    serde_json::to_string(&e.attendees).unwrap_or_else(|_| "[]".into());
+                let reminders_json =
+                    serde_json::to_string(&e.reminders).unwrap_or_else(|_| "[]".into());
                 stmt.execute(params![
                     id,
                     calendar_id,
@@ -600,15 +586,13 @@ impl Cache {
         );
 
         let mut stmt = conn.prepare(&sql)?;
-        let mut bound: Vec<Box<dyn rusqlite::ToSql>> =
-            Vec::with_capacity(calendar_ids.len() + 2);
+        let mut bound: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(calendar_ids.len() + 2);
         for id in calendar_ids {
             bound.push(Box::new(id.clone()));
         }
         bound.push(Box::new(range_start.timestamp()));
         bound.push(Box::new(range_end.timestamp()));
-        let param_refs: Vec<&dyn rusqlite::ToSql> =
-            bound.iter().map(|b| b.as_ref()).collect();
+        let param_refs: Vec<&dyn rusqlite::ToSql> = bound.iter().map(|b| b.as_ref()).collect();
 
         let rows = stmt.query_map(param_refs.as_slice(), row_to_calendar_event)?;
         let mut out = Vec::new();
@@ -704,8 +688,7 @@ impl Cache {
         range: Option<(DateTime<Utc>, DateTime<Utc>)>,
     ) -> Result<Vec<CalendarEvent>, CacheError> {
         let mut stmt = conn.prepare(sql)?;
-        let mut bound: Vec<Box<dyn rusqlite::ToSql>> =
-            Vec::with_capacity(calendar_ids.len() + 2);
+        let mut bound: Vec<Box<dyn rusqlite::ToSql>> = Vec::with_capacity(calendar_ids.len() + 2);
         for id in calendar_ids {
             bound.push(Box::new(id.clone()));
         }
@@ -713,8 +696,7 @@ impl Cache {
             bound.push(Box::new(rs.timestamp()));
             bound.push(Box::new(re.timestamp()));
         }
-        let param_refs: Vec<&dyn rusqlite::ToSql> =
-            bound.iter().map(|b| b.as_ref()).collect();
+        let param_refs: Vec<&dyn rusqlite::ToSql> = bound.iter().map(|b| b.as_ref()).collect();
         let rows = stmt.query_map(param_refs.as_slice(), row_to_calendar_event)?;
         let mut out = Vec::new();
         for r in rows {
@@ -762,8 +744,7 @@ impl Cache {
                         uid: r.get(0)?,
                         href: r.get(1)?,
                         etag: r.get(2)?,
-                        recurrence_id: recurrence_ts
-                            .and_then(|t| Utc.timestamp_opt(t, 0).single()),
+                        recurrence_id: recurrence_ts.and_then(|t| Utc.timestamp_opt(t, 0).single()),
                         ics_raw: r.get(4)?,
                         calendar_id: r.get(5)?,
                         nextcloud_account_id: r.get(6)?,
@@ -805,18 +786,14 @@ impl Cache {
     ) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
         let id = event_row_id(calendar_id, &row.uid, row.recurrence_id);
-        let rdate_json = serde_json::to_string(
-            &row.rdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>(),
-        )
-        .unwrap_or_else(|_| "[]".into());
-        let exdate_json = serde_json::to_string(
-            &row.exdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>(),
-        )
-        .unwrap_or_else(|_| "[]".into());
-        let attendees_json =
-            serde_json::to_string(&row.attendees).unwrap_or_else(|_| "[]".into());
-        let reminders_json =
-            serde_json::to_string(&row.reminders).unwrap_or_else(|_| "[]".into());
+        let rdate_json =
+            serde_json::to_string(&row.rdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>())
+                .unwrap_or_else(|_| "[]".into());
+        let exdate_json =
+            serde_json::to_string(&row.exdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>())
+                .unwrap_or_else(|_| "[]".into());
+        let attendees_json = serde_json::to_string(&row.attendees).unwrap_or_else(|_| "[]".into());
+        let reminders_json = serde_json::to_string(&row.reminders).unwrap_or_else(|_| "[]".into());
         let now = Utc::now().timestamp();
         conn.execute(
             "INSERT INTO calendar_events
@@ -876,11 +853,7 @@ impl Cache {
     /// the SMTP server, so the card can re-render in the chosen
     /// state on next open.  Overwrites a previous answer, which is
     /// the right semantics: changing your mind replaces the row.
-    pub fn upsert_rsvp_response(
-        &self,
-        uid: &str,
-        partstat: &str,
-    ) -> Result<(), CacheError> {
+    pub fn upsert_rsvp_response(&self, uid: &str, partstat: &str) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
         let now = Utc::now().timestamp();
         conn.execute(
@@ -897,10 +870,7 @@ impl Cache {
     /// Look up the user's last RSVP answer for `uid`. Returns
     /// `Ok(None)` if the user has never answered this invite (the
     /// card should show the fresh Accept/Decline/Tentative state).
-    pub fn get_rsvp_response(
-        &self,
-        uid: &str,
-    ) -> Result<Option<String>, CacheError> {
+    pub fn get_rsvp_response(&self, uid: &str) -> Result<Option<String>, CacheError> {
         let conn = self.pool.get()?;
         let row = conn
             .query_row(
@@ -952,10 +922,7 @@ impl Cache {
     /// meeting we previously accepted, the inbound mail only carries
     /// the UID — we need to map that back to the local event so we
     /// can remove it from the user's calendar.
-    pub fn find_event_id_by_uid(
-        &self,
-        uid: &str,
-    ) -> Result<Option<String>, CacheError> {
+    pub fn find_event_id_by_uid(&self, uid: &str) -> Result<Option<String>, CacheError> {
         let conn = self.pool.get()?;
         let row = conn
             .query_row(
@@ -1001,18 +968,13 @@ pub struct CalendarEventServerHandle {
     pub ics_raw: String,
 }
 
-
 /// Build the stable app-side event id.
 ///
 /// Matches the schema comment: `{calendar_id}::{uid}` for a master
 /// (or a non-recurring VEVENT), and `{calendar_id}::{uid}::{epoch}`
 /// for a RECURRENCE-ID override. Callers use this id as their single
 /// handle to a row.
-fn event_row_id(
-    calendar_id: &str,
-    uid: &str,
-    recurrence_id: Option<DateTime<Utc>>,
-) -> String {
+fn event_row_id(calendar_id: &str, uid: &str, recurrence_id: Option<DateTime<Utc>>) -> String {
     match recurrence_id {
         Some(t) => format!("{calendar_id}::{uid}::{}", t.timestamp()),
         None => format!("{calendar_id}::{uid}"),
@@ -1022,8 +984,7 @@ fn event_row_id(
 /// Column list the three event queries select in lockstep so
 /// `row_to_calendar_event` can address them by index without drifting
 /// out of sync with individual `SELECT` statements.
-const EVENT_COLUMNS: &str =
-    "id, calendar_id, summary, description, start_utc, end_utc, \
+const EVENT_COLUMNS: &str = "id, calendar_id, summary, description, start_utc, end_utc, \
      location, rrule, rdate_json, exdate_json, recurrence_id, \
      url, transparency, attendees_json, reminders_json";
 
@@ -1032,7 +993,10 @@ const EVENT_COLUMNS: &str =
 /// caller has — the result is always safe because the string only
 /// contains `?` and digits, never user input.
 fn sql_placeholders(n: usize) -> String {
-    (1..=n).map(|i| format!("?{i}")).collect::<Vec<_>>().join(", ")
+    (1..=n)
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Shared row → `CalendarEvent` mapper. All three event queries keep
@@ -1048,10 +1012,8 @@ fn row_to_calendar_event(r: &rusqlite::Row<'_>) -> rusqlite::Result<CalendarEven
     let reminders_json: String = r.get(14)?;
     let rdate_epochs: Vec<i64> = serde_json::from_str(&rdate_json).unwrap_or_default();
     let exdate_epochs: Vec<i64> = serde_json::from_str(&exdate_json).unwrap_or_default();
-    let attendees: Vec<EventAttendee> =
-        serde_json::from_str(&attendees_json).unwrap_or_default();
-    let reminders: Vec<EventReminder> =
-        serde_json::from_str(&reminders_json).unwrap_or_default();
+    let attendees: Vec<EventAttendee> = serde_json::from_str(&attendees_json).unwrap_or_default();
+    let reminders: Vec<EventReminder> = serde_json::from_str(&reminders_json).unwrap_or_default();
     Ok(CalendarEvent {
         id: r.get(0)?,
         summary: r.get(2)?,
@@ -1305,13 +1267,7 @@ mod tests {
         };
 
         cache
-            .apply_event_delta(
-                &cal_id,
-                &[master, override_row],
-                &[],
-                Some("tok"),
-                None,
-            )
+            .apply_event_delta(&cal_id, &[master, override_row], &[], Some("tok"), None)
             .unwrap();
 
         let got = cache
@@ -1352,13 +1308,7 @@ mod tests {
         };
 
         cache
-            .apply_event_delta(
-                &cal_id,
-                &[master.clone(), override_row],
-                &[],
-                None,
-                None,
-            )
+            .apply_event_delta(&cal_id, &[master.clone(), override_row], &[], None, None)
             .unwrap();
         assert_eq!(
             cache

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -167,11 +167,9 @@ impl Cache {
                 let id = format!("{nc_account_id}::{}", c.vcard_uid);
                 let emails = serde_json::to_string(&c.emails).unwrap_or_else(|_| "[]".into());
                 let phones = serde_json::to_string(&c.phones).unwrap_or_else(|_| "[]".into());
-                let addresses =
-                    serde_json::to_string(&c.addresses).unwrap_or_else(|_| "[]".into());
+                let addresses = serde_json::to_string(&c.addresses).unwrap_or_else(|_| "[]".into());
                 let urls = serde_json::to_string(&c.urls).unwrap_or_else(|_| "[]".into());
-                let members =
-                    serde_json::to_string(&c.member_uids).unwrap_or_else(|_| "[]".into());
+                let members = serde_json::to_string(&c.member_uids).unwrap_or_else(|_| "[]".into());
                 let categories =
                     serde_json::to_string(&c.categories).unwrap_or_else(|_| "[]".into());
                 stmt.execute(params![
@@ -525,10 +523,8 @@ impl Cache {
                  WHERE COALESCE(categories_json, '[]') = '[]'
                    AND vcard_raw LIKE '%CATEGORIES%'",
             )?;
-            stmt.query_map([], |r| {
-                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?
+            stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
+                .collect::<rusqlite::Result<Vec<_>>>()?
         };
         let mut updated = 0u32;
         for (id, raw) in pairs {
@@ -553,9 +549,7 @@ impl Cache {
     /// category; the unified mailing-list view derives a
     /// virtual mailing list per row.  Empty when no card has a
     /// CATEGORIES tag.
-    pub fn list_contact_categories(
-        &self,
-    ) -> Result<Vec<(String, u32)>, CacheError> {
+    pub fn list_contact_categories(&self) -> Result<Vec<(String, u32)>, CacheError> {
         let conn = self.pool.get()?;
         let mut stmt = conn.prepare(
             "SELECT categories_json FROM contacts
@@ -566,8 +560,7 @@ impl Cache {
             let v: String = r.get(0)?;
             Ok(v)
         })?;
-        let mut counts: std::collections::HashMap<String, u32> =
-            std::collections::HashMap::new();
+        let mut counts: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
         for r in rows {
             let json = r?;
             let cats: Vec<String> = serde_json::from_str(&json).unwrap_or_default();
@@ -599,10 +592,7 @@ impl Cache {
     /// Iterating every row is fine at typical addressbook
     /// sizes — one cheap SELECT per Lists-tab open, not per
     /// keystroke.
-    pub fn list_contacts_with_category(
-        &self,
-        category: &str,
-    ) -> Result<Vec<Contact>, CacheError> {
+    pub fn list_contacts_with_category(&self, category: &str) -> Result<Vec<Contact>, CacheError> {
         let conn = self.pool.get()?;
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, display_name, emails_json,
@@ -701,9 +691,7 @@ impl Cache {
             "SELECT id, emoji FROM mailing_list_settings
              WHERE emoji IS NOT NULL AND emoji != ''",
         )?;
-        let rows = stmt.query_map([], |r| {
-            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
-        })?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
         let mut out = std::collections::HashMap::new();
         for r in rows {
             let (k, v) = r?;
@@ -712,11 +700,7 @@ impl Cache {
         Ok(out)
     }
 
-    pub fn set_mailing_list_emoji(
-        &self,
-        id: &str,
-        emoji: Option<&str>,
-    ) -> Result<(), CacheError> {
+    pub fn set_mailing_list_emoji(&self, id: &str, emoji: Option<&str>) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
         conn.execute(
             "INSERT INTO mailing_list_settings (id, hidden_from_autocomplete, emoji)
@@ -770,8 +754,7 @@ impl Cache {
             let members_json: String = r.get(3)?;
             let emoji: Option<String> = r.get(4)?;
             let hidden: i64 = r.get(5)?;
-            let raw_uris: Vec<String> =
-                serde_json::from_str(&members_json).unwrap_or_default();
+            let raw_uris: Vec<String> = serde_json::from_str(&members_json).unwrap_or_default();
             // Strip the `urn:uuid:` prefix that vCard 4 prescribes
             // so the frontend gets bare UIDs ready to match against
             // contact rows.  Anything that isn't a urn:uuid form
@@ -802,11 +785,7 @@ impl Cache {
     }
 
     /// Toggle the local `group_hidden` flag for one group.
-    pub fn set_contact_group_hidden(
-        &self,
-        group_id: &str,
-        hidden: bool,
-    ) -> Result<(), CacheError> {
+    pub fn set_contact_group_hidden(&self, group_id: &str, hidden: bool) -> Result<(), CacheError> {
         let conn = self.pool.get()?;
         conn.execute(
             "UPDATE contacts SET group_hidden = ?2 WHERE id = ?1",
@@ -869,9 +848,12 @@ impl Cache {
             let id: String = r.get(0)?;
             let name: String = r.get(1)?;
             let emails_json: String = r.get(2)?;
-            let emails: Vec<ContactEmail> =
-                serde_json::from_str(&emails_json).unwrap_or_default();
-            let first_email = emails.into_iter().next().map(|e| e.value).unwrap_or_default();
+            let emails: Vec<ContactEmail> = serde_json::from_str(&emails_json).unwrap_or_default();
+            let first_email = emails
+                .into_iter()
+                .next()
+                .map(|e| e.value)
+                .unwrap_or_default();
             Ok((id, name, first_email))
         })?;
         let mut out = Vec::new();

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -177,10 +177,7 @@ impl Cache {
     ///
     /// Returns the count of orphan account ids that were pruned —
     /// zero on a clean cache, any other number is worth a log line.
-    pub fn prune_orphan_accounts(
-        &self,
-        active_ids: &[String],
-    ) -> Result<usize, CacheError> {
+    pub fn prune_orphan_accounts(&self, active_ids: &[String]) -> Result<usize, CacheError> {
         let conn = self.pool.get()?;
         // Collect every distinct account_id across the three tables
         // that might hold orphans. Using a union keeps this robust
@@ -874,8 +871,7 @@ impl Cache {
                         is_read: r.get::<_, i64>(3)? != 0,
                         is_starred: r.get::<_, i64>(4)? != 0,
                         has_attachments: r.get::<_, i64>(7)? != 0,
-                        attachments: serde_json::from_str(&attachments_json)
-                            .unwrap_or_default(),
+                        attachments: serde_json::from_str(&attachments_json).unwrap_or_default(),
                     })
                 },
             )
@@ -1175,11 +1171,36 @@ mod tests {
     fn folders_preserve_server_order() {
         let cache = open_test_cache();
         let server_order = vec![
-            Folder { name: "INBOX".into(), delimiter: None, attributes: vec![], unread_count: None },
-            Folder { name: "Drafts".into(), delimiter: None, attributes: vec![], unread_count: None },
-            Folder { name: "Sent".into(), delimiter: None, attributes: vec![], unread_count: None },
-            Folder { name: "Archive".into(), delimiter: None, attributes: vec![], unread_count: None },
-            Folder { name: "Trash".into(), delimiter: None, attributes: vec![], unread_count: None },
+            Folder {
+                name: "INBOX".into(),
+                delimiter: None,
+                attributes: vec![],
+                unread_count: None,
+            },
+            Folder {
+                name: "Drafts".into(),
+                delimiter: None,
+                attributes: vec![],
+                unread_count: None,
+            },
+            Folder {
+                name: "Sent".into(),
+                delimiter: None,
+                attributes: vec![],
+                unread_count: None,
+            },
+            Folder {
+                name: "Archive".into(),
+                delimiter: None,
+                attributes: vec![],
+                unread_count: None,
+            },
+            Folder {
+                name: "Trash".into(),
+                delimiter: None,
+                attributes: vec![],
+                unread_count: None,
+            },
         ];
         cache.upsert_folders("acc", &server_order).unwrap();
 

--- a/crates/nimbus-store/src/cache/search.rs
+++ b/crates/nimbus-store/src/cache/search.rs
@@ -653,13 +653,7 @@ mod tests {
         // via FTS5's prefix-match operator, not just exact "dam".
         let cache = open();
         cache
-            .upsert_message(&email(
-                1,
-                "INBOX",
-                "Damm das Tor",
-                "body",
-                "a@x.de",
-            ))
+            .upsert_message(&email(1, "INBOX", "Damm das Tor", "body", "a@x.de"))
             .unwrap();
         cache
             .upsert_message(&email(

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -208,9 +208,10 @@ mod tests {
         // alpha values, not a binary inside/outside mask.
         let img = render_taskbar_overlay(1).expect("expected overlay");
         let pixels = img.rgba();
-        let has_partial = pixels
-            .chunks_exact(4)
-            .any(|p| (1..230).contains(&p[3]));
-        assert!(has_partial, "expected at least one partially-covered AA edge pixel");
+        let has_partial = pixels.chunks_exact(4).any(|p| (1..230).contains(&p[3]));
+        assert!(
+            has_partial,
+            "expected at least one partially-covered AA edge pixel"
+        );
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,8 +22,8 @@ use nimbus_carddav::{
 };
 use nimbus_core::NimbusError;
 use nimbus_core::models::{
-    Account, AppSettings, CalendarEvent, Contact, CustomTheme, Email, EmailEnvelope,
-    EventAttendee, EventReminder, Folder, NextcloudAccount, OutgoingEmail,
+    Account, AppSettings, CalendarEvent, Contact, CustomTheme, Email, EmailEnvelope, EventAttendee,
+    EventReminder, Folder, NextcloudAccount, OutgoingEmail,
 };
 use nimbus_imap::ImapClient;
 use nimbus_jmap::JmapClient;
@@ -140,10 +140,7 @@ fn send_native_notification(
 /// without needing to ask the OS layer about the platform.
 #[cfg(not(target_os = "linux"))]
 #[tauri::command]
-fn send_native_notification(
-    _title: String,
-    _body: String,
-) -> Result<bool, NimbusError> {
+fn send_native_notification(_title: String, _body: String) -> Result<bool, NimbusError> {
     Ok(false)
 }
 
@@ -346,8 +343,7 @@ async fn test_connection(
 ) -> Result<String, NimbusError> {
     tracing::info!("Testing IMAP connection to {host}:{port} as {username}");
     let trusted = trusted_certs.unwrap_or_default();
-    let client =
-        ImapClient::connect(&host, port, &username, &password, &trusted).await?;
+    let client = ImapClient::connect(&host, port, &username, &password, &trusted).await?;
     let _ = client.logout().await;
     Ok(format!("IMAP login to {host}:{port} succeeded"))
 }
@@ -531,19 +527,11 @@ fn open_url(url: String) -> Result<(), NimbusError> {
 /// Returns directories and files mixed, in the order the server sent
 /// them — the UI sorts if it wants a particular display order.
 #[tauri::command]
-async fn list_nextcloud_files(
-    nc_id: String,
-    path: String,
-) -> Result<Vec<FileEntry>, NimbusError> {
+async fn list_nextcloud_files(nc_id: String, path: String) -> Result<Vec<FileEntry>, NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
-    nimbus_nextcloud::list_directory(
-        &account.server_url,
-        &account.username,
-        &app_password,
-        &path,
-    )
-    .await
+    nimbus_nextcloud::list_directory(&account.server_url, &account.username, &app_password, &path)
+        .await
 }
 
 /// Download a single file from Nextcloud.
@@ -553,19 +541,11 @@ async fn list_nextcloud_files(
 /// for now — matches how locally-picked attachments work. A streaming
 /// path is a separate future issue once compose itself streams.
 #[tauri::command]
-async fn download_nextcloud_file(
-    nc_id: String,
-    path: String,
-) -> Result<Vec<u8>, NimbusError> {
+async fn download_nextcloud_file(nc_id: String, path: String) -> Result<Vec<u8>, NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
-    nimbus_nextcloud::download_file(
-        &account.server_url,
-        &account.username,
-        &app_password,
-        &path,
-    )
-    .await
+    nimbus_nextcloud::download_file(&account.server_url, &account.username, &app_password, &path)
+        .await
 }
 
 /// Result of `create_nextcloud_share` — both the public URL (for
@@ -694,19 +674,11 @@ async fn upload_to_nextcloud(
 /// inside the currently-open directory; on success the picker re-lists
 /// the parent so the new entry shows up.
 #[tauri::command]
-async fn create_nextcloud_directory(
-    nc_id: String,
-    path: String,
-) -> Result<(), NimbusError> {
+async fn create_nextcloud_directory(nc_id: String, path: String) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
-    nimbus_nextcloud::create_directory(
-        &account.server_url,
-        &account.username,
-        &app_password,
-        &path,
-    )
-    .await
+    nimbus_nextcloud::create_directory(&account.server_url, &account.username, &app_password, &path)
+        .await
 }
 
 // ── Office viewer (issue #65) ────────────────────────────────
@@ -754,7 +726,10 @@ struct OfficeOpenResult {
 /// exists" as `NimbusError::Nextcloud` which we swallow so a
 /// pre-existing folder doesn't fail the open. Anything else
 /// propagates so quota / 401 / network errors surface to the user.
-async fn ensure_temp_dir(account: &NextcloudAccount, app_password: &str) -> Result<(), NimbusError> {
+async fn ensure_temp_dir(
+    account: &NextcloudAccount,
+    app_password: &str,
+) -> Result<(), NimbusError> {
     for dir in [NIMBUS_TEMP_ROOT, NIMBUS_TEMP_DIR] {
         match nimbus_nextcloud::create_directory(
             &account.server_url,
@@ -792,12 +767,7 @@ async fn office_open_attachment(
     // viewer windows, and gives the sweeper a way to recognise our
     // own files without a metadata round-trip.
     let safe_name = filename.replace(['/', '\\'], "_");
-    let temp_path = format!(
-        "{}/{}-{}",
-        NIMBUS_TEMP_DIR,
-        uuid::Uuid::new_v4(),
-        safe_name
-    );
+    let temp_path = format!("{}/{}-{}", NIMBUS_TEMP_DIR, uuid::Uuid::new_v4(), safe_name);
 
     nimbus_nextcloud::upload_file(
         &account.server_url,
@@ -834,10 +804,7 @@ async fn office_open_attachment(
 /// the frontend logs and moves on — leftover files get caught by
 /// `office_sweep_temp` at next connect.
 #[tauri::command]
-async fn office_close_attachment(
-    nc_id: String,
-    temp_path: String,
-) -> Result<(), NimbusError> {
+async fn office_close_attachment(nc_id: String, temp_path: String) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
     nimbus_nextcloud::delete_path(
@@ -886,12 +853,7 @@ async fn pdf_open_attachment(
     ensure_temp_dir(&account, &app_password).await?;
 
     let safe_name = filename.replace(['/', '\\'], "_");
-    let temp_path = format!(
-        "{}/{}-{}",
-        NIMBUS_TEMP_DIR,
-        uuid::Uuid::new_v4(),
-        safe_name
-    );
+    let temp_path = format!("{}/{}-{}", NIMBUS_TEMP_DIR, uuid::Uuid::new_v4(), safe_name);
 
     nimbus_nextcloud::upload_file(
         &account.server_url,
@@ -920,10 +882,7 @@ async fn pdf_open_attachment(
 /// Office — kept as its own command so the frontend's per-viewer
 /// dispatch stays straightforward.
 #[tauri::command]
-async fn pdf_close_attachment(
-    nc_id: String,
-    temp_path: String,
-) -> Result<(), NimbusError> {
+async fn pdf_close_attachment(nc_id: String, temp_path: String) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
     nimbus_nextcloud::delete_path(
@@ -965,10 +924,7 @@ async fn office_sweep_temp(nc_id: String) -> Result<u32, NimbusError> {
     let cutoff = chrono::Utc::now() - chrono::Duration::hours(1);
     let mut swept = 0u32;
     for entry in entries {
-        let stale = entry
-            .modified
-            .map(|t| t < cutoff)
-            .unwrap_or(true);
+        let stale = entry.modified.map(|t| t < cutoff).unwrap_or(true);
         if !stale {
             continue;
         }
@@ -1341,10 +1297,7 @@ async fn add_talk_participants(
 /// in the session — without it, the room would dangle empty in the
 /// user's Talk list with no context.
 #[tauri::command]
-async fn delete_talk_room(
-    nc_id: String,
-    room_token: String,
-) -> Result<(), NimbusError> {
+async fn delete_talk_room(nc_id: String, room_token: String) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
     nimbus_nextcloud::delete_room(
@@ -1392,9 +1345,7 @@ async fn rename_talk_room(
 
 /// List every note the connected Nextcloud user can see.
 #[tauri::command]
-async fn list_nextcloud_notes(
-    nc_id: String,
-) -> Result<Vec<nimbus_nextcloud::Note>, NimbusError> {
+async fn list_nextcloud_notes(nc_id: String) -> Result<Vec<nimbus_nextcloud::Note>, NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
     nimbus_nextcloud::list_notes(&account.server_url, &account.username, &app_password).await
@@ -1478,10 +1429,7 @@ async fn update_nextcloud_note(
 /// Delete a note. Called by the trash button in NotesView; the
 /// frontend confirms in JS first so we don't need a confirm here.
 #[tauri::command]
-async fn delete_nextcloud_note(
-    nc_id: String,
-    note_id: u64,
-) -> Result<(), NimbusError> {
+async fn delete_nextcloud_note(nc_id: String, note_id: u64) -> Result<(), NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
     nimbus_nextcloud::delete_note(
@@ -1651,9 +1599,7 @@ fn get_contacts_sync_status(
         .latest_addressbook_sync_at(&nc_id)
         .map_err(NimbusError::from)?
         .map(|t| t.to_rfc3339());
-    let count = cache
-        .count_contacts(&nc_id)
-        .map_err(NimbusError::from)?;
+    let count = cache.count_contacts(&nc_id).map_err(NimbusError::from)?;
     Ok(SyncStatus {
         last_synced_at: last,
         count,
@@ -1926,12 +1872,22 @@ async fn update_contact(
     )
     .await?;
 
-    let row = parsed_to_row(&outcome.href, &outcome.etag, &handle.vcard_uid, &parsed, vcard);
+    let row = parsed_to_row(
+        &outcome.href,
+        &outcome.etag,
+        &handle.vcard_uid,
+        &parsed,
+        vcard,
+    );
     cache
         .upsert_single_contact(&handle.nextcloud_account_id, &handle.addressbook, &row)
         .map_err(NimbusError::from)?;
 
-    Ok(row_to_contact(&handle.nextcloud_account_id, &handle.addressbook, &row))
+    Ok(row_to_contact(
+        &handle.nextcloud_account_id,
+        &handle.addressbook,
+        &row,
+    ))
 }
 
 /// Delete a contact from the server and the local cache. The
@@ -2121,10 +2077,7 @@ async fn rename_contact_category(
 /// Delete a category — strips the tag from every contact.  The
 /// underlying contacts are untouched, just no longer tagged.
 #[tauri::command]
-async fn delete_contact_category(
-    name: String,
-    cache: State<'_, Cache>,
-) -> Result<(), NimbusError> {
+async fn delete_contact_category(name: String, cache: State<'_, Cache>) -> Result<(), NimbusError> {
     let contacts = cache
         .list_contacts_with_category(&name)
         .map_err(NimbusError::from)?;
@@ -2192,7 +2145,13 @@ where
         &vcard,
     )
     .await?;
-    let row = parsed_to_row(&outcome.href, &outcome.etag, &handle.vcard_uid, &parsed, vcard);
+    let row = parsed_to_row(
+        &outcome.href,
+        &outcome.etag,
+        &handle.vcard_uid,
+        &parsed,
+        vcard,
+    );
     cache
         .upsert_single_contact(&handle.nextcloud_account_id, &handle.addressbook, &row)
         .map_err(NimbusError::from)?;
@@ -2243,9 +2202,7 @@ struct MailingListMemberView {
 /// SQL pass and the NC group / team list reuses the existing
 /// list_nextcloud_groups path.
 #[tauri::command]
-async fn list_mailing_lists(
-    cache: State<'_, Cache>,
-) -> Result<Vec<MailingListView>, NimbusError> {
+async fn list_mailing_lists(cache: State<'_, Cache>) -> Result<Vec<MailingListView>, NimbusError> {
     // Same lazy backfill list_contact_categories does — this
     // IPC is the entry point the autocomplete uses on first
     // launch, before the contacts UI was opened, so we have to
@@ -2259,9 +2216,7 @@ async fn list_mailing_lists(
     let suppressed = cache
         .get_mailing_list_suppressed()
         .map_err(NimbusError::from)?;
-    let emojis = cache
-        .get_mailing_list_emojis()
-        .map_err(NimbusError::from)?;
+    let emojis = cache.get_mailing_list_emojis().map_err(NimbusError::from)?;
     let mut out: Vec<MailingListView> = Vec::new();
 
     // 1. Categories.  Skip the reserved one we use as a holder
@@ -2279,9 +2234,7 @@ async fn list_mailing_lists(
         // suppresses suggestions; the row carries the flag so
         // the UI can render it greyed-out.
         let hidden_from_autocomplete = suppressed.contains(&id);
-        let contacts = cache
-            .list_contacts_with_category(&name)
-            .unwrap_or_default();
+        let contacts = cache.list_contacts_with_category(&name).unwrap_or_default();
         // Drop members that have no email — a category-derived
         // mailing list is only useful as a sending target, and
         // a row with empty email would just be noise (and
@@ -2292,7 +2245,12 @@ async fn list_mailing_lists(
         let members: Vec<MailingListMemberView> = contacts
             .into_iter()
             .filter_map(|c| {
-                let email = c.email.into_iter().next().map(|e| e.value).unwrap_or_default();
+                let email = c
+                    .email
+                    .into_iter()
+                    .next()
+                    .map(|e| e.value)
+                    .unwrap_or_default();
                 if email.is_empty() {
                     None
                 } else {
@@ -2473,9 +2431,7 @@ struct GroupMemberView {
 /// each with its members already resolved to (id, name, email)
 /// triples so the UI doesn't have to chase referenced UIDs.
 #[tauri::command]
-fn list_contact_groups(
-    cache: State<'_, Cache>,
-) -> Result<Vec<ContactGroupView>, NimbusError> {
+fn list_contact_groups(cache: State<'_, Cache>) -> Result<Vec<ContactGroupView>, NimbusError> {
     let groups = cache.list_contact_groups().map_err(NimbusError::from)?;
     let mut out = Vec::with_capacity(groups.len());
     for g in groups {
@@ -2616,7 +2572,13 @@ async fn update_contact_group(
         &vcard,
     )
     .await?;
-    let row = parsed_to_row(&outcome.href, &outcome.etag, &handle.vcard_uid, &parsed, vcard);
+    let row = parsed_to_row(
+        &outcome.href,
+        &outcome.etag,
+        &handle.vcard_uid,
+        &parsed,
+        vcard,
+    );
     cache
         .upsert_single_contact(&handle.nextcloud_account_id, &handle.addressbook, &row)
         .map_err(NimbusError::from)?;
@@ -2733,9 +2695,8 @@ struct NextcloudGroupMemberView {
 /// else passes through untouched.
 fn humanize_nc_group_name(raw: &str) -> String {
     const PREFIXES: &[&str] = &[
-        "SAML_", "saml_", "saml-", "SAML-",
-        "LDAP_", "ldap_", "ldap-", "LDAP-",
-        "OIDC_", "oidc_", "oidc-", "OIDC-",
+        "SAML_", "saml_", "saml-", "SAML-", "LDAP_", "ldap_", "ldap-", "LDAP-", "OIDC_", "oidc_",
+        "oidc-", "OIDC-",
     ];
     for p in PREFIXES {
         if let Some(rest) = raw.strip_prefix(p) {
@@ -2766,7 +2727,12 @@ async fn list_nextcloud_groups(
         .unwrap_or_default()
         .into_iter()
         .filter_map(|c| {
-            let email = c.email.into_iter().next().map(|e| e.value).unwrap_or_default();
+            let email = c
+                .email
+                .into_iter()
+                .next()
+                .map(|e| e.value)
+                .unwrap_or_default();
             if email.is_empty() {
                 return None;
             }
@@ -2784,19 +2750,16 @@ async fn list_nextcloud_groups(
             }
         };
         // OCS user groups -------------------------------------------------
-        let group_ids = match nimbus_nextcloud::fetch_my_groups(
-            &acc.server_url,
-            &acc.username,
-            &app_password,
-        )
-        .await
-        {
-            Ok(g) => g,
-            Err(e) => {
-                tracing::warn!("fetch_my_groups failed for {}: {e}", acc.id);
-                Vec::new()
-            }
-        };
+        let group_ids =
+            match nimbus_nextcloud::fetch_my_groups(&acc.server_url, &acc.username, &app_password)
+                .await
+            {
+                Ok(g) => g,
+                Err(e) => {
+                    tracing::warn!("fetch_my_groups failed for {}: {e}", acc.id);
+                    Vec::new()
+                }
+            };
         for gid in group_ids {
             let members = collect_group_members(acc, &app_password, &gid, &cache_uid_email).await;
             // OCS groups + Circles both surface as "team" so
@@ -2813,19 +2776,16 @@ async fn list_nextcloud_groups(
             });
         }
         // Circles / Teams ------------------------------------------------
-        let circles = match nimbus_nextcloud::fetch_my_circles(
-            &acc.server_url,
-            &acc.username,
-            &app_password,
-        )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!("fetch_my_circles failed for {}: {e}", acc.id);
-                Vec::new()
-            }
-        };
+        let circles =
+            match nimbus_nextcloud::fetch_my_circles(&acc.server_url, &acc.username, &app_password)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!("fetch_my_circles failed for {}: {e}", acc.id);
+                    Vec::new()
+                }
+            };
         for c in circles {
             let mids = match nimbus_nextcloud::fetch_circle_member_ids(
                 &acc.server_url,
@@ -2841,13 +2801,7 @@ async fn list_nextcloud_groups(
                     Vec::new()
                 }
             };
-            let members = resolve_member_profiles(
-                acc,
-                &app_password,
-                mids,
-                &cache_uid_email,
-            )
-            .await;
+            let members = resolve_member_profiles(acc, &app_password, mids, &cache_uid_email).await;
             out.push(NextcloudGroupView {
                 nextcloud_account_id: acc.id.clone(),
                 id: format!("team:{}", c.id),
@@ -3029,9 +2983,7 @@ struct SyncCalendarsReport {
 /// no cache write. Used in settings UIs where the user just wants
 /// to see what calendars exist server-side before toggling sync on.
 #[tauri::command]
-async fn list_nextcloud_calendars(
-    nc_id: String,
-) -> Result<Vec<CalendarSummary>, NimbusError> {
+async fn list_nextcloud_calendars(nc_id: String) -> Result<Vec<CalendarSummary>, NimbusError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
     let calendars: Vec<CaldavCalendar> =
@@ -3147,11 +3099,8 @@ async fn sync_nextcloud_calendars(
         // onto every row from the same href — the raw blob stays
         // identical, and the store is optimised for per-row reads,
         // not per-href grouping.
-        let upserts: Vec<CalendarEventRow> = delta
-            .upserts
-            .iter()
-            .flat_map(raw_event_to_rows)
-            .collect();
+        let upserts: Vec<CalendarEventRow> =
+            delta.upserts.iter().flat_map(raw_event_to_rows).collect();
 
         if let Err(e) = cache.apply_event_delta(
             &cal_id,
@@ -3383,7 +3332,12 @@ fn get_cached_events(
             .get(master.id.as_str())
             .cloned()
             .unwrap_or_default();
-        out.extend(nimbus_caldav::expand_event(master, &ovs, range_start, range_end));
+        out.extend(nimbus_caldav::expand_event(
+            master,
+            &ovs,
+            range_start,
+            range_end,
+        ));
     }
     // Expansion doesn't guarantee chronological order across the whole
     // set (singletons come first, then per-master occurrences). Sort
@@ -3438,10 +3392,8 @@ fn input_to_calendar_event(uid: &str, input: &CalendarEventInput) -> CalendarEve
         use chrono::TimeZone;
         let start_day = input.start.date_naive();
         let end_day = input.end.date_naive();
-        let s = chrono::Utc
-            .from_utc_datetime(&start_day.and_hms_opt(0, 0, 0).unwrap());
-        let e = chrono::Utc
-            .from_utc_datetime(&end_day.and_hms_opt(23, 59, 59).unwrap());
+        let s = chrono::Utc.from_utc_datetime(&start_day.and_hms_opt(0, 0, 0).unwrap());
+        let e = chrono::Utc.from_utc_datetime(&end_day.and_hms_opt(23, 59, 59).unwrap());
         (s, e)
     } else {
         (input.start, input.end)
@@ -3584,13 +3536,14 @@ async fn create_calendar_event(
     input: CalendarEventInput,
     cache: State<'_, Cache>,
 ) -> Result<CalendarEvent, NimbusError> {
-    let (nc_id, calendar_path) = cache
-        .get_calendar_server_path(&calendar_id)?
-        .ok_or_else(|| {
-            NimbusError::Other(format!(
-                "calendar '{calendar_id}' is not in the local cache — refresh and try again"
-            ))
-        })?;
+    let (nc_id, calendar_path) =
+        cache
+            .get_calendar_server_path(&calendar_id)?
+            .ok_or_else(|| {
+                NimbusError::Other(format!(
+                    "calendar '{calendar_id}' is not in the local cache — refresh and try again"
+                ))
+            })?;
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
 
@@ -3598,11 +3551,7 @@ async fn create_calendar_event(
     let event = input_to_calendar_event(&uid, &input);
     let (organizer_email, organizer_name) =
         resolve_organizer(&account, &app_password, !event.attendees.is_empty()).await;
-    let ics = caldav_build_ics(
-        &event,
-        Some(&organizer_email),
-        organizer_name.as_deref(),
-    );
+    let ics = caldav_build_ics(&event, Some(&organizer_email), organizer_name.as_deref());
 
     // `calendar_path` from the cache is already an absolute URL —
     // `nimbus-caldav::discovery` resolves it via `absolute_url` before
@@ -3651,17 +3600,12 @@ async fn update_calendar_event(
 
     let (organizer_email, organizer_name) =
         resolve_organizer(&account, &app_password, !event.attendees.is_empty()).await;
-    let ics = caldav_build_ics(
-        &event,
-        Some(&organizer_email),
-        organizer_name.as_deref(),
-    );
+    let ics = caldav_build_ics(&event, Some(&organizer_email), organizer_name.as_deref());
     // Use the etag-aware retry helper so a concurrent edit on
     // another device (NC web, phone) doesn't surface to the
     // user as "refresh and try again" — it transparently syncs
     // and re-PUTs once.
-    let (outcome, handle) =
-        update_event_with_etag_retry(&cache, &event_id, &ics).await?;
+    let (outcome, handle) = update_event_with_etag_retry(&cache, &event_id, &ics).await?;
 
     let row = calendar_event_to_row(&event, &outcome.href, &outcome.etag, &ics);
     cache.upsert_single_event(&handle.calendar_id, &row)?;
@@ -3684,7 +3628,13 @@ async fn delete_calendar_event(
     let nc_account = load_nextcloud_account(&handle.nextcloud_account_id)?;
     let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
 
-    caldav_delete_event(&handle.href, &nc_account.username, &app_password, &handle.etag).await?;
+    caldav_delete_event(
+        &handle.href,
+        &nc_account.username,
+        &app_password,
+        &handle.etag,
+    )
+    .await?;
     cache.delete_event_by_id(&event_id)?;
     Ok(())
 }
@@ -3743,10 +3693,7 @@ fn is_invite_cancelled(uid: String, cache: State<'_, Cache>) -> Result<bool, Nim
 }
 
 #[tauri::command]
-async fn dismiss_cancelled_event(
-    uid: String,
-    cache: State<'_, Cache>,
-) -> Result<(), NimbusError> {
+async fn dismiss_cancelled_event(uid: String, cache: State<'_, Cache>) -> Result<(), NimbusError> {
     let Some(event_id) = cache.find_event_id_by_uid(&uid)? else {
         tracing::info!(
             "dismiss_cancelled_event: no cached event with UID {uid}, treating as no-op"
@@ -3945,13 +3892,14 @@ async fn respond_to_invite(
     cache: State<'_, Cache>,
 ) -> Result<(), NimbusError> {
     // Resolve the chosen calendar's location on the server.
-    let (nc_id, calendar_path) = cache
-        .get_calendar_server_path(&calendar_id)?
-        .ok_or_else(|| {
-            NimbusError::Other(format!(
-                "calendar '{calendar_id}' is not in the local cache — refresh and try again"
-            ))
-        })?;
+    let (nc_id, calendar_path) =
+        cache
+            .get_calendar_server_path(&calendar_id)?
+            .ok_or_else(|| {
+                NimbusError::Other(format!(
+                    "calendar '{calendar_id}' is not in the local cache — refresh and try again"
+                ))
+            })?;
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
 
@@ -4123,9 +4071,7 @@ async fn respond_to_invite(
     let mut existing_id = cache.find_event_id_by_uid(&event.id)?;
     if existing_id.is_none() {
         if let Err(e) = refresh_calendar_cache(&cache, &nc_id, &calendar_path).await {
-            tracing::warn!(
-                "RSVP: pre-PUT cache refresh failed (continuing): {e}"
-            );
+            tracing::warn!("RSVP: pre-PUT cache refresh failed (continuing): {e}");
         }
         existing_id = cache.find_event_id_by_uid(&event.id)?;
     }
@@ -4155,8 +4101,7 @@ async fn respond_to_invite(
                 &partstat,
                 true,
             );
-            let (out, _) =
-                update_event_with_etag_retry(&cache, &existing_id, &surgical).await?;
+            let (out, _) = update_event_with_etag_retry(&cache, &existing_id, &surgical).await?;
             body_put = surgical;
             out
         }
@@ -4372,9 +4317,7 @@ async fn update_event_with_etag_retry(
     {
         Ok(o) => Ok((o, handle)),
         Err(NimbusError::EtagMismatch(_)) => {
-            tracing::info!(
-                "stale etag for {event_id}; refreshing calendar cache and retrying"
-            );
+            tracing::info!("stale etag for {event_id}; refreshing calendar cache and retrying");
             let cal_path = cache
                 .get_calendar_server_path(&handle.calendar_id)?
                 .map(|(_, p)| p)
@@ -4438,8 +4381,7 @@ async fn refresh_calendar_cache(
         prev_token.as_deref(),
     )
     .await?;
-    let upserts: Vec<CalendarEventRow> =
-        delta.upserts.iter().flat_map(raw_event_to_rows).collect();
+    let upserts: Vec<CalendarEventRow> = delta.upserts.iter().flat_map(raw_event_to_rows).collect();
     cache.apply_event_delta(
         &cal.id,
         &upserts,
@@ -4760,7 +4702,9 @@ async fn fetch_unified_envelopes(
             tracing::warn!("unified poll failed for '{}': {e}", account.id);
         }
     }
-    cache.get_unified_envelopes(&folder, limit).map_err(Into::into)
+    cache
+        .get_unified_envelopes(&folder, limit)
+        .map_err(Into::into)
 }
 
 /// Outcome of polling a single folder — used by both the user-facing
@@ -5191,9 +5135,10 @@ async fn delete_message(
     // reason we hit that error *is* a stale cache row, so dropping it
     // unblocks the user's next refresh.
     if should_clean_cache_for_delete(&result)
-        && let Err(e) = cache.remove_envelope(&account_id, &folder, uid) {
-            tracing::warn!("remove_envelope after delete_message failed: {e}");
-        }
+        && let Err(e) = cache.remove_envelope(&account_id, &folder, uid)
+    {
+        tracing::warn!("remove_envelope after delete_message failed: {e}");
+    }
 
     result
 }
@@ -5528,11 +5473,7 @@ async fn send_email(
 /// Locate the account's Sent folder (via the IMAP `\Sent` attribute,
 /// or a name-based fallback) and `APPEND` the raw RFC 822 bytes there.
 /// Marked `\Seen` so it doesn't add to the unread badge.
-async fn append_to_sent(
-    account: &Account,
-    raw: &[u8],
-    cache: &Cache,
-) -> Result<(), NimbusError> {
+async fn append_to_sent(account: &Account, raw: &[u8], cache: &Cache) -> Result<(), NimbusError> {
     let sent_folder = pick_sent_folder(&account.id, cache);
     let Some(sent) = sent_folder else {
         return Err(NimbusError::Other(
@@ -5643,9 +5584,10 @@ async fn save_draft(
         if let Some(src) = replace_source {
             let delete_result = client.delete_message(&src.folder, src.uid).await;
             if should_clean_cache_for_delete(&delete_result)
-                && let Err(e) = cache.remove_envelope(&account_id, &src.folder, src.uid) {
-                    tracing::warn!("remove_envelope after save_draft replace failed: {e}");
-                }
+                && let Err(e) = cache.remove_envelope(&account_id, &src.folder, src.uid)
+            {
+                tracing::warn!("remove_envelope after save_draft replace failed: {e}");
+            }
             match delete_result {
                 Ok(()) => Ok(()),
                 Err(e) => Err(NimbusError::Other(format!(
@@ -5822,9 +5764,10 @@ async fn delete_folder(
     let _ = client.logout().await;
 
     if result.is_ok()
-        && let Err(e) = cache.wipe_folder(&account_id, &name) {
-            tracing::warn!("wipe_folder after delete_folder failed: {e}");
-        }
+        && let Err(e) = cache.wipe_folder(&account_id, &name)
+    {
+        tracing::warn!("wipe_folder after delete_folder failed: {e}");
+    }
 
     result
 }
@@ -5850,9 +5793,10 @@ async fn rename_folder(
     let _ = client.logout().await;
 
     if result.is_ok()
-        && let Err(e) = cache.rename_folder(&account_id, &old_name, &new_name) {
-            tracing::warn!("cache.rename_folder failed: {e}");
-        }
+        && let Err(e) = cache.rename_folder(&account_id, &old_name, &new_name)
+    {
+        tracing::warn!("cache.rename_folder failed: {e}");
+    }
 
     result
 }
@@ -5886,7 +5830,9 @@ fn get_unified_cached_envelopes(
     limit: u32,
     cache: State<'_, Cache>,
 ) -> Result<Vec<EmailEnvelope>, NimbusError> {
-    cache.get_unified_envelopes(&folder, limit).map_err(Into::into)
+    cache
+        .get_unified_envelopes(&folder, limit)
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -6403,7 +6349,15 @@ fn extract_meeting_url(event: &CalendarEvent) -> Option<String> {
         // doesn't end up baked into the captured URL.
         for token in s.split_whitespace() {
             let url = token.trim_matches(|c: char| {
-                c == '<' || c == '>' || c == '"' || c == '\'' || c == ',' || c == '.' || c == ';' || c == ')' || c == '('
+                c == '<'
+                    || c == '>'
+                    || c == '"'
+                    || c == '\''
+                    || c == ','
+                    || c == '.'
+                    || c == ';'
+                    || c == ')'
+                    || c == '('
             });
             if url.starts_with("http://") || url.starts_with("https://") {
                 return Some(url.to_string());
@@ -6504,7 +6458,12 @@ async fn check_talk_reminders_inner(app: &AppHandle) -> Result<(), NimbusError> 
             .get(master.id.as_str())
             .cloned()
             .unwrap_or_default();
-        events.extend(nimbus_caldav::expand_event(master, &ovs, range_start, range_end));
+        events.extend(nimbus_caldav::expand_event(
+            master,
+            &ovs,
+            range_start,
+            range_end,
+        ));
     }
 
     let state = app.state::<TalkReminderState>();
@@ -6522,7 +6481,10 @@ async fn check_talk_reminders_inner(app: &AppHandle) -> Result<(), NimbusError> 
         fired.retain(|(uid, _)| active_uids.contains(uid));
     }
     let dismissed_snapshot: HashSet<String> = {
-        let d = state.dismissed.lock().expect("talk-reminder dismissed mutex");
+        let d = state
+            .dismissed
+            .lock()
+            .expect("talk-reminder dismissed mutex");
         d.clone()
     };
 
@@ -6620,7 +6582,10 @@ fn dismiss_talk_reminder(
     state: State<'_, TalkReminderState>,
 ) -> Result<(), NimbusError> {
     {
-        let mut d = state.dismissed.lock().expect("talk-reminder dismissed mutex");
+        let mut d = state
+            .dismissed
+            .lock()
+            .expect("talk-reminder dismissed mutex");
         d.insert(uid.clone());
     }
     {
@@ -6724,7 +6689,10 @@ fn extract_theme_slug(css: &str, fallback: &str) -> String {
         // Accept both `"foo"` and `'foo'` quoting, tolerate
         // intra-attribute whitespace.
         let trimmed = tail.trim_start();
-        if let Some(rest) = trimmed.strip_prefix('"').or_else(|| trimmed.strip_prefix('\'')) {
+        if let Some(rest) = trimmed
+            .strip_prefix('"')
+            .or_else(|| trimmed.strip_prefix('\''))
+        {
             if let Some(end) = rest.find(['"', '\'']) {
                 let slug = rest[..end].trim();
                 if !slug.is_empty() {
@@ -6768,8 +6736,7 @@ async fn import_custom_theme(
     let slug = extract_theme_slug(&css, &stem);
     let dir = custom_themes_dir()?;
     let dest = dir.join(format!("{slug}.css"));
-    std::fs::write(&dest, &css)
-        .map_err(|e| NimbusError::Other(format!("copy theme file: {e}")))?;
+    std::fs::write(&dest, &css).map_err(|e| NimbusError::Other(format!("copy theme file: {e}")))?;
 
     let record = CustomTheme {
         id: slug.clone(),
@@ -6808,7 +6775,11 @@ async fn remove_custom_theme(
 ) -> Result<(), NimbusError> {
     let path: Option<String> = {
         let mut s = settings.write().await;
-        let path = s.custom_themes.iter().find(|t| t.id == id).map(|t| t.path.clone());
+        let path = s
+            .custom_themes
+            .iter()
+            .find(|t| t.id == id)
+            .map(|t| t.path.clone());
         s.custom_themes.retain(|t| t.id != id);
         // If the removed theme was the active one, drop back to
         // the default so the UI doesn't try to render a missing
@@ -6820,9 +6791,10 @@ async fn remove_custom_theme(
         path
     };
     if let Some(p) = path
-        && let Err(e) = std::fs::remove_file(&p) {
-            tracing::warn!("remove theme file {p}: {e}");
-        }
+        && let Err(e) = std::fs::remove_file(&p)
+    {
+        tracing::warn!("remove theme file {p}: {e}");
+    }
     if let Err(e) = app.emit("custom-themes-changed", ()) {
         tracing::warn!("emit custom-themes-changed failed: {e}");
     }
@@ -6865,15 +6837,14 @@ fn main() {
     // cache got into that state.
     match account_store::load_accounts(&cache) {
         Ok(accounts) => {
-            let active_ids: Vec<String> =
-                accounts.iter().map(|a| a.id.clone()).collect();
+            let active_ids: Vec<String> = accounts.iter().map(|a| a.id.clone()).collect();
             if let Err(e) = cache.prune_orphan_accounts(&active_ids) {
                 tracing::warn!("startup orphan-account prune failed: {e}");
             }
         }
-        Err(e) => tracing::warn!(
-            "skipping startup orphan-account prune — load_accounts failed: {e}"
-        ),
+        Err(e) => {
+            tracing::warn!("skipping startup orphan-account prune — load_accounts failed: {e}")
+        }
     }
 
     // App-wide preferences (Issue #16). A missing file is fine on first

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -292,7 +292,9 @@
         filters: [{ name: 'CSS theme', extensions: ['css'] }],
       })
       if (!picked) return
-      const path = typeof picked === 'string' ? picked : picked.path
+      // tauri-plugin-dialog returns the path as a plain string when
+      // `multiple: false, directory: false` is set.
+      const path = picked
       const fileName = path.split(/[\\/]/).pop() ?? ''
       const stem = fileName.replace(/\.css$/i, '')
       // Reasonable default label — the user can rename later.


### PR DESCRIPTION
## Summary
Main has been red since the last contact-groups merges — every new PR (e.g. #145, #147) is showing as BLOCKED because branch protection requires green CI. Two unrelated failures, fixed here:

- **cargo fmt --all -- --check** — drift across 28 .rs files. Ran rustfmt 1.9.0 (edition 2024) against everything under `crates/` and `src-tauri/`. Pure whitespace / line-break shuffles, no behavioural change.
- **`npm run check`** — `ui/src/lib/AccountSettings.svelte:295` was narrowing an `openFileDialog` return to `string | { path }`, but the plugin returns a plain string when `multiple: false, directory: false`. The `else` branch typed as `never`, so `picked.path` failed. Removed the dead branch.

## Test plan
- [ ] CI on this branch should be green (rustfmt, frontend check, plus everything else).
- [ ] Once merged, rebase / re-run CI on the queued PRs (#145, #147) and confirm they unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)