### PR TITLE
Cross-client rendering for @ mentions and / attachment refs (#93)

### DIFF
--- a/crates/nimbus-nextcloud/src/files.rs
+++ b/crates/nimbus-nextcloud/src/files.rs
@@ -297,6 +297,77 @@ pub async fn download_file(
     Ok(bytes.to_vec())
 }
 
+/// Fetch a server-rendered preview thumbnail of a file via
+/// `/index.php/core/preview.png?file=<path>&x=…&y=…`.  Used by
+/// the Nextcloud file picker to render an inline thumbnail on
+/// image and video rows.
+///
+/// `path` is relative to the user's root (the same form
+/// `download_file` takes).  `size` caps the long edge in pixels;
+/// Nextcloud renders a smaller image to fit and we let the
+/// browser scale it down further.  Returns the raw bytes — the
+/// caller decides whether to base64 it for a `data:` URL or
+/// stream it through a custom URI scheme.
+///
+/// Errors mirror `download_file`: 401 → `Auth`, 404 → `Nextcloud`,
+/// other non-2xx → `Nextcloud`.  Files with no available preview
+/// (e.g. ones the server hasn't generated thumbnails for yet)
+/// surface as 404 too; the caller treats that as "skip preview,
+/// fall back to the typed icon".
+pub async fn fetch_preview(
+    server_url: &str,
+    username: &str,
+    app_password: &str,
+    path: &str,
+    size: u32,
+) -> Result<Vec<u8>, NimbusError> {
+    let server = client::normalize_server_url(server_url);
+    let inner = normalise_input_path(path);
+    // The preview endpoint accepts the path relative to the
+    // user's root in the `file` query parameter.  `forceIcon=0`
+    // means "return 404 if no preview exists" rather than serving
+    // the generic mimetype icon, so we know to fall back.
+    // `a=1` keeps aspect ratio so portraits don't get cropped.
+    let url = format!(
+        "{server}/index.php/core/preview.png?file={}&x={size}&y={size}&a=1&forceIcon=0",
+        encode_path(&inner),
+    );
+
+    tracing::debug!("GET preview {url}");
+
+    let http = client::build()?;
+    let resp = http
+        .get(&url)
+        .header("OCS-APIRequest", "true")
+        .basic_auth(username, Some(app_password))
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("preview GET failed: {e}")))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(NimbusError::Auth(
+            "Nextcloud rejected app password (revoked or expired)".into(),
+        ));
+    }
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Err(NimbusError::Nextcloud(format!(
+            "no preview available for {path}"
+        )));
+    }
+    if !status.is_success() {
+        return Err(NimbusError::Nextcloud(format!(
+            "preview GET returned HTTP {status}"
+        )));
+    }
+
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| NimbusError::Network(format!("preview body read failed: {e}")))?;
+    Ok(bytes.to_vec())
+}
+
 /// Upload (or overwrite) a file via WebDAV PUT.
 ///
 /// `path` is the destination, relative to the user's root — e.g.

--- a/crates/nimbus-nextcloud/src/files.rs
+++ b/crates/nimbus-nextcloud/src/files.rs
@@ -328,8 +328,12 @@ pub async fn fetch_preview(
     // means "return 404 if no preview exists" rather than serving
     // the generic mimetype icon, so we know to fall back.
     // `a=1` keeps aspect ratio so portraits don't get cropped.
+    // `mimeFallback=false` is explicit insurance against future
+    // NC versions flipping the default — we want a real preview
+    // or a 404, never a mime-typed icon.  `forceIcon=0` belongs
+    // to the same family.
     let url = format!(
-        "{server}/index.php/core/preview.png?file={}&x={size}&y={size}&a=1&forceIcon=0",
+        "{server}/index.php/core/preview.png?file={}&x={size}&y={size}&a=1&forceIcon=0&mimeFallback=false",
         encode_path(&inner),
     );
 
@@ -356,6 +360,7 @@ pub async fn fetch_preview(
         )));
     }
     if !status.is_success() {
+        tracing::warn!("preview GET {url} returned HTTP {status}");
         return Err(NimbusError::Nextcloud(format!(
             "preview GET returned HTTP {status}"
         )));

--- a/crates/nimbus-nextcloud/src/lib.rs
+++ b/crates/nimbus-nextcloud/src/lib.rs
@@ -26,8 +26,8 @@ pub mod user;
 pub use auth::{LoginFlowInit, LoginFlowResult, poll_login, start_login};
 pub use capabilities::fetch_capabilities;
 pub use files::{
-    FileEntry, create_directory, delete_path, download_file, list_directory, propfind_fileid,
-    upload_file,
+    FileEntry, create_directory, delete_path, download_file, fetch_preview, list_directory,
+    propfind_fileid, upload_file,
 };
 pub use notes::{
     NewNote, Note, NoteUpdate, create_note, delete_note, get_note, list_notes, update_note,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -548,6 +548,38 @@ async fn download_nextcloud_file(nc_id: String, path: String) -> Result<Vec<u8>,
         .await
 }
 
+/// Fetch a server-rendered preview thumbnail for a Nextcloud
+/// file.  Used by the file picker to render inline thumbnails
+/// for image / video rows.  Returns `None` (`Ok(None)`) when the
+/// server has no preview for this file (404) so the frontend
+/// silently falls back to the typed icon instead of surfacing an
+/// error to the user.
+#[tauri::command]
+async fn nextcloud_file_preview(
+    nc_id: String,
+    path: String,
+    size: Option<u32>,
+) -> Result<Option<Vec<u8>>, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    let s = size.unwrap_or(96);
+    match nimbus_nextcloud::fetch_preview(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &path,
+        s,
+    )
+    .await
+    {
+        Ok(bytes) => Ok(Some(bytes)),
+        // The 404 ("no preview available") path is legitimate —
+        // surface as None so the picker just shows the icon.
+        Err(NimbusError::Nextcloud(_)) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
 /// Result of `create_nextcloud_share` — both the public URL (for
 /// pasting into the email body) and the share id (for later
 /// label updates via `update_nextcloud_share_label`).
@@ -7292,6 +7324,7 @@ fn main() {
             open_url,
             list_nextcloud_files,
             download_nextcloud_file,
+            nextcloud_file_preview,
             create_nextcloud_share,
             update_nextcloud_share_label,
             create_nextcloud_directory,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -434,6 +434,7 @@
     let unlistenCompose: UnlistenFn | null = null
     let unlistenComposeFromMail: UnlistenFn | null = null
     let unlistenEditDraftFromMail: UnlistenFn | null = null
+    let unlistenMailtoFromMail: UnlistenFn | null = null
     ;(async () => {
       unlistenNewMail = await listen<NewMail>('new-mail', (e) =>
         handleNewMail(e.payload),
@@ -468,6 +469,9 @@
         'edit-draft-from-mail',
         (e) => onEditDraft(e.payload.mail),
       )
+      unlistenMailtoFromMail = await listen<{
+        init: { to?: string; cc?: string; bcc?: string; subject?: string; body?: string }
+      }>('mailto-from-mail', (e) => openCompose(e.payload.init))
     })()
     return () => {
       unlistenNewMail?.()
@@ -476,6 +480,7 @@
       unlistenCompose?.()
       unlistenComposeFromMail?.()
       unlistenEditDraftFromMail?.()
+      unlistenMailtoFromMail?.()
       if (pendingSummaryTimer) clearTimeout(pendingSummaryTimer)
     }
   })
@@ -1134,6 +1139,7 @@
         isSentFolder={isSentFolder}
         oneditdraft={onEditDraft}
         onmessageremoved={onMessageRemoved}
+        onmailto={(init) => openCompose(init)}
       />
     {/if}
 

--- a/ui/src/lib/AddressAutocomplete.svelte
+++ b/ui/src/lib/AddressAutocomplete.svelte
@@ -28,6 +28,7 @@
 
   import { convertFileSrc, invoke } from '@tauri-apps/api/core'
   import { onDestroy } from 'svelte'
+  import EmailKindChip from './EmailKindChip.svelte'
 
   interface ContactEmail {
     kind: string
@@ -336,10 +337,10 @@
             {/if}
             <div class="flex-1 min-w-0">
               <p class="font-medium truncate">{c.display_name}</p>
-              <p class="text-xs text-surface-500 truncate">
-                {#if s.email.kind}<span class="uppercase tracking-wide mr-1 text-[10px]">{s.email.kind}</span>{/if}
-                {s.email.value}
-                {#if c.organization}· {c.organization}{/if}
+              <p class="text-xs text-surface-500 truncate flex items-center gap-1.5">
+                <EmailKindChip kind={s.email.kind} />
+                <span class="truncate">{s.email.value}</span>
+                {#if c.organization}<span class="shrink-0">· {c.organization}</span>{/if}
               </p>
             </div>
           {:else}

--- a/ui/src/lib/AddressAutocomplete.svelte
+++ b/ui/src/lib/AddressAutocomplete.svelte
@@ -61,7 +61,15 @@
    *  which case selecting it expands every member into the
    *  field rather than inserting a single address. */
   type Suggestion =
-    | { kind: 'contact'; contact: Contact }
+    | {
+        kind: 'contact'
+        contact: Contact
+        /** Specific email of the contact this row represents.
+         *  Each contact expands into one suggestion per email
+         *  address so users can pick a Home vs Work address
+         *  directly from the dropdown. */
+        email: { kind: string; value: string }
+      }
     | { kind: 'list'; list: MailingListSuggestion }
   interface MailingListSuggestion {
     id: string
@@ -129,9 +137,22 @@
       // almost always intent to address the bundle), then
       // individual contacts.  Matches Outlook / Apple Mail's
       // ranking.
+      // Expand each contact into one suggestion per email
+      // address so a contact with both home and work emails
+      // shows up twice — the user can pick the address they
+      // want without first selecting the contact and then
+      // editing.
+      const contactSuggestions: Suggestion[] = []
+      for (const c of rows) {
+        const emails = c.email.filter((e) => e.value.length > 0)
+        if (emails.length === 0) continue
+        for (const e of emails) {
+          contactSuggestions.push({ kind: 'contact', contact: c, email: e })
+        }
+      }
       const merged: Suggestion[] = [
         ...listHits.map((m) => ({ kind: 'list' as const, list: m })),
-        ...rows.map((c) => ({ kind: 'contact' as const, contact: c })),
+        ...contactSuggestions,
       ]
       suggestions = merged.slice(0, LIMIT)
       activeIndex = 0
@@ -151,32 +172,24 @@
     debounceTimer = window.setTimeout(() => runSearch(token), DEBOUNCE_MS)
   }
 
-  /** Pick the first non-empty email address. Each entry now
-      carries a kind hint (Home / Work / Other from vCard
-      `EMAIL;TYPE=…`); the autocomplete only needs the value. */
-  function primaryEmail(c: Contact): string {
-    return c.email.find((e) => e.value.length > 0)?.value ?? ''
-  }
-
   /**
-   * Format a contact as an RFC-style address. We prefer
-   * `"Display Name" <addr@x>` when a display name is present so the
-   * SMTP send path gets a friendly From header; bare address if not.
+   * Format a contact + chosen email into an RFC-style address.
+   * Prefer `"Display Name" <addr@x>` when a display name is
+   * present so the SMTP send path gets a friendly From header;
+   * bare address if not.
    */
-  function formatAddress(c: Contact): string {
-    const addr = primaryEmail(c)
+  function formatAddress(c: Contact, addr: string): string {
     if (!addr) return ''
     if (c.display_name && c.display_name !== addr) {
-      // Escape embedded quotes; most names don't have them but be safe.
       const safe = c.display_name.replace(/"/g, '\\"')
       return `"${safe}" <${addr}>`
     }
     return addr
   }
 
-  function pickContact(c: Contact) {
+  function pickContact(c: Contact, email: string) {
     const { prefix } = currentToken(value)
-    const formatted = formatAddress(c)
+    const formatted = formatAddress(c, email)
     if (!formatted) return
     // Insert the selected address and a trailing `, ` so the user can
     // keep typing the next one without extra keystrokes.
@@ -211,7 +224,7 @@
   }
 
   function pick(s: Suggestion) {
-    if (s.kind === 'contact') pickContact(s.contact)
+    if (s.kind === 'contact') pickContact(s.contact, s.email.value)
     else pickList(s.list)
   }
 
@@ -296,7 +309,7 @@
              dark:border-surface-700 rounded-md shadow-lg"
       role="listbox"
     >
-      {#each suggestions as s, i (s.kind === 'contact' ? s.contact.id : s.list.id)}
+      {#each suggestions as s, i (s.kind === 'contact' ? `${s.contact.id}::${s.email.value}` : s.list.id)}
         <li
           role="option"
           aria-selected={i === activeIndex}
@@ -324,7 +337,8 @@
             <div class="flex-1 min-w-0">
               <p class="font-medium truncate">{c.display_name}</p>
               <p class="text-xs text-surface-500 truncate">
-                {primaryEmail(c)}
+                {#if s.email.kind}<span class="uppercase tracking-wide mr-1 text-[10px]">{s.email.kind}</span>{/if}
+                {s.email.value}
                 {#if c.organization}· {c.organization}{/if}
               </p>
             </div>

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -144,13 +144,28 @@
       }
       const draw = () => {
         try {
+          // Scale the canvas to a thumbnail-sized output rather
+          // than drawing at the source video's full resolution.
+          // A 4K clip would otherwise produce a 3840×2160 PNG
+          // encode per file — hundreds of ms each, serialised
+          // through the extractionChain, which is exactly what
+          // made the picker feel slow with video attachments.
+          // 192 px on the long edge fits the largest preview
+          // we render (NC picker) with room for high-DPI.
+          const MAX_DIM = 192
+          const sw = v.videoWidth || MAX_DIM
+          const sh = v.videoHeight || MAX_DIM
+          const scale = Math.min(1, MAX_DIM / Math.max(sw, sh))
           const canvas = document.createElement('canvas')
-          canvas.width = v.videoWidth || 192
-          canvas.height = v.videoHeight || 192
+          canvas.width = Math.max(1, Math.round(sw * scale))
+          canvas.height = Math.max(1, Math.round(sh * scale))
           const ctx = canvas.getContext('2d')
           if (!ctx) return finish(null)
           ctx.drawImage(v, 0, 0, canvas.width, canvas.height)
-          finish(canvas.toDataURL('image/png'))
+          // JPEG rather than PNG — ~10× smaller, a fraction of
+          // the encode cost, and we don't need transparency for
+          // a video frame.
+          finish(canvas.toDataURL('image/jpeg', 0.78))
         } catch {
           finish(null)
         }

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -1,13 +1,73 @@
-<script lang="ts">
-  // Square inline thumbnail for an attachment — renders a real
-  // image preview when the attachment is an image (bytes already
-  // in memory, so we can build a blob URL synchronously) and
-  // falls through to <FileTypeIcon> for everything else.
-  //
-  // Used by Compose's attachment chip strip and MailView's
-  // attachment chip strip (the latter passes lazily-fetched
-  // bytes via `bytesProvider`).
+<script lang="ts" module>
+  // Cache: video bytes → first-frame data URL.  Keyed by the
+  // bytes reference (Compose attaches reuse the same number[]
+  // across renders) plus an optional explicit string key for
+  // hosts that build fresh byte arrays each time (MailView).
+  // Decoding once costs a transient GStreamer pipeline init
+  // on Linux WebKit; subsequent mounts of the same file render
+  // a plain <img> with no codec activity at all.
+  const FRAME_CACHE = new Map<unknown, string>()
+  // Serialise extractions so a folder full of videos doesn't
+  // spin up N pipelines simultaneously — Linux WebKit hits a
+  // visible stall when more than two or three pipelines are
+  // alive at once.
+  let extractionChain: Promise<void> = Promise.resolve()
 
+  function extractFirstFrame(blobUrl: string): Promise<string | null> {
+    return new Promise<string | null>((resolve) => {
+      const v = document.createElement('video')
+      v.muted = true
+      v.playsInline = true
+      v.preload = 'metadata'
+      v.src = blobUrl
+      let resolved = false
+      const finish = (val: string | null) => {
+        if (resolved) return
+        resolved = true
+        try {
+          v.removeAttribute('src')
+          v.load()
+        } catch {
+          /* swallow — element is being torn down anyway */
+        }
+        v.remove()
+        resolve(val)
+      }
+      const draw = () => {
+        try {
+          const canvas = document.createElement('canvas')
+          canvas.width = v.videoWidth || 192
+          canvas.height = v.videoHeight || 192
+          const ctx = canvas.getContext('2d')
+          if (!ctx) return finish(null)
+          ctx.drawImage(v, 0, 0, canvas.width, canvas.height)
+          finish(canvas.toDataURL('image/png'))
+        } catch {
+          finish(null)
+        }
+      }
+      v.addEventListener('loadeddata', () => {
+        try {
+          v.currentTime = Math.min(0.1, v.duration || 0.1)
+        } catch {
+          draw()
+        }
+      })
+      v.addEventListener('seeked', draw)
+      v.addEventListener('error', () => finish(null))
+      // Hard cap so a stuck decoder doesn't pin the chain.
+      setTimeout(() => finish(null), 8000)
+    })
+  }
+</script>
+
+<script lang="ts">
+  // Square inline thumbnail for an attachment.  Image: blob URL
+  // → <img> directly.  Video: first frame extracted to a data
+  // URL once, cached, rendered as <img> — no <video> elements
+  // in the live DOM, which keeps the GStreamer cost limited to
+  // the one-time extraction.  Everything else falls through to
+  // <FileTypeIcon>.
   import FileTypeIcon from './FileTypeIcon.svelte'
 
   interface Props {
@@ -23,6 +83,13 @@
     filename: string
     /** Tailwind sizing — default w-9 h-9. */
     class?: string
+    /** Stable key for the video first-frame cache.  When the
+     *  host always passes the same `bytes` reference (Compose),
+     *  omit it and the bytes ref doubles as the key.  When the
+     *  host produces fresh byte arrays each mount (MailView's
+     *  `bytesProvider`), pass an account/path-derived string so
+     *  re-mounts hit the cache instead of re-decoding. */
+    cacheKey?: string | null
   }
   let {
     bytes = null,
@@ -30,6 +97,7 @@
     contentType = '',
     filename,
     class: cls = 'w-9 h-9',
+    cacheKey = null,
   }: Props = $props()
 
   function ext(): string {
@@ -47,72 +115,90 @@
     return ['mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpg', 'mpeg', '3gp', 'wmv', 'flv'].includes(ext())
   }
 
-  let blobUrl = $state<string | null>(null)
+  /** Source for the rendered <img>.  For images: a blob URL.
+   *  For videos: a data URL produced by canvas first-frame
+   *  extraction (cached so subsequent mounts skip the decode). */
+  let imgUrl = $state<string | null>(null)
 
   function makeBlobUrl(b: Uint8Array | number[]): string {
-    // Use the actual content-type when we have one so the browser
-    // picks the right decoder; fall back to image/png for images
-    // and video/mp4 for videos when missing.
     let ct = contentType ?? ''
     if (!ct) ct = isVideo() ? 'video/mp4' : 'image/png'
     const u8 = b instanceof Uint8Array ? b : new Uint8Array(b)
     return URL.createObjectURL(new Blob([u8], { type: ct }))
   }
 
+  function frameKey(b: Uint8Array | number[]): unknown {
+    return cacheKey ?? b
+  }
+
+  async function loadFrame(b: Uint8Array | number[]): Promise<string | null> {
+    const key = frameKey(b)
+    const hit = FRAME_CACHE.get(key)
+    if (hit) return hit
+    const url = makeBlobUrl(b)
+    // Chain through the global queue so concurrent mounts don't
+    // each instantiate a GStreamer pipeline at the same time.
+    let frame: string | null = null
+    extractionChain = extractionChain.then(async () => {
+      frame = await extractFirstFrame(url)
+    })
+    await extractionChain
+    URL.revokeObjectURL(url)
+    if (frame) FRAME_CACHE.set(key, frame)
+    return frame
+  }
+
   $effect(() => {
     if (!isImage() && !isVideo()) {
-      blobUrl = null
+      imgUrl = null
       return
     }
     let cancelled = false
-    let createdUrl: string | null = null
+    let createdBlobUrl: string | null = null
+    const apply = async (b: Uint8Array | number[] | null | undefined) => {
+      if (!b || b.length === 0 || cancelled) return
+      if (isImage()) {
+        createdBlobUrl = makeBlobUrl(b)
+        imgUrl = createdBlobUrl
+      } else if (isVideo()) {
+        const frame = await loadFrame(b)
+        if (cancelled) return
+        imgUrl = frame
+      }
+    }
     if (bytes && bytes.length > 0) {
-      createdUrl = makeBlobUrl(bytes)
-      blobUrl = createdUrl
+      void apply(bytes)
     } else if (bytesProvider) {
       void (async () => {
         try {
           const b = await bytesProvider()
           if (cancelled) return
-          if (!b || b.length === 0) {
-            blobUrl = null
-            return
-          }
-          createdUrl = makeBlobUrl(b)
-          blobUrl = createdUrl
+          await apply(b)
         } catch (e) {
           console.warn('attachment thumb load failed', e)
         }
       })()
     } else {
-      blobUrl = null
+      imgUrl = null
     }
     return () => {
       cancelled = true
-      if (createdUrl) URL.revokeObjectURL(createdUrl)
+      if (createdBlobUrl) URL.revokeObjectURL(createdBlobUrl)
     }
   })
 </script>
 
-{#if blobUrl && isImage()}
+{#if imgUrl}
   <img
-    src={blobUrl}
+    src={imgUrl}
     alt=""
     loading="lazy"
     class="{cls} object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
   />
-{:else if blobUrl && isVideo()}
-  <!-- `preload="metadata"` + `muted` is enough for every modern
-       webview to render the first frame as a static thumbnail
-       without playback.  No controls so the chip stays visually
-       a thumbnail. -->
-  <video
-    src={blobUrl}
-    muted
-    preload="metadata"
-    playsinline
-    class="{cls} object-cover rounded shrink-0 bg-black"
-  ></video>
 {:else}
+  <!-- Fallback while a video frame is extracting (or for non-
+       previewable types).  Replaced live by an <img> once the
+       extraction chain resolves; cached extractions skip the
+       icon and render the image immediately. -->
   <FileTypeIcon contentType={contentType} filename={filename} class={cls} />
 {/if}

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -1,12 +1,28 @@
 <script lang="ts" module>
-  // Cache: video bytes → first-frame data URL.  Keyed by the
-  // bytes reference (Compose attaches reuse the same number[]
-  // across renders) plus an optional explicit string key for
-  // hosts that build fresh byte arrays each time (MailView).
-  // Decoding once costs a transient GStreamer pipeline init
-  // on Linux WebKit; subsequent mounts of the same file render
-  // a plain <img> with no codec activity at all.
-  const FRAME_CACHE = new Map<unknown, string>()
+  // Cache: video bytes → first-frame data URL.  Two backings so
+  // we can be honest about lifetimes:
+  //
+  // - WeakMap keyed by the bytes reference — used by hosts that
+  //   reuse the same array each render (Compose).  When the
+  //   Compose surface unmounts and drops the Attachment object,
+  //   the bytes array becomes unreferenced and GC reclaims its
+  //   cache entry too.  A "send" or "cancel" therefore frees
+  //   every cached poster for that draft automatically.
+  // - Map keyed by an explicit string id — used when the host
+  //   produces fresh byte arrays per mount (MailView fetches
+  //   bytes on demand).  Session-scoped so re-opening the same
+  //   mail later doesn't re-decode.
+  const FRAME_CACHE_REF = new WeakMap<object, string>()
+  const FRAME_CACHE_KEY = new Map<string, string>()
+  function cacheGet(key: unknown): string | undefined {
+    if (typeof key === 'string') return FRAME_CACHE_KEY.get(key)
+    if (key && typeof key === 'object') return FRAME_CACHE_REF.get(key as object)
+    return undefined
+  }
+  function cachePut(key: unknown, val: string): void {
+    if (typeof key === 'string') FRAME_CACHE_KEY.set(key, val)
+    else if (key && typeof key === 'object') FRAME_CACHE_REF.set(key as object, val)
+  }
   // Serialise extractions so a folder full of videos doesn't
   // spin up N pipelines simultaneously — Linux WebKit hits a
   // visible stall when more than two or three pipelines are
@@ -133,7 +149,7 @@
 
   async function loadFrame(b: Uint8Array | number[]): Promise<string | null> {
     const key = frameKey(b)
-    const hit = FRAME_CACHE.get(key)
+    const hit = cacheGet(key)
     if (hit) return hit
     const url = makeBlobUrl(b)
     // Chain through the global queue so concurrent mounts don't
@@ -144,7 +160,7 @@
     })
     await extractionChain
     URL.revokeObjectURL(url)
-    if (frame) FRAME_CACHE.set(key, frame)
+    if (frame) cachePut(key, frame)
     return frame
   }
 

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -23,6 +23,91 @@
     if (typeof key === 'string') FRAME_CACHE_KEY.set(key, val)
     else if (key && typeof key === 'object') FRAME_CACHE_REF.set(key as object, val)
   }
+
+  // Image blob URLs cached so re-mounts (e.g. opening the `/`
+  // picker repeatedly) reuse the same Blob URL instead of
+  // building a fresh one each time — building a Blob from a
+  // multi-MB number[] is an O(n) copy that adds up across a
+  // dropdown of attachments.
+  const IMAGE_BLOB_REF = new WeakMap<object, string>()
+  const IMAGE_BLOB_KEY = new Map<string, string>()
+  function imageBlobGet(key: unknown): string | undefined {
+    if (typeof key === 'string') return IMAGE_BLOB_KEY.get(key)
+    if (key && typeof key === 'object') return IMAGE_BLOB_REF.get(key as object)
+    return undefined
+  }
+  function imageBlobPut(key: unknown, val: string): void {
+    if (typeof key === 'string') IMAGE_BLOB_KEY.set(key, val)
+    else if (key && typeof key === 'object') IMAGE_BLOB_REF.set(key as object, val)
+  }
+
+  function isImageGuess(contentType: string | null | undefined, filename: string): boolean {
+    const ct = (contentType ?? '').toLowerCase()
+    if (ct.startsWith('image/')) return true
+    const dot = filename.lastIndexOf('.')
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif', 'svg'].includes(ext)
+  }
+  function isVideoGuess(contentType: string | null | undefined, filename: string): boolean {
+    const ct = (contentType ?? '').toLowerCase()
+    if (ct.startsWith('video/')) return true
+    const dot = filename.lastIndexOf('.')
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+    return ['mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpg', 'mpeg', '3gp', 'wmv', 'flv'].includes(ext)
+  }
+
+  /** Pre-warm the image blob URL + video first-frame caches for
+   *  an attachment off the critical path.  Compose calls this
+   *  the moment an attachment is added so the `/` picker, which
+   *  may open milliseconds later, sees fully-resolved thumbs
+   *  instead of icons that progressively swap in.
+   *
+   *  Runs through `requestIdleCallback` (with a setTimeout fallback)
+   *  so it never blocks the UI thread when a file is dropped. */
+  export function prewarm(opts: {
+    bytes: Uint8Array | number[]
+    contentType?: string | null
+    filename: string
+    cacheKey?: string | null
+  }): void {
+    const { bytes, contentType = null, filename, cacheKey = null } = opts
+    if (!bytes || bytes.length === 0) return
+    const key = cacheKey ?? bytes
+    const schedule = (cb: () => void) => {
+      const w = window as unknown as {
+        requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => void
+      }
+      if (typeof w.requestIdleCallback === 'function') {
+        w.requestIdleCallback(cb, { timeout: 200 })
+      } else {
+        setTimeout(cb, 0)
+      }
+    }
+    schedule(() => {
+      if (isImageGuess(contentType, filename)) {
+        if (!imageBlobGet(key)) {
+          let ct = contentType ?? ''
+          if (!ct) ct = 'image/png'
+          const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+          const url = URL.createObjectURL(new Blob([u8], { type: ct }))
+          imageBlobPut(key, url)
+        }
+      } else if (isVideoGuess(contentType, filename)) {
+        if (!cacheGet(key)) {
+          let ct = contentType ?? ''
+          if (!ct) ct = 'video/mp4'
+          const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+          const url = URL.createObjectURL(new Blob([u8], { type: ct }))
+          extractionChain = extractionChain
+            .then(async () => {
+              const frame = await extractFirstFrame(url)
+              if (frame) cachePut(key, frame)
+            })
+            .finally(() => URL.revokeObjectURL(url))
+        }
+      }
+    })
+  }
   // Serialise extractions so a folder full of videos doesn't
   // spin up N pipelines simultaneously — Linux WebKit hits a
   // visible stall when more than two or three pipelines are
@@ -170,12 +255,18 @@
       return
     }
     let cancelled = false
-    let createdBlobUrl: string | null = null
     const apply = async (b: Uint8Array | number[] | null | undefined) => {
       if (!b || b.length === 0 || cancelled) return
       if (isImage()) {
-        createdBlobUrl = makeBlobUrl(b)
-        imgUrl = createdBlobUrl
+        const key = cacheKey ?? b
+        const cached = imageBlobGet(key)
+        if (cached) {
+          imgUrl = cached
+          return
+        }
+        const url = makeBlobUrl(b)
+        imageBlobPut(key, url)
+        imgUrl = url
       } else if (isVideo()) {
         const frame = await loadFrame(b)
         if (cancelled) return
@@ -199,7 +290,11 @@
     }
     return () => {
       cancelled = true
-      if (createdBlobUrl) URL.revokeObjectURL(createdBlobUrl)
+      // Image blob URLs live in the cache and are reused across
+      // mounts; we don't revoke them here.  When the bytes ref
+      // becomes unreferenced (Compose unmounts and drops the
+      // Attachment), the WeakMap entry is GC'd, which makes the
+      // blob URL unreachable and the browser reclaims it.
     }
   })
 </script>

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -57,13 +57,17 @@
   }
 
   /** Pre-warm the image blob URL + video first-frame caches for
-   *  an attachment off the critical path.  Compose calls this
-   *  the moment an attachment is added so the `/` picker, which
-   *  may open milliseconds later, sees fully-resolved thumbs
-   *  instead of icons that progressively swap in.
+   *  an attachment.  Compose calls this the moment an attachment
+   *  is added so the editor's `/` picker, which may open
+   *  milliseconds later, sees fully-resolved thumbs without
+   *  having to mount any preview component.
    *
-   *  Runs through `requestIdleCallback` (with a setTimeout fallback)
-   *  so it never blocks the UI thread when a file is dropped. */
+   *  Image blob URLs are built synchronously (cheap O(n) array
+   *  copy) so they're guaranteed available the instant the
+   *  picker opens.  Video first-frame extraction is async (a
+   *  GStreamer pipeline cycle on Linux WebKit) and runs through
+   *  the global extractionChain so the picker may briefly show
+   *  the typed icon for a video that's still decoding. */
   export function prewarm(opts: {
     bytes: Uint8Array | number[]
     contentType?: string | null
@@ -73,40 +77,44 @@
     const { bytes, contentType = null, filename, cacheKey = null } = opts
     if (!bytes || bytes.length === 0) return
     const key = cacheKey ?? bytes
-    const schedule = (cb: () => void) => {
-      const w = window as unknown as {
-        requestIdleCallback?: (cb: () => void, opts?: { timeout?: number }) => void
-      }
-      if (typeof w.requestIdleCallback === 'function') {
-        w.requestIdleCallback(cb, { timeout: 200 })
-      } else {
-        setTimeout(cb, 0)
-      }
+    if (isImageGuess(contentType, filename)) {
+      if (imageBlobGet(key)) return
+      let ct = contentType ?? ''
+      if (!ct) ct = 'image/png'
+      const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+      const url = URL.createObjectURL(new Blob([u8], { type: ct }))
+      imageBlobPut(key, url)
+    } else if (isVideoGuess(contentType, filename)) {
+      if (cacheGet(key)) return
+      let ct = contentType ?? ''
+      if (!ct) ct = 'video/mp4'
+      const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+      const url = URL.createObjectURL(new Blob([u8], { type: ct }))
+      extractionChain = extractionChain
+        .then(async () => {
+          const frame = await extractFirstFrame(url)
+          if (frame) cachePut(key, frame)
+        })
+        .finally(() => URL.revokeObjectURL(url))
     }
-    schedule(() => {
-      if (isImageGuess(contentType, filename)) {
-        if (!imageBlobGet(key)) {
-          let ct = contentType ?? ''
-          if (!ct) ct = 'image/png'
-          const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
-          const url = URL.createObjectURL(new Blob([u8], { type: ct }))
-          imageBlobPut(key, url)
-        }
-      } else if (isVideoGuess(contentType, filename)) {
-        if (!cacheGet(key)) {
-          let ct = contentType ?? ''
-          if (!ct) ct = 'video/mp4'
-          const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
-          const url = URL.createObjectURL(new Blob([u8], { type: ct }))
-          extractionChain = extractionChain
-            .then(async () => {
-              const frame = await extractFirstFrame(url)
-              if (frame) cachePut(key, frame)
-            })
-            .finally(() => URL.revokeObjectURL(url))
-        }
-      }
-    })
+  }
+
+  /** Synchronous read of whatever's currently cached for a
+   *  given attachment.  Used by hosts that want to render the
+   *  thumb inline without paying the cost of mounting an
+   *  AttachmentThumb component (the editor's `/` picker
+   *  dropdown).  Returns the blob/data URL, or null if not
+   *  cached yet — caller falls back to a typed icon. */
+  export function thumbUrlSync(opts: {
+    bytes?: Uint8Array | number[] | null
+    contentType?: string | null
+    filename: string
+    cacheKey?: string | null
+  }): string | null {
+    const { bytes = null, cacheKey = null } = opts
+    const key = cacheKey ?? bytes ?? null
+    if (key === null) return null
+    return imageBlobGet(key) ?? cacheGet(key) ?? null
   }
   // Serialise extractions so a folder full of videos doesn't
   // spin up N pipelines simultaneously — Linux WebKit hits a

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -32,24 +32,35 @@
     class: cls = 'w-9 h-9',
   }: Props = $props()
 
+  function ext(): string {
+    const dot = filename.lastIndexOf('.')
+    return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+  }
   function isImage(): boolean {
     const ct = (contentType ?? '').toLowerCase()
     if (ct.startsWith('image/')) return true
-    const dot = filename.lastIndexOf('.')
-    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
-    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif', 'svg'].includes(ext)
+    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif', 'svg'].includes(ext())
+  }
+  function isVideo(): boolean {
+    const ct = (contentType ?? '').toLowerCase()
+    if (ct.startsWith('video/')) return true
+    return ['mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpg', 'mpeg', '3gp', 'wmv', 'flv'].includes(ext())
   }
 
   let blobUrl = $state<string | null>(null)
 
   function makeBlobUrl(b: Uint8Array | number[]): string {
-    const ct = contentType && contentType.startsWith('image/') ? contentType : 'image/png'
+    // Use the actual content-type when we have one so the browser
+    // picks the right decoder; fall back to image/png for images
+    // and video/mp4 for videos when missing.
+    let ct = contentType ?? ''
+    if (!ct) ct = isVideo() ? 'video/mp4' : 'image/png'
     const u8 = b instanceof Uint8Array ? b : new Uint8Array(b)
     return URL.createObjectURL(new Blob([u8], { type: ct }))
   }
 
   $effect(() => {
-    if (!isImage()) {
+    if (!isImage() && !isVideo()) {
       blobUrl = null
       return
     }
@@ -83,13 +94,25 @@
   })
 </script>
 
-{#if blobUrl}
+{#if blobUrl && isImage()}
   <img
     src={blobUrl}
     alt=""
     loading="lazy"
     class="{cls} object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
   />
+{:else if blobUrl && isVideo()}
+  <!-- `preload="metadata"` + `muted` is enough for every modern
+       webview to render the first frame as a static thumbnail
+       without playback.  No controls so the chip stays visually
+       a thumbnail. -->
+  <video
+    src={blobUrl}
+    muted
+    preload="metadata"
+    playsinline
+    class="{cls} object-cover rounded shrink-0 bg-black"
+  ></video>
 {:else}
   <FileTypeIcon contentType={contentType} filename={filename} class={cls} />
 {/if}

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  // Square inline thumbnail for an attachment — renders a real
+  // image preview when the attachment is an image (bytes already
+  // in memory, so we can build a blob URL synchronously) and
+  // falls through to <FileTypeIcon> for everything else.
+  //
+  // Used by Compose's attachment chip strip and MailView's
+  // attachment chip strip (the latter passes lazily-fetched
+  // bytes via `bytesProvider`).
+
+  import FileTypeIcon from './FileTypeIcon.svelte'
+
+  interface Props {
+    /** Bytes the host already has in memory (Compose path).
+     *  Mutually exclusive with `bytesProvider`. */
+    bytes?: Uint8Array | number[] | null
+    /** Async loader for cases where bytes aren't in memory yet
+     *  (MailView lazy-fetches via download_email_attachment).
+     *  Resolves to the raw bytes, or `null` to fall back to the
+     *  typed icon. */
+    bytesProvider?: () => Promise<Uint8Array | number[] | null>
+    contentType?: string | null
+    filename: string
+    /** Tailwind sizing — default w-9 h-9. */
+    class?: string
+  }
+  let {
+    bytes = null,
+    bytesProvider,
+    contentType = '',
+    filename,
+    class: cls = 'w-9 h-9',
+  }: Props = $props()
+
+  function isImage(): boolean {
+    const ct = (contentType ?? '').toLowerCase()
+    if (ct.startsWith('image/')) return true
+    const dot = filename.lastIndexOf('.')
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif', 'svg'].includes(ext)
+  }
+
+  let blobUrl = $state<string | null>(null)
+
+  function makeBlobUrl(b: Uint8Array | number[]): string {
+    const ct = contentType && contentType.startsWith('image/') ? contentType : 'image/png'
+    const u8 = b instanceof Uint8Array ? b : new Uint8Array(b)
+    return URL.createObjectURL(new Blob([u8], { type: ct }))
+  }
+
+  $effect(() => {
+    if (!isImage()) {
+      blobUrl = null
+      return
+    }
+    let cancelled = false
+    let createdUrl: string | null = null
+    if (bytes && bytes.length > 0) {
+      createdUrl = makeBlobUrl(bytes)
+      blobUrl = createdUrl
+    } else if (bytesProvider) {
+      void (async () => {
+        try {
+          const b = await bytesProvider()
+          if (cancelled) return
+          if (!b || b.length === 0) {
+            blobUrl = null
+            return
+          }
+          createdUrl = makeBlobUrl(b)
+          blobUrl = createdUrl
+        } catch (e) {
+          console.warn('attachment thumb load failed', e)
+        }
+      })()
+    } else {
+      blobUrl = null
+    }
+    return () => {
+      cancelled = true
+      if (createdUrl) URL.revokeObjectURL(createdUrl)
+    }
+  })
+</script>
+
+{#if blobUrl}
+  <img
+    src={blobUrl}
+    alt=""
+    loading="lazy"
+    class="{cls} object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
+  />
+{:else}
+  <FileTypeIcon contentType={contentType} filename={filename} class={cls} />
+{/if}

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -25,6 +25,7 @@
   } from './RichTextEditor.svelte'
   import AddressAutocomplete from './AddressAutocomplete.svelte'
   import NextcloudFilePicker, { type ShareLink } from './NextcloudFilePicker.svelte'
+  import FileTypeIcon from './FileTypeIcon.svelte'
   import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
   import { openComposeInStandaloneWindow } from './standaloneComposeWindow'
 
@@ -215,7 +216,7 @@
     {
       id: 'attach',
       label: 'Attach',
-      icon: '🖇️',
+      icon: '📎',
       content: attachTabContent,
     },
     {
@@ -1290,7 +1291,8 @@
         <div class="flex flex-wrap gap-2">
           {#each attachments as att, i (i)}
             <span class="inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface-200 dark:bg-surface-800 text-xs">
-              <span>🖇️ {att.filename}</span>
+              <FileTypeIcon contentType={att.content_type ?? null} filename={att.filename} class="w-4 h-4" />
+              <span>{att.filename}</span>
               <button class="text-surface-500 hover:text-red-500" onclick={() => removeAttachment(i)} aria-label="Remove">✕</button>
             </span>
           {/each}
@@ -1319,7 +1321,7 @@
      reads as visually indistinguishable from a built-in. -->
 {#snippet attachTabContent()}
   <label class="rt-btn cursor-pointer" title="Attach a file from your computer">
-    <span class="rt-btn-icon">🖇️</span>
+    <span class="rt-btn-icon">📎</span>
     <span class="rt-btn-label">Attach</span>
     <input type="file" multiple class="hidden" onchange={onPickFiles} />
   </label>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1286,6 +1286,7 @@
               content_id: a.content_id,
               filename: a.filename,
               content_type: a.content_type,
+              data: a.data,
             }))}
           actionsTrailing={sendActions}
           extraTabs={composeExtraTabs}

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -26,7 +26,7 @@
   import AddressAutocomplete from './AddressAutocomplete.svelte'
   import NextcloudFilePicker, { type ShareLink } from './NextcloudFilePicker.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
-  import AttachmentThumb from './AttachmentThumb.svelte'
+  import AttachmentThumb, { prewarm as prewarmAttachmentThumb } from './AttachmentThumb.svelte'
   import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
   import { openComposeInStandaloneWindow } from './standaloneComposeWindow'
 
@@ -188,6 +188,19 @@
   let body = $state(initial?.body ?? '')
   // svelte-ignore state_referenced_locally
   let attachments = $state<Attachment[]>(initial?.attachments ?? [])
+  // Pre-warm thumb caches for any attachments seeded by the
+  // host (FilesView's "New mail with attachment", reply-with-
+  // attachment paths) so the `/` picker is instant on its
+  // first open.
+  $effect(() => {
+    for (const a of initial?.attachments ?? []) {
+      prewarmAttachmentThumb({
+        bytes: a.data,
+        contentType: a.content_type,
+        filename: a.filename,
+      })
+    }
+  })
 
 
   /** Human-readable label attached to every Nextcloud share minted
@@ -906,6 +919,16 @@
       })
     }
     attachments = [...attachments, ...picked]
+    // Pre-warm the thumbnail cache off the critical path so the
+    // editor's `/` picker opens to fully-rendered tiles instead
+    // of icons that progressively swap in.
+    for (const a of picked) {
+      prewarmAttachmentThumb({
+        bytes: a.data,
+        contentType: a.content_type,
+        filename: a.filename,
+      })
+    }
     input.value = ''
   }
 
@@ -1408,6 +1431,13 @@
       // Compose is the earliest point where we can assign one.
       const stamped = picked.map((a) => ({ ...a, content_id: makeContentId() }))
       attachments = [...attachments, ...stamped]
+      for (const a of stamped) {
+        prewarmAttachmentThumb({
+          bytes: a.data,
+          contentType: a.content_type,
+          filename: a.filename,
+        })
+      }
     }}
     onlinks={(links) => {
       // Track every share that's been minted from this Compose so a

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -215,7 +215,7 @@
     {
       id: 'attach',
       label: 'Attach',
-      icon: '📎',
+      icon: '🖇️',
       content: attachTabContent,
     },
     {
@@ -300,7 +300,7 @@
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
       const items = initial.nextcloudLinks
-        .map((l) => `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`)
+        .map((l) => `<p>🖇️ <a href="${l.url}">${esc(l.filename)}</a></p>`)
         .join('')
       html += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
     }
@@ -1290,7 +1290,7 @@
         <div class="flex flex-wrap gap-2">
           {#each attachments as att, i (i)}
             <span class="inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface-200 dark:bg-surface-800 text-xs">
-              <span>📎 {att.filename}</span>
+              <span>🖇️ {att.filename}</span>
               <button class="text-surface-500 hover:text-red-500" onclick={() => removeAttachment(i)} aria-label="Remove">✕</button>
             </span>
           {/each}
@@ -1319,7 +1319,7 @@
      reads as visually indistinguishable from a built-in. -->
 {#snippet attachTabContent()}
   <label class="rt-btn cursor-pointer" title="Attach a file from your computer">
-    <span class="rt-btn-icon">📎</span>
+    <span class="rt-btn-icon">🖇️</span>
     <span class="rt-btn-label">Attach</span>
     <input type="file" multiple class="hidden" onchange={onPickFiles} />
   </label>
@@ -1410,7 +1410,7 @@
       const items = links
         .map(
           (l) =>
-            `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`,
+            `<p>🖇️ <a href="${l.url}">${esc(l.filename)}</a></p>`,
         )
         .join('')
       const block = `<p><strong>Shared via Nextcloud:</strong></p>${items}`

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -26,6 +26,7 @@
   import AddressAutocomplete from './AddressAutocomplete.svelte'
   import NextcloudFilePicker, { type ShareLink } from './NextcloudFilePicker.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
+  import AttachmentThumb from './AttachmentThumb.svelte'
   import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
   import { openComposeInStandaloneWindow } from './standaloneComposeWindow'
 
@@ -1281,7 +1282,11 @@
           oncontactpicked={onContactPicked}
           attachmentsForRef={attachments
             .filter((a): a is Attachment & { content_id: string } => !!a.content_id)
-            .map((a) => ({ content_id: a.content_id, filename: a.filename }))}
+            .map((a) => ({
+              content_id: a.content_id,
+              filename: a.filename,
+              content_type: a.content_type,
+            }))}
           actionsTrailing={sendActions}
           extraTabs={composeExtraTabs}
         />
@@ -1291,7 +1296,12 @@
         <div class="flex flex-wrap gap-2">
           {#each attachments as att, i (i)}
             <span class="inline-flex items-center gap-2 px-2 py-1 rounded-md bg-surface-200 dark:bg-surface-800 text-xs">
-              <FileTypeIcon contentType={att.content_type ?? null} filename={att.filename} class="w-4 h-4" />
+              <AttachmentThumb
+                bytes={att.data}
+                contentType={att.content_type}
+                filename={att.filename}
+                class="w-7 h-7"
+              />
               <span>{att.filename}</span>
               <button class="text-surface-500 hover:text-red-500" onclick={() => removeAttachment(i)} aria-label="Remove">✕</button>
             </span>

--- a/ui/src/lib/EmailKindChip.svelte
+++ b/ui/src/lib/EmailKindChip.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  // Small coloured chip for vCard email-kind labels (HOME / WORK
+  // / CELL / OTHER / …) shown next to an address in autocomplete
+  // dropdowns.  Colours are Skeleton theme tokens, so the chip
+  // re-tints automatically when the user switches themes.
+  //
+  // Visual: rounded-full pill, 10px uppercase semibold text,
+  // subtle alpha background with matching foreground colour.
+  // Same shape we use for source pills on the Mailing Lists tab
+  // so the chip language reads consistently across the app.
+
+  interface Props {
+    /** vCard kind string — `HOME`, `WORK`, `CELL`, `OTHER`,
+     *  `INTERNET`, etc.  Case-insensitive. */
+    kind?: string | null
+    /** Optional extra classes (margins / inline-block flags). */
+    class?: string
+  }
+  let { kind = '', class: cls = '' }: Props = $props()
+
+  const meta = $derived.by(() => {
+    const k = (kind ?? '').toLowerCase()
+    if (!k) return null
+    if (k.includes('work'))
+      return {
+        label: 'Work',
+        classes: 'bg-primary-500/15 text-primary-700 dark:text-primary-300',
+      }
+    if (k.includes('home'))
+      return {
+        label: 'Home',
+        classes: 'bg-success-500/15 text-success-700 dark:text-success-300',
+      }
+    if (k.includes('cell') || k.includes('mobile'))
+      return {
+        label: 'Mobile',
+        classes: 'bg-secondary-500/15 text-secondary-700 dark:text-secondary-300',
+      }
+    if (k.includes('fax'))
+      return {
+        label: 'Fax',
+        classes: 'bg-warning-500/15 text-warning-700 dark:text-warning-300',
+      }
+    if (k.includes('internet'))
+      return {
+        label: 'Internet',
+        classes: 'bg-tertiary-500/15 text-tertiary-700 dark:text-tertiary-300',
+      }
+    return {
+      label: kind ?? 'Other',
+      classes:
+        'bg-surface-300/40 dark:bg-surface-700/40 text-surface-700 dark:text-surface-300',
+    }
+  })
+</script>
+
+{#if meta}
+  <span
+    class="inline-block px-2 py-[1px] rounded-full text-[10px] font-semibold uppercase tracking-wide leading-tight align-middle {meta.classes} {cls}"
+  >{meta.label}</span>
+{/if}

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -37,6 +37,7 @@
   import DateField from './DateField.svelte'
   import TimeField from './TimeField.svelte'
   import Select from './Select.svelte'
+  import EmailKindChip from './EmailKindChip.svelte'
 
   // ── Types (kept local; these mirror the Rust models) ──────────
   interface EventAttendee {
@@ -1526,10 +1527,10 @@
                     {/if}
                     <div class="flex-1 min-w-0">
                       <p class="font-medium truncate">{c.display_name}</p>
-                      <p class="text-xs text-surface-500 truncate">
-                        {#if s.email.kind}<span class="uppercase tracking-wide mr-1 text-[10px]">{s.email.kind}</span>{/if}
-                        {s.email.value}
-                        {#if c.organization}· {c.organization}{/if}
+                      <p class="text-xs text-surface-500 truncate flex items-center gap-1.5">
+                        <EmailKindChip kind={s.email.kind} />
+                        <span class="truncate">{s.email.value}</span>
+                        {#if c.organization}<span class="shrink-0">· {c.organization}</span>{/if}
                       </p>
                     </div>
                   {:else}

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -499,7 +499,7 @@
     emoji: string | null
   }
   type Suggestion =
-    | { kind: 'contact'; contact: Contact }
+    | { kind: 'contact'; contact: Contact; email: ContactEmail }
     | { kind: 'list'; list: MailingListSuggestion }
   let activeSuggestionRole = $state<Role | null>(null)
   let dropdownSuggestions = $state<Suggestion[]>([])
@@ -538,9 +538,20 @@
         const listHits = allLists
           .filter((m) => m.name.toLowerCase().includes(ql))
           .slice(0, SUGGESTION_LIMIT)
+        // Expand each contact into one suggestion per email so
+        // multi-address contacts (Home + Work) surface every
+        // address in the dropdown.
+        const contactSuggestions: Suggestion[] = []
+        for (const c of rows) {
+          const emails = c.email.filter((e) => e.value.length > 0)
+          if (emails.length === 0) continue
+          for (const e of emails) {
+            contactSuggestions.push({ kind: 'contact', contact: c, email: e })
+          }
+        }
         const merged: Suggestion[] = [
           ...listHits.map((m) => ({ kind: 'list' as const, list: m })),
-          ...rows.map((c) => ({ kind: 'contact' as const, contact: c })),
+          ...contactSuggestions,
         ]
         dropdownSuggestions = merged.slice(0, SUGGESTION_LIMIT)
         activeIndex = 0
@@ -576,7 +587,7 @@
   function pickSuggestion(role: Role, s: Suggestion) {
     if (s.kind === 'contact') {
       const c = s.contact
-      const addr = primaryEmail(c)
+      const addr = s.email.value
       clearSuggestionInput(role)
       if (!addr) return
       const exists = [...requiredAttendees, ...optionalAttendees, ...chairAttendees].some(
@@ -1485,7 +1496,7 @@
               class="absolute left-0 right-0 top-full mt-1 z-50 max-h-72 overflow-y-auto bg-surface-50 dark:bg-surface-900 border border-surface-300 dark:border-surface-700 rounded-md shadow-lg"
               role="listbox"
             >
-              {#each dropdownSuggestions as s, i (s.kind === 'contact' ? s.contact.id : s.list.id)}
+              {#each dropdownSuggestions as s, i (s.kind === 'contact' ? `${s.contact.id}::${s.email.value}` : s.list.id)}
                 <li
                   role="option"
                   aria-selected={i === activeIndex}
@@ -1516,7 +1527,8 @@
                     <div class="flex-1 min-w-0">
                       <p class="font-medium truncate">{c.display_name}</p>
                       <p class="text-xs text-surface-500 truncate">
-                        {primaryEmail(c)}
+                        {#if s.email.kind}<span class="uppercase tracking-wide mr-1 text-[10px]">{s.email.kind}</span>{/if}
+                        {s.email.value}
                         {#if c.organization}· {c.organization}{/if}
                       </p>
                     </div>

--- a/ui/src/lib/FileTypeIcon.svelte
+++ b/ui/src/lib/FileTypeIcon.svelte
@@ -89,6 +89,24 @@
       const label = ext === 'jpeg' ? 'JPG' : ext.toUpperCase()
       return { label: label.slice(0, 4), colorClass: 'text-cyan-500' }
     }
+    // Video — pink to stand apart from the doc/archive palette.
+    if (ct.startsWith('video/')) {
+      const sub = ct.slice('video/'.length).split(';')[0].trim()
+      const label = (sub || 'VID').toUpperCase().slice(0, 4)
+      return { label, colorClass: 'text-pink-500' }
+    }
+    if (['mp4', 'mkv', 'mov', 'avi', 'wmv', 'flv', 'webm', 'm4v', 'mpg', 'mpeg', '3gp'].includes(ext)) {
+      return { label: ext.toUpperCase().slice(0, 4), colorClass: 'text-pink-500' }
+    }
+    // Audio — purple, distinct from the cyan/sky/pink trio.
+    if (ct.startsWith('audio/')) {
+      const sub = ct.slice('audio/'.length).split(';')[0].trim()
+      const label = (sub || 'AUD').toUpperCase().slice(0, 4)
+      return { label, colorClass: 'text-purple-500' }
+    }
+    if (['mp3', 'flac', 'wav', 'ogg', 'm4a', 'aac', 'opus', 'wma', 'aiff', 'alac'].includes(ext)) {
+      return { label: ext.toUpperCase().slice(0, 4), colorClass: 'text-purple-500' }
+    }
     return null
   }
 

--- a/ui/src/lib/FileTypeIcon.svelte
+++ b/ui/src/lib/FileTypeIcon.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  // Inline-SVG file-type icons (#93 follow-up).  Replaces the
+  // generic emoji `attachmentIcon()` for document/office/archive
+  // types with a recognisable per-format glyph: a Tabler-style
+  // file outline (corner fold) with a small text label inside —
+  // PDF, DOC, XLS, PPT, CSV, ZIP — tinted in a colour the user
+  // already associates with that format (red for PDF, blue for
+  // Word, green for Excel, orange for PowerPoint, violet for ZIP).
+  //
+  // Why inline SVG instead of a Tabler/Phosphor npm package:
+  // - Zero dep churn, no build-tool surprises.
+  // - Tree-shaking is automatic — only the icons we actually
+  //   render ship.
+  // - Matches the existing pattern in CalendarView's pin SVG.
+  //
+  // Media types (image / video / audio) keep their emoji glyphs;
+  // they're visually distinct enough that a colour-coded label
+  // doesn't add anything.
+
+  interface Props {
+    contentType?: string | null
+    filename?: string
+    /** Tailwind sizing classes; defaults to `w-4 h-4` for the
+     *  16px attachment chip but the Files browser uses `w-5 h-5`. */
+    class?: string
+  }
+  let { contentType = '', filename = '', class: cls = 'w-4 h-4' }: Props = $props()
+
+  type Kind = {
+    /** Three-letter label rendered inside the file outline. */
+    label: string
+    /** Tailwind colour class — applied to stroke + fill via
+     *  `currentColor`, so the SVG inherits it. */
+    colorClass: string
+  }
+
+  function detectKind(): Kind | null {
+    const ct = (contentType ?? '').toLowerCase()
+    const dot = filename.lastIndexOf('.')
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+    if (ct.includes('pdf') || ext === 'pdf')
+      return { label: 'PDF', colorClass: 'text-rose-500' }
+    if (
+      ct.includes('msword') ||
+      ct.includes('officedocument.wordprocessing') ||
+      ct.includes('opendocument.text') ||
+      ext === 'doc' ||
+      ext === 'docx' ||
+      ext === 'odt' ||
+      ext === 'rtf'
+    )
+      return { label: 'DOC', colorClass: 'text-blue-500' }
+    if (ct.includes('csv') || ext === 'csv')
+      return { label: 'CSV', colorClass: 'text-emerald-500' }
+    if (
+      ct.includes('ms-excel') ||
+      ct.includes('officedocument.spreadsheet') ||
+      ct.includes('opendocument.spreadsheet') ||
+      ext === 'xls' ||
+      ext === 'xlsx' ||
+      ext === 'ods'
+    )
+      return { label: 'XLS', colorClass: 'text-emerald-600' }
+    if (
+      ct.includes('ms-powerpoint') ||
+      ct.includes('officedocument.presentation') ||
+      ct.includes('opendocument.presentation') ||
+      ext === 'ppt' ||
+      ext === 'pptx' ||
+      ext === 'odp'
+    )
+      return { label: 'PPT', colorClass: 'text-amber-500' }
+    if (
+      ct.includes('zip') ||
+      ct.includes('compressed') ||
+      ext === 'zip' ||
+      ext === '7z' ||
+      ext === 'rar' ||
+      ext === 'tar' ||
+      ext === 'gz' ||
+      ext === 'xz'
+    )
+      return { label: 'ZIP', colorClass: 'text-violet-500' }
+    return null
+  }
+
+  const kind = $derived(detectKind())
+</script>
+
+{#if kind}
+  <!-- Tabler-style file outline (corner fold) + a tiny per-type
+       label centred near the bottom. -->
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="{cls} {kind.colorClass} shrink-0"
+    aria-label={kind.label}
+  >
+    <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+    <path d="M17 21H7a2 2 0 0 1 -2 -2V5a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+    <text
+      x="12"
+      y="17.5"
+      text-anchor="middle"
+      font-size="6.5"
+      font-weight="700"
+      stroke="none"
+      fill="currentColor"
+      font-family="ui-sans-serif, system-ui, sans-serif"
+    >{kind.label}</text>
+  </svg>
+{:else}
+  <!-- Generic file outline.  Surface-toned so it doesn't compete
+       with the typed icons; callers that prefer an emoji for
+       images / video / audio can branch before mounting this
+       component. -->
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    class="{cls} text-surface-500 shrink-0"
+    aria-hidden="true"
+  >
+    <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+    <path d="M17 21H7a2 2 0 0 1 -2 -2V5a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+  </svg>
+{/if}

--- a/ui/src/lib/FileTypeIcon.svelte
+++ b/ui/src/lib/FileTypeIcon.svelte
@@ -44,43 +44,51 @@
       ct.includes('msword') ||
       ct.includes('officedocument.wordprocessing') ||
       ct.includes('opendocument.text') ||
-      ext === 'doc' ||
-      ext === 'docx' ||
-      ext === 'odt' ||
-      ext === 'rtf'
+      ['doc', 'docx', 'docm', 'dot', 'dotx', 'dotm', 'odt', 'ott', 'rtf'].includes(ext)
     )
       return { label: 'DOC', colorClass: 'text-blue-500' }
-    if (ct.includes('csv') || ext === 'csv')
+    if (ct.includes('csv') || ['csv', 'tsv'].includes(ext))
       return { label: 'CSV', colorClass: 'text-emerald-500' }
     if (
       ct.includes('ms-excel') ||
       ct.includes('officedocument.spreadsheet') ||
       ct.includes('opendocument.spreadsheet') ||
-      ext === 'xls' ||
-      ext === 'xlsx' ||
-      ext === 'ods'
+      ['xls', 'xlsx', 'xlsm', 'xlt', 'xltx', 'xltm', 'ods', 'ots'].includes(ext)
     )
       return { label: 'XLS', colorClass: 'text-emerald-600' }
     if (
       ct.includes('ms-powerpoint') ||
       ct.includes('officedocument.presentation') ||
       ct.includes('opendocument.presentation') ||
-      ext === 'ppt' ||
-      ext === 'pptx' ||
-      ext === 'odp'
+      ['ppt', 'pptx', 'pptm', 'pot', 'potx', 'potm', 'odp', 'otp'].includes(ext)
     )
       return { label: 'PPT', colorClass: 'text-amber-500' }
     if (
       ct.includes('zip') ||
       ct.includes('compressed') ||
-      ext === 'zip' ||
-      ext === '7z' ||
-      ext === 'rar' ||
-      ext === 'tar' ||
-      ext === 'gz' ||
-      ext === 'xz'
+      ['zip', '7z', 'rar', 'tar', 'gz', 'xz', 'bz2', 'tgz'].includes(ext)
     )
       return { label: 'ZIP', colorClass: 'text-violet-500' }
+    // Markdown — render as `MD` in a distinct sky tone so a
+    // README in an attachment list jumps out from the surrounding
+    // plain-text files.
+    if (ct.includes('markdown') || ['md', 'markdown', 'mdx', 'mkd'].includes(ext))
+      return { label: 'MD', colorClass: 'text-sky-500' }
+    // Images — show the format code (PNG / JPG / GIF / SVG / etc.)
+    // rather than a generic photo glyph, so a thumbnail strip
+    // tells you at a glance which format each row is.
+    if (ct.startsWith('image/')) {
+      const sub = ct.slice('image/'.length).split(';')[0].trim()
+      const fromCt = sub === 'jpeg' ? 'JPG' : sub === 'svg+xml' ? 'SVG' : sub.toUpperCase()
+      const label = (fromCt || 'IMG').slice(0, 4)
+      return { label, colorClass: 'text-cyan-500' }
+    }
+    if (
+      ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'svg', 'heic', 'heif', 'ico'].includes(ext)
+    ) {
+      const label = ext === 'jpeg' ? 'JPG' : ext.toUpperCase()
+      return { label: label.slice(0, 4), colorClass: 'text-cyan-500' }
+    }
     return null
   }
 

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -223,7 +223,7 @@
             ? 'Folders can be shared as a link, but not attached as bytes'
             : 'Open a new mail with the selected files attached'}
         >
-          {attaching ? 'Downloading…' : '📎 New mail with attachment'}
+          {attaching ? 'Downloading…' : '🖇️ New mail with attachment'}
         </button>
       </footer>
     {/if}

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -223,7 +223,7 @@
             ? 'Folders can be shared as a link, but not attached as bytes'
             : 'Open a new mail with the selected files attached'}
         >
-          {attaching ? 'Downloading…' : '🖇️ New mail with attachment'}
+          {attaching ? 'Downloading…' : '📎 New mail with attachment'}
         </button>
       </footer>
     {/if}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1201,6 +1201,7 @@
                 <AttachmentThumb
                   contentType={att.content_type}
                   filename={att.filename}
+                  cacheKey={`${email!.account_id}::${email!.folder}::${uid}::${att.part_id}`}
                   bytesProvider={tooLarge
                     ? undefined
                     : () =>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -797,8 +797,6 @@
   function attachmentEmoji(att: EmailAttachment): string | null {
     const ct = att.content_type || ''
     const fn = att.filename.toLowerCase()
-    if (ct.startsWith('video/')) return '🎞️'
-    if (ct.startsWith('audio/')) return '🎵'
     // Plain text files that aren't markdown still get the memo
     // emoji — a CHANGELOG.txt looks more "note" than "code".
     if (ct.startsWith('text/') && !ct.includes('markdown') && !fn.endsWith('.md') && !fn.endsWith('.markdown'))

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -99,6 +99,10 @@
         button (no point inside the window it would open) and
         otherwise behaves identically. */
     inStandaloneWindow?: boolean
+    /** Open compose pre-filled with a recipient (and optional
+        cc/bcc/subject/body) — used when the user clicks a
+        `mailto:` link inside a rendered email. */
+    onmailto?: (init: { to?: string; cc?: string; bcc?: string; subject?: string; body?: string }) => void
   }
   let {
     accountId,
@@ -116,6 +120,7 @@
     onmessageremoved,
     inStandaloneWindow = false,
     forceWhiteBackground = true,
+    onmailto,
   }: Props = $props()
 
   let email = $state<Email | null>(null)
@@ -498,10 +503,71 @@
     }
 
     const href = anchor.getAttribute('href') ?? ''
-    if (href && href !== '#' && !href.startsWith('javascript:')) {
+    if (!href || href === '#' || href.startsWith('javascript:')) return
+    // mailto: → open Compose pre-filled rather than handing the
+    // URL to the OS (which would launch the default mail handler,
+    // unhelpful when Nimbus *is* the user's mail client).  RFC 6068
+    // allows `mailto:to?subject=...&cc=...&bcc=...&body=...`, with
+    // multiple addresses comma-separated and percent-encoded.
+    if (href.toLowerCase().startsWith('mailto:')) {
       e.preventDefault()
-      void invoke('open_url', { url: href })
+      e.stopPropagation()
+      const init = parseMailtoUrl(href)
+      onmailto?.(init)
+      return
     }
+    e.preventDefault()
+    void invoke('open_url', { url: href })
+  }
+
+  /** Parse a `mailto:` URL into ComposeInitial-shaped fields per
+   *  RFC 6068.  Tolerant: missing pieces just stay undefined so
+   *  the caller's defaults take over. */
+  function parseMailtoUrl(raw: string): {
+    to?: string
+    cc?: string
+    bcc?: string
+    subject?: string
+    body?: string
+  } {
+    const stripped = raw.replace(/^mailto:/i, '')
+    const qIdx = stripped.indexOf('?')
+    const recipientsPart = qIdx === -1 ? stripped : stripped.slice(0, qIdx)
+    const queryPart = qIdx === -1 ? '' : stripped.slice(qIdx + 1)
+    const decode = (s: string) => {
+      try {
+        return decodeURIComponent(s.replace(/\+/g, '%20'))
+      } catch {
+        return s
+      }
+    }
+    const out: { to?: string; cc?: string; bcc?: string; subject?: string; body?: string } = {}
+    if (recipientsPart) out.to = decode(recipientsPart)
+    if (!queryPart) return out
+    for (const pair of queryPart.split('&')) {
+      if (!pair) continue
+      const eq = pair.indexOf('=')
+      const key = (eq === -1 ? pair : pair.slice(0, eq)).toLowerCase()
+      const val = eq === -1 ? '' : decode(pair.slice(eq + 1))
+      switch (key) {
+        case 'to':
+          out.to = out.to ? `${out.to}, ${val}` : val
+          break
+        case 'cc':
+          out.cc = out.cc ? `${out.cc}, ${val}` : val
+          break
+        case 'bcc':
+          out.bcc = out.bcc ? `${out.bcc}, ${val}` : val
+          break
+        case 'subject':
+          out.subject = val
+          break
+        case 'body':
+          out.body = val
+          break
+      }
+    }
+    return out
   }
 
   /** MIME types Nextcloud Office (Collabora) opens in-browser via

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1181,8 +1181,8 @@
             {@const isOffice = isOfficeAttachment(att)}
             {@const isPdf = isPdfAttachment(att)}
             {@const menuOpen = openMenuFor === att.part_id}
+            {@const emoji = attachmentEmoji(att)}
             <li class="relative flex items-center gap-2 pl-3 pr-1 py-1.5 rounded-md bg-surface-100 dark:bg-surface-800 text-sm">
-              {@const emoji = attachmentEmoji(att)}
               {#if emoji}
                 <span class="text-base">{emoji}</span>
               {:else}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -16,6 +16,7 @@
   import NextcloudFilePicker from './NextcloudFilePicker.svelte'
   import MoveFolderPicker from './MoveFolderPicker.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
+  import AttachmentThumb from './AttachmentThumb.svelte'
   import CalendarInviteCard, { type InviteSummary } from './CalendarInviteCard.svelte'
   import { openMailInStandaloneWindow } from './standaloneMailWindow'
 
@@ -1187,7 +1188,21 @@
               {#if emoji}
                 <span class="text-base">{emoji}</span>
               {:else}
-                <FileTypeIcon contentType={att.content_type} filename={att.filename} class="w-5 h-5" />
+                {@const tooLarge = att.size != null && att.size > 4 * 1024 * 1024}
+                <AttachmentThumb
+                  contentType={att.content_type}
+                  filename={att.filename}
+                  bytesProvider={tooLarge
+                    ? undefined
+                    : () =>
+                        invoke<number[]>('download_email_attachment', {
+                          accountId: email!.account_id,
+                          folder: email!.folder,
+                          uid: uid!,
+                          partId: att.part_id,
+                        })}
+                  class="w-9 h-9"
+                />
               {/if}
               <span class="font-medium truncate max-w-60" title={att.filename}>{att.filename}</span>
               {#if att.size != null}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1188,7 +1188,16 @@
               {#if emoji}
                 <span class="text-base">{emoji}</span>
               {:else}
-                {@const tooLarge = att.size != null && att.size > 4 * 1024 * 1024}
+                <!-- Bytes are lazy-fetched only when the chip
+                     mounts and only for sub-threshold sizes —
+                     a 100 MiB MOV shouldn't trigger an IPC just
+                     to render a 36×36 cell.  Images cap at 4 MiB
+                     (typical phone photo); videos cap at 16 MiB
+                     (most short clips that actually fit on a
+                     mail server). -->
+                {@const isVid = (att.content_type || '').startsWith('video/')}
+                {@const sizeCap = isVid ? 16 * 1024 * 1024 : 4 * 1024 * 1024}
+                {@const tooLarge = att.size != null && att.size > sizeCap}
                 <AttachmentThumb
                   contentType={att.content_type}
                   filename={att.filename}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -15,6 +15,7 @@
   import { formatError } from './errors'
   import NextcloudFilePicker from './NextcloudFilePicker.svelte'
   import MoveFolderPicker from './MoveFolderPicker.svelte'
+  import FileTypeIcon from './FileTypeIcon.svelte'
   import CalendarInviteCard, { type InviteSummary } from './CalendarInviteCard.svelte'
   import { openMailInStandaloneWindow } from './standaloneMailWindow'
 
@@ -789,15 +790,17 @@
     return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`
   }
 
-  function attachmentIcon(att: EmailAttachment): string {
+  /** Returns an emoji glyph for media types that read better as
+   *  pictographs.  Documents (pdf / office / zip) fall through
+   *  to `null` so the chip renders the typed `FileTypeIcon`
+   *  SVG instead of an emoji. */
+  function attachmentEmoji(att: EmailAttachment): string | null {
     const ct = att.content_type || ''
     if (ct.startsWith('image/')) return '🖼️'
     if (ct.startsWith('video/')) return '🎞️'
     if (ct.startsWith('audio/')) return '🎵'
-    if (ct.includes('pdf')) return '📄'
-    if (ct.includes('zip') || ct.includes('compressed')) return '🗜️'
     if (ct.startsWith('text/')) return '📝'
-    return '🖇️'
+    return null
   }
 
   /**
@@ -1179,7 +1182,12 @@
             {@const isPdf = isPdfAttachment(att)}
             {@const menuOpen = openMenuFor === att.part_id}
             <li class="relative flex items-center gap-2 pl-3 pr-1 py-1.5 rounded-md bg-surface-100 dark:bg-surface-800 text-sm">
-              <span class="text-base">{attachmentIcon(att)}</span>
+              {@const emoji = attachmentEmoji(att)}
+              {#if emoji}
+                <span class="text-base">{emoji}</span>
+              {:else}
+                <FileTypeIcon contentType={att.content_type} filename={att.filename} class="w-5 h-5" />
+              {/if}
               <span class="font-medium truncate max-w-60" title={att.filename}>{att.filename}</span>
               {#if att.size != null}
                 <span class="text-xs text-surface-500">{formatAttSize(att.size)}</span>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -797,7 +797,7 @@
     if (ct.includes('pdf')) return '📄'
     if (ct.includes('zip') || ct.includes('compressed')) return '🗜️'
     if (ct.startsWith('text/')) return '📝'
-    return '📎'
+    return '🖇️'
   }
 
   /**

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -498,25 +498,52 @@
     const target = e.target as HTMLElement | null
     if (!target) return
 
-    // Tiptap-rendered attachment refs from Nimbus (#93): a
-    // <span data-attachment-ref data-cid=...> badge + filename.
-    // Other clients see plain styled text — Nimbus picks up
-    // the click and opens the matching attachment by cid (or
-    // by filename, if cid wasn't preserved on round-trip).
+    // Tiptap-rendered attachment refs from Nimbus (#93).
+    // Two on-the-wire shapes float around:
+    //   - new: <span data-attachment-ref data-cid=... data-filename=...>
+    //   - legacy: <a href="cid:..." data-attachment-ref>
+    // Plus an intermediate where DOMPurify's cid: handler has
+    // already moved the cid into `data-nimbus-cid`.  We resolve
+    // through every channel so a click works regardless of the
+    // sending client's age or what survived the round-trip.
     const refEl = target.closest('[data-attachment-ref]') as HTMLElement | null
     if (refEl) {
       e.preventDefault()
       e.stopPropagation()
       if (!email) return
-      const cidAttr = (refEl.getAttribute('data-cid') ?? '').toLowerCase()
-      const fnAttr = (refEl.getAttribute('data-filename') ?? '').toLowerCase()
+      // CID resolution: explicit data-cid → data-nimbus-cid
+      // (set by processEmailHtml on legacy anchors) → href.
+      let cidAttr = (refEl.getAttribute('data-cid') ?? '').trim()
+      if (!cidAttr) cidAttr = (refEl.getAttribute('data-nimbus-cid') ?? '').trim()
+      if (!cidAttr) {
+        const href = (refEl.getAttribute('href') ?? '').trim()
+        if (href.toLowerCase().startsWith('cid:')) {
+          cidAttr = href.slice(4).replace(/^<|>$/g, '')
+        }
+      }
+      const cidLower = cidAttr.toLowerCase()
+      // Filename resolution: explicit data-filename →
+      // data-label → the visible text after the leading badge
+      // letters, as a last resort.
+      let fnAttr = (
+        refEl.getAttribute('data-filename') ?? refEl.getAttribute('data-label') ?? ''
+      ).trim()
+      if (!fnAttr) {
+        fnAttr = (refEl.textContent ?? '')
+          .trim()
+          .replace(/^[A-Z]{2,4}\s+/, '')
+      }
+      const fnLower = fnAttr.toLowerCase()
       const att = email.attachments.find((a) => {
-        if (cidAttr && a.content_id && a.content_id.toLowerCase() === cidAttr) return true
-        if (fnAttr && a.filename.toLowerCase() === fnAttr) return true
+        if (cidLower && a.content_id && a.content_id.toLowerCase() === cidLower) return true
+        if (fnLower && a.filename.toLowerCase() === fnLower) return true
         return false
       })
       if (att) void attachmentClicked(att)
-      else console.warn(`MailView: attachment-ref click had no match (cid=${cidAttr}, filename=${fnAttr})`)
+      else
+        console.warn(
+          `MailView: attachment-ref click had no match (cid=${cidLower}, filename=${fnLower})`,
+        )
       return
     }
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -791,15 +791,18 @@
   }
 
   /** Returns an emoji glyph for media types that read better as
-   *  pictographs.  Documents (pdf / office / zip) fall through
-   *  to `null` so the chip renders the typed `FileTypeIcon`
-   *  SVG instead of an emoji. */
+   *  pictographs.  Documents (pdf / office / zip / images /
+   *  markdown) fall through to `null` so the chip renders the
+   *  typed `FileTypeIcon` SVG instead of an emoji. */
   function attachmentEmoji(att: EmailAttachment): string | null {
     const ct = att.content_type || ''
-    if (ct.startsWith('image/')) return '🖼️'
+    const fn = att.filename.toLowerCase()
     if (ct.startsWith('video/')) return '🎞️'
     if (ct.startsWith('audio/')) return '🎵'
-    if (ct.startsWith('text/')) return '📝'
+    // Plain text files that aren't markdown still get the memo
+    // emoji — a CHANGELOG.txt looks more "note" than "code".
+    if (ct.startsWith('text/') && !ct.includes('markdown') && !fn.endsWith('.md') && !fn.endsWith('.markdown'))
+      return '📝'
     return null
   }
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -421,7 +421,19 @@
           'form', 'input', 'textarea', 'select', 'button',
           'base', 'meta', 'link', 'style',
         ],
-        ADD_ATTR: ['target', 'data-nimbus-cid', 'data-nimbus-blocked-src', 'title'],
+        ADD_ATTR: [
+          'target',
+          'data-nimbus-cid',
+          'data-nimbus-blocked-src',
+          'title',
+          // Attachment-ref (#93) — survive sanitisation so the
+          // body click handler can route the click back to the
+          // matching attachment row.
+          'data-attachment-ref',
+          'data-cid',
+          'data-filename',
+          'data-label',
+        ],
         FORCE_BODY: true,
       })
 
@@ -485,6 +497,29 @@
   function onBodyClick(e: MouseEvent) {
     const target = e.target as HTMLElement | null
     if (!target) return
+
+    // Tiptap-rendered attachment refs from Nimbus (#93): a
+    // <span data-attachment-ref data-cid=...> badge + filename.
+    // Other clients see plain styled text — Nimbus picks up
+    // the click and opens the matching attachment by cid (or
+    // by filename, if cid wasn't preserved on round-trip).
+    const refEl = target.closest('[data-attachment-ref]') as HTMLElement | null
+    if (refEl) {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!email) return
+      const cidAttr = (refEl.getAttribute('data-cid') ?? '').toLowerCase()
+      const fnAttr = (refEl.getAttribute('data-filename') ?? '').toLowerCase()
+      const att = email.attachments.find((a) => {
+        if (cidAttr && a.content_id && a.content_id.toLowerCase() === cidAttr) return true
+        if (fnAttr && a.filename.toLowerCase() === fnAttr) return true
+        return false
+      })
+      if (att) void attachmentClicked(att)
+      else console.warn(`MailView: attachment-ref click had no match (cid=${cidAttr}, filename=${fnAttr})`)
+      return
+    }
+
     const anchor = target.closest('a') as HTMLAnchorElement | null
     if (!anchor) return
 

--- a/ui/src/lib/NcPreview.svelte
+++ b/ui/src/lib/NcPreview.svelte
@@ -1,0 +1,102 @@
+<script lang="ts" module>
+  // Session-scoped preview cache shared across every NcPreview
+  // instance.  Keyed by `${accountId}::${path}` and stores either
+  // a blob URL (success) or null (no preview available — server
+  // 404 or unsupported type), so subsequent mounts of the same
+  // file skip the IPC entirely.  Blob URLs are intentionally
+  // not revoked: the picker is opened for a few seconds at a
+  // time and the URLs become stale on app restart.
+  const PREVIEW_CACHE = new Map<string, string | null>()
+</script>
+
+<script lang="ts">
+  // Inline thumbnail for a file in the Nextcloud picker.  For
+  // image and video rows it lazy-fetches the server-rendered
+  // preview from `/index.php/core/preview.png?...` via the
+  // `nextcloud_file_preview` Tauri command and renders an
+  // `<img>` once the bytes land; everything else falls through
+  // to <FileTypeIcon>.
+  import { invoke } from '@tauri-apps/api/core'
+  import FileTypeIcon from './FileTypeIcon.svelte'
+
+  interface Props {
+    accountId: string
+    path: string
+    contentType?: string | null
+    filename: string
+    /** Square thumbnail size — Tailwind utility (e.g. `w-9 h-9`). */
+    class?: string
+  }
+  let {
+    accountId,
+    path,
+    contentType = '',
+    filename,
+    class: cls = 'w-9 h-9',
+  }: Props = $props()
+
+  function isPreviewable(): boolean {
+    const ct = (contentType ?? '').toLowerCase()
+    if (ct.startsWith('image/') || ct.startsWith('video/')) return true
+    const dot = filename.lastIndexOf('.')
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+    return [
+      'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif',
+      'mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpeg', 'mpg', '3gp', 'wmv', 'flv',
+    ].includes(ext)
+  }
+
+  let previewUrl = $state<string | null>(null)
+  $effect(() => {
+    if (!isPreviewable()) {
+      previewUrl = null
+      return
+    }
+    const key = `${accountId}::${path}`
+    if (PREVIEW_CACHE.has(key)) {
+      previewUrl = PREVIEW_CACHE.get(key) ?? null
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const bytes = await invoke<number[] | null>('nextcloud_file_preview', {
+          ncId: accountId,
+          path,
+          size: 128,
+        })
+        if (cancelled) return
+        if (!bytes || bytes.length === 0) {
+          PREVIEW_CACHE.set(key, null)
+          return
+        }
+        // Nextcloud's preview endpoint always re-encodes to PNG
+        // regardless of source format, so the MIME we hand to
+        // the Blob is fine to hardcode.
+        const blob = new Blob([new Uint8Array(bytes)], { type: 'image/png' })
+        const url = URL.createObjectURL(blob)
+        PREVIEW_CACHE.set(key, url)
+        previewUrl = url
+      } catch (e) {
+        if (!cancelled) {
+          console.warn('nextcloud_file_preview failed', e)
+          PREVIEW_CACHE.set(key, null)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  })
+</script>
+
+{#if previewUrl}
+  <img
+    src={previewUrl}
+    alt=""
+    loading="lazy"
+    class="{cls} object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
+  />
+{:else}
+  <FileTypeIcon contentType={contentType} filename={filename} class={cls} />
+{/if}

--- a/ui/src/lib/NcPreview.svelte
+++ b/ui/src/lib/NcPreview.svelte
@@ -18,7 +18,6 @@
   // to <FileTypeIcon>.
   import { invoke } from '@tauri-apps/api/core'
   import FileTypeIcon from './FileTypeIcon.svelte'
-  import AttachmentThumb from './AttachmentThumb.svelte'
 
   interface Props {
     accountId: string
@@ -27,11 +26,6 @@
     filename: string
     /** Square thumbnail size — Tailwind utility (e.g. `w-9 h-9`). */
     class?: string
-    /** File size in bytes, when known.  Used to skip the
-     *  client-side video first-frame fallback for files that
-     *  are too large to be worth downloading just for a
-     *  thumbnail. */
-    size?: number | null
   }
   let {
     accountId,
@@ -39,59 +33,34 @@
     contentType = '',
     filename,
     class: cls = 'w-9 h-9',
-    size = null,
   }: Props = $props()
 
-  /** Cap for the client-side video poster fallback when NC
-   *  doesn't return a server-rendered preview.  Anything above
-   *  this stays on the typed icon — downloading a 200 MiB clip
-   *  for a 36px chip is never worth it. */
-  const VIDEO_FALLBACK_MAX_BYTES = 16 * 1024 * 1024
-
-  function ext(): string {
-    const dot = filename.lastIndexOf('.')
-    return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
-  }
-  function isVideo(): boolean {
-    const ct = (contentType ?? '').toLowerCase()
-    if (ct.startsWith('video/')) return true
-    return ['mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpeg', 'mpg', '3gp', 'wmv', 'flv'].includes(
-      ext(),
-    )
-  }
   function isPreviewable(): boolean {
+    // Only types Nextcloud's `core/preview` endpoint reliably
+    // serves out of the box: images and (with previewgenerator
+    // installed) PDFs.  Video preview generation is opt-in on
+    // the server, not the default — and downloading the full
+    // file client-side just to extract a poster frame is too
+    // much overhead for a 36 px chip.  When the server has no
+    // preview, we fall through to the typed icon.
     const ct = (contentType ?? '').toLowerCase()
-    if (ct.startsWith('image/') || ct.startsWith('video/')) return true
+    if (ct.startsWith('image/')) return true
+    const dot = filename.lastIndexOf('.')
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
     return [
       'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif',
-      'mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpeg', 'mpg', '3gp', 'wmv', 'flv',
-    ].includes(ext())
-  }
-  /** True when we should fall back to client-side first-frame
-   *  extraction (download bytes + canvas).  Reserved for video
-   *  files NC didn't return a server-rendered poster for, and
-   *  only when the file isn't huge. */
-  function shouldFallbackToBytes(): boolean {
-    if (!isVideo()) return false
-    if (size != null && size > VIDEO_FALLBACK_MAX_BYTES) return false
-    return true
+    ].includes(ext)
   }
 
   let previewUrl = $state<string | null>(null)
-  /** Set when NC didn't return a server-rendered poster for a
-   *  video file and we want to hand the rendering off to
-   *  AttachmentThumb's client-side first-frame extractor. */
-  let useBytesFallback = $state(false)
   $effect(() => {
     if (!isPreviewable()) {
       previewUrl = null
-      useBytesFallback = false
       return
     }
     const key = `${accountId}::${path}`
     if (PREVIEW_CACHE.has(key)) {
       previewUrl = PREVIEW_CACHE.get(key) ?? null
-      useBytesFallback = previewUrl === null && shouldFallbackToBytes()
       return
     }
     let cancelled = false
@@ -105,7 +74,6 @@
         if (cancelled) return
         if (!bytes || bytes.length === 0) {
           PREVIEW_CACHE.set(key, null)
-          useBytesFallback = shouldFallbackToBytes()
           return
         }
         // Nextcloud's preview endpoint always re-encodes to PNG
@@ -119,7 +87,6 @@
         if (!cancelled) {
           console.warn('nextcloud_file_preview failed', e)
           PREVIEW_CACHE.set(key, null)
-          useBytesFallback = shouldFallbackToBytes()
         }
       }
     })()
@@ -135,20 +102,6 @@
     alt=""
     loading="lazy"
     class="{cls} object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
-  />
-{:else if useBytesFallback}
-  <!-- NC didn't return a server-side poster (no previewgenerator
-       installed, or simply not generated yet for this file).
-       Pull the bytes down once and let AttachmentThumb pull a
-       first frame off the moov atom client-side; cached, so
-       only the first reach actually downloads. -->
-  <AttachmentThumb
-    contentType={contentType}
-    filename={filename}
-    cacheKey={`nc::${accountId}::${path}`}
-    bytesProvider={() =>
-      invoke<number[]>('download_nextcloud_file', { ncId: accountId, path })}
-    class={cls}
   />
 {:else}
   <FileTypeIcon contentType={contentType} filename={filename} class={cls} />

--- a/ui/src/lib/NcPreview.svelte
+++ b/ui/src/lib/NcPreview.svelte
@@ -18,6 +18,7 @@
   // to <FileTypeIcon>.
   import { invoke } from '@tauri-apps/api/core'
   import FileTypeIcon from './FileTypeIcon.svelte'
+  import AttachmentThumb from './AttachmentThumb.svelte'
 
   interface Props {
     accountId: string
@@ -26,6 +27,11 @@
     filename: string
     /** Square thumbnail size — Tailwind utility (e.g. `w-9 h-9`). */
     class?: string
+    /** File size in bytes, when known.  Used to skip the
+     *  client-side video first-frame fallback for files that
+     *  are too large to be worth downloading just for a
+     *  thumbnail. */
+    size?: number | null
   }
   let {
     accountId,
@@ -33,28 +39,59 @@
     contentType = '',
     filename,
     class: cls = 'w-9 h-9',
+    size = null,
   }: Props = $props()
 
+  /** Cap for the client-side video poster fallback when NC
+   *  doesn't return a server-rendered preview.  Anything above
+   *  this stays on the typed icon — downloading a 200 MiB clip
+   *  for a 36px chip is never worth it. */
+  const VIDEO_FALLBACK_MAX_BYTES = 16 * 1024 * 1024
+
+  function ext(): string {
+    const dot = filename.lastIndexOf('.')
+    return dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
+  }
+  function isVideo(): boolean {
+    const ct = (contentType ?? '').toLowerCase()
+    if (ct.startsWith('video/')) return true
+    return ['mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpeg', 'mpg', '3gp', 'wmv', 'flv'].includes(
+      ext(),
+    )
+  }
   function isPreviewable(): boolean {
     const ct = (contentType ?? '').toLowerCase()
     if (ct.startsWith('image/') || ct.startsWith('video/')) return true
-    const dot = filename.lastIndexOf('.')
-    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : ''
     return [
       'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'heic', 'heif',
       'mp4', 'mkv', 'mov', 'avi', 'webm', 'm4v', 'mpeg', 'mpg', '3gp', 'wmv', 'flv',
-    ].includes(ext)
+    ].includes(ext())
+  }
+  /** True when we should fall back to client-side first-frame
+   *  extraction (download bytes + canvas).  Reserved for video
+   *  files NC didn't return a server-rendered poster for, and
+   *  only when the file isn't huge. */
+  function shouldFallbackToBytes(): boolean {
+    if (!isVideo()) return false
+    if (size != null && size > VIDEO_FALLBACK_MAX_BYTES) return false
+    return true
   }
 
   let previewUrl = $state<string | null>(null)
+  /** Set when NC didn't return a server-rendered poster for a
+   *  video file and we want to hand the rendering off to
+   *  AttachmentThumb's client-side first-frame extractor. */
+  let useBytesFallback = $state(false)
   $effect(() => {
     if (!isPreviewable()) {
       previewUrl = null
+      useBytesFallback = false
       return
     }
     const key = `${accountId}::${path}`
     if (PREVIEW_CACHE.has(key)) {
       previewUrl = PREVIEW_CACHE.get(key) ?? null
+      useBytesFallback = previewUrl === null && shouldFallbackToBytes()
       return
     }
     let cancelled = false
@@ -68,6 +105,7 @@
         if (cancelled) return
         if (!bytes || bytes.length === 0) {
           PREVIEW_CACHE.set(key, null)
+          useBytesFallback = shouldFallbackToBytes()
           return
         }
         // Nextcloud's preview endpoint always re-encodes to PNG
@@ -81,6 +119,7 @@
         if (!cancelled) {
           console.warn('nextcloud_file_preview failed', e)
           PREVIEW_CACHE.set(key, null)
+          useBytesFallback = shouldFallbackToBytes()
         }
       }
     })()
@@ -96,6 +135,20 @@
     alt=""
     loading="lazy"
     class="{cls} object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
+  />
+{:else if useBytesFallback}
+  <!-- NC didn't return a server-side poster (no previewgenerator
+       installed, or simply not generated yet for this file).
+       Pull the bytes down once and let AttachmentThumb pull a
+       first frame off the moov atom client-side; cached, so
+       only the first reach actually downloads. -->
+  <AttachmentThumb
+    contentType={contentType}
+    filename={filename}
+    cacheKey={`nc::${accountId}::${path}`}
+    bytesProvider={() =>
+      invoke<number[]>('download_nextcloud_file', { ncId: accountId, path })}
+    class={cls}
   />
 {:else}
   <FileTypeIcon contentType={contentType} filename={filename} class={cls} />

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -190,7 +190,7 @@
     if (ct.includes('pdf')) return '📄'
     if (ct.includes('zip') || ct.includes('compressed')) return '🗜️'
     if (ct.startsWith('text/')) return '📝'
-    return '📎'
+    return '🖇️'
   }
 
   function navigateTo(path: string) {

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -365,7 +365,6 @@
                     path={entry.path}
                     contentType={entry.content_type}
                     filename={entry.name}
-                    size={entry.size}
                     class="w-9 h-9"
                   />
                 {/if}

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -31,6 +31,7 @@
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
   import FileTypeIcon from './FileTypeIcon.svelte'
+  import NcPreview from './NcPreview.svelte'
 
   interface NextcloudCapabilities {
     version?: string | null
@@ -190,8 +191,6 @@
     if (entry.is_dir) return '📁'
     const ct = entry.content_type ?? ''
     const fn = entry.name.toLowerCase()
-    if (ct.startsWith('video/')) return '🎞️'
-    if (ct.startsWith('audio/')) return '🎵'
     if (ct.startsWith('text/') && !ct.includes('markdown') && !fn.endsWith('.md') && !fn.endsWith('.markdown'))
       return '📝'
     return null
@@ -359,9 +358,15 @@
                   />
                 {/if}
                 {#if emoji}
-                  <span class="text-lg">{emoji}</span>
+                  <span class="text-lg w-9 h-9 flex items-center justify-center shrink-0">{emoji}</span>
                 {:else}
-                  <FileTypeIcon contentType={entry.content_type} filename={entry.name} class="w-5 h-5" />
+                  <NcPreview
+                    {accountId}
+                    path={entry.path}
+                    contentType={entry.content_type}
+                    filename={entry.name}
+                    class="w-9 h-9"
+                  />
                 {/if}
                 <span class="flex-1 truncate text-sm">{entry.name}</span>
                 <span class="text-xs text-surface-500">{formatSize(entry.size)}</span>

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -30,6 +30,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import FileTypeIcon from './FileTypeIcon.svelte'
 
   interface NextcloudCapabilities {
     version?: string | null
@@ -181,16 +182,17 @@
     return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`
   }
 
-  function iconFor(entry: FileEntry): string {
+  /** Emoji glyph for entries that read better as pictographs
+   *  (folders + media types).  Documents fall through to `null`
+   *  so the row renders the typed `FileTypeIcon` SVG instead. */
+  function iconEmojiFor(entry: FileEntry): string | null {
     if (entry.is_dir) return '📁'
     const ct = entry.content_type ?? ''
     if (ct.startsWith('image/')) return '🖼️'
     if (ct.startsWith('video/')) return '🎞️'
     if (ct.startsWith('audio/')) return '🎵'
-    if (ct.includes('pdf')) return '📄'
-    if (ct.includes('zip') || ct.includes('compressed')) return '🗜️'
     if (ct.startsWith('text/')) return '📝'
-    return '🖇️'
+    return null
   }
 
   function navigateTo(path: string) {
@@ -353,7 +355,12 @@
                     onchange={() => toggleSelected(entry.path)}
                   />
                 {/if}
-                <span class="text-lg">{iconFor(entry)}</span>
+                {@const emoji = iconEmojiFor(entry)}
+                {#if emoji}
+                  <span class="text-lg">{emoji}</span>
+                {:else}
+                  <FileTypeIcon contentType={entry.content_type} filename={entry.name} class="w-5 h-5" />
+                {/if}
                 <span class="flex-1 truncate text-sm">{entry.name}</span>
                 <span class="text-xs text-surface-500">{formatSize(entry.size)}</span>
               </button>

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -183,15 +183,17 @@
   }
 
   /** Emoji glyph for entries that read better as pictographs
-   *  (folders + media types).  Documents fall through to `null`
-   *  so the row renders the typed `FileTypeIcon` SVG instead. */
+   *  (folders + media types).  Documents (images, markdown,
+   *  office, archives) fall through to `null` so the row
+   *  renders the typed `FileTypeIcon` SVG instead. */
   function iconEmojiFor(entry: FileEntry): string | null {
     if (entry.is_dir) return '📁'
     const ct = entry.content_type ?? ''
-    if (ct.startsWith('image/')) return '🖼️'
+    const fn = entry.name.toLowerCase()
     if (ct.startsWith('video/')) return '🎞️'
     if (ct.startsWith('audio/')) return '🎵'
-    if (ct.startsWith('text/')) return '📝'
+    if (ct.startsWith('text/') && !ct.includes('markdown') && !fn.endsWith('.md') && !fn.endsWith('.markdown'))
+      return '📝'
     return null
   }
 

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -335,6 +335,7 @@
       {:else}
         <ul class="divide-y divide-surface-200 dark:divide-surface-800">
           {#each entries as entry (entry.path)}
+            {@const emoji = iconEmojiFor(entry)}
             <li>
               <button
                 class="w-full flex items-center gap-3 px-5 py-2 text-left hover:bg-surface-100 dark:hover:bg-surface-800"
@@ -355,7 +356,6 @@
                     onchange={() => toggleSelected(entry.path)}
                   />
                 {/if}
-                {@const emoji = iconEmojiFor(entry)}
                 {#if emoji}
                   <span class="text-lg">{emoji}</span>
                 {:else}

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -63,6 +63,14 @@
     accountId?: string
     currentPath?: string
     selected?: Set<string>
+    /** Subset of `selected` whose paths are folders.  Tracked
+     *  alongside `selected` so the picker can distinguish file
+     *  vs. folder selections even when the user has navigated
+     *  away from the folder where they were ticked.  Without
+     *  this, the file/folder count derives only from the
+     *  currently-visible `entries` list and lies whenever the
+     *  user changes folders mid-selection. */
+    selectedDirs?: Set<string>
     entries?: FileEntry[]
     accounts?: NextcloudAccount[]
     error?: string
@@ -72,6 +80,7 @@
     accountId = $bindable(''),
     currentPath = $bindable('/'),
     selected = $bindable(new Set<string>()),
+    selectedDirs = $bindable(new Set<string>()),
     entries = $bindable<FileEntry[]>([]),
     accounts = $bindable<NextcloudAccount[]>([]),
     error = $bindable(''),
@@ -111,6 +120,7 @@
   async function selectAccount(id: string) {
     accountId = id
     selected = new Set()
+    selectedDirs = new Set()
     await loadFolder('/')
   }
 
@@ -163,16 +173,23 @@
     } else if (!pickFolderMode) {
       // In folder-pick mode files aren't selectable — they're shown
       // only as a preview of what's already in the destination folder.
-      toggleSelected(entry.path)
+      toggleSelected(entry.path, entry.is_dir)
     }
   }
 
-  function toggleSelected(path: string) {
+  function toggleSelected(path: string, isDir: boolean) {
     // Svelte 5 Sets need reassignment to trigger reactivity.
     const next = new Set(selected)
-    if (next.has(path)) next.delete(path)
-    else next.add(path)
+    const nextDirs = new Set(selectedDirs)
+    if (next.has(path)) {
+      next.delete(path)
+      nextDirs.delete(path)
+    } else {
+      next.add(path)
+      if (isDir) nextDirs.add(path)
+    }
     selected = next
+    selectedDirs = nextDirs
   }
 
   function formatSize(bytes: number | null): string {
@@ -354,7 +371,7 @@
                     class="checkbox"
                     checked={selected.has(entry.path)}
                     onclick={(e) => e.stopPropagation()}
-                    onchange={() => toggleSelected(entry.path)}
+                    onchange={() => toggleSelected(entry.path, entry.is_dir)}
                   />
                 {/if}
                 {#if emoji}

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -87,6 +87,28 @@
   }: Props = $props()
 
   let loading = $state(false)
+  /** Per-`${accountId}::${path}` cache of folder listings.
+   *  Re-visiting a folder during the same picker session
+   *  (very common while ticking files across folders) is now
+   *  synchronous — no blank flash, no IPC.  Stale data is
+   *  refreshed in the background so the user sees additions
+   *  / removals without having to manually reload. */
+  const FOLDER_CACHE = new Map<string, FileEntry[]>()
+  function folderCacheKey(p: string): string {
+    return `${accountId}::${p}`
+  }
+  function sortEntries(list: FileEntry[]) {
+    // Folders first, then files.  Within each group, natural
+    // sort so numbered names (1, 2, 9, 10, 11) come out the
+    // way humans expect — matches the NC web UI ordering.
+    list.sort((a, b) => {
+      if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1
+      return a.name.localeCompare(b.name, undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      })
+    })
+  }
   // "+ New folder" inline input — hidden until the user clicks the
   // button. Driven by component state so we can validate and show
   // errors inline rather than via a blocking `prompt()`.
@@ -126,27 +148,37 @@
 
   async function loadFolder(path: string) {
     if (!accountId) return
-    loading = true
     error = ''
+    const cacheKey = folderCacheKey(path)
+    const cached = FOLDER_CACHE.get(cacheKey)
+    if (cached) {
+      // Cached — paint immediately, refresh in the background.
+      // Re-visiting a folder during the same picker session is
+      // synchronous, no blank flash and no spinner.  If the
+      // server-side listing has changed since the last visit
+      // the background refresh below silently updates entries.
+      entries = cached
+      currentPath = path
+      loading = false
+    } else {
+      // First visit — clear entries so the breadcrumb and the
+      // list stay in sync.  Showing the previous folder's
+      // entries under a new breadcrumb path is more confusing
+      // than a brief loading state.
+      entries = []
+      currentPath = path
+      loading = true
+    }
     try {
       const list = await invoke<FileEntry[]>('list_nextcloud_files', {
         ncId: accountId,
         path,
       })
-      // Folders first, then files. Within each group, natural sort so
-      // numbered names (1, 2, 9, 10, 11) come out the way humans expect
-      // — `numeric: true` reads runs of digits as whole numbers, and
-      // `sensitivity: 'base'` makes it case-insensitive. Matches the
-      // Nextcloud web UI ordering.
-      list.sort((a, b) => {
-        if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1
-        return a.name.localeCompare(b.name, undefined, {
-          numeric: true,
-          sensitivity: 'base',
-        })
-      })
-      entries = list
-      currentPath = path
+      sortEntries(list)
+      FOLDER_CACHE.set(cacheKey, list)
+      // Race-guard: the user may have navigated again before
+      // this refresh returned.
+      if (currentPath === path) entries = list
     } catch (e) {
       error = formatError(e) || 'Failed to list folder'
     } finally {
@@ -258,6 +290,9 @@
       })
       creatingFolder = false
       newFolderName = ''
+      // Invalidate the parent's cached listing so loadFolder
+      // re-fetches and shows the new directory.
+      FOLDER_CACHE.delete(folderCacheKey(currentPath))
       await loadFolder(currentPath)
       const folderPath = `${fullPath}/`
       const next = new Set(selected)

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -365,6 +365,7 @@
                     path={entry.path}
                     contentType={entry.content_type}
                     filename={entry.name}
+                    size={entry.size}
                     class="w-9 h-9"
                   />
                 {/if}

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -353,7 +353,7 @@
             ? 'Folders can be shared as a link, but not attached as bytes'
             : 'Download selected files and attach them to the email'}
         >
-          {downloading ? 'Downloading…' : '🖇️ Attach'}
+          {downloading ? 'Downloading…' : '📎 Attach'}
         </button>
       {/if}
     </footer>

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -353,7 +353,7 @@
             ? 'Folders can be shared as a link, but not attached as bytes'
             : 'Download selected files and attach them to the email'}
         >
-          {downloading ? 'Downloading…' : '📎 Attach'}
+          {downloading ? 'Downloading…' : '🖇️ Attach'}
         </button>
       {/if}
     </footer>

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -85,6 +85,11 @@
   let accountId = $state('')
   let currentPath = $state('/')
   let selected = $state<Set<string>>(new Set())
+  /** Subset of `selected` whose paths are folders.  Tracked
+   *  alongside `selected` so file vs. folder counts stay
+   *  accurate even after the user navigates to a different
+   *  folder mid-selection. */
+  let selectedDirs = $state<Set<string>>(new Set())
   let entries = $state<FileEntry[]>([])
   let accounts = $state<NextcloudAccount[]>([])
   let error = $state('')
@@ -160,21 +165,23 @@
   // links but not attached as bytes (Nextcloud has no zip-folder
   // endpoint, so there's nothing meaningful to download). The footer
   // uses these counts to label and disable buttons appropriately.
-  let selectedFileCount = $derived.by(() => {
-    let n = 0
-    for (const e of entries) if (!e.is_dir && selected.has(e.path)) n++
-    return n
-  })
-  let selectedFolderCount = $derived(selected.size - selectedFileCount)
+  // Selection split is computed straight off the two
+  // bindable sets, so it stays correct across folder
+  // navigation: selectedDirs always contains *every* folder
+  // ever ticked, not just ones currently rendered.
+  let selectedFolderCount = $derived(selectedDirs.size)
+  let selectedFileCount = $derived(selected.size - selectedDirs.size)
 
   function basename(path: string): string {
     return path.split('/').filter(Boolean).pop() ?? path
   }
 
   async function attachSelected() {
-    const filePaths = entries
-      .filter((e) => !e.is_dir && selected.has(e.path))
-      .map((e) => e.path)
+    // Pull from `selected` / `selectedDirs` directly so files
+    // ticked in folders the user has since navigated away from
+    // still get downloaded.  Filtering by the current `entries`
+    // list (the previous behaviour) silently dropped them.
+    const filePaths = [...selected].filter((p) => !selectedDirs.has(p))
     if (filePaths.length === 0) return
     downloading = true
     error = ''
@@ -187,6 +194,10 @@
             ncId: accountId,
             path: p,
           })
+          // Content-type from the current folder's entries when
+          // available; fall back to a neutral default for files
+          // selected in other folders (the SMTP build path
+          // re-derives from filename when this is unset).
           const ct =
             entries.find((e) => e.path === p)?.content_type ??
             'application/octet-stream'
@@ -213,14 +224,9 @@
       a share if the user changes their mind mid-click. */
   function shareSelected() {
     if (selected.size === 0 || !onlinks) return
-    // Snapshot whether any of the selected entries is a folder so
-    // the dropdown can hide the folder-only permission options for
-    // pure-file shares.  Looked up against the current `entries`
-    // listing — the user can only select within one folder at a
-    // time, so this is always the right source of truth.
-    const hasFolders = entries.some(
-      (e) => e.is_dir && selected.has(e.path),
-    )
+    // `selectedDirs` is the source of truth for "is any of the
+    // ticked paths a folder" — survives folder navigation.
+    const hasFolders = selectedDirs.size > 0
     sharePrompt = {
       paths: Array.from(selected),
       password: '',
@@ -294,6 +300,7 @@
       bind:accountId
       bind:currentPath
       bind:selected
+      bind:selectedDirs
       bind:entries
       bind:accounts
       bind:error

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -595,6 +595,19 @@
         renderHTML({ node, HTMLAttributes }) {
           const cid = node.attrs.id ?? ''
           const label = node.attrs.label ?? cid
+          // Pick a per-format emoji so the recipient sees a typed
+          // glyph (📕 PDF / 📘 DOC / 📗 XLS / 📙 PPT / 🗜️ ZIP) —
+          // pure-emoji rather than inline SVG because Gmail and
+          // Outlook strip <svg> from message bodies.
+          const ext = label.includes('.')
+            ? label.slice(label.lastIndexOf('.') + 1).toLowerCase()
+            : ''
+          let glyph = '🖇️'
+          if (ext === 'pdf') glyph = '📕'
+          else if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) glyph = '📘'
+          else if (['xls', 'xlsx', 'ods', 'csv'].includes(ext)) glyph = '📗'
+          else if (['ppt', 'pptx', 'odp'].includes(ext)) glyph = '📙'
+          else if (['zip', '7z', 'rar', 'tar', 'gz', 'xz'].includes(ext)) glyph = '🗜️'
           return [
             'a',
             {
@@ -606,7 +619,7 @@
                 'background:rgba(245,158,11,0.15);color:#b45309;' +
                 'text-decoration:none;font-weight:500;',
             },
-            `🖇️ ${label}`,
+            `${glyph} ${label}`,
           ]
         },
         renderText({ node }) {
@@ -621,7 +634,7 @@
                 const href = (el as HTMLElement).getAttribute('href') ?? ''
                 const id = href.replace(/^cid:/, '')
                 const text = (el as HTMLElement).textContent ?? ''
-                const label = text.replace(/^🖇️\s*/, '') || id
+                const label = text.replace(/^(?:🖇️|📕|📘|📗|📙|🗜️|📎)\s*/, '') || id
                 return { id, label }
               },
             },

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -456,10 +456,16 @@
       // Renamed from the default `mention` so it can coexist with
       // the `/` attachment-ref extension below (Tiptap's Mention is
       // a single Node type — to register two we extend twice with
-      // different `name`s). Renders to the wire as
-      // `<a href="mailto:…" data-contact-mention>@Alice</a>` so
-      // non-Tiptap clients see a clickable mailto link, while the
-      // `data-` marker lets us re-parse it on draft round-trip.
+      // different `name`s).
+      //
+      // Wire format (#93): mailto-anchor wrapping the pill, plus
+      // *inline* styles that mirror our editor's Tailwind look.
+      // Email clients (Gmail, Outlook web, Apple Mail) strip
+      // class= and external CSS but keep `style` attrs and
+      // `title` tooltips, so recipients on those clients see a
+      // styled pill + can hover to read the full address.  The
+      // `data-contact-mention` marker survives the round-trip so
+      // a Nimbus reply re-parses our own pills.
       Mention.extend({
         name: 'contactMention',
         renderHTML({ node, HTMLAttributes }) {
@@ -467,7 +473,15 @@
           const label = node.attrs.label ?? email
           return [
             'a',
-            { ...HTMLAttributes, href: `mailto:${email}` },
+            {
+              ...HTMLAttributes,
+              href: `mailto:${email}`,
+              title: label && email && label !== email ? `${label} <${email}>` : email,
+              style:
+                'display:inline-block;padding:0 4px;border-radius:4px;' +
+                'background:rgba(59,130,246,0.12);color:#1d4ed8;' +
+                'text-decoration:none;font-weight:500;',
+            },
             `@${label}`,
           ]
         },
@@ -562,12 +576,20 @@
       }),
 
       // ── `/` attachment reference ───────────────────────────
-      // Same Mention machinery, different node + char + render. The
-      // inserted node is a clickable `cid:` link — recipients on
-      // Nimbus (or any client that resolves `cid:` href) get a
-      // direct jump to the attachment; on Gmail / web clients it
-      // falls back to plain link text with the attachment still
-      // visible in the message's attachment tray.
+      // Same Mention machinery, different node + char + render.
+      //
+      // Wire format (#93): cid-anchor + inline styles + a title
+      // tooltip identifying it as an attachment.  Clients that
+      // resolve `cid:` (Apple Mail, Thunderbird, our own renderer)
+      // get a direct jump to the part; Gmail / Outlook strip
+      // cid: but the recipient still sees a styled "📎 filename
+      // (attached)" badge and the file is in the message's
+      // attachment tray anyway.
+      //
+      // The plain-text fallback annotates the filename with
+      // "(attached)" so a recipient reading the text/plain part
+      // immediately knows the reference points at the attachment
+      // tray, not a missing inline link.
       Mention.extend({
         name: 'attachmentRef',
         renderHTML({ node, HTMLAttributes }) {
@@ -575,14 +597,21 @@
           const label = node.attrs.label ?? cid
           return [
             'a',
-            { ...HTMLAttributes, href: `cid:${cid}` },
+            {
+              ...HTMLAttributes,
+              href: `cid:${cid}`,
+              title: `Attached file: ${label}`,
+              style:
+                'display:inline-block;padding:0 4px;border-radius:4px;' +
+                'background:rgba(245,158,11,0.15);color:#b45309;' +
+                'text-decoration:none;font-weight:500;',
+            },
             `📎 ${label}`,
           ]
         },
         renderText({ node }) {
-          // Plain-text fallback is just the filename — `cid:` URIs
-          // mean nothing to a human reading the text/plain part.
-          return node.attrs.label ?? ''
+          const label = node.attrs.label ?? ''
+          return label ? `${label} (attached)` : ''
         },
         parseHTML() {
           return [

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -228,15 +228,15 @@
     position: { left: 0, top: 0 },
     command: null,
   })
-  /** Latches `true` the first time the picker becomes visible
-   *  and stays true for the rest of the editor's lifetime.
-   *  Drives the `{#if}` guarding the popup DOM so we mint it
-   *  exactly once, then toggle visibility via CSS instead of
-   *  mounting / unmounting on every `/`. */
-  let attachmentPickerEverShown = $state(false)
-  $effect(() => {
-    if (attachmentPicker.visible) attachmentPickerEverShown = true
-  })
+  /** Always true — kept as a $state flag so the {#if} below
+   *  doesn't fall back to constant folding (which Svelte would
+   *  treat as unconditional anyway, but the named flag makes
+   *  the intent obvious).  Mounting the popup DOM eagerly
+   *  with the editor itself means even the very first `/` is
+   *  a CSS flag flip, no DOM allocation cost on the critical
+   *  path.  The hidden <ul> is one detached element — a
+   *  rounding-error memory cost for the latency win. */
+  const attachmentPickerEverShown = true
 
   /** Compute the popup anchor from the trigger char's bounding
    *  rect. Clamped to the viewport so a `@` typed near the right

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -748,8 +748,13 @@
           ]
         },
       }).configure({
+        // Use a truthy marker value rather than the empty
+        // string — some HTML serialisers drop empty-valued
+        // attributes during round-trip, which would silently
+        // break the MailView click handler that looks for
+        // `[data-attachment-ref]`.
         HTMLAttributes: {
-          'data-attachment-ref': '',
+          'data-attachment-ref': 'true',
           class: 'inline-block text-primary-600 dark:text-primary-400 underline',
         },
         suggestion: {

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -228,6 +228,15 @@
     position: { left: 0, top: 0 },
     command: null,
   })
+  /** Latches `true` the first time the picker becomes visible
+   *  and stays true for the rest of the editor's lifetime.
+   *  Drives the `{#if}` guarding the popup DOM so we mint it
+   *  exactly once, then toggle visibility via CSS instead of
+   *  mounting / unmounting on every `/`. */
+  let attachmentPickerEverShown = $state(false)
+  $effect(() => {
+    if (attachmentPicker.visible) attachmentPickerEverShown = true
+  })
 
   /** Compute the popup anchor from the trigger char's bounding
    *  rect. Clamped to the viewport so a `@` typed near the right
@@ -1867,11 +1876,17 @@
      Same shape as the contact picker, narrower because rows are
      just a filename + a paperclip glyph. Only attachments with a
      `content_id` show up — everything else has nothing to link to. -->
-{#if attachmentPicker.visible}
+{#if attachmentPickerEverShown}
+  <!-- Keep the DOM mounted across opens — `display: none` when
+       hidden so the first open mints the rows once and every
+       subsequent `/` is just a CSS flag flip plus a coordinate
+       update.  Mounting only flips on first reach to avoid
+       allocating the popup at all in the common case where the
+       user never types `/`. -->
   <ul
     class="fixed z-60 max-h-72 min-w-64 overflow-y-auto rounded-md border border-surface-300
            dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg py-1 text-sm"
-    style="left: {attachmentPicker.position.left}px; top: {attachmentPicker.position.top}px;"
+    style="left: {attachmentPicker.position.left}px; top: {attachmentPicker.position.top}px; display: {attachmentPicker.visible ? 'block' : 'none'};"
     role="listbox"
   >
     {#if attachmentPicker.items.length === 0}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -41,7 +41,7 @@
   import type { Range } from '@tiptap/core'
   import EmojiPicker from './EmojiPicker.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
-  import AttachmentThumb from './AttachmentThumb.svelte'
+  import { thumbUrlSync } from './AttachmentThumb.svelte'
   import { invoke } from '@tauri-apps/api/core'
 
   /**
@@ -604,6 +604,20 @@
       // tray, not a missing inline link.
       Mention.extend({
         name: 'attachmentRef',
+        // Render as a styled <span>, NOT an <a href="cid:...">.
+        // Most email clients (Gmail, Outlook web, modern Apple
+        // Mail) try to navigate when the user clicks an
+        // anchor and surface a "can't open cid:..." error
+        // because they don't expose CID handlers to the
+        // surrounding chrome.  A <span> is just inline text:
+        // recipients see the typed badge + filename, no
+        // hyperlink, no broken-link UX.  Nimbus's own reader
+        // intercepts the click via the `data-attachment-ref`
+        // attribute (see MailView.onBodyClick) so jumping to
+        // the attachment still works locally.  Both the cid
+        // and the raw filename ride along on data-* attrs so
+        // a recipient can match the inline reference to the
+        // file in their attachment tray by name.
         renderHTML({ node, HTMLAttributes }) {
           const cid = node.attrs.id ?? ''
           const label = node.attrs.label ?? cid
@@ -670,16 +684,17 @@
             'font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;' +
             'letter-spacing:0.04em;text-align:center;vertical-align:middle;'
           return [
-            'a',
+            'span',
             {
               ...HTMLAttributes,
-              href: `cid:${cid}`,
               title: `Attached file: ${label}`,
               'data-label': label,
+              'data-cid': cid,
+              'data-filename': label,
               style:
                 'display:inline-flex;align-items:center;padding:0 6px;border-radius:4px;' +
                 'background:rgba(245,158,11,0.12);color:#b45309;' +
-                'text-decoration:none;font-weight:500;',
+                'font-weight:500;cursor:pointer;',
             },
             ['span', { style: badgeStyle }, badgeText],
             label,
@@ -692,16 +707,22 @@
         parseHTML() {
           return [
             {
-              tag: 'a[data-attachment-ref]',
+              // Match both the new <span> and the legacy <a>
+              // shape so messages composed before the cid-anchor
+              // → span migration still re-import correctly.
+              tag: '[data-attachment-ref]',
               getAttrs: (el) => {
                 const e = el as HTMLElement
+                // Prefer `data-cid` (new), fall back to parsing
+                // the legacy href="cid:..." attribute.
+                const dataCid = e.getAttribute('data-cid')
                 const href = e.getAttribute('href') ?? ''
-                const id = href.replace(/^cid:/, '')
+                const id = dataCid || href.replace(/^cid:/, '')
                 // `data-label` is the canonical recovery path
                 // (set by renderHTML).  Older messages that
                 // pre-date the badge still parse via textContent
                 // with the leading badge code or emoji stripped.
-                const dataLabel = e.getAttribute('data-label')
+                const dataLabel = e.getAttribute('data-label') ?? e.getAttribute('data-filename')
                 if (dataLabel) return { id, label: dataLabel }
                 const text = e.textContent ?? ''
                 const label =
@@ -1869,12 +1890,20 @@
             attachmentPicker.command?.(a)
           }}
         >
-          <AttachmentThumb
-            bytes={a.data ?? null}
-            contentType={a.content_type ?? null}
-            filename={a.filename}
-            class="w-7 h-7"
-          />
+          {@const thumb = thumbUrlSync({
+            bytes: a.data ?? null,
+            contentType: a.content_type ?? null,
+            filename: a.filename,
+          })}
+          {#if thumb}
+            <img
+              src={thumb}
+              alt=""
+              class="w-7 h-7 object-cover rounded shrink-0 bg-surface-200 dark:bg-surface-800"
+            />
+          {:else}
+            <FileTypeIcon contentType={a.content_type ?? null} filename={a.filename} class="w-7 h-7" />
+          {/if}
           <span class="truncate">{a.filename}</span>
         </li>
       {/each}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -530,6 +530,11 @@
           ]
         },
       }).configure({
+        // Backspace deletes the whole mention node without re-
+        // inserting the trigger character — without this, a
+        // user removing a contact pill ends up with a stray `@`
+        // glyph after the deletion.
+        deleteTriggerWithBackspace: true,
         HTMLAttributes: {
           'data-contact-mention': '',
           class:
@@ -747,6 +752,10 @@
           ]
         },
       }).configure({
+        // Backspace removes the whole reference node without
+        // dropping a stray `/` glyph — same reasoning as the
+        // contactMention configure block above.
+        deleteTriggerWithBackspace: true,
         // Use a truthy marker value rather than the empty
         // string — some HTML serialisers drop empty-valued
         // attributes during round-trip, which would silently

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -595,31 +595,62 @@
         renderHTML({ node, HTMLAttributes }) {
           const cid = node.attrs.id ?? ''
           const label = node.attrs.label ?? cid
-          // Pick a per-format emoji so the recipient sees a typed
-          // glyph (📕 PDF / 📘 DOC / 📗 XLS / 📙 PPT / 🗜️ ZIP) —
-          // pure-emoji rather than inline SVG because Gmail and
-          // Outlook strip <svg> from message bodies.
+          // Render an inline-styled file-type badge + filename
+          // instead of a leading emoji.  A coloured rounded box
+          // with the format code (PDF/DOC/XLS/PPT/CSV/ZIP) in
+          // bold survives every major MUA's content sanitiser
+          // because it's just <span style="..."> — no <svg>, no
+          // class names, no external CSS.  Recipients on Gmail
+          // / Outlook web / Apple Mail get a typed-icon look
+          // close to what they'd see in a file explorer.
+          //
+          // `data-label` carries the filename verbatim so a
+          // round-trip back into Tiptap recovers it without
+          // having to slice the badge out of textContent.
           const ext = label.includes('.')
             ? label.slice(label.lastIndexOf('.') + 1).toLowerCase()
             : ''
-          let glyph = '🖇️'
-          if (ext === 'pdf') glyph = '📕'
-          else if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) glyph = '📘'
-          else if (['xls', 'xlsx', 'ods', 'csv'].includes(ext)) glyph = '📗'
-          else if (['ppt', 'pptx', 'odp'].includes(ext)) glyph = '📙'
-          else if (['zip', '7z', 'rar', 'tar', 'gz', 'xz'].includes(ext)) glyph = '🗜️'
+          let badgeText = 'FILE'
+          let badgeBg = '#64748b' // slate
+          if (ext === 'pdf') {
+            badgeText = 'PDF'
+            badgeBg = '#e11d48' // rose
+          } else if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) {
+            badgeText = 'DOC'
+            badgeBg = '#2563eb' // blue
+          } else if (['xls', 'xlsx', 'ods'].includes(ext)) {
+            badgeText = 'XLS'
+            badgeBg = '#059669' // emerald-600
+          } else if (ext === 'csv') {
+            badgeText = 'CSV'
+            badgeBg = '#10b981' // emerald-500
+          } else if (['ppt', 'pptx', 'odp'].includes(ext)) {
+            badgeText = 'PPT'
+            badgeBg = '#f59e0b' // amber
+          } else if (['zip', '7z', 'rar', 'tar', 'gz', 'xz'].includes(ext)) {
+            badgeText = 'ZIP'
+            badgeBg = '#7c3aed' // violet
+          }
+          const badgeStyle =
+            'display:inline-block;min-width:2.2em;padding:1px 4px;margin-right:6px;' +
+            `background:${badgeBg};color:#ffffff;` +
+            'border-radius:3px;font-size:0.7em;font-weight:700;' +
+            'font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;' +
+            'letter-spacing:0.04em;text-align:center;vertical-align:middle;'
           return [
             'a',
             {
               ...HTMLAttributes,
               href: `cid:${cid}`,
               title: `Attached file: ${label}`,
+              'data-label': label,
               style:
-                'display:inline-block;padding:0 4px;border-radius:4px;' +
-                'background:rgba(245,158,11,0.15);color:#b45309;' +
+                'display:inline-flex;align-items:center;padding:0 6px;border-radius:4px;' +
+                'background:rgba(245,158,11,0.12);color:#b45309;' +
                 'text-decoration:none;font-weight:500;',
             },
-            `${glyph} ${label}`,
+            ['span', { style: badgeStyle }, badgeText],
+            label,
           ]
         },
         renderText({ node }) {
@@ -631,10 +662,20 @@
             {
               tag: 'a[data-attachment-ref]',
               getAttrs: (el) => {
-                const href = (el as HTMLElement).getAttribute('href') ?? ''
+                const e = el as HTMLElement
+                const href = e.getAttribute('href') ?? ''
                 const id = href.replace(/^cid:/, '')
-                const text = (el as HTMLElement).textContent ?? ''
-                const label = text.replace(/^(?:🖇️|📕|📘|📗|📙|🗜️|📎)\s*/, '') || id
+                // `data-label` is the canonical recovery path
+                // (set by renderHTML).  Older messages that
+                // pre-date the badge still parse via textContent
+                // with the leading badge code or emoji stripped.
+                const dataLabel = e.getAttribute('data-label')
+                if (dataLabel) return { id, label: dataLabel }
+                const text = e.textContent ?? ''
+                const label =
+                  text
+                    .replace(/^(?:PDF|DOC|XLS|XLSX|CSV|PPT|PPTX|ZIP|FILE)\s*/i, '')
+                    .replace(/^(?:🖇️|📕|📘|📗|📙|🗜️|📎)\s*/, '') || id
                 return { id, label }
               },
             },

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -41,6 +41,7 @@
   import type { Range } from '@tiptap/core'
   import EmojiPicker from './EmojiPicker.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
+  import AttachmentThumb from './AttachmentThumb.svelte'
   import { invoke } from '@tauri-apps/api/core'
 
   /**
@@ -162,6 +163,12 @@
      *  popup.  Optional so older callers (and the picker's
      *  parseHTML round-trip) keep working without it. */
     content_type?: string
+    /** Raw bytes of the attachment, when available — Compose
+     *  always has them in memory so we can render an inline
+     *  image / video thumbnail in the picker dropdown.  Omitted
+     *  for non-Compose callers (the picker then falls back to
+     *  the typed icon). */
+    data?: number[] | Uint8Array
   }
   let {
     content = '',
@@ -1862,7 +1869,12 @@
             attachmentPicker.command?.(a)
           }}
         >
-          <FileTypeIcon contentType={a.content_type ?? null} filename={a.filename} class="w-4 h-4" />
+          <AttachmentThumb
+            bytes={a.data ?? null}
+            contentType={a.content_type ?? null}
+            filename={a.filename}
+            class="w-7 h-7"
+          />
           <span class="truncate">{a.filename}</span>
         </li>
       {/each}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1878,6 +1878,11 @@
       <li class="px-3 py-2 text-xs text-surface-500">No attachments to reference</li>
     {:else}
       {#each attachmentPicker.items as a, i (a.content_id)}
+        {@const thumb = thumbUrlSync({
+          bytes: a.data ?? null,
+          contentType: a.content_type ?? null,
+          filename: a.filename,
+        })}
         <li
           role="option"
           aria-selected={i === attachmentPicker.selectedIndex}
@@ -1890,11 +1895,6 @@
             attachmentPicker.command?.(a)
           }}
         >
-          {@const thumb = thumbUrlSync({
-            bytes: a.data ?? null,
-            contentType: a.content_type ?? null,
-            filename: a.filename,
-          })}
           {#if thumb}
             <img
               src={thumb}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -40,6 +40,7 @@
   import Mention from '@tiptap/extension-mention'
   import type { Range } from '@tiptap/core'
   import EmojiPicker from './EmojiPicker.svelte'
+  import FileTypeIcon from './FileTypeIcon.svelte'
   import { invoke } from '@tauri-apps/api/core'
 
   /**
@@ -157,6 +158,10 @@
      *  inserted link. Stamped at attachment-pick time in Compose. */
     content_id: string
     filename: string
+    /** MIME type — drives the per-format icon in the `/` picker
+     *  popup.  Optional so older callers (and the picker's
+     *  parseHTML round-trip) keep working without it. */
+    content_type?: string
   }
   let {
     content = '',
@@ -1857,7 +1862,7 @@
             attachmentPicker.command?.(a)
           }}
         >
-          <span class="text-base shrink-0">🖇️</span>
+          <FileTypeIcon contentType={a.content_type ?? null} filename={a.filename} class="w-4 h-4" />
           <span class="truncate">{a.filename}</span>
         </li>
       {/each}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -613,20 +613,18 @@
       // tray, not a missing inline link.
       Mention.extend({
         name: 'attachmentRef',
-        // Render as a styled <span>, NOT an <a href="cid:...">.
-        // Most email clients (Gmail, Outlook web, modern Apple
-        // Mail) try to navigate when the user clicks an
-        // anchor and surface a "can't open cid:..." error
-        // because they don't expose CID handlers to the
-        // surrounding chrome.  A <span> is just inline text:
-        // recipients see the typed badge + filename, no
-        // hyperlink, no broken-link UX.  Nimbus's own reader
-        // intercepts the click via the `data-attachment-ref`
-        // attribute (see MailView.onBodyClick) so jumping to
-        // the attachment still works locally.  Both the cid
-        // and the raw filename ride along on data-* attrs so
-        // a recipient can match the inline reference to the
-        // file in their attachment tray by name.
+        // Render as <a href="cid:..."> so Nimbus's own reader
+        // (MailView.processEmailHtml) picks it up the same way
+        // it always did — by matching cid: anchors and routing
+        // their click to the attachment via `data-nimbus-cid`.
+        // The data-* attrs (data-cid, data-filename,
+        // data-attachment-ref) ride along for the new robust
+        // click handler and as a cross-client identifier.
+        // Cross-client trade-off: Gmail / Outlook web may
+        // surface a "can't open cid:..." error if the user
+        // *clicks* the link.  The visible badge + filename is
+        // the part those recipients are meant to read; the
+        // hyperlink is purely a Nimbus affordance.
         renderHTML({ node, HTMLAttributes }) {
           const cid = node.attrs.id ?? ''
           const label = node.attrs.label ?? cid
@@ -693,9 +691,10 @@
             'font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;' +
             'letter-spacing:0.04em;text-align:center;vertical-align:middle;'
           return [
-            'span',
+            'a',
             {
               ...HTMLAttributes,
+              href: `cid:${cid}`,
               title: `Attached file: ${label}`,
               'data-label': label,
               'data-cid': cid,
@@ -703,7 +702,7 @@
               style:
                 'display:inline-flex;align-items:center;padding:0 6px;border-radius:4px;' +
                 'background:rgba(245,158,11,0.12);color:#b45309;' +
-                'font-weight:500;cursor:pointer;',
+                'text-decoration:none;font-weight:500;',
             },
             ['span', { style: badgeStyle }, badgeText],
             label,

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -615,21 +615,31 @@
           if (ext === 'pdf') {
             badgeText = 'PDF'
             badgeBg = '#e11d48' // rose
-          } else if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) {
+          } else if (
+            ['doc', 'docx', 'docm', 'dot', 'dotx', 'dotm', 'odt', 'ott', 'rtf'].includes(ext)
+          ) {
             badgeText = 'DOC'
             badgeBg = '#2563eb' // blue
-          } else if (['xls', 'xlsx', 'ods'].includes(ext)) {
+          } else if (['xls', 'xlsx', 'xlsm', 'xlt', 'xltx', 'xltm', 'ods', 'ots'].includes(ext)) {
             badgeText = 'XLS'
             badgeBg = '#059669' // emerald-600
-          } else if (ext === 'csv') {
+          } else if (['csv', 'tsv'].includes(ext)) {
             badgeText = 'CSV'
             badgeBg = '#10b981' // emerald-500
-          } else if (['ppt', 'pptx', 'odp'].includes(ext)) {
+          } else if (['ppt', 'pptx', 'pptm', 'pot', 'potx', 'potm', 'odp', 'otp'].includes(ext)) {
             badgeText = 'PPT'
             badgeBg = '#f59e0b' // amber
-          } else if (['zip', '7z', 'rar', 'tar', 'gz', 'xz'].includes(ext)) {
+          } else if (['zip', '7z', 'rar', 'tar', 'gz', 'xz', 'bz2', 'tgz'].includes(ext)) {
             badgeText = 'ZIP'
             badgeBg = '#7c3aed' // violet
+          } else if (['md', 'markdown', 'mdx', 'mkd'].includes(ext)) {
+            badgeText = 'MD'
+            badgeBg = '#0ea5e9' // sky
+          } else if (
+            ['jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'bmp', 'tif', 'tiff', 'svg', 'heic', 'heif', 'ico'].includes(ext)
+          ) {
+            badgeText = (ext === 'jpeg' ? 'JPG' : ext.toUpperCase()).slice(0, 4)
+            badgeBg = '#06b6d4' // cyan
           }
           const badgeStyle =
             'display:inline-block;min-width:2.2em;padding:1px 4px;margin-right:6px;' +
@@ -674,7 +684,11 @@
                 const text = e.textContent ?? ''
                 const label =
                   text
-                    .replace(/^(?:PDF|DOC|XLS|XLSX|CSV|PPT|PPTX|ZIP|FILE)\s*/i, '')
+                    // Strip any 2–4 letter ALL-CAPS leader
+                    // (PDF / DOC / XLS / CSV / PPT / ZIP / MD /
+                    // JPG / PNG / SVG / TIFF / FILE / …) the
+                    // wire-format renderer might have prepended.
+                    .replace(/^[A-Z]{2,4}\s+/, '')
                     .replace(/^(?:🖇️|📕|📘|📗|📙|🗜️|📎)\s*/, '') || id
                 return { id, label }
               },

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -582,7 +582,7 @@
       // tooltip identifying it as an attachment.  Clients that
       // resolve `cid:` (Apple Mail, Thunderbird, our own renderer)
       // get a direct jump to the part; Gmail / Outlook strip
-      // cid: but the recipient still sees a styled "📎 filename
+      // cid: but the recipient still sees a styled "🖇️ filename
       // (attached)" badge and the file is in the message's
       // attachment tray anyway.
       //
@@ -606,7 +606,7 @@
                 'background:rgba(245,158,11,0.15);color:#b45309;' +
                 'text-decoration:none;font-weight:500;',
             },
-            `📎 ${label}`,
+            `🖇️ ${label}`,
           ]
         },
         renderText({ node }) {
@@ -621,7 +621,7 @@
                 const href = (el as HTMLElement).getAttribute('href') ?? ''
                 const id = href.replace(/^cid:/, '')
                 const text = (el as HTMLElement).textContent ?? ''
-                const label = text.replace(/^📎\s*/, '') || id
+                const label = text.replace(/^🖇️\s*/, '') || id
                 return { id, label }
               },
             },
@@ -1779,7 +1779,7 @@
             attachmentPicker.command?.(a)
           }}
         >
-          <span class="text-base shrink-0">📎</span>
+          <span class="text-base shrink-0">🖇️</span>
           <span class="truncate">{a.filename}</span>
         </li>
       {/each}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -640,6 +640,16 @@
           ) {
             badgeText = (ext === 'jpeg' ? 'JPG' : ext.toUpperCase()).slice(0, 4)
             badgeBg = '#06b6d4' // cyan
+          } else if (
+            ['mp4', 'mkv', 'mov', 'avi', 'wmv', 'flv', 'webm', 'm4v', 'mpg', 'mpeg', '3gp'].includes(ext)
+          ) {
+            badgeText = ext.toUpperCase().slice(0, 4)
+            badgeBg = '#ec4899' // pink
+          } else if (
+            ['mp3', 'flac', 'wav', 'ogg', 'm4a', 'aac', 'opus', 'wma', 'aiff', 'alac'].includes(ext)
+          ) {
+            badgeText = ext.toUpperCase().slice(0, 4)
+            badgeBg = '#a855f7' // purple
           }
           const badgeStyle =
             'display:inline-block;min-width:2.2em;padding:1px 4px;margin-right:6px;' +

--- a/ui/src/lib/StandaloneMail.svelte
+++ b/ui/src/lib/StandaloneMail.svelte
@@ -99,6 +99,11 @@
       console.warn('edit-draft-from-mail emit failed', e)
     })
   }
+  function onMailto(init: { to?: string; cc?: string; bcc?: string; subject?: string; body?: string }) {
+    void emit('mailto-from-mail', { init }).catch((e) => {
+      console.warn('mailto-from-mail emit failed', e)
+    })
+  }
 
   function closeWindow() {
     void getCurrentWindow().close()
@@ -117,5 +122,6 @@
     onforward={onForward}
     oneditdraft={onEditDraft}
     onmessageremoved={closeWindow}
+    onmailto={onMailto}
   />
 </div>


### PR DESCRIPTION
Closes #93.

## Summary
Email clients (Gmail web, Outlook web, Apple Mail) strip class= and external CSS, so recipients of our outbound mail were seeing the raw \`@Name\` token without the styled pill we use inside the Nimbus editor. The same applied to / attachment references.

Solution: keep the Tailwind classes for our own editor look (no visual change for Nimbus authors), but additionally emit *inline style* attributes on the wire-format \`<a>\` elements. Inline styles survive every major MUA's content sanitiser, so the pill renders identically across clients.

Specific changes per token type:

**@-mentions**
- Inline pill styling (rounded background + primary colour).
- \`title="Display Name <addr>"\` tooltip so recipients can hover for the full address.
- \`mailto:\` href unchanged.

**/-attachment refs**
- Inline badge styling (amber tint to differentiate from mentions).
- \`title="Attached file: <name>"\` makes the intent clear in clients that strip \`cid:\`.
- Plain-text fallback now appends \`(attached)\` so a recipient reading text/plain understands the token points at the attachment tray, not a broken link.

\`parseHTML\` matchers are unchanged, so round-tripping a Nimbus reply through these still re-parses cleanly.

## Test plan
- [x] Send a mail with an @ mention to a Gmail recipient — recipient sees a styled pill, hovering shows full address.
- [x] Send to an Outlook web / Apple Mail recipient — same as above.
- [x] Send a / attachment ref — recipient sees a styled badge, attachment is in the tray, text/plain reads \`filename (attached)\`.
- [x] Reply within Nimbus — both pills round-trip through Tiptap parseHTML correctly.
- [x] Open the same mail in our own renderer — pill / badge looks identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)