### PR TITLE
FIDO unlock — Phase 1A foundation (#164)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,6 +1041,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2080,6 +2081,15 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3180,13 +3190,16 @@ dependencies = [
  "dirs 6.0.0",
  "getrandom 0.2.17",
  "hex",
+ "hmac",
  "keyring",
  "nimbus-core",
+ "pbkdf2",
  "r2d2",
  "r2d2_sqlite",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3571,6 +3584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +670,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -871,6 +917,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1731,6 +1786,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,6 +2438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -3100,6 +3174,8 @@ dependencies = [
 name = "nimbus-store"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
  "chrono",
  "dirs 6.0.0",
  "getrandom 0.2.17",
@@ -3330,6 +3406,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -3802,6 +3884,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -6035,6 +6129,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,13 @@ base64 = "0.22"
 # PRF output so the plain key never persists in the keychain
 # once FIDO mode is enabled.
 aes-gcm = "0.10"
+# PBKDF2-HMAC-SHA-256 for the passphrase-derived master-key wrap
+# (#164).  Sibling shape to the FIDO PRF wrap — same envelope,
+# different way to produce the 32-byte unwrap key.  Doubles as
+# the Phase 1B recovery passphrase so a lost hardware key
+# doesn't permanently lock the cache.
+pbkdf2 = "0.12"
+hmac = "0.12"
 # UUIDs for fresh vCard UIDs on contact create — we picked `urn:uuid:`
 # form to match what other CardDAV clients emit.
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,11 @@ ical = { version = "0.11", default-features = false, features = ["vcard", "ical"
 # vCard PHOTO is base64-encoded inline; we decode once on import so
 # the cached row holds raw image bytes.
 base64 = "0.22"
+# AES-256-GCM for the FIDO wrap of the SQLCipher master key
+# (#164).  Used to seal the master key under a per-credential
+# PRF output so the plain key never persists in the keychain
+# once FIDO mode is enabled.
+aes-gcm = "0.10"
 # UUIDs for fresh vCard UIDs on contact create — we picked `urn:uuid:`
 # form to match what other CardDAV clients emit.
 uuid = { version = "1", features = ["v4"] }

--- a/crates/nimbus-store/Cargo.toml
+++ b/crates/nimbus-store/Cargo.toml
@@ -18,3 +18,5 @@ r2d2.workspace = true
 r2d2_sqlite.workspace = true
 getrandom.workspace = true
 hex.workspace = true
+base64.workspace = true
+aes-gcm.workspace = true

--- a/crates/nimbus-store/Cargo.toml
+++ b/crates/nimbus-store/Cargo.toml
@@ -20,3 +20,6 @@ getrandom.workspace = true
 hex.workspace = true
 base64.workspace = true
 aes-gcm.workspace = true
+pbkdf2.workspace = true
+hmac.workspace = true
+sha2.workspace = true

--- a/crates/nimbus-store/src/cache/key.rs
+++ b/crates/nimbus-store/src/cache/key.rs
@@ -38,6 +38,8 @@ use keyring::Entry;
 use nimbus_core::NimbusError;
 use tracing::{debug, info};
 
+use crate::fido::{KeychainEnvelope, WrappedKey, parse_envelope, serialize_envelope};
+
 /// Keychain service name for the DB master key. Separate from the IMAP
 /// service so the entry is easy to spot in Credential Manager / Keychain
 /// Access, and so revoking the DB key can't touch account passwords.
@@ -60,29 +62,39 @@ fn entry() -> Result<Entry, NimbusError> {
 ///
 /// Returned as a 64-character lowercase hex string, ready to be embedded
 /// directly into a `PRAGMA key = "x'<hex>'"` statement.
+///
+/// Reads the keychain envelope (#164).  In **plain mode** (or the
+/// pre-FIDO format with a bare hex string), the envelope's
+/// `plain_key` is the answer.  When the envelope is in FIDO-only
+/// mode (no `plain_key`), the caller must instead unwrap one of the
+/// stored wraps via [`unlock_with_prf`].
 pub fn get_or_create_master_key() -> Result<String, NimbusError> {
     let entry = entry()?;
     match entry.get_password() {
-        Ok(hex_key) if hex_key.len() == KEY_LEN * 2 => {
-            debug!("Loaded existing DB master key from keychain");
-            Ok(hex_key)
-        }
-        Ok(other) => {
-            // Somehow a wrong-length value ended up in the slot — almost
-            // certainly a past-version bug or manual tampering. Refuse to
-            // proceed rather than silently generate a new one, which would
-            // orphan whatever encrypted DB the old key was unlocking.
-            Err(NimbusError::Storage(format!(
-                "unexpected master key length in keychain: {} chars (expected {})",
-                other.len(),
-                KEY_LEN * 2
-            )))
+        Ok(raw) => {
+            let env = parse_envelope(&raw)?;
+            if let Some(hex) = env.plain_key.as_deref() {
+                if hex.len() != KEY_LEN * 2 {
+                    return Err(NimbusError::Storage(format!(
+                        "unexpected master key length: {} chars (expected {})",
+                        hex.len(),
+                        KEY_LEN * 2
+                    )));
+                }
+                debug!("Loaded existing DB master key from keychain");
+                Ok(hex.to_string())
+            } else {
+                Err(NimbusError::Auth(
+                    "Database is in FIDO-only mode — call unlock_with_prf first".into(),
+                ))
+            }
         }
         Err(keyring::Error::NoEntry) => {
             info!("No DB master key in keychain — generating a new one");
             let hex_key = generate_hex_key()?;
+            let env = KeychainEnvelope::new_plain(hex_key.clone());
             entry
-                .set_password(&hex_key)
+                .set_password(&serialize_envelope(&env)?)
                 .map_err(|e| NimbusError::Storage(format!("failed to store master key: {e}")))?;
             Ok(hex_key)
         }
@@ -90,6 +102,56 @@ pub fn get_or_create_master_key() -> Result<String, NimbusError> {
             "failed to read master key: {e}"
         ))),
     }
+}
+
+/// Read the raw keychain envelope.  Used by FIDO management
+/// commands (list / remove credentials) and by the boot path that
+/// decides whether to show the lock screen.
+pub fn load_envelope() -> Result<KeychainEnvelope, NimbusError> {
+    let entry = entry()?;
+    match entry.get_password() {
+        Ok(raw) => parse_envelope(&raw),
+        Err(keyring::Error::NoEntry) => Ok(KeychainEnvelope {
+            version: 1,
+            plain_key: None,
+            wraps: Vec::new(),
+        }),
+        Err(e) => Err(NimbusError::Storage(format!(
+            "failed to read master key: {e}"
+        ))),
+    }
+}
+
+/// Persist a mutated envelope back to the keychain.
+pub fn save_envelope(env: &KeychainEnvelope) -> Result<(), NimbusError> {
+    let entry = entry()?;
+    entry
+        .set_password(&serialize_envelope(env)?)
+        .map_err(|e| NimbusError::Storage(format!("failed to store master key: {e}")))
+}
+
+/// Append (or replace) a wrap in the envelope, keyed on
+/// `credential_id` so re-enrolling the same authenticator just
+/// updates the existing entry.
+pub fn add_wrap(new: WrappedKey) -> Result<(), NimbusError> {
+    let mut env = load_envelope()?;
+    env.wraps.retain(|w| w.credential_id != new.credential_id);
+    env.wraps.push(new);
+    save_envelope(&env)
+}
+
+/// Remove a wrap by credential id.  Returns whether something was
+/// actually removed (caller may want to surface "no such credential"
+/// to the user).
+pub fn remove_wrap(credential_id_b64: &str) -> Result<bool, NimbusError> {
+    let mut env = load_envelope()?;
+    let before = env.wraps.len();
+    env.wraps.retain(|w| w.credential_id != credential_id_b64);
+    let removed = env.wraps.len() < before;
+    if removed {
+        save_envelope(&env)?;
+    }
+    Ok(removed)
 }
 
 fn generate_hex_key() -> Result<String, NimbusError> {

--- a/crates/nimbus-store/src/fido.rs
+++ b/crates/nimbus-store/src/fido.rs
@@ -1,0 +1,317 @@
+//! FIDO unlock for the SQLCipher master key (#164).
+//!
+//! # What this is
+//!
+//! The cache database is encrypted with a 32-byte AES-256 master
+//! key.  Today that key sits in plaintext in the OS keychain — fine
+//! against "someone copies the disk" but not against malware running
+//! as the same OS user (which can ask the keychain itself for the
+//! key).  This module adds an opt-in second layer: instead of the
+//! plain key, the keychain holds an *envelope* containing zero or
+//! more wraps, each one a copy of the master key sealed by a
+//! per-credential PRF output that only a registered FIDO2
+//! authenticator (USB key, Touch ID, Windows Hello, …) can produce.
+//!
+//! Without the credential, the wrap is opaque.  An attacker with full
+//! keychain access still can't reach the master key without the
+//! user touching their authenticator.
+//!
+//! # The PRF protocol
+//!
+//! WebAuthn's PRF extension (RFC-bound; backed by CTAP2's
+//! `hmac-secret`) lets us evaluate
+//!
+//!     prf_output = HMAC-SHA-256(per-credential-secret, salt)
+//!
+//! The per-credential secret never leaves the authenticator.  Same
+//! `(credential_id, salt)` always produces the same 32-byte output,
+//! but only after the user authenticates.  We store `salt` per wrap
+//! and treat the resulting `prf_output` as a key.
+//!
+//! # The wrap
+//!
+//! For each registered credential we draw a random 12-byte nonce and
+//! seal the master key with AES-256-GCM under `prf_output`, with the
+//! `credential_id` as additional authenticated data so a wrap can't
+//! be confused for one belonging to a different credential.
+//!
+//! ```text
+//! ciphertext, tag = AES-256-GCM(
+//!     key   = prf_output,
+//!     nonce = random,
+//!     aad   = credential_id,
+//!     msg   = master_key,
+//! )
+//! ```
+//!
+//! Each wrap independently encrypts the *same* master key, so any
+//! one registered credential is enough to unlock.  Adding /
+//! removing a key only mutates the wraps array — the master key
+//! itself never changes (so the encrypted DB doesn't have to be
+//! re-keyed).
+//!
+//! # Storage shape
+//!
+//! The `nimbus-mail-db` keychain entry holds JSON:
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "plain_key": "<64-char hex>",
+//!   "wraps": [
+//!     {
+//!       "credential_id": "<base64>",
+//!       "salt":          "<base64>",
+//!       "label":         "YubiKey 5C",
+//!       "nonce":         "<base64>",
+//!       "ciphertext":    "<base64>",
+//!       "created_at":    1735689600
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! `plain_key` is present in plain mode and after enrolling the
+//! first FIDO credential (Phase 1A keeps it for backwards-compat).
+//! Phase 1B will null it once startup unlock through FIDO is
+//! wired, leaving the wraps as the only path to the master key.
+//!
+//! Pre-#164 keychains hold the bare 64-char hex string instead of
+//! JSON; `parse_envelope` migrates that to the new shape on first
+//! read.
+
+use aes_gcm::{
+    Aes256Gcm, Key, Nonce,
+    aead::{Aead, KeyInit, Payload},
+};
+use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+use chrono::Utc;
+use getrandom::getrandom;
+use nimbus_core::NimbusError;
+use serde::{Deserialize, Serialize};
+
+/// Bytes in a master key (AES-256).
+const MASTER_KEY_LEN: usize = 32;
+/// Bytes in the PRF output WebAuthn returns to us (HMAC-SHA-256).
+const PRF_LEN: usize = 32;
+/// AES-GCM nonce length.
+const NONCE_LEN: usize = 12;
+/// Bytes in a wrap salt — the WebAuthn PRF eval input.
+const SALT_LEN: usize = 32;
+
+/// One sealed copy of the master key, bound to a single registered
+/// FIDO credential.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WrappedKey {
+    /// Base64-encoded WebAuthn credential id.
+    pub credential_id: String,
+    /// Base64-encoded random 32-byte salt — the PRF input we
+    /// re-supply at unlock to derive the same secret.
+    pub salt: String,
+    /// User-readable label.  `"YubiKey 5C"`, `"Touch ID — MacBook"`.
+    pub label: String,
+    /// Base64-encoded AES-GCM nonce (12 bytes).
+    pub nonce: String,
+    /// Base64-encoded AES-GCM ciphertext + tag.
+    pub ciphertext: String,
+    /// Unix epoch seconds — purely informational, surfaced in the
+    /// Settings list.
+    pub created_at: i64,
+}
+
+/// The keychain entry's payload.  See the module-level doc for the
+/// exact JSON shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeychainEnvelope {
+    pub version: u32,
+    /// 64-character lowercase hex master key.  Present in plain
+    /// mode and during the Phase 1A grace period; null once
+    /// FIDO-only mode is active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plain_key: Option<String>,
+    #[serde(default)]
+    pub wraps: Vec<WrappedKey>,
+}
+
+impl KeychainEnvelope {
+    pub fn new_plain(plain_key_hex: String) -> Self {
+        Self {
+            version: 1,
+            plain_key: Some(plain_key_hex),
+            wraps: Vec::new(),
+        }
+    }
+}
+
+/// Parse the keychain entry's stored value into an envelope.  Old
+/// builds wrote a bare hex string; we treat that as a plain-only
+/// envelope so the migration is invisible to the caller.
+pub fn parse_envelope(raw: &str) -> Result<KeychainEnvelope, NimbusError> {
+    if looks_like_plain_hex(raw) {
+        return Ok(KeychainEnvelope::new_plain(raw.to_string()));
+    }
+    serde_json::from_str(raw)
+        .map_err(|e| NimbusError::Storage(format!("master-key envelope decode: {e}")))
+}
+
+fn looks_like_plain_hex(s: &str) -> bool {
+    s.len() == MASTER_KEY_LEN * 2 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Serialise an envelope for the keychain.
+pub fn serialize_envelope(env: &KeychainEnvelope) -> Result<String, NimbusError> {
+    serde_json::to_string(env)
+        .map_err(|e| NimbusError::Storage(format!("master-key envelope encode: {e}")))
+}
+
+// ── Wrap helpers ──────────────────────────────────────────────
+
+/// Seal `master_key` under the FIDO PRF output.  Used at enrollment
+/// time once the frontend has run WebAuthn and ferried the PRF bytes
+/// back to us.
+///
+/// The salt is generated here (not by the caller) so each wrap has
+/// independent, fresh entropy — it's encoded into the returned
+/// `WrappedKey.salt` and *must* be supplied to WebAuthn at unlock
+/// time as the PRF eval input.
+pub fn wrap_master_key(
+    master_key: &[u8],
+    prf_output: &[u8],
+    credential_id: &[u8],
+    salt: &[u8],
+    label: String,
+) -> Result<WrappedKey, NimbusError> {
+    if master_key.len() != MASTER_KEY_LEN {
+        return Err(NimbusError::Storage(format!(
+            "wrap_master_key: master_key must be {MASTER_KEY_LEN} bytes, got {}",
+            master_key.len()
+        )));
+    }
+    if prf_output.len() != PRF_LEN {
+        return Err(NimbusError::Storage(format!(
+            "wrap_master_key: prf_output must be {PRF_LEN} bytes, got {}",
+            prf_output.len()
+        )));
+    }
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    getrandom(&mut nonce_bytes)
+        .map_err(|e| NimbusError::Storage(format!("wrap nonce RNG: {e}")))?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(prf_output));
+    let ct = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: master_key,
+                aad: credential_id,
+            },
+        )
+        .map_err(|e| NimbusError::Storage(format!("AES-GCM seal: {e}")))?;
+    Ok(WrappedKey {
+        credential_id: B64.encode(credential_id),
+        salt: B64.encode(salt),
+        label,
+        nonce: B64.encode(nonce_bytes),
+        ciphertext: B64.encode(&ct),
+        created_at: Utc::now().timestamp(),
+    })
+}
+
+/// Open a single wrap with the FIDO PRF output computed at unlock
+/// time.  Returns the recovered master key bytes (32 bytes).
+pub fn unwrap_master_key(
+    wrap: &WrappedKey,
+    prf_output: &[u8],
+) -> Result<Vec<u8>, NimbusError> {
+    if prf_output.len() != PRF_LEN {
+        return Err(NimbusError::Storage(format!(
+            "unwrap_master_key: prf_output must be {PRF_LEN} bytes, got {}",
+            prf_output.len()
+        )));
+    }
+    let credential_id = B64
+        .decode(wrap.credential_id.as_bytes())
+        .map_err(|e| NimbusError::Storage(format!("wrap credential_id b64: {e}")))?;
+    let nonce_bytes = B64
+        .decode(wrap.nonce.as_bytes())
+        .map_err(|e| NimbusError::Storage(format!("wrap nonce b64: {e}")))?;
+    if nonce_bytes.len() != NONCE_LEN {
+        return Err(NimbusError::Storage(format!(
+            "wrap nonce must be {NONCE_LEN} bytes, got {}",
+            nonce_bytes.len()
+        )));
+    }
+    let ct = B64
+        .decode(wrap.ciphertext.as_bytes())
+        .map_err(|e| NimbusError::Storage(format!("wrap ciphertext b64: {e}")))?;
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(prf_output));
+    let pt = cipher
+        .decrypt(
+            Nonce::from_slice(&nonce_bytes),
+            Payload {
+                msg: &ct,
+                aad: &credential_id,
+            },
+        )
+        .map_err(|e| NimbusError::Storage(format!("AES-GCM open: {e}")))?;
+    if pt.len() != MASTER_KEY_LEN {
+        return Err(NimbusError::Storage(format!(
+            "unwrapped master key has wrong length: {}",
+            pt.len()
+        )));
+    }
+    Ok(pt)
+}
+
+/// Generate a fresh random salt for a new wrap.  The frontend feeds
+/// this back into WebAuthn's `prf.eval.first` at unlock time.
+pub fn generate_salt() -> Result<[u8; SALT_LEN], NimbusError> {
+    let mut buf = [0u8; SALT_LEN];
+    getrandom(&mut buf).map_err(|e| NimbusError::Storage(format!("salt RNG: {e}")))?;
+    Ok(buf)
+}
+
+/// Decode a base64-encoded credential id (helper for the Tauri layer).
+pub fn decode_b64(s: &str) -> Result<Vec<u8>, NimbusError> {
+    B64.decode(s.as_bytes())
+        .map_err(|e| NimbusError::Storage(format!("base64 decode: {e}")))
+}
+
+/// Encode bytes as base64 (helper for the Tauri layer).
+pub fn encode_b64(bytes: &[u8]) -> String {
+    B64.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_then_unwrap_roundtrips() {
+        let master = [0xAB_u8; MASTER_KEY_LEN];
+        let prf = [0xCD_u8; PRF_LEN];
+        let cred = b"fake-credential-id";
+        let salt = generate_salt().unwrap();
+        let wrap = wrap_master_key(&master, &prf, cred, &salt, "Test".into()).unwrap();
+        let recovered = unwrap_master_key(&wrap, &prf).unwrap();
+        assert_eq!(recovered, master);
+    }
+
+    #[test]
+    fn unwrap_with_wrong_prf_fails() {
+        let master = [0x01_u8; MASTER_KEY_LEN];
+        let prf = [0x02_u8; PRF_LEN];
+        let wrong_prf = [0x03_u8; PRF_LEN];
+        let cred = b"id";
+        let salt = generate_salt().unwrap();
+        let wrap = wrap_master_key(&master, &prf, cred, &salt, "X".into()).unwrap();
+        assert!(unwrap_master_key(&wrap, &wrong_prf).is_err());
+    }
+
+    #[test]
+    fn plain_hex_treated_as_plain_envelope() {
+        let hex = "a".repeat(64);
+        let env = parse_envelope(&hex).unwrap();
+        assert_eq!(env.plain_key.as_deref(), Some(hex.as_str()));
+        assert!(env.wraps.is_empty());
+    }
+}

--- a/crates/nimbus-store/src/fido.rs
+++ b/crates/nimbus-store/src/fido.rs
@@ -87,8 +87,11 @@ use aes_gcm::{
 use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
 use chrono::Utc;
 use getrandom::getrandom;
+use hmac::Hmac;
 use nimbus_core::NimbusError;
+use pbkdf2::pbkdf2;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 
 /// Bytes in a master key (AES-256).
 const MASTER_KEY_LEN: usize = 32;
@@ -96,19 +99,55 @@ const MASTER_KEY_LEN: usize = 32;
 const PRF_LEN: usize = 32;
 /// AES-GCM nonce length.
 const NONCE_LEN: usize = 12;
-/// Bytes in a wrap salt — the WebAuthn PRF eval input.
+/// Bytes in a wrap salt — the WebAuthn PRF eval input AND the
+/// PBKDF2 salt for passphrase wraps.  Same value, different
+/// derivation downstream.
 const SALT_LEN: usize = 32;
 
-/// One sealed copy of the master key, bound to a single registered
-/// FIDO credential.
+/// PBKDF2-HMAC-SHA-256 iteration count for passphrase wraps.
+/// OWASP's 2024 floor for SHA-256 is 600 000 — we round up to
+/// match a Bitwarden-class baseline.  At ~1 ms per 100 000 iters
+/// on modern CPUs this is ~7 ms total at unlock, imperceptible.
+pub const PASSPHRASE_PBKDF2_ITERS: u32 = 720_000;
+
+/// What kind of source produced the AES key that sealed a wrap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WrapKind {
+    /// FIDO2 WebAuthn PRF / hmac-secret extension.  The
+    /// `credential_id` field identifies the authenticator and
+    /// the `salt` is fed back to WebAuthn's `prf.eval.first` at
+    /// unlock to reproduce the same 32-byte output.
+    FidoPrf,
+    /// PBKDF2-HMAC-SHA-256(passphrase, salt, iters).  Used for
+    /// the recovery-passphrase fallback (so a lost hardware key
+    /// isn't a permanent lockout) and as a development-only path
+    /// on platforms whose WebAuthn implementation can't reach
+    /// PRF / hmac-secret yet (Linux WebKitGTK < 2.46, …).
+    Passphrase,
+}
+
+/// One sealed copy of the master key.  Bound to a single
+/// authentication "method" — either a registered FIDO credential
+/// (one wrap per authenticator) or a passphrase.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WrappedKey {
-    /// Base64-encoded WebAuthn credential id.
+    /// Which derivation produced the AES key for this wrap.
+    /// `#[serde(default = ...)]` keeps pre-#164-passphrase
+    /// envelopes (which only had FIDO PRF wraps) deserialising
+    /// cleanly as `FidoPrf`.
+    #[serde(default = "default_wrap_kind")]
+    pub kind: WrapKind,
+    /// Base64-encoded WebAuthn credential id (FIDO PRF wraps).
+    /// Empty for passphrase wraps; a synthetic id is stored
+    /// instead so the entry has a stable identity for the UI's
+    /// "remove this method" action.
     pub credential_id: String,
-    /// Base64-encoded random 32-byte salt — the PRF input we
-    /// re-supply at unlock to derive the same secret.
+    /// Base64-encoded random 32-byte salt.  PRF input for FIDO,
+    /// PBKDF2 salt for passphrase.
     pub salt: String,
-    /// User-readable label.  `"YubiKey 5C"`, `"Touch ID — MacBook"`.
+    /// User-readable label.  `"YubiKey 5C"`, `"Touch ID — MacBook"`,
+    /// `"Recovery passphrase"`.
     pub label: String,
     /// Base64-encoded AES-GCM nonce (12 bytes).
     pub nonce: String,
@@ -117,6 +156,10 @@ pub struct WrappedKey {
     /// Unix epoch seconds — purely informational, surfaced in the
     /// Settings list.
     pub created_at: i64,
+}
+
+fn default_wrap_kind() -> WrapKind {
+    WrapKind::FidoPrf
 }
 
 /// The keychain entry's payload.  See the module-level doc for the
@@ -175,8 +218,9 @@ pub fn serialize_envelope(env: &KeychainEnvelope) -> Result<String, NimbusError>
 /// `WrappedKey.salt` and *must* be supplied to WebAuthn at unlock
 /// time as the PRF eval input.
 pub fn wrap_master_key(
+    kind: WrapKind,
     master_key: &[u8],
-    prf_output: &[u8],
+    aes_key: &[u8],
     credential_id: &[u8],
     salt: &[u8],
     label: String,
@@ -187,16 +231,16 @@ pub fn wrap_master_key(
             master_key.len()
         )));
     }
-    if prf_output.len() != PRF_LEN {
+    if aes_key.len() != PRF_LEN {
         return Err(NimbusError::Storage(format!(
-            "wrap_master_key: prf_output must be {PRF_LEN} bytes, got {}",
-            prf_output.len()
+            "wrap_master_key: aes_key must be {PRF_LEN} bytes, got {}",
+            aes_key.len()
         )));
     }
     let mut nonce_bytes = [0u8; NONCE_LEN];
     getrandom(&mut nonce_bytes)
         .map_err(|e| NimbusError::Storage(format!("wrap nonce RNG: {e}")))?;
-    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(prf_output));
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(aes_key));
     let ct = cipher
         .encrypt(
             Nonce::from_slice(&nonce_bytes),
@@ -207,6 +251,7 @@ pub fn wrap_master_key(
         )
         .map_err(|e| NimbusError::Storage(format!("AES-GCM seal: {e}")))?;
     Ok(WrappedKey {
+        kind,
         credential_id: B64.encode(credential_id),
         salt: B64.encode(salt),
         label,
@@ -214,6 +259,30 @@ pub fn wrap_master_key(
         ciphertext: B64.encode(&ct),
         created_at: Utc::now().timestamp(),
     })
+}
+
+/// Derive a 32-byte AES key from a user passphrase and the
+/// stored salt via PBKDF2-HMAC-SHA-256.  Same input always
+/// produces the same output, so the user can unlock by typing
+/// the passphrase again.
+pub fn derive_passphrase_key(passphrase: &str, salt: &[u8]) -> Result<[u8; PRF_LEN], NimbusError> {
+    if passphrase.is_empty() {
+        return Err(NimbusError::Other("passphrase must not be empty".into()));
+    }
+    let mut out = [0u8; PRF_LEN];
+    pbkdf2::<Hmac<Sha256>>(passphrase.as_bytes(), salt, PASSPHRASE_PBKDF2_ITERS, &mut out)
+        .map_err(|e| NimbusError::Storage(format!("pbkdf2 derive: {e}")))?;
+    Ok(out)
+}
+
+/// Generate a synthetic credential id for a passphrase wrap.
+/// Lets the UI uniquely identify and remove a passphrase entry
+/// the same way it'd identify a FIDO credential.  16 random
+/// bytes — collisions are not a concern.
+pub fn generate_passphrase_id() -> Result<[u8; 16], NimbusError> {
+    let mut buf = [0u8; 16];
+    getrandom(&mut buf).map_err(|e| NimbusError::Storage(format!("synth id RNG: {e}")))?;
+    Ok(buf)
 }
 
 /// Open a single wrap with the FIDO PRF output computed at unlock
@@ -286,14 +355,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wrap_then_unwrap_roundtrips() {
+    fn wrap_then_unwrap_roundtrips_fido() {
         let master = [0xAB_u8; MASTER_KEY_LEN];
         let prf = [0xCD_u8; PRF_LEN];
         let cred = b"fake-credential-id";
         let salt = generate_salt().unwrap();
-        let wrap = wrap_master_key(&master, &prf, cred, &salt, "Test".into()).unwrap();
+        let wrap =
+            wrap_master_key(WrapKind::FidoPrf, &master, &prf, cred, &salt, "Test".into())
+                .unwrap();
         let recovered = unwrap_master_key(&wrap, &prf).unwrap();
         assert_eq!(recovered, master);
+    }
+
+    #[test]
+    fn wrap_then_unwrap_roundtrips_passphrase() {
+        let master = [0x77_u8; MASTER_KEY_LEN];
+        let salt = generate_salt().unwrap();
+        let id = generate_passphrase_id().unwrap();
+        let key = derive_passphrase_key("correct horse battery staple", &salt).unwrap();
+        let wrap =
+            wrap_master_key(WrapKind::Passphrase, &master, &key, &id, &salt, "Recovery".into())
+                .unwrap();
+        let derived =
+            derive_passphrase_key("correct horse battery staple", &salt).unwrap();
+        let recovered = unwrap_master_key(&wrap, &derived).unwrap();
+        assert_eq!(recovered, master);
+    }
+
+    #[test]
+    fn unwrap_with_wrong_passphrase_fails() {
+        let master = [0x01_u8; MASTER_KEY_LEN];
+        let salt = generate_salt().unwrap();
+        let id = generate_passphrase_id().unwrap();
+        let key = derive_passphrase_key("right answer", &salt).unwrap();
+        let wrap =
+            wrap_master_key(WrapKind::Passphrase, &master, &key, &id, &salt, "X".into())
+                .unwrap();
+        let wrong = derive_passphrase_key("wrong answer", &salt).unwrap();
+        assert!(unwrap_master_key(&wrap, &wrong).is_err());
     }
 
     #[test]
@@ -303,7 +402,8 @@ mod tests {
         let wrong_prf = [0x03_u8; PRF_LEN];
         let cred = b"id";
         let salt = generate_salt().unwrap();
-        let wrap = wrap_master_key(&master, &prf, cred, &salt, "X".into()).unwrap();
+        let wrap =
+            wrap_master_key(WrapKind::FidoPrf, &master, &prf, cred, &salt, "X".into()).unwrap();
         assert!(unwrap_master_key(&wrap, &wrong_prf).is_err());
     }
 

--- a/crates/nimbus-store/src/lib.rs
+++ b/crates/nimbus-store/src/lib.rs
@@ -7,6 +7,7 @@ pub mod account_store;
 pub mod app_settings;
 pub mod cache;
 pub mod credentials;
+pub mod fido;
 pub mod nextcloud_store;
 
 pub use cache::Cache;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6893,6 +6893,8 @@ fn save_font_cache_file(file: &FontCacheFile) {
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct FidoCredentialView {
+    /// `"fido_prf"` or `"passphrase"`.
+    kind: String,
     credential_id: String,
     label: String,
     salt: String,
@@ -6922,6 +6924,10 @@ fn fido_status() -> Result<FidoStatusView, NimbusError> {
             .wraps
             .into_iter()
             .map(|w| FidoCredentialView {
+                kind: match w.kind {
+                    nimbus_store::fido::WrapKind::FidoPrf => "fido_prf".to_string(),
+                    nimbus_store::fido::WrapKind::Passphrase => "passphrase".to_string(),
+                },
                 credential_id: w.credential_id,
                 label: w.label,
                 salt: w.salt,
@@ -6965,9 +6971,101 @@ fn fido_enroll(
     let credential_id = fido::decode_b64(&credential_id_b64)?;
     let salt = fido::decode_b64(&salt_b64)?;
     let prf_output = fido::decode_b64(&prf_output_b64)?;
-    let wrap = fido::wrap_master_key(&master_key, &prf_output, &credential_id, &salt, label)?;
+    let wrap = fido::wrap_master_key(
+        fido::WrapKind::FidoPrf,
+        &master_key,
+        &prf_output,
+        &credential_id,
+        &salt,
+        label,
+    )?;
     nimbus_store::cache::key::add_wrap(wrap)?;
     Ok(())
+}
+
+/// Wrap the current master key under a passphrase-derived AES key
+/// (PBKDF2-HMAC-SHA-256, 720 000 iters).  Doubles as recovery
+/// passphrase for Phase 1B and as the test path on platforms
+/// where WebAuthn PRF isn't reachable yet (Linux WebKitGTK <
+/// 2.46).  Salt + synthetic credential id are server-side
+/// generated so the frontend never produces them.
+#[tauri::command]
+fn fido_enroll_passphrase(passphrase: String, label: String) -> Result<(), NimbusError> {
+    use nimbus_store::fido;
+    if passphrase.trim().is_empty() {
+        return Err(NimbusError::Other("passphrase must not be empty".into()));
+    }
+    let env = nimbus_store::cache::key::load_envelope()?;
+    let plain_hex = env.plain_key.as_deref().ok_or_else(|| {
+        NimbusError::Auth(
+            "Cannot enroll a passphrase while the database is FIDO-only (use unlock first)".into(),
+        )
+    })?;
+    let master_key = hex::decode(plain_hex)
+        .map_err(|e| NimbusError::Storage(format!("master key hex decode: {e}")))?;
+    let salt = fido::generate_salt()?;
+    let id = fido::generate_passphrase_id()?;
+    let aes_key = fido::derive_passphrase_key(&passphrase, &salt)?;
+    let wrap = fido::wrap_master_key(
+        fido::WrapKind::Passphrase,
+        &master_key,
+        &aes_key,
+        &id,
+        &salt,
+        label,
+    )?;
+    nimbus_store::cache::key::add_wrap(wrap)?;
+    Ok(())
+}
+
+/// Test-only: verify a passphrase wraps unlock the master key.
+/// Phase 1B will call this from the lock screen when the user
+/// chooses passphrase unlock; today it lets users sanity-check
+/// their passphrase entry on Linux without restructuring boot.
+/// Returns `true` on success, `false` on a wrong passphrase /
+/// no matching wrap, error on storage / crypto failure.
+#[tauri::command]
+fn fido_verify_passphrase(passphrase: String) -> Result<bool, NimbusError> {
+    use nimbus_store::fido::{self, WrapKind};
+    let env = nimbus_store::cache::key::load_envelope()?;
+    for wrap in &env.wraps {
+        if wrap.kind != WrapKind::Passphrase {
+            continue;
+        }
+        let salt = fido::decode_b64(&wrap.salt)?;
+        let aes_key = fido::derive_passphrase_key(&passphrase, &salt)?;
+        if fido::unwrap_master_key(wrap, &aes_key).is_ok() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Mirror of `fido_verify_passphrase` for FIDO PRF wraps.  The
+/// frontend has already run WebAuthn `credentials.get` against
+/// the credential's stored salt and forwards the PRF output
+/// here.  Phase 1B's lock screen will use this; today it lets
+/// you sanity-check that a registered hardware key still works.
+#[tauri::command]
+fn fido_verify_prf(
+    credential_id_b64: String,
+    prf_output_b64: String,
+) -> Result<bool, NimbusError> {
+    use nimbus_store::fido::{self, WrapKind};
+    let env = nimbus_store::cache::key::load_envelope()?;
+    let prf = fido::decode_b64(&prf_output_b64)?;
+    for wrap in &env.wraps {
+        if wrap.kind != WrapKind::FidoPrf {
+            continue;
+        }
+        if wrap.credential_id != credential_id_b64 {
+            continue;
+        }
+        if fido::unwrap_master_key(wrap, &prf).is_ok() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Remove a registered credential.  Refuses to drop the last wrap
@@ -7579,6 +7677,9 @@ fn main() {
             fido_status,
             fido_generate_salt,
             fido_enroll,
+            fido_enroll_passphrase,
+            fido_verify_passphrase,
+            fido_verify_prf,
             fido_remove,
             update_app_settings,
             import_custom_theme,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6882,6 +6882,109 @@ fn save_font_cache_file(file: &FontCacheFile) {
     }
 }
 
+// ── FIDO unlock (#164, Phase 1A) ──────────────────────────────
+//
+// These commands manage the wraps inside the keychain envelope.
+// They don't yet replace the plain-mode startup path — registering
+// keys is observable via the Settings UI, and the unlock-at-boot
+// flow lands as a separate phase once the wrap/unwrap loop is
+// hardware-verified.
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FidoCredentialView {
+    credential_id: String,
+    label: String,
+    salt: String,
+    created_at: i64,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FidoStatusView {
+    /// Always Some in plain / hybrid mode, None once the keychain
+    /// is in FIDO-only mode (Phase 1B+).
+    has_plain_key: bool,
+    /// How many credentials the user has registered.
+    credentials: Vec<FidoCredentialView>,
+}
+
+/// Snapshot of the keychain envelope.  Used by Settings to render
+/// the "Hardware authentication" panel and (later) by the boot
+/// path to decide whether to require an unlock before opening the
+/// cache.
+#[tauri::command]
+fn fido_status() -> Result<FidoStatusView, NimbusError> {
+    let env = nimbus_store::cache::key::load_envelope()?;
+    Ok(FidoStatusView {
+        has_plain_key: env.plain_key.is_some(),
+        credentials: env
+            .wraps
+            .into_iter()
+            .map(|w| FidoCredentialView {
+                credential_id: w.credential_id,
+                label: w.label,
+                salt: w.salt,
+                created_at: w.created_at,
+            })
+            .collect(),
+    })
+}
+
+/// Generate a fresh PRF salt for a new enrollment.  The frontend
+/// supplies it as the `prf.eval.first` input to `navigator.
+/// credentials.create` so the authenticator returns the matching
+/// PRF output.
+#[tauri::command]
+fn fido_generate_salt() -> Result<String, NimbusError> {
+    let salt = nimbus_store::fido::generate_salt()?;
+    Ok(nimbus_store::fido::encode_b64(&salt))
+}
+
+/// Wrap the current master key under a freshly-registered FIDO
+/// credential's PRF output.  Frontend has already called
+/// WebAuthn `credentials.create` with the salt from
+/// `fido_generate_salt`, received the credential id and the PRF
+/// bytes back, and forwards them here for storage.
+#[tauri::command]
+fn fido_enroll(
+    credential_id_b64: String,
+    salt_b64: String,
+    prf_output_b64: String,
+    label: String,
+) -> Result<(), NimbusError> {
+    use nimbus_store::fido;
+    let env = nimbus_store::cache::key::load_envelope()?;
+    let plain_hex = env.plain_key.as_deref().ok_or_else(|| {
+        NimbusError::Auth(
+            "Cannot enroll a credential while the database is FIDO-only (use unlock first)".into(),
+        )
+    })?;
+    let master_key = hex::decode(plain_hex)
+        .map_err(|e| NimbusError::Storage(format!("master key hex decode: {e}")))?;
+    let credential_id = fido::decode_b64(&credential_id_b64)?;
+    let salt = fido::decode_b64(&salt_b64)?;
+    let prf_output = fido::decode_b64(&prf_output_b64)?;
+    let wrap = fido::wrap_master_key(&master_key, &prf_output, &credential_id, &salt, label)?;
+    nimbus_store::cache::key::add_wrap(wrap)?;
+    Ok(())
+}
+
+/// Remove a registered credential.  Refuses to drop the last wrap
+/// when the keychain is in FIDO-only mode (would orphan the
+/// encrypted DB).
+#[tauri::command]
+fn fido_remove(credential_id_b64: String) -> Result<(), NimbusError> {
+    let env = nimbus_store::cache::key::load_envelope()?;
+    if env.plain_key.is_none() && env.wraps.len() <= 1 {
+        return Err(NimbusError::Other(
+            "Cannot remove the last hardware key while FIDO-only mode is active".into(),
+        ));
+    }
+    nimbus_store::cache::key::remove_wrap(&credential_id_b64)?;
+    Ok(())
+}
+
 /// Return the cached font list to the frontend.  Reads from
 /// the shared `SystemFontsCache` populated at startup; if the
 /// cache is somehow empty (startup warmer failed or hasn't run
@@ -7473,6 +7576,10 @@ fn main() {
             // Issue #16: tray + notifications + preferences
             get_app_settings,
             list_system_fonts,
+            fido_status,
+            fido_generate_salt,
+            fido_enroll,
+            fido_remove,
             update_app_settings,
             import_custom_theme,
             remove_custom_theme,

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -13,6 +13,7 @@
   import NextcloudSettings from './NextcloudSettings.svelte'
   import SecuritySettings from './SecuritySettings.svelte'
   import EmojiPicker from './EmojiPicker.svelte'
+  import Toggle from './Toggle.svelte'
   import {
     STOCK_THEMES,
     applyTheme,
@@ -719,33 +720,30 @@
         </div>
       </div>
 
-      <div class="space-y-2 text-sm">
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+      <div class="space-y-3 text-sm">
+        <div class="flex items-start gap-3">
+          <Toggle
             bind:checked={appSettings.minimize_to_tray}
-            onchange={scheduleSave}
+            label="Minimize to tray when closing the window"
+            onchange={() => scheduleSave()}
           />
           <span>Minimize to tray when closing the window</span>
-        </label>
+        </div>
 
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+        <div class="flex items-start gap-3">
+          <Toggle
             bind:checked={appSettings.start_minimized}
-            onchange={scheduleSave}
+            label="Start minimized to tray"
+            onchange={() => scheduleSave()}
           />
           <span>Start minimized to tray</span>
-        </label>
+        </div>
 
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+        <div class="flex items-start gap-3">
+          <Toggle
             checked={appSettings.autostart_enabled}
-            onchange={(e) => void onAutostartToggle((e.currentTarget as HTMLInputElement).checked)}
+            label="Launch Nimbus when I sign in"
+            onchange={(v) => void onAutostartToggle(v)}
           />
           <span>
             Launch Nimbus when I sign in
@@ -753,17 +751,16 @@
               Adds an entry to your OS's autostart list. Combine with "Start minimized to tray" for a quiet boot.
             </span>
           </span>
-        </label>
+        </div>
 
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+        <div class="flex items-start gap-3">
+          <Toggle
             bind:checked={appSettings.auto_advance_after_remove}
-            onchange={scheduleSave}
+            label="After delete / archive, open the next message automatically"
+            onchange={() => scheduleSave()}
           />
           <span>After delete / archive, open the next message automatically</span>
-        </label>
+        </div>
       </div>
     </div>
     {/if}
@@ -790,18 +787,17 @@
           </button>
         </div>
       </div>
-      <div class="space-y-2 text-sm">
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+      <div class="space-y-3 text-sm">
+        <div class="flex items-start gap-3">
+          <Toggle
             bind:checked={appSettings.background_sync_enabled}
-            onchange={scheduleSave}
+            label="Run background mail sync"
+            onchange={() => scheduleSave()}
           />
           <span>Run background mail sync</span>
-        </label>
+        </div>
 
-        <label class="flex items-center gap-2 pl-6">
+        <label class="flex items-center gap-2 pl-12">
           <span class="text-surface-500">Interval (seconds):</span>
           <input
             type="number"
@@ -815,15 +811,14 @@
           <span class="text-xs text-surface-400">min. 30</span>
         </label>
 
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+        <div class="flex items-start gap-3">
+          <Toggle
             bind:checked={appSettings.notifications_enabled}
-            onchange={scheduleSave}
+            label="Show desktop notifications for new mail"
+            onchange={() => scheduleSave()}
           />
           <span>Show desktop notifications for new mail</span>
-        </label>
+        </div>
       </div>
     </div>
     {/if}
@@ -841,13 +836,12 @@
           <span class="text-xs text-success-500">Saved</span>
         {/if}
       </div>
-      <div class="space-y-2 text-sm">
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            class="checkbox"
+      <div class="space-y-3 text-sm">
+        <div class="flex items-start gap-3">
+          <Toggle
             bind:checked={appSettings.talk_reminder_enabled}
-            onchange={scheduleSave}
+            label="Notify me before meetings with a Talk room"
+            onchange={() => scheduleSave()}
           />
           <span>
             Notify me before meetings with a Talk room

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -11,6 +11,7 @@
   import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
   import { enable as autostartEnable, disable as autostartDisable, isEnabled as autostartIsEnabled } from '@tauri-apps/plugin-autostart'
   import NextcloudSettings from './NextcloudSettings.svelte'
+  import SecuritySettings from './SecuritySettings.svelte'
   import EmojiPicker from './EmojiPicker.svelte'
   import {
     STOCK_THEMES,
@@ -80,7 +81,7 @@
   // categories users actually look for.  The nav lives in a
   // left column and `activeCategory` gates which section block
   // renders so each panel stays focused.
-  type SettingsCategory = 'general' | 'design' | 'mail' | 'calendar' | 'nextcloud'
+  type SettingsCategory = 'general' | 'design' | 'mail' | 'calendar' | 'nextcloud' | 'security'
   let activeCategory = $state<SettingsCategory>('general')
   interface CategoryEntry {
     id: SettingsCategory
@@ -93,6 +94,7 @@
     { id: 'mail', label: 'E-Mail', icon: '📧' },
     { id: 'calendar', label: 'Calendar', icon: '📅' },
     { id: 'nextcloud', label: 'Nextcloud', icon: '☁️' },
+    { id: 'security', label: 'Security', icon: '🔒' },
   ]
 
   // ── State ───────────────────────────────────────────────────
@@ -1252,6 +1254,10 @@
 
     {#if activeCategory === 'nextcloud'}
     <NextcloudSettings />
+    {/if}
+
+    {#if activeCategory === 'security'}
+    <SecuritySettings />
     {/if}
     </div>
   </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -849,7 +849,7 @@
               Lead time follows the event's own reminder.
             </span>
           </span>
-        </label>
+        </div>
 
         <!-- Default calendar.  Used by the EventEditor as the
              pre-selected calendar in create-mode, and by the

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -38,6 +38,7 @@
   import TimeField from './TimeField.svelte'
   import Select from './Select.svelte'
   import EmailKindChip from './EmailKindChip.svelte'
+  import Toggle from './Toggle.svelte'
 
   // ── Types (kept local; these mirror the Rust models) ──────────
   interface EventAttendee {
@@ -1298,15 +1299,14 @@
       <!-- All-day toggle on its own thin row above the
            date/time grid so Start and End sit symmetrically
            on the row beneath it. -->
-      <label class="flex items-center gap-2 text-xs text-surface-600 dark:text-surface-300">
-        <input
-          type="checkbox"
-          class="checkbox"
+      <div class="flex items-center gap-2 text-xs text-surface-600 dark:text-surface-300">
+        <Toggle
           bind:checked={allDay}
-          onchange={onToggleAllDay}
+          label="All-day event"
+          onchange={() => onToggleAllDay()}
         />
         All-day event
-      </label>
+      </div>
 
       <!-- Symmetric Start ↔ End row.  Two equal columns, each
            with its own date + (optional) time field.  When

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -16,6 +16,7 @@
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
   import SyncStatusRow from './SyncStatusRow.svelte'
+  import Toggle from './Toggle.svelte'
 
   // ── Types (mirror the Rust models) ──────────────────────────
   interface NextcloudCapabilities {
@@ -445,19 +446,14 @@
                     <ul class="space-y-0.5">
                       {#each calendarsList[acct.id] as c (c.id)}
                         <li>
-                          <label
-                            class="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-200/60 dark:hover:bg-surface-700/40 cursor-pointer text-xs"
+                          <div
+                            class="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-200/60 dark:hover:bg-surface-700/40 text-xs"
                           >
-                            <input
-                              type="checkbox"
-                              class="checkbox"
+                            <Toggle
                               checked={!c.hidden}
-                              onchange={(e) =>
-                                void toggleCalendarHidden(
-                                  acct.id,
-                                  c.id,
-                                  !(e.currentTarget as HTMLInputElement).checked,
-                                )}
+                              label={c.display_name}
+                              onchange={(v) =>
+                                void toggleCalendarHidden(acct.id, c.id, !v)}
                             />
                             <span
                               class="w-2.5 h-2.5 rounded-sm shrink-0"
@@ -466,7 +462,7 @@
                             <span class="truncate" title={c.display_name}>
                               {c.display_name}
                             </span>
-                          </label>
+                          </div>
                         </li>
                       {/each}
                     </ul>

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -22,7 +22,7 @@
   import {
     enrollFidoCredential,
     evaluateFidoPrf,
-    isPrfSupported,
+    isWebAuthnAvailable,
   } from './webauthnPrf'
 
   interface FidoCredential {
@@ -40,7 +40,10 @@
   let loading = $state(true)
   let busy = $state(false)
   let error = $state('')
-  let prfSupported = $state(false)
+  // Just a coarse "WebAuthn API exists" check.  Don't gate on
+  // PRF capability up front — older engines mis-report it; let
+  // the actual `credentials.create` reveal the truth.
+  const webauthnAvailable = $state(isWebAuthnAvailable())
 
   let newLabel = $state('')
 
@@ -57,7 +60,6 @@
 
   $effect(() => {
     void loadStatus()
-    void isPrfSupported().then((v) => (prfSupported = v))
   })
 
   async function addKey() {
@@ -133,13 +135,13 @@
 
   {#if loading}
     <p class="text-sm text-surface-500">Loading…</p>
-  {:else if !prfSupported}
+  {:else if !webauthnAvailable}
     <div class="rounded-md border border-warning-500/40 bg-warning-500/10 p-4 text-sm">
-      Your platform's WebAuthn implementation doesn't expose the PRF
-      extension we need to derive a stable key from your authenticator.
-      Update your OS / browser engine, or pick a different platform —
-      modern Safari, Edge / Chrome, and recent WebKitGTK builds all
-      support it.
+      WebAuthn isn't available in this build's webview.  Hardware
+      authentication needs the OS-shipped browser engine to expose
+      <code>navigator.credentials</code>; update your platform's
+      webview component (libwebkit2gtk on Linux, WebView2 on
+      Windows, system Safari on macOS) and try again.
     </div>
   {:else}
     <div class="space-y-4">

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -53,6 +53,29 @@
   const PASSPHRASE_LABEL = 'Recovery passphrase'
   let passphraseValue = $state('')
   let passphraseConfirm = $state('')
+  /** Master "Key Encryption" toggle.  Gates whether the
+   *  enrollment forms below are interactive — the rest of the
+   *  panel greys out when this is off so the section reads as
+   *  "feature opt-in".  Persisted in localStorage; flipping it
+   *  doesn't yet flip the backend into FIDO-only mode (that's
+   *  Phase 1B), but it scopes the UI so users who don't want
+   *  the feature don't accidentally enroll a credential. */
+  let keyEncryptionEnabled = $state(false)
+  $effect(() => {
+    try {
+      keyEncryptionEnabled = localStorage.getItem('nimbus.keyEncryption') === '1'
+    } catch {
+      /* localStorage may be unavailable in some webview modes */
+    }
+  })
+  function setKeyEncryption(v: boolean) {
+    keyEncryptionEnabled = v
+    try {
+      localStorage.setItem('nimbus.keyEncryption', v ? '1' : '0')
+    } catch {
+      /* swallow — same reason as above */
+    }
+  }
 
   async function loadStatus() {
     loading = true
@@ -158,23 +181,42 @@
 </script>
 
 <section class="space-y-6">
-  <header>
-    <h2 class="text-xl font-semibold">Security</h2>
-    <p class="text-sm text-surface-500 mt-1">
-      Hardware-backed authentication for the local mail cache. Register a
-      hardware key (YubiKey, Apple Touch ID, Windows Hello, …) to seal the
-      cache's encryption key behind a tap or biometric.
-    </p>
+  <header class="flex items-start justify-between gap-4">
+    <div>
+      <h2 class="text-xl font-semibold">Security</h2>
+      <p class="text-sm text-surface-500 mt-1 max-w-xl">
+        Hardware-backed authentication for the local mail cache. Register a
+        hardware key (YubiKey, Apple Touch ID, Windows Hello, …) to seal the
+        cache's encryption key behind a tap or biometric.
+      </p>
+    </div>
+    <!-- Master toggle.  When off, the sub-sections grey out and
+         their controls reject input — clear visual signal that
+         the feature is opt-in. -->
+    <label class="flex items-center gap-2 shrink-0 cursor-pointer">
+      <span class="text-sm font-medium">Key Encryption</span>
+      <input
+        type="checkbox"
+        class="toggle"
+        checked={keyEncryptionEnabled}
+        onchange={(e) => setKeyEncryption((e.currentTarget as HTMLInputElement).checked)}
+      />
+    </label>
   </header>
 
   {#if loading}
     <p class="text-sm text-surface-500">Loading…</p>
   {:else}
-    <div class="space-y-4">
+    <div
+      class="space-y-4 transition-opacity {keyEncryptionEnabled
+        ? ''
+        : 'opacity-50 pointer-events-none select-none'}"
+      aria-disabled={!keyEncryptionEnabled}
+    >
       <!-- Hardware-key enrollment is gated on a working WebAuthn
            API.  Linux builds whose libwebkit2gtk lacks WebAuthn
            (the default on most stable distros today) get a
-           one-line note instead of the form, but passphrase
+           warning box instead of the form, but passphrase
            enrollment below still works and is the recommended
            path on those systems. -->
       {#if webauthnAvailable}
@@ -201,7 +243,7 @@
           </div>
         </div>
       {:else}
-        <div class="rounded-md border border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800/40 p-4 text-sm text-surface-600 dark:text-surface-400">
+        <div class="rounded-md border border-warning-500/40 bg-warning-500/10 p-4 text-sm text-warning-700 dark:text-warning-300">
           <p class="font-medium mb-1">Hardware-key registration is unavailable on this build.</p>
           <p class="text-xs">
             The webview Tauri uses on Linux (<code>libwebkit2gtk</code>) doesn't

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -166,38 +166,50 @@
 
   {#if loading}
     <p class="text-sm text-surface-500">Loading…</p>
-  {:else if !webauthnAvailable}
-    <div class="rounded-md border border-warning-500/40 bg-warning-500/10 p-4 text-sm">
-      WebAuthn isn't available in this build's webview.  Hardware
-      authentication needs the OS-shipped browser engine to expose
-      <code>navigator.credentials</code>; update your platform's
-      webview component (libwebkit2gtk on Linux, WebView2 on
-      Windows, system Safari on macOS) and try again.
-    </div>
   {:else}
     <div class="space-y-4">
-      <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
-        <h3 class="font-medium mb-2">Add a hardware key</h3>
-        <p class="text-xs text-surface-500 mb-3">
-          You'll be asked to authenticate (touch your security key, scan
-          a fingerprint, …). The OS handles the prompt; Nimbus only sees
-          the resulting key material.
-        </p>
-        <div class="flex items-center gap-2">
-          <input
-            type="text"
-            class="input flex-1 text-sm px-3 py-1.5 rounded-md"
-            placeholder="Label — e.g. “YubiKey 5C”, “MacBook Touch ID”"
-            bind:value={newLabel}
-            disabled={busy}
-          />
-          <button
-            class="btn preset-filled-primary-500"
-            disabled={busy}
-            onclick={() => void addKey()}
-          >{busy ? 'Working…' : 'Add'}</button>
+      <!-- Hardware-key enrollment is gated on a working WebAuthn
+           API.  Linux builds whose libwebkit2gtk lacks WebAuthn
+           (the default on most stable distros today) get a
+           one-line note instead of the form, but passphrase
+           enrollment below still works and is the recommended
+           path on those systems. -->
+      {#if webauthnAvailable}
+        <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
+          <h3 class="font-medium mb-2">Add a hardware key</h3>
+          <p class="text-xs text-surface-500 mb-3">
+            You'll be asked to authenticate (touch your security key, scan
+            a fingerprint, …). The OS handles the prompt; Nimbus only sees
+            the resulting key material.
+          </p>
+          <div class="flex items-center gap-2">
+            <input
+              type="text"
+              class="input flex-1 text-sm px-3 py-1.5 rounded-md"
+              placeholder="Label — e.g. “YubiKey 5C”, “MacBook Touch ID”"
+              bind:value={newLabel}
+              disabled={busy}
+            />
+            <button
+              class="btn preset-filled-primary-500"
+              disabled={busy}
+              onclick={() => void addKey()}
+            >{busy ? 'Working…' : 'Add'}</button>
+          </div>
         </div>
-      </div>
+      {:else}
+        <div class="rounded-md border border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800/40 p-4 text-sm text-surface-600 dark:text-surface-400">
+          <p class="font-medium mb-1">Hardware-key registration is unavailable on this build.</p>
+          <p class="text-xs">
+            The webview Tauri uses on Linux (<code>libwebkit2gtk</code>) doesn't
+            expose <code>navigator.credentials</code> on most stable distros
+            yet.  You can still register a recovery passphrase below — it
+            uses the same envelope and unlocks the same way at startup.
+            Hardware keys will become available once your distro ships
+            WebKitGTK ≥ 2.46 with WebAuthn enabled.
+          </p>
+        </div>
+      {/if}
 
       <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
         <h3 class="font-medium mb-2">Add a recovery passphrase</h3>

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -26,6 +26,7 @@
   } from './webauthnPrf'
 
   interface FidoCredential {
+    kind: 'fido_prf' | 'passphrase'
     credentialId: string
     label: string
     salt: string
@@ -46,6 +47,9 @@
   const webauthnAvailable = $state(isWebAuthnAvailable())
 
   let newLabel = $state('')
+  let passphraseLabel = $state('Recovery passphrase')
+  let passphraseValue = $state('')
+  let passphraseConfirm = $state('')
 
   async function loadStatus() {
     loading = true
@@ -84,6 +88,33 @@
       await loadStatus()
     } catch (e) {
       error = formatError(e) || 'Failed to enroll hardware key'
+    } finally {
+      busy = false
+    }
+  }
+
+  async function addPassphrase() {
+    if (busy) return
+    if (passphraseValue.length < 8) {
+      error = 'Passphrase must be at least 8 characters.'
+      return
+    }
+    if (passphraseValue !== passphraseConfirm) {
+      error = "Passphrase and confirmation don't match."
+      return
+    }
+    busy = true
+    error = ''
+    try {
+      await invoke('fido_enroll_passphrase', {
+        passphrase: passphraseValue,
+        label: passphraseLabel.trim() || 'Recovery passphrase',
+      })
+      passphraseValue = ''
+      passphraseConfirm = ''
+      await loadStatus()
+    } catch (e) {
+      error = formatError(e) || 'Failed to enroll passphrase'
     } finally {
       busy = false
     }
@@ -168,21 +199,65 @@
         </div>
       </div>
 
+      <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
+        <h3 class="font-medium mb-2">Add a recovery passphrase</h3>
+        <p class="text-xs text-surface-500 mb-3">
+          A passphrase derives the same kind of 32-byte key (via
+          PBKDF2-HMAC-SHA-256, 720 000 iterations) that a FIDO
+          authenticator's PRF output would. Useful as a fallback when a
+          hardware key is lost — and as the primary unlock method on
+          Linux until WebKitGTK ships the WebAuthn PRF extension.
+        </p>
+        <div class="space-y-2">
+          <input
+            type="text"
+            class="input w-full text-sm px-3 py-1.5 rounded-md"
+            placeholder="Label — e.g. “Recovery passphrase”"
+            bind:value={passphraseLabel}
+            disabled={busy}
+          />
+          <input
+            type="password"
+            class="input w-full text-sm px-3 py-1.5 rounded-md"
+            placeholder="Passphrase (8+ characters)"
+            bind:value={passphraseValue}
+            disabled={busy}
+            autocomplete="new-password"
+          />
+          <input
+            type="password"
+            class="input w-full text-sm px-3 py-1.5 rounded-md"
+            placeholder="Confirm passphrase"
+            bind:value={passphraseConfirm}
+            disabled={busy}
+            autocomplete="new-password"
+          />
+          <button
+            class="btn preset-filled-primary-500 w-full"
+            disabled={busy || passphraseValue.length < 8}
+            onclick={() => void addPassphrase()}
+          >{busy ? 'Working…' : 'Save passphrase'}</button>
+        </div>
+      </div>
+
       <div>
-        <h3 class="font-medium mb-2">Registered keys</h3>
+        <h3 class="font-medium mb-2">Registered methods</h3>
         {#if status && status.credentials.length === 0}
           <p class="text-sm text-surface-500 italic">
-            No hardware keys registered yet.
+            No unlock methods registered yet.
           </p>
         {:else if status}
           <ul class="divide-y divide-surface-200 dark:divide-surface-700 rounded-md border border-surface-200 dark:border-surface-700">
             {#each status.credentials as c (c.credentialId)}
               <li class="flex items-center gap-3 p-3">
-                <span class="text-lg" aria-hidden="true">🔑</span>
+                <span class="text-lg" aria-hidden="true">
+                  {c.kind === 'passphrase' ? '🔐' : '🔑'}
+                </span>
                 <div class="flex-1 min-w-0">
                   <p class="font-medium truncate">{c.label}</p>
                   <p class="text-xs text-surface-500 truncate">
-                    Added {fmtDate(c.createdAt)}
+                    {c.kind === 'passphrase' ? 'Passphrase' : 'Hardware key'}
+                    · Added {fmtDate(c.createdAt)}
                   </p>
                 </div>
                 <button

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -24,6 +24,7 @@
     evaluateFidoPrf,
     isWebAuthnAvailable,
   } from './webauthnPrf'
+  import Toggle from './Toggle.svelte'
 
   interface FidoCredential {
     kind: 'fido_prf' | 'passphrase'
@@ -200,24 +201,11 @@
          accepting input — clear visual signal that the feature
          is opt-in. -->
     <div class="flex items-center gap-3">
-      <button
-        type="button"
-        role="switch"
-        aria-checked={keyEncryptionEnabled}
-        aria-label="Enable key encryption"
-        onclick={() => setKeyEncryption(!keyEncryptionEnabled)}
-        class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-150
-               focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2
-               focus:ring-offset-surface-50 dark:focus:ring-offset-surface-900
-               {keyEncryptionEnabled
-                 ? 'bg-primary-500'
-                 : 'bg-surface-300 dark:bg-surface-600'}"
-      >
-        <span
-          class="inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform duration-150
-                 {keyEncryptionEnabled ? 'translate-x-5' : 'translate-x-0.5'}"
-        ></span>
-      </button>
+      <Toggle
+        checked={keyEncryptionEnabled}
+        label="Enable key encryption"
+        onchange={(v) => setKeyEncryption(v)}
+      />
       <div>
         <p class="font-medium leading-tight">Key Encryption</p>
         <p class="text-xs text-surface-500 leading-tight">

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -47,7 +47,10 @@
   const webauthnAvailable = $state(isWebAuthnAvailable())
 
   let newLabel = $state('')
-  let passphraseLabel = $state('Recovery passphrase')
+  /** Fixed label for the passphrase entry — there's only ever
+   *  one passphrase wrap (it's the recovery slot, not a per-
+   *  device thing), so the user doesn't need to name it. */
+  const PASSPHRASE_LABEL = 'Recovery passphrase'
   let passphraseValue = $state('')
   let passphraseConfirm = $state('')
 
@@ -108,7 +111,7 @@
     try {
       await invoke('fido_enroll_passphrase', {
         passphrase: passphraseValue,
-        label: passphraseLabel.trim() || 'Recovery passphrase',
+        label: PASSPHRASE_LABEL,
       })
       passphraseValue = ''
       passphraseConfirm = ''
@@ -222,13 +225,6 @@
         </p>
         <div class="space-y-2">
           <input
-            type="text"
-            class="input w-full text-sm px-3 py-1.5 rounded-md"
-            placeholder="Label — e.g. “Recovery passphrase”"
-            bind:value={passphraseLabel}
-            disabled={busy}
-          />
-          <input
             type="password"
             class="input w-full text-sm px-3 py-1.5 rounded-md"
             placeholder="Passphrase (8+ characters)"
@@ -266,9 +262,17 @@
                   {c.kind === 'passphrase' ? '🔐' : '🔑'}
                 </span>
                 <div class="flex-1 min-w-0">
-                  <p class="font-medium truncate">{c.label}</p>
+                  <!-- For passphrase entries we surface the kind
+                       directly; the internal label is an
+                       implementation detail the user never set
+                       and shouldn't have to see.  Hardware keys
+                       keep the user-supplied label since that's
+                       what distinguishes one device from another. -->
+                  <p class="font-medium truncate">
+                    {c.kind === 'passphrase' ? 'Passphrase' : c.label}
+                  </p>
                   <p class="text-xs text-surface-500 truncate">
-                    {c.kind === 'passphrase' ? 'Passphrase' : 'Hardware key'}
+                    {c.kind === 'passphrase' ? 'Recovery method' : 'Hardware key'}
                     · Added {fmtDate(c.createdAt)}
                   </p>
                 </div>

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  /**
+   * Security settings — FIDO unlock enrollment (#164, Phase 1A).
+   *
+   * Lists registered FIDO credentials for the SQLCipher database
+   * and lets the user add or remove them.  Enrollment uses
+   * WebAuthn's PRF extension via the OS — Touch ID, Windows
+   * Hello, USB hardware key, whichever the user picks at the
+   * authenticator sheet.  The PRF output gets shipped to Rust,
+   * which uses it as an AES-256-GCM key to wrap the DB master
+   * key inside the keychain envelope.
+   *
+   * Phase 1A: enrollment scaffolding.  The plain master key
+   * stays in the keychain alongside the wraps so cold launch
+   * still works without a hardware-key tap.  Phase 1B will
+   * delete the plain key, gate startup on unlock, and surface
+   * a real lock screen.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+  import {
+    enrollFidoCredential,
+    evaluateFidoPrf,
+    isPrfSupported,
+  } from './webauthnPrf'
+
+  interface FidoCredential {
+    credentialId: string
+    label: string
+    salt: string
+    createdAt: number
+  }
+  interface FidoStatus {
+    hasPlainKey: boolean
+    credentials: FidoCredential[]
+  }
+
+  let status = $state<FidoStatus | null>(null)
+  let loading = $state(true)
+  let busy = $state(false)
+  let error = $state('')
+  let prfSupported = $state(false)
+
+  let newLabel = $state('')
+
+  async function loadStatus() {
+    loading = true
+    try {
+      status = await invoke<FidoStatus>('fido_status')
+    } catch (e) {
+      error = formatError(e) || 'Failed to load FIDO status'
+    } finally {
+      loading = false
+    }
+  }
+
+  $effect(() => {
+    void loadStatus()
+    void isPrfSupported().then((v) => (prfSupported = v))
+  })
+
+  async function addKey() {
+    if (busy) return
+    const label = newLabel.trim() || 'Untitled hardware key'
+    busy = true
+    error = ''
+    try {
+      // Generate a fresh PRF salt server-side so it shares the
+      // app's RNG and can't be influenced from the renderer.
+      const saltB64 = await invoke<string>('fido_generate_salt')
+      // The OS shows its own auth sheet here; we receive the
+      // PRF output once the user authenticates.
+      const enrolled = await enrollFidoCredential(saltB64, 'nimbus-user', label)
+      await invoke('fido_enroll', {
+        credentialIdB64: enrolled.credentialIdB64,
+        saltB64: enrolled.saltB64,
+        prfOutputB64: enrolled.prfOutputB64,
+        label,
+      })
+      newLabel = ''
+      await loadStatus()
+    } catch (e) {
+      error = formatError(e) || 'Failed to enroll hardware key'
+    } finally {
+      busy = false
+    }
+  }
+
+  async function removeKey(credentialId: string, salt: string, label: string) {
+    if (busy) return
+    if (!confirm(`Remove "${label}"? You'll need to re-enroll to use it again.`))
+      return
+    busy = true
+    error = ''
+    try {
+      // Require the user to actually still possess the key
+      // before we let them drop the wrap.  Skipped in plain-
+      // key mode for the trivial case of an enrolled key the
+      // user already lost — they can always reset by removing
+      // the plain key entry from the keychain manually.
+      if (status && !status.hasPlainKey) {
+        await evaluateFidoPrf(credentialId, salt)
+      }
+      await invoke('fido_remove', { credentialIdB64: credentialId })
+      await loadStatus()
+    } catch (e) {
+      error = formatError(e) || 'Failed to remove hardware key'
+    } finally {
+      busy = false
+    }
+  }
+
+  function fmtDate(epoch: number): string {
+    if (!epoch) return ''
+    return new Date(epoch * 1000).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+</script>
+
+<section class="space-y-6">
+  <header>
+    <h2 class="text-xl font-semibold">Security</h2>
+    <p class="text-sm text-surface-500 mt-1">
+      Hardware-backed authentication for the local mail cache. Register a
+      hardware key (YubiKey, Apple Touch ID, Windows Hello, …) to seal the
+      cache's encryption key behind a tap or biometric.
+    </p>
+  </header>
+
+  {#if loading}
+    <p class="text-sm text-surface-500">Loading…</p>
+  {:else if !prfSupported}
+    <div class="rounded-md border border-warning-500/40 bg-warning-500/10 p-4 text-sm">
+      Your platform's WebAuthn implementation doesn't expose the PRF
+      extension we need to derive a stable key from your authenticator.
+      Update your OS / browser engine, or pick a different platform —
+      modern Safari, Edge / Chrome, and recent WebKitGTK builds all
+      support it.
+    </div>
+  {:else}
+    <div class="space-y-4">
+      <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
+        <h3 class="font-medium mb-2">Add a hardware key</h3>
+        <p class="text-xs text-surface-500 mb-3">
+          You'll be asked to authenticate (touch your security key, scan
+          a fingerprint, …). The OS handles the prompt; Nimbus only sees
+          the resulting key material.
+        </p>
+        <div class="flex items-center gap-2">
+          <input
+            type="text"
+            class="input flex-1 text-sm px-3 py-1.5 rounded-md"
+            placeholder="Label — e.g. “YubiKey 5C”, “MacBook Touch ID”"
+            bind:value={newLabel}
+            disabled={busy}
+          />
+          <button
+            class="btn preset-filled-primary-500"
+            disabled={busy}
+            onclick={() => void addKey()}
+          >{busy ? 'Working…' : 'Add'}</button>
+        </div>
+      </div>
+
+      <div>
+        <h3 class="font-medium mb-2">Registered keys</h3>
+        {#if status && status.credentials.length === 0}
+          <p class="text-sm text-surface-500 italic">
+            No hardware keys registered yet.
+          </p>
+        {:else if status}
+          <ul class="divide-y divide-surface-200 dark:divide-surface-700 rounded-md border border-surface-200 dark:border-surface-700">
+            {#each status.credentials as c (c.credentialId)}
+              <li class="flex items-center gap-3 p-3">
+                <span class="text-lg" aria-hidden="true">🔑</span>
+                <div class="flex-1 min-w-0">
+                  <p class="font-medium truncate">{c.label}</p>
+                  <p class="text-xs text-surface-500 truncate">
+                    Added {fmtDate(c.createdAt)}
+                  </p>
+                </div>
+                <button
+                  class="btn btn-sm preset-outlined-error-500"
+                  disabled={busy}
+                  onclick={() => void removeKey(c.credentialId, c.salt, c.label)}
+                >Remove</button>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+
+      {#if status && status.hasPlainKey}
+        <p class="text-xs text-surface-500">
+          The plain master key remains in the OS keychain alongside any
+          registered hardware keys — Nimbus opens the cache without
+          asking for a tap. A future release will let you switch to
+          FIDO-only mode, where the cache only opens after you
+          authenticate at startup.
+        </p>
+      {/if}
+
+      {#if error}
+        <p class="text-sm text-red-500 wrap-break-word">{error}</p>
+      {/if}
+    </div>
+  {/if}
+</section>

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -181,32 +181,53 @@
 </script>
 
 <section class="space-y-6">
-  <header class="flex items-start justify-between gap-4">
-    <div>
-      <h2 class="text-xl font-semibold">Security</h2>
-      <p class="text-sm text-surface-500 mt-1 max-w-xl">
-        Hardware-backed authentication for the local mail cache. Register a
-        hardware key (YubiKey, Apple Touch ID, Windows Hello, …) to seal the
-        cache's encryption key behind a tap or biometric.
-      </p>
-    </div>
-    <!-- Master toggle.  When off, the sub-sections grey out and
-         their controls reject input — clear visual signal that
-         the feature is opt-in. -->
-    <label class="flex items-center gap-2 shrink-0 cursor-pointer">
-      <span class="text-sm font-medium">Key Encryption</span>
-      <input
-        type="checkbox"
-        class="toggle"
-        checked={keyEncryptionEnabled}
-        onchange={(e) => setKeyEncryption((e.currentTarget as HTMLInputElement).checked)}
-      />
-    </label>
+  <header>
+    <h2 class="text-xl font-semibold">Security</h2>
+    <p class="text-sm text-surface-500 mt-1 max-w-xl">
+      Hardware-backed authentication for the local mail cache. Register a
+      hardware key (YubiKey, Apple Touch ID, Windows Hello, …) to seal the
+      cache's encryption key behind a tap or biometric.
+    </p>
   </header>
 
   {#if loading}
     <p class="text-sm text-surface-500">Loading…</p>
   {:else}
+    <!-- Master toggle.  Sits above the registration sections,
+         left-aligned, rendered as a true iOS-style switch
+         (track + sliding thumb) rather than a native checkbox.
+         When off, every section below greys out and stops
+         accepting input — clear visual signal that the feature
+         is opt-in. -->
+    <div class="flex items-center gap-3">
+      <button
+        type="button"
+        role="switch"
+        aria-checked={keyEncryptionEnabled}
+        aria-label="Enable key encryption"
+        onclick={() => setKeyEncryption(!keyEncryptionEnabled)}
+        class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-150
+               focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2
+               focus:ring-offset-surface-50 dark:focus:ring-offset-surface-900
+               {keyEncryptionEnabled
+                 ? 'bg-primary-500'
+                 : 'bg-surface-300 dark:bg-surface-600'}"
+      >
+        <span
+          class="inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform duration-150
+                 {keyEncryptionEnabled ? 'translate-x-5' : 'translate-x-0.5'}"
+        ></span>
+      </button>
+      <div>
+        <p class="font-medium leading-tight">Key Encryption</p>
+        <p class="text-xs text-surface-500 leading-tight">
+          {keyEncryptionEnabled
+            ? 'On — register methods below'
+            : 'Off — the cache uses the plain key from the OS keychain'}
+        </p>
+      </div>
+    </div>
+
     <div
       class="space-y-4 transition-opacity {keyEncryptionEnabled
         ? ''

--- a/ui/src/lib/Toggle.svelte
+++ b/ui/src/lib/Toggle.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  // Reusable iOS-style switch.  Replaces native checkboxes
+  // across Settings (#164 follow-up) for a lighter, more modern
+  // look.  Smaller than the original Security toggle (h-5 / w-9
+  // vs h-6 / w-11) so it sits comfortably on dense settings
+  // rows without dominating the line.
+  //
+  // Use:
+  //   <Toggle bind:checked={value} label="Enable feature" />
+  //
+  // Accessible: rendered as a real <button role="switch"> with
+  // aria-checked, focusable, Space / Enter activates.
+
+  interface Props {
+    checked: boolean
+    /** Optional aria label.  When omitted callers should
+     *  associate the toggle with surrounding text via context. */
+    label?: string
+    disabled?: boolean
+    onchange?: (checked: boolean) => void
+    class?: string
+  }
+  let {
+    checked = $bindable(),
+    label = '',
+    disabled = false,
+    onchange,
+    class: cls = '',
+  }: Props = $props()
+
+  function flip() {
+    if (disabled) return
+    checked = !checked
+    onchange?.(checked)
+  }
+</script>
+
+<button
+  type="button"
+  role="switch"
+  aria-checked={checked}
+  aria-label={label || undefined}
+  disabled={disabled || undefined}
+  onclick={flip}
+  class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors duration-150
+         focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2
+         focus:ring-offset-surface-50 dark:focus:ring-offset-surface-900
+         disabled:opacity-50 disabled:cursor-not-allowed
+         {checked ? 'bg-primary-500' : 'bg-surface-300 dark:bg-surface-600'}
+         {cls}"
+>
+  <span
+    class="inline-block h-4 w-4 transform rounded-full bg-white shadow-sm transition-transform duration-150
+           {checked ? 'translate-x-[18px]' : 'translate-x-0.5'}"
+  ></span>
+</button>

--- a/ui/src/lib/webauthnPrf.ts
+++ b/ui/src/lib/webauthnPrf.ts
@@ -34,27 +34,24 @@ function b64ToBuf(s: string): Uint8Array {
 }
 
 /**
- * True if the current webview exposes the WebAuthn PRF extension.
- * Used by the Settings UI to gate the "Add hardware key" button —
- * older WebKitGTK builds don't ship PRF support.
+ * Coarse check that WebAuthn itself is wired up.  We deliberately
+ * *don't* gate on `getClientCapabilities().extensionPrf` here —
+ * older engines (Linux WebKitGTK < 2.46, in particular) advertise
+ * `extensionPrf: false` even when an authenticator that supports
+ * hmac-secret would otherwise work, and there are
+ * authenticator+engine combinations that surprise the static
+ * capability table either way.  The honest source of truth is
+ * whether `credentials.create({ extensions: { prf: ... } })`
+ * returns a PRF output; the UI just calls it and surfaces a
+ * specific error if the result is missing.
  */
-export async function isPrfSupported(): Promise<boolean> {
-  // PublicKeyCredential is the entry point for WebAuthn; if it's
-  // not present the engine doesn't know about the spec at all.
-  if (typeof PublicKeyCredential === 'undefined') return false
-  if (typeof PublicKeyCredential.getClientCapabilities === 'function') {
-    try {
-      const caps = await PublicKeyCredential.getClientCapabilities()
-      const r = caps as Record<string, boolean>
-      if (typeof r.extensionPrf === 'boolean') return r.extensionPrf
-    } catch {
-      /* fall through to feature-test */
-    }
-  }
-  // Best-effort feature detect — if we got this far, assume the
-  // extension *might* work and let the caller surface a real
-  // error from the create() call if it doesn't.
-  return true
+export function isWebAuthnAvailable(): boolean {
+  return (
+    typeof PublicKeyCredential !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    !!navigator.credentials &&
+    typeof navigator.credentials.create === 'function'
+  )
 }
 
 export interface EnrolledCredential {
@@ -118,8 +115,32 @@ export async function enrollFidoCredential(
   }
   const prfFirst = exts.prf?.results?.first
   if (!prfFirst) {
+    // Three reasons we'd land here:
+    //   1. The webview doesn't implement the PRF extension.  On
+    //      Linux this means WebKitGTK < 2.46.  Update libwebkit2gtk
+    //      via the system package manager — Ubuntu 24.04, Fedora
+    //      40, and Arch all carry 2.46+ on stable.
+    //   2. The selected authenticator doesn't support hmac-secret.
+    //      Most YubiKey 5 / SoloKey 2 / Touch ID / Windows Hello
+    //      builds do; some older third-party USB keys do not.
+    //   3. `prf.enabled` came back true at create-time but the
+    //      engine elected not to evaluate the salt during this
+    //      registration (a few WebKit builds defer first eval to
+    //      the first credentials.get).  We could retry via
+    //      credentials.get with the same salt, but in practice
+    //      this surfaces the same root cause as #1.
+    const enabled = exts.prf?.enabled === true
+    if (enabled) {
+      throw new Error(
+        'Authenticator registered, but the PRF extension didn\'t evaluate at enroll time. ' +
+          'Try a different authenticator, or wait for the next browser engine update.',
+      )
+    }
     throw new Error(
-      'Authenticator did not return a PRF output. Your hardware key or browser may not support WebAuthn PRF (hmac-secret).',
+      'PRF extension unavailable from this WebAuthn implementation. ' +
+        'On Linux this usually means WebKitGTK is below 2.46 — update libwebkit2gtk ' +
+        '(Ubuntu 24.04+, Fedora 40+, Arch all ship 2.46+). On macOS / Windows the OS ' +
+        'shipped engines support PRF on recent versions.',
     )
   }
   return {

--- a/ui/src/lib/webauthnPrf.ts
+++ b/ui/src/lib/webauthnPrf.ts
@@ -1,0 +1,166 @@
+// WebAuthn PRF helper for the FIDO unlock feature (#164).
+//
+// We use the PRF extension — WebAuthn's standardised wrapping of
+// CTAP2's hmac-secret — to derive a stable 32-byte key from a FIDO
+// authenticator (USB hardware key, Touch ID, Windows Hello, ...).
+// The OS handles the auth UX entirely; we hand the PRF output to
+// the Rust side which uses it as an AES-256-GCM key to wrap /
+// unwrap the SQLCipher master key.
+//
+// Browser support landscape (as of 2026):
+// - Safari 17+ on macOS / iOS — supports PRF.
+// - Edge / Chrome on Windows / macOS — supports PRF for hmac-secret.
+// - WebKitGTK on Linux — depends on the libwebkit2gtk-4.1 build
+//   shipped by the distro; users may need a recent enough version.
+// All fall back to "PRF extension not supported" with a clean
+// error if the engine doesn't expose it; the Settings UI surfaces
+// that as a tooltip on the disabled button.
+
+const RP_ID = 'nimbus-mail.local'
+const RP_NAME = 'Nimbus Mail'
+
+function bufToB64(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf)
+  let bin = ''
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin)
+}
+
+function b64ToBuf(s: string): Uint8Array {
+  const bin = atob(s)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+/**
+ * True if the current webview exposes the WebAuthn PRF extension.
+ * Used by the Settings UI to gate the "Add hardware key" button —
+ * older WebKitGTK builds don't ship PRF support.
+ */
+export async function isPrfSupported(): Promise<boolean> {
+  // PublicKeyCredential is the entry point for WebAuthn; if it's
+  // not present the engine doesn't know about the spec at all.
+  if (typeof PublicKeyCredential === 'undefined') return false
+  if (typeof PublicKeyCredential.getClientCapabilities === 'function') {
+    try {
+      const caps = await PublicKeyCredential.getClientCapabilities()
+      const r = caps as Record<string, boolean>
+      if (typeof r.extensionPrf === 'boolean') return r.extensionPrf
+    } catch {
+      /* fall through to feature-test */
+    }
+  }
+  // Best-effort feature detect — if we got this far, assume the
+  // extension *might* work and let the caller surface a real
+  // error from the create() call if it doesn't.
+  return true
+}
+
+export interface EnrolledCredential {
+  /** Base64-encoded credential id from the authenticator. */
+  credentialIdB64: string
+  /** Base64-encoded PRF output (32 bytes). */
+  prfOutputB64: string
+  /** Base64-encoded salt the credential was registered with. */
+  saltB64: string
+}
+
+/**
+ * Run WebAuthn `credentials.create` with the PRF extension enabled
+ * and the supplied salt as the eval input.  Returns the credential
+ * id plus the matching PRF output, both base64-encoded for the
+ * Rust IPC.
+ *
+ * The OS shows its own auth sheet — Touch ID prompt, Windows Hello
+ * sign-in, "Tap your security key", whatever's appropriate.  We
+ * never see the biometric or the per-credential secret; we only
+ * receive the deterministic PRF output that's reproducible by
+ * future `credentials.get` calls with the same salt.
+ */
+export async function enrollFidoCredential(
+  saltB64: string,
+  userHandle: string,
+  label: string,
+): Promise<EnrolledCredential> {
+  const salt = b64ToBuf(saltB64)
+  // Random per-call challenge.  PRF doesn't care about the
+  // challenge contents (it's bound to the credential, not the
+  // assertion), but WebAuthn requires one.
+  const challenge = crypto.getRandomValues(new Uint8Array(32))
+  const userIdBytes = new TextEncoder().encode(userHandle)
+  const cred = (await navigator.credentials.create({
+    publicKey: {
+      rp: { id: RP_ID, name: RP_NAME },
+      user: {
+        id: userIdBytes,
+        name: userHandle,
+        displayName: label,
+      },
+      challenge,
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 }, // ES256
+        { type: 'public-key', alg: -257 }, // RS256
+      ],
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'required',
+      },
+      timeout: 60_000,
+      extensions: {
+        prf: { eval: { first: salt } },
+      } as AuthenticationExtensionsClientInputs,
+    },
+  })) as PublicKeyCredential | null
+  if (!cred) throw new Error('WebAuthn returned no credential')
+  const exts = cred.getClientExtensionResults() as AuthenticationExtensionsClientOutputs & {
+    prf?: { enabled?: boolean; results?: { first?: ArrayBuffer } }
+  }
+  const prfFirst = exts.prf?.results?.first
+  if (!prfFirst) {
+    throw new Error(
+      'Authenticator did not return a PRF output. Your hardware key or browser may not support WebAuthn PRF (hmac-secret).',
+    )
+  }
+  return {
+    credentialIdB64: bufToB64(cred.rawId),
+    prfOutputB64: bufToB64(prfFirst),
+    saltB64,
+  }
+}
+
+/**
+ * Run `credentials.get` against a previously-enrolled credential
+ * and return its PRF output.  Used by the unlock flow (Phase 1B —
+ * not wired yet at boot) and by the "Remove this key" confirm step
+ * to prove the user can still authenticate before we drop a wrap.
+ */
+export async function evaluateFidoPrf(
+  credentialIdB64: string,
+  saltB64: string,
+): Promise<string> {
+  const credentialId = b64ToBuf(credentialIdB64)
+  const salt = b64ToBuf(saltB64)
+  const challenge = crypto.getRandomValues(new Uint8Array(32))
+  const assertion = (await navigator.credentials.get({
+    publicKey: {
+      challenge,
+      rpId: RP_ID,
+      allowCredentials: [{ type: 'public-key', id: credentialId }],
+      userVerification: 'required',
+      timeout: 60_000,
+      extensions: {
+        prf: { eval: { first: salt } },
+      } as AuthenticationExtensionsClientInputs,
+    },
+  })) as PublicKeyCredential | null
+  if (!assertion) throw new Error('WebAuthn returned no assertion')
+  const exts = assertion.getClientExtensionResults() as AuthenticationExtensionsClientOutputs & {
+    prf?: { results?: { first?: ArrayBuffer } }
+  }
+  const prfFirst = exts.prf?.results?.first
+  if (!prfFirst) {
+    throw new Error('Authenticator did not return a PRF output')
+  }
+  return bufToB64(prfFirst)
+}


### PR DESCRIPTION
Closes part of #164 (Phase 1A — enrollment scaffolding).

## Summary
Hardware-backed unlock of the SQLCipher master key.  Phase 1A delivers the wrap / unwrap plumbing and the enrollment UI; cold launch still uses the plain key from the keychain, so no user-visible behaviour changes until Phase 1B flips the unlock-at-startup switch.

**Architecture** — WebAuthn PRF extension from the webview, OS handles the auth UX (Touch ID / Windows Hello / hardware-key tap), PRF output → Rust → AES-256-GCM seal of the master key inside a JSON envelope in the keychain.

**Backend (nimbus-store)** — new `fido` module with `WrappedKey` / `KeychainEnvelope` serde types, AES-256-GCM wrap/unwrap (credential_id as AAD), salt + base64 helpers, and unit tests for roundtrip + tamper resistance.  `key.rs` migrated to read/write the JSON envelope; pre-#164 keychain values (bare hex) auto-migrate on first read.

**Tauri commands** — `fido_status`, `fido_generate_salt`, `fido_enroll`, `fido_remove`.

**Frontend** — new `webauthnPrf.ts` (PRF feature-detect, `credentials.create` + `credentials.get`), `SecuritySettings.svelte` panel listing registered credentials with add / remove, "Security" category tab in AccountSettings.

## Test plan
- [x] **Backend unit tests**: `cargo test -p nimbus-store fido::tests` — wrap/unwrap roundtrip, wrong-PRF rejection, plain-hex back-compat.
- [x] **Settings UI**: Settings → Security shows the panel with "Add a hardware key".  Click "Add", type a label, OS authenticator sheet appears, tap → entry shows in the registered list.
- [ ] **Re-add same authenticator**: existing wrap is replaced (no duplicate).
- [x] **Remove**: confirms, drops the wrap.
- [x] **Cold launch unchanged**: app still opens straight to the inbox without prompting.

## Phase 1B (next PR)
- Lock-screen UI + boot-flow restructure (cache opens *after* unlock).
- "Switch to FIDO-only mode" action that clears `plain_key`.
- Recovery passphrase OR mandatory ≥ 2 keys before allowing the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)