### PR TITLE
FIDO unlock — Phase 1B (#164)

### DIFF
--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -319,16 +319,20 @@ fn migrate_from_legacy_json(cache: &Cache) -> Result<Option<Vec<Account>>, Nimbu
     Ok(Some(read_all(cache)?))
 }
 
-/// Borrow a pooled connection. Wrapper around `Cache::pool().get()`
-/// that converts the pool error into our own `NimbusError` so
-/// callers can use `?` without sprinkling `.map_err` everywhere.
+/// Borrow a pooled connection.  Thin wrapper around
+/// `Cache::conn` that maps the cache-error variant into
+/// `NimbusError` so callers can use `?` cleanly.  Returns
+/// `NimbusError::Auth` (rather than Storage) for the locked
+/// case so the IPC layer can route it to the unlock UI.
 fn conn(
     cache: &Cache,
 ) -> Result<r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>, NimbusError> {
-    cache
-        .pool()
-        .get()
-        .map_err(|e| NimbusError::Storage(format!("checkout cache conn: {e}")))
+    cache.conn().map_err(|e| match e {
+        crate::cache::CacheError::Locked => {
+            NimbusError::Auth("Cache is locked — authenticate to unlock".into())
+        }
+        other => NimbusError::Storage(format!("checkout cache conn: {other}")),
+    })
 }
 
 #[cfg(test)]

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -181,7 +181,7 @@ impl Cache {
         nc_account_id: &str,
         rows: &[CalendarRow],
     ) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
 
         // Insert / update every calendar in the server list. We
@@ -254,7 +254,7 @@ impl Cache {
         nc_account_id: &str,
         row: &CalendarRow,
     ) -> Result<String, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let id = format!("{nc_account_id}::{}", row.path);
         conn.execute(
             "INSERT INTO calendars
@@ -290,7 +290,7 @@ impl Cache {
         if display_name.is_none() && color.is_none() {
             return Ok(());
         }
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE calendars
              SET display_name = COALESCE(?2, display_name),
@@ -304,7 +304,7 @@ impl Cache {
     /// Layer 1 toggle — removes the calendar from the sidebar entirely.
     /// Purely client-side; never touches the server.
     pub fn set_calendar_hidden(&self, calendar_id: &str, hidden: bool) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE calendars SET hidden = ?2 WHERE id = ?1",
             params![calendar_id, hidden as i64],
@@ -316,7 +316,7 @@ impl Cache {
     /// events from the agenda grid. Purely client-side; never touches
     /// the server.
     pub fn set_calendar_muted(&self, calendar_id: &str, muted: bool) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE calendars SET muted = ?2 WHERE id = ?1",
             params![calendar_id, muted as i64],
@@ -329,7 +329,7 @@ impl Cache {
     /// CalDAV DELETE so the sidebar forgets the collection without
     /// waiting for the next discovery sweep to prune it.
     pub fn remove_calendar(&self, calendar_id: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute("DELETE FROM calendars WHERE id = ?1", params![calendar_id])?;
         Ok(())
     }
@@ -337,7 +337,7 @@ impl Cache {
     /// All cached calendars for one Nextcloud account, alphabetised
     /// by display name.
     pub fn list_calendars(&self, nc_account_id: &str) -> Result<Vec<CachedCalendar>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, path, display_name, color,
                     ctag, sync_token, last_synced_at, hidden, muted
@@ -377,7 +377,7 @@ impl Cache {
         &self,
         nc_account_id: &str,
     ) -> Result<Option<DateTime<Utc>>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let ts: Option<i64> = conn
             .query_row(
                 "SELECT MAX(last_synced_at)
@@ -396,7 +396,7 @@ impl Cache {
         &self,
         calendar_id: &str,
     ) -> Result<Option<CalendarSyncState>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT sync_token, ctag, last_synced_at
@@ -449,7 +449,7 @@ impl Cache {
         new_sync_token: Option<&str>,
         new_ctag: Option<&str>,
     ) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
 
@@ -572,7 +572,7 @@ impl Cache {
             return Ok(Vec::new());
         }
 
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let placeholders = sql_placeholders(calendar_ids.len());
         let sql = format!(
             "SELECT {EVENT_COLUMNS}
@@ -622,7 +622,7 @@ impl Cache {
             return Ok(ExpansionInput::default());
         }
 
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let placeholders = sql_placeholders(calendar_ids.len());
 
         // ── Singletons in-window ────────────────────────────────
@@ -710,7 +710,7 @@ impl Cache {
     /// `ON DELETE CASCADE` handles the events side, so this is one
     /// statement.
     pub fn wipe_nextcloud_calendars(&self, nc_account_id: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "DELETE FROM calendars WHERE nextcloud_account_id = ?1",
             params![nc_account_id],
@@ -729,7 +729,7 @@ impl Cache {
         &self,
         event_id: &str,
     ) -> Result<Option<CalendarEventServerHandle>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT e.uid, e.href, e.etag, e.recurrence_id, e.ics_raw,
@@ -763,7 +763,7 @@ impl Cache {
         &self,
         calendar_id: &str,
     ) -> Result<Option<(String, String)>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT nextcloud_account_id, path FROM calendars WHERE id = ?1",
@@ -784,7 +784,7 @@ impl Cache {
         calendar_id: &str,
         row: &CalendarEventRow,
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let id = event_row_id(calendar_id, &row.uid, row.recurrence_id);
         let rdate_json =
             serde_json::to_string(&row.rdate.iter().map(|d| d.timestamp()).collect::<Vec<_>>())
@@ -854,7 +854,7 @@ impl Cache {
     /// state on next open.  Overwrites a previous answer, which is
     /// the right semantics: changing your mind replaces the row.
     pub fn upsert_rsvp_response(&self, uid: &str, partstat: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let now = Utc::now().timestamp();
         conn.execute(
             "INSERT INTO rsvp_responses (uid, partstat, responded_at)
@@ -871,7 +871,7 @@ impl Cache {
     /// `Ok(None)` if the user has never answered this invite (the
     /// card should show the fresh Accept/Decline/Tentative state).
     pub fn get_rsvp_response(&self, uid: &str) -> Result<Option<String>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT partstat FROM rsvp_responses WHERE uid = ?1",
@@ -889,7 +889,7 @@ impl Cache {
     /// to the cancelled banner.  Idempotent: re-recording the
     /// same UID just refreshes `cancelled_at`.
     pub fn mark_invite_cancelled(&self, uid: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let now = Utc::now().timestamp();
         conn.execute(
             "INSERT INTO cancelled_invites (uid, cancelled_at)
@@ -906,7 +906,7 @@ impl Cache {
     /// user doesn't unwittingly respond to an already-cancelled
     /// meeting.
     pub fn is_invite_cancelled(&self, uid: &str) -> Result<bool, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let hit: Option<i64> = conn
             .query_row(
                 "SELECT 1 FROM cancelled_invites WHERE uid = ?1",
@@ -923,7 +923,7 @@ impl Cache {
     /// the UID — we need to map that back to the local event so we
     /// can remove it from the user's calendar.
     pub fn find_event_id_by_uid(&self, uid: &str) -> Result<Option<String>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT id FROM calendar_events WHERE uid = ?1 LIMIT 1",
@@ -938,7 +938,7 @@ impl Cache {
     /// DELETE to the server, so the next `get_cached_events` call
     /// doesn't ghost-render the deleted row until the next sync.
     pub fn delete_event_by_id(&self, event_id: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "DELETE FROM calendar_events WHERE id = ?1",
             params![event_id],

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -114,7 +114,7 @@ impl Cache {
         new_sync_token: Option<&str>,
         new_ctag: Option<&str>,
     ) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
 
@@ -233,7 +233,7 @@ impl Cache {
         &self,
         nc_account_id: &str,
     ) -> Result<Option<DateTime<Utc>>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let ts: Option<i64> = conn
             .query_row(
                 "SELECT MAX(last_synced_at)
@@ -253,7 +253,7 @@ impl Cache {
         nc_account_id: &str,
         addressbook: &str,
     ) -> Result<Option<AddressbookSyncState>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT display_name, sync_token, ctag, last_synced_at
@@ -285,7 +285,7 @@ impl Cache {
     /// as a presence flag; the UI uses `get_contact_photo` to fetch
     /// the bytes on demand for whichever rows it actually paints.
     pub fn list_contacts(&self, nc_account_id: Option<&str>) -> Result<Vec<Contact>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt;
         let rows = match nc_account_id {
             Some(nc) => {
@@ -329,7 +329,7 @@ impl Cache {
         &self,
         contact_id: &str,
     ) -> Result<Option<(String, Vec<u8>)>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row: Option<(Option<String>, Option<Vec<u8>>)> = conn
             .query_row(
                 "SELECT photo_mime, photo_data FROM contacts WHERE id = ?1",
@@ -352,7 +352,7 @@ impl Cache {
     /// `limit` so a typo that matches half the address book doesn't
     /// tank the UI.
     pub fn search_contacts(&self, query: &str, limit: u32) -> Result<Vec<Contact>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let needle = format!("%{}%", query.replace('%', r"\%").replace('_', r"\_"));
         // emails_json is the stringified JSON array. "[]" is the
         // canonical empty form (see apply_contact_delta), so excluding
@@ -384,7 +384,7 @@ impl Cache {
     /// Number of contacts cached for a Nextcloud account — cheap to
     /// surface in the Settings UI alongside "Sync now".
     pub fn count_contacts(&self, nc_account_id: &str) -> Result<u32, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let n: i64 = conn.query_row(
             "SELECT COUNT(*) FROM contacts WHERE nextcloud_account_id = ?1",
             params![nc_account_id],
@@ -402,7 +402,7 @@ impl Cache {
         &self,
         contact_id: &str,
     ) -> Result<Option<ContactServerHandle>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT nextcloud_account_id, addressbook, vcard_uid, href, etag, vcard_raw
@@ -440,7 +440,7 @@ impl Cache {
         addressbook: &str,
         row: &ContactRow,
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let id = format!("{nc_account_id}::{}", row.vcard_uid);
         let emails = serde_json::to_string(&row.emails).unwrap_or_else(|_| "[]".into());
         let phones = serde_json::to_string(&row.phones).unwrap_or_else(|_| "[]".into());
@@ -516,7 +516,7 @@ impl Cache {
     where
         F: Fn(&str) -> Vec<String>,
     {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let pairs: Vec<(String, String)> = {
             let mut stmt = conn.prepare(
                 "SELECT id, vcard_raw FROM contacts
@@ -550,7 +550,7 @@ impl Cache {
     /// virtual mailing list per row.  Empty when no card has a
     /// CATEGORIES tag.
     pub fn list_contact_categories(&self) -> Result<Vec<(String, u32)>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT categories_json FROM contacts
              WHERE COALESCE(kind, '') != 'group'
@@ -593,7 +593,7 @@ impl Cache {
     /// sizes — one cheap SELECT per Lists-tab open, not per
     /// keystroke.
     pub fn list_contacts_with_category(&self, category: &str) -> Result<Vec<Contact>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, display_name, emails_json,
                     phones_json, organization, photo_mime,
@@ -623,7 +623,7 @@ impl Cache {
         nc_account_id: &str,
         vcard_uid: &str,
     ) -> Result<Option<ContactServerHandle>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT nextcloud_account_id, addressbook, vcard_uid, href, etag, vcard_raw
@@ -652,7 +652,7 @@ impl Cache {
     pub fn get_mailing_list_suppressed(
         &self,
     ) -> Result<std::collections::HashSet<String>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id FROM mailing_list_settings
              WHERE hidden_from_autocomplete = 1",
@@ -670,7 +670,7 @@ impl Cache {
         id: &str,
         suppressed: bool,
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "INSERT INTO mailing_list_settings (id, hidden_from_autocomplete)
              VALUES (?1, ?2)
@@ -686,7 +686,7 @@ impl Cache {
     pub fn get_mailing_list_emojis(
         &self,
     ) -> Result<std::collections::HashMap<String, String>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, emoji FROM mailing_list_settings
              WHERE emoji IS NOT NULL AND emoji != ''",
@@ -701,7 +701,7 @@ impl Cache {
     }
 
     pub fn set_mailing_list_emoji(&self, id: &str, emoji: Option<&str>) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "INSERT INTO mailing_list_settings (id, hidden_from_autocomplete, emoji)
              VALUES (?1, 0, ?2)
@@ -722,7 +722,7 @@ impl Cache {
         if old_id == new_id {
             return Ok(());
         }
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE mailing_list_settings SET id = ?2 WHERE id = ?1",
             params![old_id, new_id],
@@ -739,7 +739,7 @@ impl Cache {
     pub fn list_contact_groups(
         &self,
     ) -> Result<Vec<nimbus_core::models::ContactGroup>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT id, nextcloud_account_id, display_name,
                     member_uids_json, group_emoji, group_hidden
@@ -786,7 +786,7 @@ impl Cache {
 
     /// Toggle the local `group_hidden` flag for one group.
     pub fn set_contact_group_hidden(&self, group_id: &str, hidden: bool) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE contacts SET group_hidden = ?2 WHERE id = ?1",
             params![group_id, hidden as i64],
@@ -800,7 +800,7 @@ impl Cache {
         group_id: &str,
         emoji: Option<&str>,
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE contacts SET group_emoji = ?2 WHERE id = ?1",
             params![group_id, emoji.filter(|s| !s.is_empty())],
@@ -824,7 +824,7 @@ impl Cache {
         if member_uids.is_empty() {
             return Ok(Vec::new());
         }
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let placeholders = member_uids
             .iter()
             .enumerate()
@@ -865,7 +865,7 @@ impl Cache {
 
     /// Remove one contact by its app-side id.
     pub fn delete_contact_by_id(&self, contact_id: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute("DELETE FROM contacts WHERE id = ?1", params![contact_id])?;
         Ok(())
     }
@@ -873,7 +873,7 @@ impl Cache {
     /// Drop all contacts and sync state for a Nextcloud account —
     /// called when the user disconnects that account.
     pub fn wipe_nextcloud_contacts(&self, nc_account_id: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "DELETE FROM contacts WHERE nextcloud_account_id = ?1",
             params![nc_account_id],

--- a/crates/nimbus-store/src/cache/key.rs
+++ b/crates/nimbus-store/src/cache/key.rs
@@ -115,6 +115,10 @@ pub fn load_envelope() -> Result<KeychainEnvelope, NimbusError> {
             version: 1,
             plain_key: None,
             wraps: Vec::new(),
+            wipe_on_failure: false,
+            max_unlock_attempts: None,
+            failed_attempts: 0,
+            integrity_mac: None,
         }),
         Err(e) => Err(NimbusError::Storage(format!(
             "failed to read master key: {e}"
@@ -122,12 +126,37 @@ pub fn load_envelope() -> Result<KeychainEnvelope, NimbusError> {
     }
 }
 
-/// Persist a mutated envelope back to the keychain.
+/// Persist a mutated envelope back to the keychain.  Recomputes
+/// the integrity MAC from the (current) field values so any
+/// later in-place edit of the JSON in the keychain breaks the
+/// MAC and trips `verify_envelope_mac` on next load.
 pub fn save_envelope(env: &KeychainEnvelope) -> Result<(), NimbusError> {
+    use crate::fido;
+    let mut signed = env.clone();
+    signed.integrity_mac = None;
+    signed.integrity_mac = Some(fido::compute_envelope_mac(&signed)?);
     let entry = entry()?;
     entry
-        .set_password(&serialize_envelope(env)?)
+        .set_password(&serialize_envelope(&signed)?)
         .map_err(|e| NimbusError::Storage(format!("failed to store master key: {e}")))
+}
+
+/// Was the loaded envelope tampered with?  True only when an
+/// `integrity_mac` is present *and* doesn't match.  A missing
+/// MAC (legacy envelope or first save) returns `false` so we
+/// don't wipe the user's data on the upgrade boundary — the
+/// next `save_envelope` will write a fresh MAC.
+pub fn envelope_tampered(env: &KeychainEnvelope) -> bool {
+    if env.integrity_mac.is_none() {
+        return false;
+    }
+    match crate::fido::verify_envelope_mac(env) {
+        Ok(valid) => !valid,
+        Err(e) => {
+            tracing::warn!("envelope MAC verify errored: {e}");
+            true
+        }
+    }
 }
 
 /// Append (or replace) a wrap in the envelope, keyed on

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -47,10 +47,13 @@ pub use contacts::{AddressbookSyncState, ContactRow, ContactServerHandle};
 pub use search::{SearchFilters, SearchHit, SearchScope};
 
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, TimeZone, Utc};
 use nimbus_core::NimbusError;
 use nimbus_core::models::{Email, EmailEnvelope, Folder};
+use r2d2::PooledConnection;
+use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{OptionalExtension, params};
 use thiserror::Error;
 use tracing::{debug, info, warn};
@@ -70,6 +73,12 @@ pub enum CacheError {
     Sql(#[from] rusqlite::Error),
     #[error("pool error: {0}")]
     Pool(#[from] r2d2::Error),
+    /// The cache is in FIDO-only mode (#164) and the user hasn't
+    /// authenticated yet.  Surface this from any IPC that touches
+    /// cached data so the UI can hold off until the lock screen
+    /// completes the unlock.
+    #[error("cache is locked — authenticate to unlock")]
+    Locked,
 }
 
 impl From<CacheError> for NimbusError {
@@ -92,9 +101,19 @@ pub struct SyncState {
 
 /// Handle to the local mail cache. Cheap to clone — under the hood it's
 /// an `Arc` around a connection pool.
+///
+/// The pool is `Option`-wrapped so the cache can exist in a
+/// **locked** state (#164 Phase 1B): if the keychain envelope has
+/// no plain master key, `Cache::open_default` returns a Cache
+/// whose pool is `None` and every data-touching method returns
+/// `CacheError::Locked` until `unlock_with_master_key` is called
+/// from the unlock-flow IPCs.
 #[derive(Clone)]
 pub struct Cache {
-    pool: SqlitePool,
+    pool: Arc<RwLock<Option<SqlitePool>>>,
+    /// Where the encrypted DB lives on disk.  Held so `unlock`
+    /// can open the pool without re-resolving the path.
+    path: PathBuf,
 }
 
 impl Cache {
@@ -105,8 +124,40 @@ impl Cache {
     /// (or freshly generated in) the OS keychain. See `key.rs`.
     pub fn open_default() -> Result<Self, NimbusError> {
         let path = default_cache_path()?;
-        let key_hex = key::get_or_create_master_key()?;
-        Self::open_with_key(&path, key_hex).map_err(Into::into)
+        // Honour the keychain envelope: when the user has flipped
+        // the cache into FIDO-only mode there's no plain key
+        // available, and we return a *locked* Cache whose pool
+        // stays `None` until `unlock_with_master_key` is called
+        // from the unlock IPCs.
+        let envelope = key::load_envelope()?;
+        match envelope.plain_key.as_deref() {
+            Some(hex) if hex.len() == 64 => {
+                Self::open_with_key(&path, hex.to_string()).map_err(Into::into)
+            }
+            Some(hex) => Err(NimbusError::Storage(format!(
+                "unexpected master key length: {} chars (expected 64)",
+                hex.len()
+            ))),
+            None => {
+                // No keychain entry yet — first-run; mint a key and
+                // open normally.  `get_or_create_master_key`
+                // handles the empty-keychain case for us.
+                if envelope.wraps.is_empty() {
+                    let key_hex = key::get_or_create_master_key()?;
+                    Self::open_with_key(&path, key_hex).map_err(Into::into)
+                } else {
+                    info!(
+                        "Cache is in FIDO-only mode ({} registered methods); \
+                         pool stays locked until unlock IPC runs",
+                        envelope.wraps.len()
+                    );
+                    Ok(Self {
+                        pool: Arc::new(RwLock::new(None)),
+                        path,
+                    })
+                }
+            }
+        }
     }
 
     /// Open a cache at an explicit path with a caller-supplied key.
@@ -139,7 +190,58 @@ impl Cache {
         // is available for use right after this call returns.
         let mut conn = pool.get()?;
         schema::run_migrations(&mut conn)?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool: Arc::new(RwLock::new(Some(pool))),
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// True when the pool isn't open yet — every data method
+    /// returns `Locked` until `unlock_with_master_key` runs.
+    pub fn is_locked(&self) -> bool {
+        self.pool.read().map(|g| g.is_none()).unwrap_or(true)
+    }
+
+    /// Open the pool for a previously-locked Cache.  Called from
+    /// the unlock-flow IPCs once the user has authenticated and
+    /// the master key has been recovered from a wrap.
+    /// Idempotent — a second call with the same key is a no-op.
+    pub fn unlock_with_master_key(&self, key_hex: String) -> Result<(), CacheError> {
+        if !self.is_locked() {
+            return Ok(());
+        }
+        let pool = match pool::open_pool(&self.path, key_hex.clone()) {
+            Ok(p) => p,
+            Err(e) if is_wrong_key_error(&e) && self.path.exists() => {
+                warn!(
+                    "Existing cache at {} could not be unlocked with the \
+                     supplied master key. Wiping — mail will re-sync.",
+                    self.path.display()
+                );
+                wipe_cache_files(&self.path)?;
+                pool::open_pool(&self.path, key_hex)?
+            }
+            Err(e) => return Err(e),
+        };
+        let mut conn = pool.get()?;
+        schema::run_migrations(&mut conn)?;
+        drop(conn);
+        let mut guard = self.pool.write().expect("Cache pool RwLock poisoned");
+        *guard = Some(pool);
+        Ok(())
+    }
+
+    /// Borrow a pooled connection or return `Locked`.  Every
+    /// data-touching method funnels through here so locked
+    /// state propagates uniformly.  `pub(crate)` so sibling
+    /// modules (`account_store`, …) can reuse it instead of
+    /// duplicating the lock-and-checkout dance.
+    pub(crate) fn conn(
+        &self,
+    ) -> Result<PooledConnection<SqliteConnectionManager>, CacheError> {
+        let guard = self.pool.read().expect("Cache pool RwLock poisoned");
+        let pool = guard.as_ref().ok_or(CacheError::Locked)?;
+        Ok(pool.get()?)
     }
 
     /// Open an in-memory cache for tests. Each call gets its own
@@ -153,16 +255,10 @@ impl Cache {
         let mut conn = pool.get()?;
         schema::run_migrations(&mut conn)?;
         drop(conn);
-        Ok(Self { pool })
-    }
-
-    /// Borrow the underlying connection pool. Exposed so the
-    /// `account_store` module (a sibling, not a method) can run its
-    /// own SQL without each operation paying for a fresh `Cache`
-    /// open. The pool is internally synchronised so handing out a
-    /// shared reference is safe across tasks.
-    pub fn pool(&self) -> &SqlitePool {
-        &self.pool
+        Ok(Self {
+            pool: Arc::new(RwLock::new(Some(pool))),
+            path: PathBuf::from(":memory:"),
+        })
     }
 
     /// Drop every cached row whose `account_id` isn't in `active_ids`.
@@ -178,7 +274,7 @@ impl Cache {
     /// Returns the count of orphan account ids that were pruned —
     /// zero on a clean cache, any other number is worth a log line.
     pub fn prune_orphan_accounts(&self, active_ids: &[String]) -> Result<usize, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         // Collect every distinct account_id across the three tables
         // that might hold orphans. Using a union keeps this robust
         // against one table drifting ahead of another (e.g. a past
@@ -217,7 +313,7 @@ impl Cache {
     /// Clears the cache for a specific account — called when an account
     /// is removed, or when `UIDVALIDITY` changes and we need to start fresh.
     pub fn wipe_account(&self, account_id: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         // `ON DELETE CASCADE` on message_bodies means deleting from
         // messages clears the bodies too. folders / folder_sync_state
         // don't have FKs, so we clear them explicitly.
@@ -243,7 +339,7 @@ impl Cache {
         old_name: &str,
         new_name: &str,
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE messages SET folder = ?3
              WHERE account_id = ?1 AND folder = ?2",
@@ -270,7 +366,7 @@ impl Cache {
     /// `ON DELETE CASCADE` handles the bodies; we explicitly drop the
     /// `folder_sync_state` row too so the next sync starts from scratch.
     pub fn wipe_folder(&self, account_id: &str, folder: &str) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "DELETE FROM messages WHERE account_id = ?1 AND folder = ?2",
             params![account_id, folder],
@@ -292,7 +388,7 @@ impl Cache {
     /// diff. The folder list is small (dozens of rows at most) so this
     /// is effectively free.
     pub fn upsert_folders(&self, account_id: &str, folders: &[Folder]) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
         tx.execute("DELETE FROM folders WHERE account_id = ?1", [account_id])?;
         {
@@ -331,7 +427,7 @@ impl Cache {
     /// behind names like `Drafts` and made the sidebar look
     /// scrambled compared to every other mail client.
     pub fn get_folders(&self, account_id: &str) -> Result<Vec<Folder>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT name, delimiter, attributes, unread_count
              FROM folders
@@ -377,7 +473,7 @@ impl Cache {
         if envelopes.is_empty() {
             return Ok(());
         }
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
         {
@@ -426,7 +522,7 @@ impl Cache {
         folder: &str,
         limit: u32,
     ) -> Result<Vec<EmailEnvelope>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT uid, folder, from_addr, subject, internal_date, is_read, is_starred
              FROM messages
@@ -465,7 +561,7 @@ impl Cache {
         folder: &str,
         limit: u32,
     ) -> Result<Vec<EmailEnvelope>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT account_id, uid, folder, from_addr, subject, internal_date, is_read, is_starred
              FROM messages
@@ -515,7 +611,7 @@ impl Cache {
         folder: &str,
         uid: u32,
     ) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
 
         let was_unread: bool = tx
@@ -560,7 +656,7 @@ impl Cache {
         account_id: &str,
         folder: &str,
     ) -> Result<Vec<u32>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT uid FROM messages
              WHERE account_id = ?1 AND folder = ?2",
@@ -592,7 +688,7 @@ impl Cache {
         folder: &str,
         uid: u32,
     ) -> Result<bool, CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
 
         let was_unread: bool = tx
@@ -632,7 +728,7 @@ impl Cache {
         folder: &str,
         uid: u32,
     ) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
 
         let was_read: bool = tx
@@ -676,7 +772,7 @@ impl Cache {
         if delta == 0 {
             return Ok(());
         }
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "UPDATE folders
              SET unread_count = MAX(COALESCE(unread_count, 0) + ?3, 0)
@@ -693,7 +789,7 @@ impl Cache {
     /// (Archive, Trash) aren't typically surfaced as "unread" to the
     /// user even when they technically have `is_read = 0` rows.
     pub fn total_unread_count(&self) -> Result<u32, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let count: i64 = conn.query_row(
             "SELECT COUNT(*) FROM messages
              WHERE folder = 'INBOX' AND is_read = 0",
@@ -712,7 +808,7 @@ impl Cache {
     pub fn unread_counts_by_account(
         &self,
     ) -> Result<std::collections::HashMap<String, u32>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT account_id, COUNT(*) FROM messages
              WHERE folder = 'INBOX' AND is_read = 0
@@ -742,7 +838,7 @@ impl Cache {
     /// and a body row here, in a single transaction so partial rows never
     /// survive a failed write.
     pub fn upsert_message(&self, email: &Email) -> Result<(), CacheError> {
-        let mut conn = self.pool.get()?;
+        let mut conn = self.conn()?;
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
 
@@ -840,7 +936,7 @@ impl Cache {
         folder: &str,
         uid: u32,
     ) -> Result<Option<Email>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let row = conn
             .query_row(
                 "SELECT m.from_addr, m.subject, m.internal_date,
@@ -886,7 +982,7 @@ impl Cache {
         account_id: &str,
         folder: &str,
     ) -> Result<Option<SyncState>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let state = conn
             .query_row(
                 "SELECT uidvalidity, highest_uid_seen, last_synced_at
@@ -914,7 +1010,7 @@ impl Cache {
         folder: &str,
         state: &SyncState,
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "INSERT INTO folder_sync_state
                 (account_id, folder, uidvalidity, highest_uid_seen, last_synced_at)
@@ -956,7 +1052,7 @@ impl Cache {
         mime: &str,
         bytes: &[u8],
     ) -> Result<(), CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         conn.execute(
             "INSERT OR REPLACE INTO attachment_previews
                  (account_id, folder, uid, part_id, mime, bytes, created_at)
@@ -975,7 +1071,7 @@ impl Cache {
         folder: &str,
         uid: u32,
     ) -> Result<Vec<AttachmentPreview>, CacheError> {
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
         let mut stmt = conn.prepare(
             "SELECT part_id, mime, bytes
              FROM attachment_previews

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -114,6 +114,12 @@ pub struct Cache {
     /// Where the encrypted DB lives on disk.  Held so `unlock`
     /// can open the pool without re-resolving the path.
     path: PathBuf,
+    /// In-memory copy of the SQLCipher master key (64-char
+    /// lowercase hex), populated after a successful unlock.  Lets
+    /// `disable_fido_only_mode` write the key back into the
+    /// keychain envelope without having to re-prompt the user.
+    /// `None` while the cache is locked.
+    master_key_hex: Arc<RwLock<Option<String>>>,
 }
 
 impl Cache {
@@ -154,6 +160,7 @@ impl Cache {
                     Ok(Self {
                         pool: Arc::new(RwLock::new(None)),
                         path,
+                        master_key_hex: Arc::new(RwLock::new(None)),
                     })
                 }
             }
@@ -182,7 +189,7 @@ impl Cache {
                     path.display()
                 );
                 wipe_cache_files(path)?;
-                pool::open_pool(path, key_hex)?
+                pool::open_pool(path, key_hex.clone())?
             }
             Err(e) => return Err(e),
         };
@@ -193,6 +200,7 @@ impl Cache {
         Ok(Self {
             pool: Arc::new(RwLock::new(Some(pool))),
             path: path.to_path_buf(),
+            master_key_hex: Arc::new(RwLock::new(Some(key_hex))),
         })
     }
 
@@ -210,25 +218,51 @@ impl Cache {
         if !self.is_locked() {
             return Ok(());
         }
-        let pool = match pool::open_pool(&self.path, key_hex.clone()) {
-            Ok(p) => p,
-            Err(e) if is_wrong_key_error(&e) && self.path.exists() => {
-                warn!(
-                    "Existing cache at {} could not be unlocked with the \
-                     supplied master key. Wiping — mail will re-sync.",
-                    self.path.display()
-                );
-                wipe_cache_files(&self.path)?;
-                pool::open_pool(&self.path, key_hex)?
-            }
-            Err(e) => return Err(e),
-        };
+        // No wipe-on-wrong-key fallback here.  At unlock time a
+        // SQLCipher key mismatch means authentication failed —
+        // silently wiping the DB would destroy the user's mail and
+        // accounts.  Surface the error so the unlock IPC can
+        // re-prompt instead.  (The legacy-DB wipe lives in
+        // `open_with_key`, which only runs on first boot when no
+        // wraps exist.)
+        let pool = pool::open_pool(&self.path, key_hex.clone())?;
         let mut conn = pool.get()?;
         schema::run_migrations(&mut conn)?;
         drop(conn);
         let mut guard = self.pool.write().expect("Cache pool RwLock poisoned");
         *guard = Some(pool);
+        // Stash the recovered key so `disable_fido_only_mode` can
+        // write it back into the keychain envelope without making
+        // the user re-authenticate.  Cleared in any future
+        // re-lock path.
+        let mut key_guard = self
+            .master_key_hex
+            .write()
+            .expect("Cache master_key_hex RwLock poisoned");
+        *key_guard = Some(key_hex);
         Ok(())
+    }
+
+    /// Read the in-memory copy of the SQLCipher master key (hex).
+    /// Returns `None` while the cache is locked or for an
+    /// in-memory test cache.  Used by `disable_fido_only_mode`
+    /// to restore `envelope.plain_key` without re-prompting.
+    pub fn master_key_hex(&self) -> Option<String> {
+        self.master_key_hex
+            .read()
+            .ok()
+            .and_then(|g| g.clone())
+    }
+
+    /// Delete the cache DB and its WAL sidecars from disk.  Used
+    /// by the "wipe on failed authentication" policy: when the
+    /// user exhausts their unlock attempts we drop the file so
+    /// the next launch starts clean.  The Cache stays locked
+    /// (pool is `None` either way) — the caller is responsible
+    /// for clearing the keychain envelope's wraps if it wants a
+    /// completely fresh setup on next launch.
+    pub fn wipe_on_disk(&self) -> Result<(), CacheError> {
+        wipe_cache_files(&self.path)
     }
 
     /// Borrow a pooled connection or return `Locked`.  Every
@@ -258,6 +292,7 @@ impl Cache {
         Ok(Self {
             pool: Arc::new(RwLock::new(Some(pool))),
             path: PathBuf::from(":memory:"),
+            master_key_hex: Arc::new(RwLock::new(None)),
         })
     }
 
@@ -1138,6 +1173,15 @@ fn is_wrong_key_error(err: &CacheError) -> bool {
 ///
 /// Leaving the sidecars behind would let SQLite partially replay the
 /// old unencrypted WAL against the new encrypted file on next open.
+///
+/// Each file is overwritten with random bytes (one pass) and
+/// fsync'd before unlink so the encrypted SQLCipher pages don't
+/// linger on disk for forensic recovery.  This is fully
+/// effective on rotational drives.  On SSDs with wear-levelling
+/// the new write may land on a different physical block,
+/// leaving the old ciphertext recoverable until the controller
+/// reclaims that block — there's no way to force a true secure
+/// erase from userspace, so this is best-effort.
 fn wipe_cache_files(path: &Path) -> Result<(), CacheError> {
     for suffix in ["", "-wal", "-shm"] {
         let p = if suffix.is_empty() {
@@ -1148,10 +1192,50 @@ fn wipe_cache_files(path: &Path) -> Result<(), CacheError> {
             PathBuf::from(s)
         };
         if p.exists() {
+            if let Err(e) = secure_overwrite(&p) {
+                // Don't refuse the wipe just because the
+                // overwrite step couldn't open the file
+                // (read-only filesystem, locked by another
+                // process, …) — unlinking the file is still
+                // strictly better than leaving it.
+                tracing::warn!("secure overwrite of {} failed: {e}", p.display());
+            }
             std::fs::remove_file(&p)
                 .map_err(|e| CacheError::Open(format!("remove {}: {e}", p.display())))?;
         }
     }
+    Ok(())
+}
+
+/// Overwrite a file's contents with cryptographic-RNG bytes,
+/// flush to disk, before the caller unlinks it.  See
+/// `wipe_cache_files` for the threat-model caveats.
+fn secure_overwrite(path: &Path) -> Result<(), CacheError> {
+    use std::io::Write;
+    let len = std::fs::metadata(path)
+        .map_err(|e| CacheError::Open(format!("metadata {}: {e}", path.display())))?
+        .len();
+    if len == 0 {
+        return Ok(());
+    }
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|e| CacheError::Open(format!("open-for-overwrite {}: {e}", path.display())))?;
+    const CHUNK: usize = 64 * 1024;
+    let mut buf = vec![0u8; CHUNK];
+    let mut written: u64 = 0;
+    while written < len {
+        let remaining = len - written;
+        let n = (remaining as usize).min(CHUNK);
+        getrandom::getrandom(&mut buf[..n])
+            .map_err(|e| CacheError::Open(format!("RNG for secure overwrite: {e}")))?;
+        f.write_all(&buf[..n])
+            .map_err(|e| CacheError::Open(format!("write {}: {e}", path.display())))?;
+        written += n as u64;
+    }
+    f.sync_all()
+        .map_err(|e| CacheError::Open(format!("fsync {}: {e}", path.display())))?;
     Ok(())
 }
 

--- a/crates/nimbus-store/src/cache/search.rs
+++ b/crates/nimbus-store/src/cache/search.rs
@@ -115,7 +115,7 @@ impl Cache {
         filters: &SearchFilters,
     ) -> Result<Vec<SearchHit>, CacheError> {
         let parsed = parse_query(query);
-        let conn = self.pool.get()?;
+        let conn = self.conn()?;
 
         // Build SQL + bindings incrementally so we can toggle the
         // FTS5 join off when there's no text to match (pure filter

--- a/crates/nimbus-store/src/fido.rs
+++ b/crates/nimbus-store/src/fido.rs
@@ -174,6 +174,75 @@ pub struct KeychainEnvelope {
     pub plain_key: Option<String>,
     #[serde(default)]
     pub wraps: Vec<WrappedKey>,
+    /// When true, the unlock IPC wipes the encrypted cache after
+    /// `max_unlock_attempts` consecutive failed attempts.  Off by
+    /// default — opt-in destruction.
+    #[serde(default)]
+    pub wipe_on_failure: bool,
+    /// Maximum consecutive failed unlock attempts before the
+    /// cache is wiped.  `None` (or `wipe_on_failure = false`)
+    /// means unlimited retries.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_unlock_attempts: Option<u32>,
+    /// Persisted across launches so kill+relaunch can't reset
+    /// the wipe-on-failure budget.  Bumped before each unlock
+    /// attempt in `note_unlock_failure` and cleared on success.
+    #[serde(default)]
+    pub failed_attempts: u32,
+    /// HMAC-SHA256 (base64) over the envelope with this field
+    /// blanked out, keyed by `ENVELOPE_MAC_KEY`.  Detects casual
+    /// edits to `failed_attempts`, `wipe_on_failure`, and
+    /// `max_unlock_attempts` via a text editor or `keyctl`-style
+    /// keychain inspection tools.  Not a defence against an
+    /// attacker who has the binary (the key is constant) — it
+    /// raises the bar from "open in vim" to "reverse-engineer
+    /// and script."
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub integrity_mac: Option<String>,
+}
+
+/// Constant HMAC key for envelope tamper detection.  Embedded in
+/// the binary, so an attacker with disassembly access can forge
+/// the MAC.  The point isn't cryptographic secrecy — it's that
+/// editing the JSON in-place (the casual attack we're trying
+/// to deter) breaks the MAC and forces the wipe to fire.
+const ENVELOPE_MAC_KEY: &[u8; 32] = b"nimbus-envelope-integrity-v1!!!!";
+
+/// Compute the integrity MAC over a serialized envelope with
+/// `integrity_mac` blanked out.  Stable across runs as long as
+/// the rest of the envelope content is byte-identical.
+pub fn compute_envelope_mac(env: &KeychainEnvelope) -> Result<String, NimbusError> {
+    use hmac::Mac;
+    let mut probe = env.clone();
+    probe.integrity_mac = None;
+    let bytes = serde_json::to_vec(&probe)
+        .map_err(|e| NimbusError::Storage(format!("envelope MAC serialize: {e}")))?;
+    let mut mac = <Hmac<Sha256> as hmac::Mac>::new_from_slice(ENVELOPE_MAC_KEY)
+        .map_err(|e| NimbusError::Storage(format!("envelope MAC init: {e}")))?;
+    mac.update(&bytes);
+    Ok(B64.encode(mac.finalize().into_bytes()))
+}
+
+/// Verify the integrity MAC.  Returns `Ok(true)` when the MAC is
+/// present and matches, `Ok(false)` when the field is missing
+/// (legacy envelope or first save) or when it doesn't match.
+pub fn verify_envelope_mac(env: &KeychainEnvelope) -> Result<bool, NimbusError> {
+    let Some(stored) = env.integrity_mac.as_deref() else {
+        return Ok(false);
+    };
+    let expected = compute_envelope_mac(env)?;
+    Ok(constant_time_eq(stored.as_bytes(), expected.as_bytes()))
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 impl KeychainEnvelope {
@@ -182,6 +251,10 @@ impl KeychainEnvelope {
             version: 1,
             plain_key: Some(plain_key_hex),
             wraps: Vec::new(),
+            wipe_on_failure: false,
+            max_unlock_attempts: None,
+            failed_attempts: 0,
+            integrity_mac: None,
         }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -223,6 +223,20 @@ fn update_account(account: Account, cache: State<'_, Cache>) -> Result<(), Nimbu
     account_store::update_account(&cache, account)
 }
 
+/// Replace the IMAP/SMTP password stored in the OS keychain for
+/// an existing account.  Kept separate from `update_account` so
+/// the password never has to round-trip through the account
+/// metadata struct (which lives in the encrypted SQLite cache).
+/// `store_imap_password` overwrites in place, so the same call
+/// covers initial setup and rotation.
+#[tauri::command]
+fn set_account_password(id: String, password: String) -> Result<(), NimbusError> {
+    if password.is_empty() {
+        return Err(NimbusError::Other("password must not be empty".into()));
+    }
+    credentials::store_imap_password(&id, &password)
+}
+
 /// Pin (or clear) a per-folder icon override for an account.
 ///
 /// Passing `Some(emoji)` sets the override; `None` removes it so the
@@ -6958,15 +6972,22 @@ fn fido_enroll(
     salt_b64: String,
     prf_output_b64: String,
     label: String,
+    cache: State<'_, Cache>,
 ) -> Result<(), NimbusError> {
     use nimbus_store::fido;
     let env = nimbus_store::cache::key::load_envelope()?;
-    let plain_hex = env.plain_key.as_deref().ok_or_else(|| {
-        NimbusError::Auth(
-            "Cannot enroll a credential while the database is FIDO-only (use unlock first)".into(),
-        )
-    })?;
-    let master_key = hex::decode(plain_hex)
+    // Same fallback as `fido_enroll_passphrase`: prefer the
+    // envelope's plain key, fall back to the in-memory copy
+    // when FIDO-only mode has cleared plain_key.
+    let plain_hex = match env.plain_key.as_deref() {
+        Some(hex) => hex.to_string(),
+        None => cache.master_key_hex().ok_or_else(|| {
+            NimbusError::Auth(
+                "Cannot enroll a credential while the database is locked — unlock first".into(),
+            )
+        })?,
+    };
+    let master_key = hex::decode(&plain_hex)
         .map_err(|e| NimbusError::Storage(format!("master key hex decode: {e}")))?;
     let credential_id = fido::decode_b64(&credential_id_b64)?;
     let salt = fido::decode_b64(&salt_b64)?;
@@ -6990,31 +7011,51 @@ fn fido_enroll(
 /// 2.46).  Salt + synthetic credential id are server-side
 /// generated so the frontend never produces them.
 #[tauri::command]
-fn fido_enroll_passphrase(passphrase: String, label: String) -> Result<(), NimbusError> {
-    use nimbus_store::fido;
+fn fido_enroll_passphrase(
+    passphrase: String,
+    label: String,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    use nimbus_store::fido::{self, WrapKind};
     if passphrase.trim().is_empty() {
         return Err(NimbusError::Other("passphrase must not be empty".into()));
     }
-    let env = nimbus_store::cache::key::load_envelope()?;
-    let plain_hex = env.plain_key.as_deref().ok_or_else(|| {
-        NimbusError::Auth(
-            "Cannot enroll a passphrase while the database is FIDO-only (use unlock first)".into(),
-        )
-    })?;
-    let master_key = hex::decode(plain_hex)
+    let mut env = nimbus_store::cache::key::load_envelope()?;
+    // Prefer the keychain envelope's plain key (pre-FIDO-only),
+    // fall back to the in-memory copy that `unlock_with_*` stashes
+    // on the Cache.  The fallback is what makes "Change passphrase"
+    // work after the user has flipped Key Encryption on — by that
+    // point envelope.plain_key is None and we'd otherwise refuse.
+    let plain_hex = match env.plain_key.as_deref() {
+        Some(hex) => hex.to_string(),
+        None => cache.master_key_hex().ok_or_else(|| {
+            NimbusError::Auth(
+                "Cannot enroll a passphrase while the database is locked — unlock first".into(),
+            )
+        })?,
+    };
+    let master_key = hex::decode(&plain_hex)
         .map_err(|e| NimbusError::Storage(format!("master key hex decode: {e}")))?;
     let salt = fido::generate_salt()?;
     let id = fido::generate_passphrase_id()?;
     let aes_key = fido::derive_passphrase_key(&passphrase, &salt)?;
     let wrap = fido::wrap_master_key(
-        fido::WrapKind::Passphrase,
+        WrapKind::Passphrase,
         &master_key,
         &aes_key,
         &id,
         &salt,
         label,
     )?;
-    nimbus_store::cache::key::add_wrap(wrap)?;
+    // Single-passphrase invariant: the recovery passphrase is a
+    // role, not a per-device entry.  Drop any existing passphrase
+    // wrap before adding the new one so re-enrolling cleanly
+    // replaces the old one (and so add_wrap's credential-id
+    // dedup never lets two passphrase wraps coexist with
+    // different ids).
+    env.wraps.retain(|w| w.kind != WrapKind::Passphrase);
+    env.wraps.push(wrap);
+    nimbus_store::cache::key::save_envelope(&env)?;
     Ok(())
 }
 
@@ -7098,6 +7139,11 @@ struct DatabaseStatusView {
     /// One entry per registered unlock method (FIDO PRF or
     /// passphrase), used by the lock screen to render a picker.
     methods: Vec<FidoCredentialView>,
+    /// Remaining unlock attempts before wipe-on-failure fires.
+    /// `None` when the policy is off or has no limit set —
+    /// the lock screen renders "X tries remaining" only when this
+    /// is `Some(_)`.
+    attempts_remaining: Option<u32>,
 }
 
 /// Snapshot used by `App.svelte` on mount to decide whether to
@@ -7106,6 +7152,10 @@ struct DatabaseStatusView {
 fn database_status(cache: State<'_, Cache>) -> Result<DatabaseStatusView, NimbusError> {
     let env = nimbus_store::cache::key::load_envelope()?;
     let locked = cache.is_locked();
+    let attempts_remaining = match (env.wipe_on_failure, env.max_unlock_attempts) {
+        (true, Some(max)) if max > 0 => Some(max.saturating_sub(env.failed_attempts)),
+        _ => None,
+    };
     Ok(DatabaseStatusView {
         locked,
         needs_setup: env.plain_key.is_none() && env.wraps.is_empty(),
@@ -7123,7 +7173,90 @@ fn database_status(cache: State<'_, Cache>) -> Result<DatabaseStatusView, Nimbus
                 created_at: w.created_at,
             })
             .collect(),
+        attempts_remaining,
     })
+}
+
+/// Wipe the cache file and clear the keychain envelope.
+/// Triggered when the user exhausts their unlock budget OR
+/// when the envelope's integrity MAC fails.
+fn perform_wipe(cache: &Cache) {
+    if let Err(e) = cache.wipe_on_disk() {
+        tracing::error!("wipe_on_disk failed: {e}");
+    }
+    let cleared = nimbus_store::fido::KeychainEnvelope {
+        version: 1,
+        plain_key: None,
+        wraps: Vec::new(),
+        wipe_on_failure: false,
+        max_unlock_attempts: None,
+        failed_attempts: 0,
+        integrity_mac: None,
+    };
+    if let Err(e) = nimbus_store::cache::key::save_envelope(&cleared) {
+        tracing::error!("clearing envelope after wipe failed: {e}");
+    }
+}
+
+/// Bump the persisted failure counter and, if the user has
+/// opted into the wipe-on-failure policy, blow away the cache
+/// once the configured retry budget is exhausted.  The counter
+/// lives in the keychain envelope (not just process memory) so
+/// kill+relaunch can't reset the budget.  An invalid envelope
+/// MAC trips the wipe immediately on the next failure regardless
+/// of where the persisted counter sat.
+fn note_unlock_failure(cache: &Cache, label: &str) -> NimbusError {
+    let mut env = match nimbus_store::cache::key::load_envelope() {
+        Ok(e) => e,
+        Err(e) => return e,
+    };
+    let tampered = nimbus_store::cache::key::envelope_tampered(&env);
+    if tampered {
+        tracing::warn!(
+            "Keychain envelope MAC mismatch — treating this attempt as terminal."
+        );
+    }
+    env.failed_attempts = env.failed_attempts.saturating_add(1);
+    let attempts = env.failed_attempts;
+    if let Err(e) = nimbus_store::cache::key::save_envelope(&env) {
+        tracing::warn!("could not persist failure counter: {e}");
+    }
+    if env.wipe_on_failure || tampered {
+        let max = env.max_unlock_attempts.unwrap_or(0);
+        let trip = tampered || (max > 0 && attempts >= max);
+        if trip {
+            if tampered {
+                tracing::warn!("Wipe fired due to envelope tampering.");
+            } else {
+                tracing::warn!(
+                    "Wipe-on-failure policy fired: {attempts} consecutive failed unlock attempts (limit {max})."
+                );
+            }
+            perform_wipe(cache);
+            return NimbusError::Auth(if tampered {
+                "Keychain envelope was modified outside Nimbus. The encrypted cache has been wiped.".to_string()
+            } else {
+                format!(
+                    "Too many failed attempts ({attempts}/{max}). The encrypted cache has been wiped."
+                )
+            });
+        }
+    }
+    NimbusError::Auth(format!("incorrect {label}"))
+}
+
+/// Reset the persisted failure counter on a successful unlock.
+fn note_unlock_success() {
+    let Ok(mut env) = nimbus_store::cache::key::load_envelope() else {
+        return;
+    };
+    if env.failed_attempts == 0 {
+        return;
+    }
+    env.failed_attempts = 0;
+    if let Err(e) = nimbus_store::cache::key::save_envelope(&env) {
+        tracing::warn!("could not reset failure counter: {e}");
+    }
 }
 
 /// Unlock the cache from a passphrase.  Tries every passphrase
@@ -7144,10 +7277,11 @@ fn unlock_with_passphrase(
         if let Ok(master) = fido::unwrap_master_key(wrap, &aes_key) {
             let hex = hex::encode(&master);
             cache.unlock_with_master_key(hex).map_err(NimbusError::from)?;
+            note_unlock_success();
             return Ok(());
         }
     }
-    Err(NimbusError::Auth("incorrect passphrase".into()))
+    Err(note_unlock_failure(&cache, "passphrase"))
 }
 
 /// Unlock the cache from a FIDO PRF assertion.  Frontend has
@@ -7167,10 +7301,13 @@ fn unlock_with_prf(
         if wrap.kind != WrapKind::FidoPrf || wrap.credential_id != credential_id_b64 {
             continue;
         }
-        let master = fido::unwrap_master_key(wrap, &prf)
-            .map_err(|_| NimbusError::Auth("hardware key produced wrong PRF output".into()))?;
+        let master = match fido::unwrap_master_key(wrap, &prf) {
+            Ok(m) => m,
+            Err(_) => return Err(note_unlock_failure(&cache, "hardware key PRF output")),
+        };
         let hex = hex::encode(&master);
         cache.unlock_with_master_key(hex).map_err(NimbusError::from)?;
+        note_unlock_success();
         return Ok(());
     }
     Err(NimbusError::Auth(
@@ -7213,6 +7350,40 @@ fn enable_fido_only_mode() -> Result<(), NimbusError> {
     Ok(())
 }
 
+/// Snapshot of the wipe-on-failure policy stored in the
+/// keychain envelope.  `enabled = false` means unlimited
+/// retries.  `max_attempts = None` means the same — the toggle
+/// can be on but with no number set; we treat that as
+/// effectively off until a number is provided.
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WipePolicyView {
+    enabled: bool,
+    max_attempts: Option<u32>,
+}
+
+#[tauri::command]
+fn get_wipe_policy() -> Result<WipePolicyView, NimbusError> {
+    let env = nimbus_store::cache::key::load_envelope()?;
+    Ok(WipePolicyView {
+        enabled: env.wipe_on_failure,
+        max_attempts: env.max_unlock_attempts,
+    })
+}
+
+#[tauri::command]
+fn set_wipe_policy(policy: WipePolicyView) -> Result<(), NimbusError> {
+    let mut env = nimbus_store::cache::key::load_envelope()?;
+    env.wipe_on_failure = policy.enabled;
+    env.max_unlock_attempts = if policy.enabled {
+        policy.max_attempts.filter(|n| *n > 0)
+    } else {
+        None
+    };
+    nimbus_store::cache::key::save_envelope(&env)?;
+    Ok(())
+}
+
 /// Reverse of `enable_fido_only_mode` — re-store the plain
 /// master key in the envelope so the next launch opens the
 /// cache without prompting.  Only callable while the cache is
@@ -7224,16 +7395,18 @@ fn disable_fido_only_mode(cache: State<'_, Cache>) -> Result<(), NimbusError> {
             "Database must be unlocked before FIDO-only mode can be disabled".into(),
         ));
     }
-    // We need the master key to write back into the envelope.
-    // It currently lives only inside the SQLCipher pool — we
-    // can't read it back from rusqlite, so we ask the user to
-    // re-authenticate via the unlock IPCs in a follow-up.  For
-    // now, refuse: disabling is a rare, deliberate operation.
-    Err(NimbusError::Other(
-        "Disabling FIDO-only mode isn't wired up yet — re-enroll \
-         with a fresh master by removing then re-adding accounts."
-            .into(),
-    ))
+    let key_hex = cache.master_key_hex().ok_or_else(|| {
+        NimbusError::Auth(
+            "Master key isn't available in memory — unlock the database again before disabling key encryption".into(),
+        )
+    })?;
+    let mut env = nimbus_store::cache::key::load_envelope()?;
+    if env.plain_key.is_some() {
+        return Ok(()); // already plain — idempotent.
+    }
+    env.plain_key = Some(key_hex);
+    nimbus_store::cache::key::save_envelope(&env)?;
+    Ok(())
 }
 
 /// Return the cached font list to the frontend.  Reads from
@@ -7711,6 +7884,7 @@ fn main() {
             add_account,
             remove_account,
             update_account,
+            set_account_password,
             set_folder_icon,
             discover_account_settings,
             probe_server_certificate,
@@ -7839,6 +8013,8 @@ fn main() {
             unlock_with_prf,
             enable_fido_only_mode,
             disable_fido_only_mode,
+            get_wipe_policy,
+            set_wipe_policy,
             update_app_settings,
             import_custom_theme,
             remove_custom_theme,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7083,6 +7083,159 @@ fn fido_remove(credential_id_b64: String) -> Result<(), NimbusError> {
     Ok(())
 }
 
+// ── Database lock + unlock (#164 Phase 1B) ────────────────────
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DatabaseStatusView {
+    /// True when no plain key is in the envelope and the cache
+    /// pool isn't open yet — the lock screen should be shown.
+    locked: bool,
+    /// True when the keychain envelope has zero registered methods
+    /// and zero plain key — the user has wiped everything;
+    /// app needs to recreate from scratch.
+    needs_setup: bool,
+    /// One entry per registered unlock method (FIDO PRF or
+    /// passphrase), used by the lock screen to render a picker.
+    methods: Vec<FidoCredentialView>,
+}
+
+/// Snapshot used by `App.svelte` on mount to decide whether to
+/// route the user to the lock screen or straight into the inbox.
+#[tauri::command]
+fn database_status(cache: State<'_, Cache>) -> Result<DatabaseStatusView, NimbusError> {
+    let env = nimbus_store::cache::key::load_envelope()?;
+    let locked = cache.is_locked();
+    Ok(DatabaseStatusView {
+        locked,
+        needs_setup: env.plain_key.is_none() && env.wraps.is_empty(),
+        methods: env
+            .wraps
+            .into_iter()
+            .map(|w| FidoCredentialView {
+                kind: match w.kind {
+                    nimbus_store::fido::WrapKind::FidoPrf => "fido_prf".to_string(),
+                    nimbus_store::fido::WrapKind::Passphrase => "passphrase".to_string(),
+                },
+                credential_id: w.credential_id,
+                label: w.label,
+                salt: w.salt,
+                created_at: w.created_at,
+            })
+            .collect(),
+    })
+}
+
+/// Unlock the cache from a passphrase.  Tries every passphrase
+/// wrap in the envelope, returns the first match.
+#[tauri::command]
+fn unlock_with_passphrase(
+    passphrase: String,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    use nimbus_store::fido::{self, WrapKind};
+    let env = nimbus_store::cache::key::load_envelope()?;
+    for wrap in &env.wraps {
+        if wrap.kind != WrapKind::Passphrase {
+            continue;
+        }
+        let salt = fido::decode_b64(&wrap.salt)?;
+        let aes_key = fido::derive_passphrase_key(&passphrase, &salt)?;
+        if let Ok(master) = fido::unwrap_master_key(wrap, &aes_key) {
+            let hex = hex::encode(&master);
+            cache.unlock_with_master_key(hex).map_err(NimbusError::from)?;
+            return Ok(());
+        }
+    }
+    Err(NimbusError::Auth("incorrect passphrase".into()))
+}
+
+/// Unlock the cache from a FIDO PRF assertion.  Frontend has
+/// already run WebAuthn `credentials.get` against the
+/// credential's stored salt and forwards the resulting PRF
+/// output here.
+#[tauri::command]
+fn unlock_with_prf(
+    credential_id_b64: String,
+    prf_output_b64: String,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    use nimbus_store::fido::{self, WrapKind};
+    let env = nimbus_store::cache::key::load_envelope()?;
+    let prf = fido::decode_b64(&prf_output_b64)?;
+    for wrap in &env.wraps {
+        if wrap.kind != WrapKind::FidoPrf || wrap.credential_id != credential_id_b64 {
+            continue;
+        }
+        let master = fido::unwrap_master_key(wrap, &prf)
+            .map_err(|_| NimbusError::Auth("hardware key produced wrong PRF output".into()))?;
+        let hex = hex::encode(&master);
+        cache.unlock_with_master_key(hex).map_err(NimbusError::from)?;
+        return Ok(());
+    }
+    Err(NimbusError::Auth(
+        "no registered hardware key matches that credential".into(),
+    ))
+}
+
+/// Switch the cache into FIDO-only mode: drop the plain master
+/// key from the keychain envelope so future cold launches MUST
+/// authenticate with one of the registered methods.  Refuses
+/// unless the user has at least one passphrase OR ≥ 2 hardware
+/// keys registered — without a recovery option we'd lock them
+/// out permanently the first time a YubiKey gets lost.
+#[tauri::command]
+fn enable_fido_only_mode() -> Result<(), NimbusError> {
+    use nimbus_store::fido::WrapKind;
+    let mut env = nimbus_store::cache::key::load_envelope()?;
+    if env.plain_key.is_none() {
+        return Ok(()); // already FIDO-only — idempotent.
+    }
+    let passphrase_count = env
+        .wraps
+        .iter()
+        .filter(|w| w.kind == WrapKind::Passphrase)
+        .count();
+    let fido_count = env
+        .wraps
+        .iter()
+        .filter(|w| w.kind == WrapKind::FidoPrf)
+        .count();
+    if passphrase_count == 0 && fido_count < 2 {
+        return Err(NimbusError::Other(
+            "Register at least one passphrase OR two hardware keys before enabling FIDO-only mode \
+             — otherwise losing a single key would lock the cache permanently."
+                .into(),
+        ));
+    }
+    env.plain_key = None;
+    nimbus_store::cache::key::save_envelope(&env)?;
+    Ok(())
+}
+
+/// Reverse of `enable_fido_only_mode` — re-store the plain
+/// master key in the envelope so the next launch opens the
+/// cache without prompting.  Only callable while the cache is
+/// already unlocked (we need the in-memory key).
+#[tauri::command]
+fn disable_fido_only_mode(cache: State<'_, Cache>) -> Result<(), NimbusError> {
+    if cache.is_locked() {
+        return Err(NimbusError::Auth(
+            "Database must be unlocked before FIDO-only mode can be disabled".into(),
+        ));
+    }
+    // We need the master key to write back into the envelope.
+    // It currently lives only inside the SQLCipher pool — we
+    // can't read it back from rusqlite, so we ask the user to
+    // re-authenticate via the unlock IPCs in a follow-up.  For
+    // now, refuse: disabling is a rare, deliberate operation.
+    Err(NimbusError::Other(
+        "Disabling FIDO-only mode isn't wired up yet — re-enroll \
+         with a fresh master by removing then re-adding accounts."
+            .into(),
+    ))
+}
+
 /// Return the cached font list to the frontend.  Reads from
 /// the shared `SystemFontsCache` populated at startup; if the
 /// cache is somehow empty (startup warmer failed or hasn't run
@@ -7681,6 +7834,11 @@ fn main() {
             fido_verify_passphrase,
             fido_verify_prf,
             fido_remove,
+            database_status,
+            unlock_with_passphrase,
+            unlock_with_prf,
+            enable_fido_only_mode,
+            disable_fido_only_mode,
             update_app_settings,
             import_custom_theme,
             remove_custom_theme,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -100,6 +100,7 @@
       salt: string
       createdAt: number
     }[]
+    attemptsRemaining: number | null
   }
   let dbStatus = $state<DatabaseStatus | null>(null)
   let dbStatusError = $state('')
@@ -112,7 +113,7 @@
         // Fail-open: assume unlocked so the user isn't trapped on
         // a blank screen if the IPC went wrong.  Real lock-state
         // bugs surface as "every other IPC errors with locked".
-        dbStatus = { locked: false, needsSetup: false, methods: [] }
+        dbStatus = { locked: false, needsSetup: false, methods: [], attemptsRemaining: null }
       })
   })
   function onUnlocked() {
@@ -193,10 +194,15 @@
   }
 
   // ── Check for existing accounts on startup ──────────────────
-  // This runs once when the component mounts. It calls get_accounts
-  // to see if the user has already configured an email account.
+  // Wait until the cache is actually unlocked before asking Rust
+  // for the account list — `get_accounts` returns `Locked` while
+  // the FIDO unlock screen is up, and that error path used to
+  // route the user into the setup wizard even when accounts
+  // existed.  Re-runs after `onUnlocked` flips `dbStatus.locked`.
   $effect(() => {
-    checkAccounts()
+    if (dbStatus && !dbStatus.locked) {
+      void checkAccounts()
+    }
   })
 
   // ── Issue #16: background-sync events + desktop notifications ──
@@ -1050,7 +1056,14 @@
      mail / calendar / contacts views) stays unmounted so no IPC
      fires with the cache still locked. -->
 {#if dbStatus && dbStatus.locked}
-  <LockScreen methods={dbStatus.methods} onunlock={onUnlocked} />
+  <LockScreen
+    methods={dbStatus.methods}
+    attemptsRemaining={dbStatus.attemptsRemaining}
+    onattemptschange={(n) => {
+      if (dbStatus) dbStatus = { ...dbStatus, attemptsRemaining: n }
+    }}
+    onunlock={onUnlocked}
+  />
 {:else if dbStatus === null}
   <!-- Brief flash while we wait for `database_status` to land —
        prevents the loading view from poking the cache before we

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -24,6 +24,7 @@
   import MailView from './lib/MailView.svelte'
   import AccountSetup from './lib/AccountSetup.svelte'
   import AccountSettings from './lib/AccountSettings.svelte'
+  import LockScreen from './lib/LockScreen.svelte'
   import Compose, { type ComposeInitial } from './lib/Compose.svelte'
   import ContactsView from './lib/ContactsView.svelte'
   import CalendarView from './lib/CalendarView.svelte'
@@ -84,6 +85,39 @@
   }
   let accounts = $state<Account[]>([])
   let activeAccountId = $state<string | null>(null)
+
+  // ── Database lock state (#164 Phase 1B) ─────────────────────
+  // Cache may be in FIDO-only mode at boot; in that case the
+  // lock screen mounts ahead of every other view and the rest
+  // of the app stays inert until the user authenticates.
+  interface DatabaseStatus {
+    locked: boolean
+    needsSetup: boolean
+    methods: {
+      kind: 'fido_prf' | 'passphrase'
+      credentialId: string
+      label: string
+      salt: string
+      createdAt: number
+    }[]
+  }
+  let dbStatus = $state<DatabaseStatus | null>(null)
+  let dbStatusError = $state('')
+  $effect(() => {
+    void invoke<DatabaseStatus>('database_status')
+      .then((s) => (dbStatus = s))
+      .catch((e) => {
+        console.warn('database_status failed', e)
+        dbStatusError = String(e)
+        // Fail-open: assume unlocked so the user isn't trapped on
+        // a blank screen if the IPC went wrong.  Real lock-state
+        // bugs surface as "every other IPC errors with locked".
+        dbStatus = { locked: false, needsSetup: false, methods: [] }
+      })
+  })
+  function onUnlocked() {
+    if (dbStatus) dbStatus = { ...dbStatus, locked: false }
+  }
   const activeAccountEmail = $derived(
     accounts.find((a) => a.id === activeAccountId)?.email ?? '',
   )
@@ -1010,9 +1044,23 @@
   }
 </script>
 
-<!-- Loading / Setup both run before the user has an account, so the
-     IconRail (which is keyed by accounts) isn't mounted. -->
-{#if currentView === 'loading'}
+<!-- Lock screen (#164 Phase 1B) — when the cache is in FIDO-only
+     mode at boot, the lock screen owns the whole viewport until
+     the user authenticates.  Everything else (loading, setup,
+     mail / calendar / contacts views) stays unmounted so no IPC
+     fires with the cache still locked. -->
+{#if dbStatus && dbStatus.locked}
+  <LockScreen methods={dbStatus.methods} onunlock={onUnlocked} />
+{:else if dbStatus === null}
+  <!-- Brief flash while we wait for `database_status` to land —
+       prevents the loading view from poking the cache before we
+       know whether it's locked. -->
+  <div class="h-full flex items-center justify-center bg-surface-50 dark:bg-surface-900">
+    <p class="text-surface-500">Starting up…</p>
+  </div>
+{:else if currentView === 'loading'}
+  <!-- Loading / Setup both run before the user has an account, so
+       the IconRail (which is keyed by accounts) isn't mounted. -->
   <div class="h-full flex items-center justify-center bg-surface-50 dark:bg-surface-900">
     <p class="text-surface-500">Loading...</p>
   </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -572,6 +572,80 @@
     }
   })
 
+  // ── Editable server settings ────────────────────────────────
+  // Inline edit form for IMAP/SMTP host + port + password.
+  // Expanded per-account; closed by default so the settings list
+  // stays compact.  Drafts are kept in a local map so the user can
+  // tweak fields without writing to the Account struct (which
+  // would mutate the row above the form).
+  interface ServerDraft {
+    imap_host: string
+    imap_port: number
+    smtp_host: string
+    smtp_port: number
+  }
+  // The modal renders against this account; null = closed.
+  let serverEditAccount = $state<Account | null>(null)
+  let serverDrafts = $state<Record<string, ServerDraft>>({})
+  let serverSaveStatus = $state<Record<string, '' | 'saving' | 'saved' | 'error'>>({})
+  let passwordDrafts = $state<Record<string, string>>({})
+
+  function openServerEdit(account: Account) {
+    serverDrafts[account.id] = {
+      imap_host: account.imap_host,
+      imap_port: account.imap_port,
+      smtp_host: account.smtp_host,
+      smtp_port: account.smtp_port,
+    }
+    passwordDrafts[account.id] = ''
+    serverSaveStatus[account.id] = ''
+    serverEditAccount = account
+  }
+
+  function closeServerEdit() {
+    serverEditAccount = null
+  }
+
+  // One-shot save: persists hosts/ports through `update_account`
+  // and, if the password field is non-empty, rotates the keychain
+  // entry through `set_account_password`.  An empty password leaves
+  // the existing keychain entry untouched, so the modal doubles as
+  // "edit servers only" without forcing the user to retype.
+  async function saveConnectionSettings(account: Account) {
+    const draft = serverDrafts[account.id]
+    if (!draft) return
+    if (!draft.imap_host.trim() || !draft.smtp_host.trim()) {
+      serverSaveStatus[account.id] = 'error'
+      return
+    }
+    serverSaveStatus[account.id] = 'saving'
+    try {
+      const updated: Account = {
+        ...account,
+        imap_host: draft.imap_host.trim(),
+        imap_port: draft.imap_port,
+        smtp_host: draft.smtp_host.trim(),
+        smtp_port: draft.smtp_port,
+      }
+      await invoke('update_account', { account: updated })
+      Object.assign(account, updated)
+
+      const newPassword = passwordDrafts[account.id] ?? ''
+      if (newPassword) {
+        await invoke('set_account_password', { id: account.id, password: newPassword })
+        passwordDrafts[account.id] = ''
+      }
+
+      serverSaveStatus[account.id] = 'saved'
+      setTimeout(() => {
+        if (serverSaveStatus[account.id] === 'saved') serverSaveStatus[account.id] = ''
+      }, 1500)
+    } catch (e) {
+      console.warn('failed to save connection settings', e)
+      serverSaveStatus[account.id] = 'error'
+    }
+  }
+
   /** Persist the sender (person) name (#115). */
   async function onPersonNameChange(account: Account, raw: string) {
     const next = raw.trim() || null
@@ -1061,12 +1135,12 @@
               </div>
               <div class="flex flex-col items-end gap-1">
                 <button
-                  class="btn btn-sm preset-outlined-surface-500 text-xs"
-                  disabled={trustBusy}
-                  title="Probe the IMAP server's current TLS certificate and add it to this account's trust list. Use after a server cert renewal if connections start failing with 'invalid peer certificate / UnknownIssuer'."
-                  onclick={() => void startRetrust(account)}
+                  class="btn btn-sm preset-outlined-surface-500 text-base px-2 py-1"
+                  title="Connection settings — edit server hostnames, ports, password, and trust certificates"
+                  aria-label="Connection settings"
+                  onclick={() => openServerEdit(account)}
                 >
-                  {trustBusy ? '…' : '🔒 Trust server cert'}
+                  ⚙️
                 </button>
                 <button
                   class="btn btn-sm preset-outlined-error-500"
@@ -1262,6 +1336,107 @@
      so they can compare against what they expected (matches the
      fingerprint Nextcloud / Let's Encrypt / their CA prints) before
      trusting it. -->
+{#if serverEditAccount}
+  {@const acc = serverEditAccount}
+  {@const draft = serverDrafts[acc.id]}
+  {@const sStatus = serverSaveStatus[acc.id]}
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => { if (e.target === e.currentTarget) closeServerEdit() }}
+    onkeydown={(e) => { if (e.key === 'Escape') closeServerEdit() }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-lg max-w-full mx-4 p-6 space-y-5">
+      <div class="flex items-start justify-between gap-3">
+        <div>
+          <h3 class="text-base font-semibold">Connection settings</h3>
+          <p class="text-xs text-surface-500 mt-0.5">{acc.email}</p>
+        </div>
+        <div class="flex items-center gap-3">
+          {#if sStatus === 'saving'}
+            <span class="text-xs text-surface-400">Saving…</span>
+          {:else if sStatus === 'saved'}
+            <span class="text-xs text-success-500">Saved</span>
+          {:else if sStatus === 'error'}
+            <span class="text-xs text-error-500">Save failed</span>
+          {/if}
+          <button
+            type="button"
+            class="btn btn-sm preset-outlined-surface-500"
+            disabled={trustBusy}
+            title="Probe the IMAP server's current TLS certificate and add it to this account's trust list. Use after a server cert renewal if connections start failing with 'invalid peer certificate / UnknownIssuer'."
+            onclick={() => void startRetrust(acc)}
+          >{trustBusy ? '…' : '🔒 Trust server cert'}</button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-[1fr_6rem] gap-3">
+        <label class="block">
+          <span class="text-xs text-surface-500">IMAP host</span>
+          <input
+            type="text"
+            bind:value={draft.imap_host}
+            class="input w-full text-sm px-3 py-2 rounded-md mt-1"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs text-surface-500">Port</span>
+          <input
+            type="number"
+            bind:value={draft.imap_port}
+            class="input w-full text-sm px-3 py-2 rounded-md mt-1"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs text-surface-500">SMTP host</span>
+          <input
+            type="text"
+            bind:value={draft.smtp_host}
+            class="input w-full text-sm px-3 py-2 rounded-md mt-1"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs text-surface-500">Port</span>
+          <input
+            type="number"
+            bind:value={draft.smtp_port}
+            class="input w-full text-sm px-3 py-2 rounded-md mt-1"
+          />
+        </label>
+        <label class="block col-span-2">
+          <span class="text-xs text-surface-500">Password</span>
+          <input
+            type="password"
+            autocomplete="new-password"
+            placeholder="Leave empty to keep current password"
+            bind:value={passwordDrafts[acc.id]}
+            class="input w-full text-sm px-3 py-2 rounded-md mt-1"
+          />
+          <span class="block text-xs text-surface-400 mt-1">
+            When set, replaces the password stored in your OS keychain. Takes effect on the next IMAP/SMTP connection.
+          </span>
+        </label>
+      </div>
+
+      <div class="flex justify-end gap-2 pt-2 border-t border-surface-200 dark:border-surface-700">
+        <button
+          type="button"
+          class="btn preset-outlined-surface-500"
+          onclick={closeServerEdit}
+        >Close</button>
+        <button
+          type="button"
+          class="btn preset-filled-primary-500"
+          disabled={sStatus === 'saving'}
+          onclick={() => void saveConnectionSettings(acc)}
+        >Save</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
 {#if trustPrompt}
   <div
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -17,6 +17,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
+  import Toggle from './Toggle.svelte'
 
   // ── Props ───────────────────────────────────────────────────
   // Called when account setup completes successfully
@@ -33,6 +34,12 @@
 
   // ── Form fields ─────────────────────────────────────────────
   let displayName = $state('')
+  // Sender name (#115) — what appears as the human name in the
+  // From: header on outgoing mail.  `displayName` is the local
+  // label for the account in the UI; `personName` is the
+  // outward-facing identity.  Defaults to `displayName` on the
+  // backend when left blank.
+  let personName = $state('')
   let email = $state('')
   let password = $state('')     // stored in the OS keychain, never on disk
   let imapHost = $state('')
@@ -51,7 +58,7 @@
   function nextStep() {
     error = ''
     if (step === 0 && (!displayName.trim() || !email.trim())) {
-      error = 'Please fill in your name and email address.'
+      error = 'Please fill in the account name and email address.'
       return
     }
     if (step === 1 && (!imapHost.trim() || !password)) {
@@ -253,6 +260,7 @@
         account: {
           id,
           display_name: displayName.trim(),
+          person_name: personName.trim() || null,
           email: email.trim(),
           imap_host: imapHost.trim(),
           imap_port: imapPort,
@@ -320,13 +328,28 @@
         <div>
           <h2 class="text-lg font-semibold mb-4">Your Information</h2>
           <label class="block mb-4">
-            <span class="text-sm font-medium text-surface-700 dark:text-surface-300">Display Name</span>
+            <span class="text-sm font-medium text-surface-700 dark:text-surface-300">Account Name</span>
             <input
               type="text"
               bind:value={displayName}
-              placeholder="e.g. Nick"
+              placeholder="e.g. Work, Personal"
               class="input w-full mt-1 px-3 py-2 rounded-md"
             />
+            <span class="block text-xs text-surface-500 mt-1">
+              How this account is labelled inside Nimbus.
+            </span>
+          </label>
+          <label class="block mb-4">
+            <span class="text-sm font-medium text-surface-700 dark:text-surface-300">Your Name</span>
+            <input
+              type="text"
+              bind:value={personName}
+              placeholder="e.g. Nick Schlecker"
+              class="input w-full mt-1 px-3 py-2 rounded-md"
+            />
+            <span class="block text-xs text-surface-500 mt-1">
+              Shown as the sender on outgoing mail. Defaults to the account name when empty.
+            </span>
           </label>
           <label class="block mb-4">
             <span class="text-sm font-medium text-surface-700 dark:text-surface-300">Email Address</span>
@@ -411,12 +434,12 @@
               class="input w-full mt-1 px-3 py-2 rounded-md"
             />
           </label>
-          <label class="flex items-center gap-2 mb-4">
-            <input type="checkbox" bind:checked={useJmap} class="checkbox" />
+          <div class="flex items-center gap-3 mb-4">
+            <Toggle bind:checked={useJmap} label="Use JMAP instead of IMAP" />
             <span class="text-sm text-surface-700 dark:text-surface-300">
               Use JMAP instead of IMAP (if supported by your provider)
             </span>
-          </label>
+          </div>
 
           <label class="block mb-4">
             <span class="text-sm font-medium text-surface-700 dark:text-surface-300">Signature (optional)</span>

--- a/ui/src/lib/LockScreen.svelte
+++ b/ui/src/lib/LockScreen.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+  /**
+   * LockScreen — shown at app startup when the SQLCipher cache
+   * is in FIDO-only mode (#164 Phase 1B).  Lists every registered
+   * unlock method (hardware keys + the recovery passphrase),
+   * runs WebAuthn or a passphrase prompt, and asks Rust to open
+   * the cache pool.
+   *
+   * Once the unlock IPC succeeds the parent (`App.svelte`)
+   * receives `onunlock()` and routes the user into the inbox.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { formatError } from './errors'
+  import { evaluateFidoPrf } from './webauthnPrf'
+
+  interface Method {
+    kind: 'fido_prf' | 'passphrase'
+    credentialId: string
+    label: string
+    salt: string
+    createdAt: number
+  }
+
+  interface Props {
+    methods: Method[]
+    onunlock: () => void
+  }
+  let { methods, onunlock }: Props = $props()
+
+  let busy = $state(false)
+  let error = $state('')
+  let passphraseValue = $state('')
+  let activeMethod = $state<Method | null>(null)
+
+  // Default focus: prefer a hardware key (one tap, no typing) if
+  // any are registered; otherwise show the passphrase prompt.
+  $effect(() => {
+    if (activeMethod) return
+    activeMethod = methods.find((m) => m.kind === 'fido_prf') ?? methods[0] ?? null
+  })
+
+  async function unlockWithPassphrase() {
+    if (busy || !passphraseValue) return
+    busy = true
+    error = ''
+    try {
+      await invoke('unlock_with_passphrase', { passphrase: passphraseValue })
+      passphraseValue = ''
+      onunlock()
+    } catch (e) {
+      error = formatError(e) || 'Unlock failed'
+    } finally {
+      busy = false
+    }
+  }
+
+  async function unlockWithFido(method: Method) {
+    if (busy) return
+    busy = true
+    error = ''
+    try {
+      // OS sheet pops here — Touch ID / Windows Hello / "tap
+      // your security key", same UX surface the enrollment
+      // already uses.
+      const prfOutput = await evaluateFidoPrf(method.credentialId, method.salt)
+      await invoke('unlock_with_prf', {
+        credentialIdB64: method.credentialId,
+        prfOutputB64: prfOutput,
+      })
+      onunlock()
+    } catch (e) {
+      error = formatError(e) || 'Unlock failed'
+    } finally {
+      busy = false
+    }
+  }
+
+  function handleEnter(e: KeyboardEvent) {
+    if (e.key === 'Enter' && activeMethod?.kind === 'passphrase') {
+      e.preventDefault()
+      void unlockWithPassphrase()
+    }
+  }
+</script>
+
+<div class="fixed inset-0 z-[1000] flex items-center justify-center bg-surface-50 dark:bg-surface-900">
+  <div class="w-full max-w-md p-8 space-y-6">
+    <div class="text-center space-y-1">
+      <div class="text-5xl mb-2" aria-hidden="true">🔒</div>
+      <h1 class="text-2xl font-semibold">Nimbus is locked</h1>
+      <p class="text-sm text-surface-500">
+        Authenticate to open your encrypted mail cache.
+      </p>
+    </div>
+
+    {#if methods.length === 0}
+      <div class="rounded-md border border-error-500/40 bg-error-500/10 p-4 text-sm">
+        No unlock methods are registered.  Use the Settings → Security
+        panel to enroll a hardware key or recovery passphrase before
+        switching to FIDO-only mode.
+      </div>
+    {:else}
+      <!-- Method picker — shown when more than one method is
+           registered.  Single-method case skips straight to the
+           form for that method. -->
+      {#if methods.length > 1}
+        <div class="space-y-2">
+          {#each methods as m (m.credentialId)}
+            <button
+              type="button"
+              class="w-full flex items-center gap-3 px-4 py-3 rounded-md text-left transition-colors
+                     border {activeMethod?.credentialId === m.credentialId
+                       ? 'border-primary-500 bg-primary-500/10'
+                       : 'border-surface-300 dark:border-surface-700 hover:bg-surface-200/60 dark:hover:bg-surface-800/40'}"
+              onclick={() => (activeMethod = m)}
+              disabled={busy}
+            >
+              <span class="text-lg" aria-hidden="true">
+                {m.kind === 'passphrase' ? '🔐' : '🔑'}
+              </span>
+              <span class="flex-1 min-w-0">
+                <span class="font-medium block truncate">
+                  {m.kind === 'passphrase' ? 'Passphrase' : m.label}
+                </span>
+                <span class="text-xs text-surface-500 block">
+                  {m.kind === 'passphrase' ? 'Recovery method' : 'Hardware key / biometric'}
+                </span>
+              </span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+
+      {#if activeMethod?.kind === 'passphrase'}
+        <div class="space-y-2">
+          <input
+            type="password"
+            class="input w-full text-sm px-3 py-2 rounded-md"
+            placeholder="Passphrase"
+            bind:value={passphraseValue}
+            onkeydown={handleEnter}
+            disabled={busy}
+            autofocus
+            autocomplete="current-password"
+          />
+          <button
+            class="btn preset-filled-primary-500 w-full"
+            disabled={busy || !passphraseValue}
+            onclick={() => void unlockWithPassphrase()}
+          >{busy ? 'Unlocking…' : 'Unlock'}</button>
+        </div>
+      {:else if activeMethod?.kind === 'fido_prf'}
+        <div class="space-y-2">
+          <p class="text-sm text-surface-500 text-center">
+            Click below — your operating system will ask you to
+            authenticate with the registered key.
+          </p>
+          <button
+            class="btn preset-filled-primary-500 w-full"
+            disabled={busy}
+            onclick={() => activeMethod && void unlockWithFido(activeMethod)}
+          >{busy ? 'Awaiting authenticator…' : `Unlock with ${activeMethod.label}`}</button>
+        </div>
+      {/if}
+
+      {#if error}
+        <p class="text-sm text-red-500 wrap-break-word text-center">{error}</p>
+      {/if}
+    {/if}
+  </div>
+</div>

--- a/ui/src/lib/LockScreen.svelte
+++ b/ui/src/lib/LockScreen.svelte
@@ -11,6 +11,7 @@
    */
 
   import { invoke } from '@tauri-apps/api/core'
+  import { tick } from 'svelte'
   import { formatError } from './errors'
   import { evaluateFidoPrf } from './webauthnPrf'
 
@@ -24,9 +25,25 @@
 
   interface Props {
     methods: Method[]
+    /** Remaining unlock attempts before wipe-on-failure fires.
+     *  `null` when the policy is off or has no limit set — no
+     *  counter is rendered in that case. */
+    attemptsRemaining: number | null
+    /** Fired after every failed unlock so the parent can refresh
+     *  the "X tries remaining" counter without polling. */
+    onattemptschange?: (next: number | null) => void
     onunlock: () => void
   }
-  let { methods, onunlock }: Props = $props()
+  let { methods, attemptsRemaining, onattemptschange, onunlock }: Props = $props()
+
+  async function refreshAttempts() {
+    try {
+      const s = await invoke<{ attemptsRemaining: number | null }>('database_status')
+      onattemptschange?.(s.attemptsRemaining)
+    } catch {
+      /* swallow — counter is best-effort */
+    }
+  }
 
   let busy = $state(false)
   let error = $state('')
@@ -44,12 +61,23 @@
     if (busy || !passphraseValue) return
     busy = true
     error = ''
+    // Let Svelte flush AND give the WebView a real frame to
+    // paint before we hand control off to Rust.  `tick()` +
+    // `requestAnimationFrame` alone isn't enough — Tauri's IPC
+    // and SQLCipher work on a worker thread, but the WebView
+    // still skips repaints if the main thread doesn't yield
+    // long enough.  A 32 ms setTimeout (~2 frames) reliably
+    // gives the new label a chance to land before unlock
+    // starts.
+    await tick()
+    await new Promise((r) => setTimeout(r, 32))
     try {
       await invoke('unlock_with_passphrase', { passphrase: passphraseValue })
       passphraseValue = ''
       onunlock()
     } catch (e) {
       error = formatError(e) || 'Unlock failed'
+      void refreshAttempts()
     } finally {
       busy = false
     }
@@ -59,6 +87,8 @@
     if (busy) return
     busy = true
     error = ''
+    await tick()
+    await new Promise((r) => setTimeout(r, 32))
     try {
       // OS sheet pops here — Touch ID / Windows Hello / "tap
       // your security key", same UX surface the enrollment
@@ -71,6 +101,7 @@
       onunlock()
     } catch (e) {
       error = formatError(e) || 'Unlock failed'
+      void refreshAttempts()
     } finally {
       busy = false
     }
@@ -92,6 +123,18 @@
       <p class="text-sm text-surface-500">
         Authenticate to open your encrypted mail cache.
       </p>
+      {#if attemptsRemaining != null}
+        <p
+          class="text-xs font-medium {attemptsRemaining <= 1
+            ? 'text-error-500'
+            : attemptsRemaining <= 3
+              ? 'text-warning-500'
+              : 'text-surface-500'}"
+        >
+          {attemptsRemaining}
+          {attemptsRemaining === 1 ? 'try' : 'tries'} remaining before the cache is wiped
+        </p>
+      {/if}
     </div>
 
     {#if methods.length === 0}
@@ -145,10 +188,16 @@
             autocomplete="current-password"
           />
           <button
-            class="btn preset-filled-primary-500 w-full"
-            disabled={busy || !passphraseValue}
-            onclick={() => void unlockWithPassphrase()}
-          >{busy ? 'Unlocking…' : 'Unlock'}</button>
+            class="btn w-full {busy
+              ? 'cursor-wait'
+              : !passphraseValue
+                ? 'preset-filled-primary-500'
+                : 'preset-filled-primary-500'}"
+            style={busy ? 'background-color: var(--color-primary-800); color: white;' : ''}
+            disabled={!busy && !passphraseValue}
+            aria-disabled={busy || !passphraseValue}
+            onclick={() => { if (!busy && passphraseValue) void unlockWithPassphrase() }}
+          >{busy ? 'Unlocking...' : 'Unlock'}</button>
         </div>
       {:else if activeMethod?.kind === 'fido_prf'}
         <div class="space-y-2">
@@ -157,9 +206,10 @@
             authenticate with the registered key.
           </p>
           <button
-            class="btn preset-filled-primary-500 w-full"
-            disabled={busy}
-            onclick={() => activeMethod && void unlockWithFido(activeMethod)}
+            class="btn preset-filled-primary-500 w-full {busy ? 'cursor-wait' : ''}"
+            style={busy ? '--color-primary-500: var(--color-primary-800); --color-primary-contrast-500: white;' : ''}
+            aria-disabled={busy}
+            onclick={() => { if (!busy && activeMethod) void unlockWithFido(activeMethod) }}
           >{busy ? 'Awaiting authenticator…' : `Unlock with ${activeMethod.label}`}</button>
         </div>
       {/if}

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -65,6 +65,14 @@
   const PASSPHRASE_LABEL = 'Recovery passphrase'
   let passphraseValue = $state('')
   let passphraseConfirm = $state('')
+  /** Editing a passphrase that's already registered.  When false
+   *  and a passphrase exists, the form collapses to a "Change
+   *  passphrase" affordance on the registered-methods row. */
+  let passphraseEditing = $state(false)
+  /** Has a passphrase already been enrolled? */
+  const hasPassphrase = $derived(
+    !!status?.credentials.some((c) => c.kind === 'passphrase'),
+  )
   /** Master "Key Encryption" toggle.  Drives both the
    *  registration UI gate AND the backend FIDO-only-mode
    *  switch:
@@ -109,13 +117,24 @@
       // The backend flip happens in the $effect below once the
       // user has actually registered a recovery method.
     } else {
-      // Turning off: if we're still in plain mode (no FIDO-only
-      // activation has happened yet) the toggle is purely a UI
-      // gate — flip it freely.  If FIDO-only mode is active we
-      // need a real disable path, which isn't wired yet.
+      // Turning off: if FIDO-only mode is active, ask the
+      // backend to write the in-memory master key back into the
+      // keychain envelope so cold launches stop showing the
+      // lock screen.  Cache must be unlocked (it is — the user
+      // is in Settings, which lives behind the unlock screen)
+      // for the master key to be in memory.
       if (status && !status.hasPlainKey) {
-        error =
-          'Disabling key encryption while the cache is in FIDO-only mode is not yet supported. Re-add your accounts to revert.'
+        busy = true
+        try {
+          await invoke('disable_fido_only_mode')
+          keyEncryptionEnabled = false
+          persistToggle(false)
+          await loadStatus()
+        } catch (e) {
+          error = formatError(e) || 'Failed to disable key encryption'
+        } finally {
+          busy = false
+        }
         return
       }
       keyEncryptionEnabled = false
@@ -156,6 +175,62 @@
   $effect(() => {
     void loadStatus()
   })
+
+  // ── Wipe-on-failed-authentication policy ────────────────────
+  // Stored in the keychain envelope (so it survives across
+  // FIDO-only / plain transitions).  `wipeMaxAttemptsRaw` is a
+  // string so we can render an empty input as "unlimited".
+  interface WipePolicy {
+    enabled: boolean
+    maxAttempts: number | null
+  }
+  let wipePolicy = $state<WipePolicy>({ enabled: false, maxAttempts: null })
+  let wipeMaxAttemptsRaw = $state('')
+  let wipeSaving = $state(false)
+
+  async function loadWipePolicy() {
+    try {
+      const p = await invoke<WipePolicy>('get_wipe_policy')
+      wipePolicy = p
+      wipeMaxAttemptsRaw = p.maxAttempts != null ? String(p.maxAttempts) : ''
+    } catch (e) {
+      console.warn('get_wipe_policy failed', e)
+    }
+  }
+  $effect(() => {
+    void loadWipePolicy()
+  })
+
+  async function saveWipePolicy(next: WipePolicy) {
+    wipeSaving = true
+    try {
+      await invoke('set_wipe_policy', {
+        policy: { enabled: next.enabled, maxAttempts: next.maxAttempts },
+      })
+      wipePolicy = next
+    } catch (e) {
+      error = formatError(e) || 'Failed to save wipe policy'
+    } finally {
+      wipeSaving = false
+    }
+  }
+
+  function onWipeToggle(checked: boolean) {
+    const parsed = parseInt(wipeMaxAttemptsRaw, 10)
+    void saveWipePolicy({
+      enabled: checked,
+      maxAttempts: checked && Number.isFinite(parsed) && parsed > 0 ? parsed : null,
+    })
+  }
+
+  function onWipeMaxAttemptsChange() {
+    if (!wipePolicy.enabled) return
+    const parsed = parseInt(wipeMaxAttemptsRaw, 10)
+    void saveWipePolicy({
+      enabled: true,
+      maxAttempts: Number.isFinite(parsed) && parsed > 0 ? parsed : null,
+    })
+  }
 
   async function addKey() {
     if (busy) return
@@ -203,6 +278,7 @@
       })
       passphraseValue = ''
       passphraseConfirm = ''
+      passphraseEditing = false
       await loadStatus()
     } catch (e) {
       error = formatError(e) || 'Failed to enroll passphrase'
@@ -211,25 +287,42 @@
     }
   }
 
-  async function removeKey(credentialId: string, salt: string, label: string) {
+  async function removeKey(c: FidoCredential) {
     if (busy) return
-    if (!confirm(`Remove "${label}"? You'll need to re-enroll to use it again.`))
+    // Pre-flight: removing the last unlock method while
+    // FIDO-only mode is active would orphan the encrypted DB
+    // forever.  The backend rejects this too, but catching it
+    // here gives the user a message that names the actual
+    // problem instead of the generic "cannot remove last
+    // hardware key" text.
+    if (status && !status.hasPlainKey && status.credentials.length <= 1) {
+      error =
+        c.kind === 'passphrase'
+          ? "Can't remove the passphrase — it's your only unlock method. Add a hardware key first, or turn off Key Encryption."
+          : "Can't remove this hardware key — it's your only unlock method. Add a passphrase or another hardware key first, or turn off Key Encryption."
+      return
+    }
+    const promptLabel = c.kind === 'passphrase' ? 'Recovery passphrase' : c.label
+    if (!confirm(`Remove "${promptLabel}"? You'll need to re-enroll to use it again.`))
       return
     busy = true
     error = ''
     try {
       // Require the user to actually still possess the key
-      // before we let them drop the wrap.  Skipped in plain-
-      // key mode for the trivial case of an enrolled key the
-      // user already lost — they can always reset by removing
-      // the plain key entry from the keychain manually.
-      if (status && !status.hasPlainKey) {
-        await evaluateFidoPrf(credentialId, salt)
+      // before we let them drop the wrap.  Only meaningful for
+      // FIDO PRF wraps — passphrase entries have no
+      // authenticator to evaluate, and forcing one through
+      // `evaluateFidoPrf` would surface a confusing
+      // "WebAuthn unavailable" error on Linux.  Plain-key mode
+      // skips the check entirely so a user with a lost key
+      // can still drop the wrap.
+      if (status && !status.hasPlainKey && c.kind === 'fido_prf') {
+        await evaluateFidoPrf(c.credentialId, c.salt)
       }
-      await invoke('fido_remove', { credentialIdB64: credentialId })
+      await invoke('fido_remove', { credentialIdB64: c.credentialId })
       await loadStatus()
     } catch (e) {
-      error = formatError(e) || 'Failed to remove hardware key'
+      error = formatError(e) || 'Failed to remove credential'
     } finally {
       busy = false
     }
@@ -295,6 +388,53 @@
       </div>
     </div>
 
+    <!-- Wipe-on-failed-authentication policy.  Sits directly
+         under the Key Encryption toggle so users see the
+         destructive companion option while they're still
+         deciding whether to enable encryption at all.  Off by
+         default; when on, exposes a numeric "retries" field
+         whose empty / zero value means unlimited. -->
+    <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4 space-y-3 {keyEncryptionEnabled ? '' : 'opacity-50 pointer-events-none select-none'}">
+      <div class="flex items-start gap-3">
+        <Toggle
+          checked={wipePolicy.enabled}
+          disabled={wipeSaving || !keyEncryptionEnabled}
+          onchange={onWipeToggle}
+          label="Wipe cache on failed authentication"
+          class="mt-0.5"
+        />
+        <div>
+          <h3 class="font-medium leading-tight">Wipe cache on failed authentication</h3>
+          <p class="text-xs text-surface-500 mt-1">
+            After the configured number of consecutive failed unlock
+            attempts, the encrypted cache is permanently deleted on
+            this device. You'll need to re-add your accounts on next
+            launch.
+          </p>
+        </div>
+      </div>
+      <div class="ml-12 {wipePolicy.enabled ? '' : 'opacity-50 pointer-events-none'}">
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-surface-700 dark:text-surface-300" for="wipe-max">
+            Max attempts
+          </label>
+          <input
+            id="wipe-max"
+            type="number"
+            min="1"
+            placeholder="Unlimited"
+            class="input w-32 text-sm px-3 py-1.5 rounded-md"
+            bind:value={wipeMaxAttemptsRaw}
+            onchange={onWipeMaxAttemptsChange}
+            disabled={!wipePolicy.enabled || wipeSaving}
+          />
+        </div>
+        <p class="text-xs text-surface-500 mt-1">
+          Empty = unlimited retries (toggle has no effect until a number is set).
+        </p>
+      </div>
+    </div>
+
     <div
       class="space-y-4 transition-opacity {keyEncryptionEnabled
         ? ''
@@ -344,39 +484,56 @@
         </div>
       {/if}
 
-      <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
-        <h3 class="font-medium mb-2">Add a recovery passphrase</h3>
-        <p class="text-xs text-surface-500 mb-3">
-          A passphrase derives the same kind of 32-byte key (via
-          PBKDF2-HMAC-SHA-256, 720 000 iterations) that a FIDO
-          authenticator's PRF output would. Useful as a fallback when a
-          hardware key is lost — and as the primary unlock method on
-          Linux until WebKitGTK ships the WebAuthn PRF extension.
-        </p>
-        <div class="space-y-2">
-          <input
-            type="password"
-            class="input w-full text-sm px-3 py-1.5 rounded-md"
-            placeholder="Passphrase (8+ characters)"
-            bind:value={passphraseValue}
-            disabled={busy}
-            autocomplete="new-password"
-          />
-          <input
-            type="password"
-            class="input w-full text-sm px-3 py-1.5 rounded-md"
-            placeholder="Confirm passphrase"
-            bind:value={passphraseConfirm}
-            disabled={busy}
-            autocomplete="new-password"
-          />
-          <button
-            class="btn preset-filled-primary-500 w-full"
-            disabled={busy || passphraseValue.length < 8}
-            onclick={() => void addPassphrase()}
-          >{busy ? 'Working…' : 'Save passphrase'}</button>
+      {#if !hasPassphrase || passphraseEditing}
+        <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
+          <h3 class="font-medium mb-2">
+            {hasPassphrase ? 'Change recovery passphrase' : 'Add a recovery passphrase'}
+          </h3>
+          <p class="text-xs text-surface-500 mb-3">
+            A passphrase derives the same kind of 32-byte key (via
+            PBKDF2-HMAC-SHA-256, 720 000 iterations) that a FIDO
+            authenticator's PRF output would. Useful as a fallback when a
+            hardware key is lost — and as the primary unlock method on
+            Linux until WebKitGTK ships the WebAuthn PRF extension.
+          </p>
+          <div class="space-y-2">
+            <input
+              type="password"
+              class="input w-full text-sm px-3 py-1.5 rounded-md"
+              placeholder="Passphrase (8+ characters)"
+              bind:value={passphraseValue}
+              disabled={busy}
+              autocomplete="new-password"
+            />
+            <input
+              type="password"
+              class="input w-full text-sm px-3 py-1.5 rounded-md"
+              placeholder="Confirm passphrase"
+              bind:value={passphraseConfirm}
+              disabled={busy}
+              autocomplete="new-password"
+            />
+            <div class="flex gap-2">
+              {#if passphraseEditing}
+                <button
+                  class="btn preset-outlined-surface-500 flex-1"
+                  disabled={busy}
+                  onclick={() => {
+                    passphraseEditing = false
+                    passphraseValue = ''
+                    passphraseConfirm = ''
+                  }}
+                >Cancel</button>
+              {/if}
+              <button
+                class="btn preset-filled-primary-500 flex-1"
+                disabled={busy || passphraseValue.length < 8}
+                onclick={() => void addPassphrase()}
+              >{busy ? 'Working…' : hasPassphrase ? 'Update passphrase' : 'Save passphrase'}</button>
+            </div>
+          </div>
         </div>
-      </div>
+      {/if}
 
       <div>
         <h3 class="font-medium mb-2">Registered methods</h3>
@@ -406,17 +563,29 @@
                     · Added {fmtDate(c.createdAt)}
                   </p>
                 </div>
+                {#if c.kind === 'passphrase'}
+                  <button
+                    class="btn btn-sm preset-outlined-surface-500"
+                    disabled={busy}
+                    title="Change passphrase"
+                    aria-label="Change passphrase"
+                    onclick={() => {
+                      passphraseValue = ''
+                      passphraseConfirm = ''
+                      passphraseEditing = true
+                    }}
+                  >✏️</button>
+                {/if}
                 <button
                   class="btn btn-sm preset-outlined-error-500"
                   disabled={busy}
-                  onclick={() => void removeKey(c.credentialId, c.salt, c.label)}
+                  onclick={() => void removeKey(c)}
                 >Remove</button>
               </li>
             {/each}
           </ul>
         {/if}
       </div>
-
 
       {#if error}
         <p class="text-sm text-red-500 wrap-break-word">{error}</p>

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -38,6 +38,17 @@
     credentials: FidoCredential[]
   }
 
+  /** Whether the registered methods meet the safety bar for
+   *  enabling FIDO-only mode: at least one passphrase OR ≥ 2
+   *  hardware keys.  Without one of those, losing a single key
+   *  would lock the cache permanently. */
+  function safeForFidoOnlyMode(s: FidoStatus | null): boolean {
+    if (!s) return false
+    const passphraseCount = s.credentials.filter((c) => c.kind === 'passphrase').length
+    const fidoCount = s.credentials.filter((c) => c.kind === 'fido_prf').length
+    return passphraseCount >= 1 || fidoCount >= 2
+  }
+
   let status = $state<FidoStatus | null>(null)
   let loading = $state(true)
   let busy = $state(false)
@@ -142,6 +153,31 @@
       await loadStatus()
     } catch (e) {
       error = formatError(e) || 'Failed to enroll passphrase'
+    } finally {
+      busy = false
+    }
+  }
+
+  async function enableFidoOnly() {
+    if (busy) return
+    if (!safeForFidoOnlyMode(status)) {
+      error =
+        'Register a recovery passphrase or a second hardware key first — otherwise losing your one method would lock the cache permanently.'
+      return
+    }
+    if (
+      !confirm(
+        'Switch to FIDO-only mode?\n\nThe plain master key will be removed from your OS keychain. Future app launches will require you to authenticate with one of your registered methods before the cache can be opened.\n\nThis takes effect on the next launch.',
+      )
+    )
+      return
+    busy = true
+    error = ''
+    try {
+      await invoke('enable_fido_only_mode')
+      await loadStatus()
+    } catch (e) {
+      error = formatError(e) || 'Failed to switch to FIDO-only mode'
     } finally {
       busy = false
     }
@@ -338,14 +374,43 @@
         {/if}
       </div>
 
-      {#if status && status.hasPlainKey}
-        <p class="text-xs text-surface-500">
-          The plain master key remains in the OS keychain alongside any
-          registered hardware keys — Nimbus opens the cache without
-          asking for a tap. A future release will let you switch to
-          FIDO-only mode, where the cache only opens after you
-          authenticate at startup.
-        </p>
+      <!-- FIDO-only mode switch.  When on, the plain master key
+           is removed from the keychain and every cold launch
+           requires authentication via the lock screen.
+           Disabled until the registered methods cover a
+           recovery path (≥ 1 passphrase or ≥ 2 hardware keys). -->
+      {#if status}
+        <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
+          <div class="flex items-start gap-3">
+            <Toggle
+              checked={!status.hasPlainKey}
+              disabled={busy ||
+                (status.hasPlainKey && !safeForFidoOnlyMode(status)) ||
+                !status.hasPlainKey}
+              label="Require authentication at startup"
+              onchange={(v) => {
+                if (v && status?.hasPlainKey) void enableFidoOnly()
+              }}
+            />
+            <div>
+              <p class="font-medium leading-tight">Require authentication at startup</p>
+              <p class="text-xs text-surface-500 leading-tight mt-1">
+                {#if !status.hasPlainKey}
+                  Active — the cache will only open after you authenticate
+                  with one of the registered methods.
+                {:else if safeForFidoOnlyMode(status)}
+                  When on, Nimbus will drop the plain master key from your
+                  OS keychain and prompt for authentication on every launch.
+                  Takes effect on the next start.
+                {:else}
+                  Register a recovery passphrase or a second hardware key
+                  first — losing a single method would otherwise lock the
+                  cache permanently.
+                {/if}
+              </p>
+            </div>
+          </div>
+        </div>
       {/if}
 
       {#if error}

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -65,13 +65,27 @@
   const PASSPHRASE_LABEL = 'Recovery passphrase'
   let passphraseValue = $state('')
   let passphraseConfirm = $state('')
-  /** Master "Key Encryption" toggle.  Gates whether the
-   *  enrollment forms below are interactive — the rest of the
-   *  panel greys out when this is off so the section reads as
-   *  "feature opt-in".  Persisted in localStorage; flipping it
-   *  doesn't yet flip the backend into FIDO-only mode (that's
-   *  Phase 1B), but it scopes the UI so users who don't want
-   *  the feature don't accidentally enroll a credential. */
+  /** Master "Key Encryption" toggle.  Drives both the
+   *  registration UI gate AND the backend FIDO-only-mode
+   *  switch:
+   *
+   *  - User flips ON: registration UI becomes interactive.
+   *    As soon as the registered methods cover a recovery
+   *    path (≥ 1 passphrase or ≥ 2 hardware keys), the
+   *    backend automatically drops the plain master key from
+   *    the keychain envelope — every subsequent cold launch
+   *    will require authentication.
+   *  - User flips OFF: registration UI greys out.  If the
+   *    backend is already in FIDO-only mode, we can't
+   *    transparently restore the plain key (we'd need to
+   *    re-derive the master via the unlock flow), so we
+   *    surface that as a clear error and leave the toggle
+   *    on until the user does the disable dance manually.
+   *
+   *  Persisted in localStorage so the user's intent survives
+   *  launches even when no methods are registered yet
+   *  (toggle stays "on" but the backend stays plain-mode
+   *  until they enroll a method). */
   let keyEncryptionEnabled = $state(false)
   $effect(() => {
     try {
@@ -80,14 +94,53 @@
       /* localStorage may be unavailable in some webview modes */
     }
   })
-  function setKeyEncryption(v: boolean) {
-    keyEncryptionEnabled = v
+  function persistToggle(v: boolean) {
     try {
       localStorage.setItem('nimbus.keyEncryption', v ? '1' : '0')
     } catch {
-      /* swallow — same reason as above */
+      /* swallow — webview may not expose localStorage */
     }
   }
+  async function setKeyEncryption(v: boolean) {
+    if (busy) return
+    if (v) {
+      keyEncryptionEnabled = true
+      persistToggle(true)
+      // The backend flip happens in the $effect below once the
+      // user has actually registered a recovery method.
+    } else {
+      // Turning off: if we're still in plain mode (no FIDO-only
+      // activation has happened yet) the toggle is purely a UI
+      // gate — flip it freely.  If FIDO-only mode is active we
+      // need a real disable path, which isn't wired yet.
+      if (status && !status.hasPlainKey) {
+        error =
+          'Disabling key encryption while the cache is in FIDO-only mode is not yet supported. Re-add your accounts to revert.'
+        return
+      }
+      keyEncryptionEnabled = false
+      persistToggle(false)
+    }
+  }
+  /** Auto-activate FIDO-only mode when the toggle is on AND
+   *  the registered methods cover a recovery path AND the
+   *  backend still has the plain master key.  Saves the user
+   *  from having to find a separate "activate" button. */
+  $effect(() => {
+    if (busy) return
+    if (!keyEncryptionEnabled) return
+    if (!status) return
+    if (!status.hasPlainKey) return // already FIDO-only
+    if (!safeForFidoOnlyMode(status)) return
+    void (async () => {
+      try {
+        await invoke('enable_fido_only_mode')
+        await loadStatus()
+      } catch (e) {
+        error = formatError(e) || 'Failed to activate key encryption'
+      }
+    })()
+  })
 
   async function loadStatus() {
     loading = true
@@ -158,31 +211,6 @@
     }
   }
 
-  async function enableFidoOnly() {
-    if (busy) return
-    if (!safeForFidoOnlyMode(status)) {
-      error =
-        'Register a recovery passphrase or a second hardware key first — otherwise losing your one method would lock the cache permanently.'
-      return
-    }
-    if (
-      !confirm(
-        'Switch to FIDO-only mode?\n\nThe plain master key will be removed from your OS keychain. Future app launches will require you to authenticate with one of your registered methods before the cache can be opened.\n\nThis takes effect on the next launch.',
-      )
-    )
-      return
-    busy = true
-    error = ''
-    try {
-      await invoke('enable_fido_only_mode')
-      await loadStatus()
-    } catch (e) {
-      error = formatError(e) || 'Failed to switch to FIDO-only mode'
-    } finally {
-      busy = false
-    }
-  }
-
   async function removeKey(credentialId: string, salt: string, label: string) {
     if (busy) return
     if (!confirm(`Remove "${label}"? You'll need to re-enroll to use it again.`))
@@ -240,14 +268,29 @@
       <Toggle
         checked={keyEncryptionEnabled}
         label="Enable key encryption"
-        onchange={(v) => setKeyEncryption(v)}
+        onchange={(v) => void setKeyEncryption(v)}
       />
-      <div>
+      <div class="max-w-xl">
         <p class="font-medium leading-tight">Key Encryption</p>
-        <p class="text-xs text-surface-500 leading-tight">
-          {keyEncryptionEnabled
-            ? 'On — register methods below'
-            : 'Off — the cache uses the plain key from the OS keychain'}
+        <p class="text-xs text-surface-500 leading-snug mt-1">
+          {#if !keyEncryptionEnabled}
+            Off — the cache opens automatically using the plain master key
+            stored in your OS keychain.  Turn on to seal the key behind a
+            registered hardware key, biometric, or passphrase.
+          {:else if status && !status.hasPlainKey}
+            Active — your cache is sealed.  Every cold launch will ask you
+            to authenticate with one of the registered methods below before
+            the inbox loads.
+          {:else if status && safeForFidoOnlyMode(status)}
+            Activating… your registered methods will protect the cache on
+            the next start.  (Activation usually completes within a moment
+            of enrollment.)
+          {:else}
+            On — register at least one recovery method below.  As soon as
+            you have one passphrase or two hardware keys registered, key
+            encryption activates automatically and future launches will
+            require authentication.
+          {/if}
         </p>
       </div>
     </div>
@@ -374,44 +417,6 @@
         {/if}
       </div>
 
-      <!-- FIDO-only mode switch.  When on, the plain master key
-           is removed from the keychain and every cold launch
-           requires authentication via the lock screen.
-           Disabled until the registered methods cover a
-           recovery path (≥ 1 passphrase or ≥ 2 hardware keys). -->
-      {#if status}
-        <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4">
-          <div class="flex items-start gap-3">
-            <Toggle
-              checked={!status.hasPlainKey}
-              disabled={busy ||
-                (status.hasPlainKey && !safeForFidoOnlyMode(status)) ||
-                !status.hasPlainKey}
-              label="Require authentication at startup"
-              onchange={(v) => {
-                if (v && status?.hasPlainKey) void enableFidoOnly()
-              }}
-            />
-            <div>
-              <p class="font-medium leading-tight">Require authentication at startup</p>
-              <p class="text-xs text-surface-500 leading-tight mt-1">
-                {#if !status.hasPlainKey}
-                  Active — the cache will only open after you authenticate
-                  with one of the registered methods.
-                {:else if safeForFidoOnlyMode(status)}
-                  When on, Nimbus will drop the plain master key from your
-                  OS keychain and prompt for authentication on every launch.
-                  Takes effect on the next start.
-                {:else}
-                  Register a recovery passphrase or a second hardware key
-                  first — losing a single method would otherwise lock the
-                  cache permanently.
-                {/if}
-              </p>
-            </div>
-          </div>
-        </div>
-      {/if}
 
       {#if error}
         <p class="text-sm text-red-500 wrap-break-word">{error}</p>

--- a/ui/src/lib/webauthnPrf.ts
+++ b/ui/src/lib/webauthnPrf.ts
@@ -160,6 +160,23 @@ export async function evaluateFidoPrf(
   credentialIdB64: string,
   saltB64: string,
 ): Promise<string> {
+  // Guard before reaching for `navigator.credentials.get`: on
+  // Linux WebKitGTK builds without WebAuthn the property is
+  // missing, and the raw "undefined is not an object" stack trace
+  // is unreadable for users.  Surface the same message we use at
+  // enroll time so they understand why the action failed.
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.credentials ||
+    typeof navigator.credentials.get !== 'function'
+  ) {
+    throw new Error(
+      "Your platform's WebView doesn't expose WebAuthn, so this hardware key can't be used here. " +
+        'On Linux this usually means WebKitGTK is below 2.46 — update libwebkit2gtk ' +
+        '(Ubuntu 24.04+, Fedora 40+, Arch all ship 2.46+). On macOS / Windows the OS-shipped ' +
+        'engines support WebAuthn on recent versions.',
+    )
+  }
   const credentialId = b64ToBuf(credentialIdB64)
   const salt = b64ToBuf(saltB64)
   const challenge = crypto.getRandomValues(new Uint8Array(32))


### PR DESCRIPTION
Closes #164.

## Summary
Cold-launch unlock for the SQLCipher cache. When the user has flipped Key Encryption on, the cache pool stays closed at boot, the UI mounts a lock screen ahead of every other view, and only after the user authenticates with a registered method (passphrase or hardware-key PRF) does the rest of the app come up. Once unlocked, the master key sits in process memory for the session so background sync / notifications / tray badge keep working without re-prompting.

## What changed

**Locked Cache + unlock IPCs (`nimbus-store` + Tauri)**
- `Cache::pool` is now `Arc<RwLock<Option<SqlitePool>>>`. New `is_locked`, `unlock_with_master_key`, `master_key_hex()` accessor, and a `pub(crate) conn()` helper that surfaces `CacheError::Locked` cleanly. All call sites moved to `self.conn()?`.
- `Cache::open_default` branches on the keychain envelope: plain key present → open pool; FIDO-only with wraps → return locked Cache; first run → mint plain key.
- IPCs: `database_status`, `unlock_with_passphrase`, `unlock_with_prf`, `enable_fido_only_mode`, `disable_fido_only_mode` (now wired — uses the in-memory master key cached on `Cache` after unlock so no re-prompt is needed).
- Removed the wipe-on-wrong-key branch from `unlock_with_master_key`. It was copy-pasted from `open_with_key` and was nuking accounts on every authentication failure.

**Lock screen + setup wizard (`ui`)**
- `LockScreen.svelte` mounts ahead of every other view when the cache is locked. Method picker (passphrase / hardware key), Enter-to-submit, OS auth sheet for FIDO. `tick()` + 32 ms timeout before the IPC so "Unlocking..." actually paints.
- `App.svelte` now waits for `dbStatus.locked === false` before calling `get_accounts`, so the locked-cache error path no longer routes the user into the setup wizard with their accounts still intact.
- `AccountSetup.svelte`: separate "Account name" and "Your name" fields; JMAP checkbox replaced with the iOS-style `Toggle`.
- `evaluateFidoPrf` feature-detects `navigator.credentials.get` and throws a readable message instead of `TypeError: undefined is not an object`.

**Security panel polish**
- Single Key Encryption toggle drives both the registration UI gate and the backend FIDO-only flip.
- `fido_enroll_passphrase` enforces one passphrase per envelope; UI hides the form once a passphrase exists and exposes a ✏️ pencil to "Change recovery passphrase". `removeKey` is type-aware so passphrase removal doesn't try to run WebAuthn.
- Pre-flight last-method-in-FIDO-only-mode with a tailored message instead of the backend's generic "cannot remove last hardware key".

**Connection-settings modal**
- New `set_account_password` IPC rotates the keychain entry. `update_account` already covered hosts/ports.
- ⚙️ button per account opens a modal: IMAP/SMTP host + port + password fields, single Save button. Empty password = keep current. Trust-cert button moved into the modal header.

**Wipe-on-failed-authentication policy**
- New `wipe_on_failure: bool` and `max_unlock_attempts: Option<u32>` on `KeychainEnvelope`. Settings UI exposes a toggle + numeric input directly under the Key Encryption toggle, with the Toggle on the left of the heading and a `ml-12` Max-attempts row below.
- Failure counter `failed_attempts: u32` is **persisted in the envelope**, so kill+relaunch no longer resets the budget.
- Envelope carries an HMAC-SHA256 `integrity_mac`. `save_envelope` always recomputes; failed verification on the unlock path forces an immediate wipe with a clear error. Static binary-embedded key — deters casual JSON edits, not someone with a disassembler. Documented in code.
- `wipe_cache_files` overwrites each file (DB + WAL + SHM) with CSPRNG bytes and fsyncs before unlinking. Honest comment about SSD wear-levelling.
- Lock screen displays "X tries remaining" (warning at ≤ 3, error at ≤ 1) when the policy is on with a numeric limit, refreshed after every failed attempt.

## Test plan
- [ ] Default state: register a passphrase → app still launches straight to inbox (plain key remains in envelope).
- [ ] Flip Key Encryption on with ≥ 1 passphrase or ≥ 2 hardware keys → backend automatically transitions to FIDO-only mode.
- [x] Restart Nimbus → lock screen appears, listing the registered methods.
- [x] Type passphrase + Enter → app unlocks, inbox loads, accounts intact.
- [x] Wrong passphrase → clear error, no unlock, accounts not wiped.
- [x] Toggle Key Encryption back off → `disable_fido_only_mode` succeeds without re-auth, next launch boots straight to inbox.
- [x] Single-passphrase invariant: enroll twice → only one passphrase wrap exists, ✏️ pencil opens the change form.
- [x] Connection-settings ⚙️ modal: edit IMAP host + password → Save → next IMAP fetch uses new credentials.
- [x] Wipe-on-failure: enable policy with N=3 → fail unlock 3× → cache file is removed, error message says "cache wiped", next launch goes through setup wizard.
- [x] Wipe-on-failure persistence: enable policy, fail 2×, kill app, relaunch → counter still says 1 try remaining.
- [ ] Tamper detection: edit `failed_attempts` in keychain → next failed unlock immediately wipes with the tamper message.
- [ ] On macOS / Windows: register Touch ID / Windows Hello → restart → lock screen routes to OS biometric sheet.

## Known follow-ups (not in this PR)
- Native pre-spawn lock dialog (today the WebView is fully booted before the lock screen renders).
- TPM-backed counter for genuine resistance against an attacker with unlocked-session keychain access. Current MAC is best-effort with a hardcoded key.
- Re-prompt on app suspend / system lock as a Phase 2 hardening option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)