### PR TITLE
Consolidate caches: Nextcloud connections into encrypted DB (#155)

### DIFF
--- a/crates/nimbus-store/src/account_store.rs
+++ b/crates/nimbus-store/src/account_store.rs
@@ -1,64 +1,20 @@
 //! Persistent account storage backed by the SQLCipher cache.
 //!
-//! Accounts used to live in a plaintext `accounts.json` next to the
-//! database. Issue #60 moved them into the encrypted cache so the
-//! whole account record (hosts, signatures, future TLS-trust state)
-//! is encrypted at rest under the same key as the message bodies.
-//!
-//! # Migration
-//!
-//! Existing installs already have an `accounts.json`. The first call
-//! to [`load_accounts`] after the upgrade detects an empty `accounts`
-//! table next to a present-and-non-empty JSON file and imports it,
-//! then renames the JSON to `accounts.json.bak` so the user can roll
-//! back if anything goes wrong. Subsequent calls find a non-empty
-//! table and skip the import. The whole dance is gated behind the
-//! emptiness check, so nothing happens on fresh installs.
+//! Accounts live in the encrypted cache (issue #60) so the whole
+//! account record (hosts, signatures, TLS-trust state) is encrypted
+//! at rest under the same key as the message bodies.
 
 use nimbus_core::NimbusError;
 use nimbus_core::models::Account;
 use rusqlite::params;
 use tracing::{debug, info};
-// `PathBuf` and `warn` are only touched by the legacy-JSON migration
-// path, which is gated to non-test builds; importing them
-// unconditionally would be `unused` under `--cfg test`.
-#[cfg(not(test))]
-use std::path::PathBuf;
-#[cfg(not(test))]
-use tracing::warn;
 
 use crate::Cache;
 
-/// Path of the legacy plaintext accounts file. Kept here (rather
-/// than deleted with the rest of the JSON code) so the import
-/// migration in [`load_accounts`] knows where to look. Gated to
-/// non-test builds because the call site in `load_accounts` is
-/// `#[cfg(not(test))]` (in-memory test caches must never touch
-/// the developer's real `accounts.json`).
-#[cfg(not(test))]
-fn legacy_json_path() -> Result<PathBuf, NimbusError> {
-    let data_dir = dirs::config_dir()
-        .ok_or_else(|| NimbusError::Storage("cannot determine config directory".into()))?;
-    Ok(data_dir.join("nimbus-mail").join("accounts.json"))
-}
-
-/// Load all saved accounts. Returns an empty list on first launch
-/// (no JSON, no rows). On the upgrade boundary — empty table next
-/// to a populated `accounts.json` — runs the one-time JSON-to-SQLite
-/// import and renames the JSON file to `.bak` so we don't try again.
-///
-/// The legacy-JSON probe is compiled out of tests so unit tests
-/// against an in-memory cache don't accidentally pick up the
-/// developer's real `accounts.json` from `dirs::config_dir()`.
+/// Load all saved accounts. Returns an empty list on a fresh
+/// install.
 pub fn load_accounts(cache: &Cache) -> Result<Vec<Account>, NimbusError> {
-    let accounts = read_all(cache)?;
-    #[cfg(not(test))]
-    if accounts.is_empty()
-        && let Some(imported) = migrate_from_legacy_json(cache)?
-    {
-        return Ok(imported);
-    }
-    Ok(accounts)
+    read_all(cache)
 }
 
 /// Read every row out of the cache, ordered by insertion. Used by
@@ -253,70 +209,6 @@ pub fn update_account(cache: &Cache, updated: Account) -> Result<(), NimbusError
         updated.display_name, updated.email
     );
     Ok(())
-}
-
-/// One-time import from the legacy JSON file. Called from
-/// [`load_accounts`] when the cache is empty — covers the upgrade
-/// path where a user already had `accounts.json` populated.
-///
-/// On success the JSON file is renamed to `accounts.json.bak` so the
-/// next launch finds an empty file-or-no-file and skips the import.
-/// We rename rather than delete so the user can manually restore if
-/// anything goes wrong with the import (we already saw a CalDAV-403
-/// regression in #56 from a similar boundary).
-#[cfg(not(test))]
-fn migrate_from_legacy_json(cache: &Cache) -> Result<Option<Vec<Account>>, NimbusError> {
-    let path = legacy_json_path()?;
-    if !path.exists() {
-        return Ok(None);
-    }
-
-    let data = match std::fs::read_to_string(&path) {
-        Ok(d) => d,
-        Err(e) => {
-            warn!("legacy accounts.json present but unreadable: {e}");
-            return Ok(None);
-        }
-    };
-    let imported: Vec<Account> = match serde_json::from_str(&data) {
-        Ok(v) => v,
-        Err(e) => {
-            warn!("legacy accounts.json present but unparsable: {e}");
-            return Ok(None);
-        }
-    };
-
-    if imported.is_empty() {
-        // Empty file — still rename it so we don't try every launch.
-        if let Err(e) = std::fs::rename(&path, path.with_extension("json.bak")) {
-            warn!("could not rename empty legacy accounts.json: {e}");
-        }
-        return Ok(None);
-    }
-
-    info!(
-        "Migrating {} account(s) from {} into the encrypted cache",
-        imported.len(),
-        path.display()
-    );
-    for account in &imported {
-        if let Err(e) = insert_one(cache, account) {
-            // Best-effort: log and continue. A single bad row shouldn't
-            // block the rest of the user's accounts from coming over.
-            warn!(
-                "skipping account '{}' during migration: {e}",
-                account.display_name
-            );
-        }
-    }
-
-    if let Err(e) = std::fs::rename(&path, path.with_extension("json.bak")) {
-        warn!("could not rename migrated accounts.json to .bak: {e}");
-    } else {
-        info!("Renamed legacy accounts.json → accounts.json.bak");
-    }
-
-    Ok(Some(read_all(cache)?))
 }
 
 /// Borrow a pooled connection.  Thin wrapper around

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -9,10 +9,6 @@
 //!
 //! # What does not live here
 //!
-//! - **Accounts**: still in `accounts.json`. Moving them into the DB is a
-//!   future exercise — worth doing once we need foreign keys from emails
-//!   to accounts or transactional account edits. See the README for the
-//!   motivation.
 //! - **Passwords**: always in the OS keychain (`credentials.rs`). Never
 //!   the DB, never disk.
 //!

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -739,6 +739,29 @@ const MIGRATIONS: &[&str] = &[
     CREATE INDEX IF NOT EXISTS idx_attachment_previews_msg
         ON attachment_previews(account_id, folder, uid);
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v20 → v21: move Nextcloud connections from
+    // `<config-dir>/nimbus-mail/nextcloud_accounts.json` into the
+    // encrypted cache (#155).  Mirrors what #60 did for the mail
+    // accounts table.
+    //
+    // - `id` is the stable UUID also used as the keychain account
+    //   key for the app password.  Keychain entry is unchanged.
+    // - `capabilities_json` is the `NextcloudCapabilities` struct
+    //   serialised as JSON.  We never query into it from SQL —
+    //   the UI deserialises the whole thing — so a single TEXT
+    //   column is simpler than splitting each cap into its own
+    //   column and re-serialising.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    CREATE TABLE IF NOT EXISTS nextcloud_accounts (
+        id                 TEXT PRIMARY KEY,
+        server_url         TEXT NOT NULL,
+        username           TEXT NOT NULL,
+        display_name       TEXT,
+        capabilities_json  TEXT
+    );
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/crates/nimbus-store/src/nextcloud_store.rs
+++ b/crates/nimbus-store/src/nextcloud_store.rs
@@ -1,57 +1,55 @@
-//! Persistent Nextcloud-connection storage backed by a JSON file.
+//! Persistent Nextcloud-connection storage backed by the SQLCipher cache.
 //!
-//! Mirrors `account_store.rs` in shape: one JSON file at
-//! `<config-dir>/nimbus-mail/nextcloud_accounts.json` containing the
-//! full list, read-whole/write-whole on every mutation. That's fine for
-//! a handful of connections and keeps this file dead-simple to inspect
-//! by hand.
+//! Mirrors `account_store.rs`: connection metadata lives in the
+//! encrypted cache so server URLs and usernames are no longer
+//! readable from a plaintext file alongside the database (#155).
+//! The app password itself stays in the OS keychain under
+//! service `nimbus-mail-nextcloud`.
 //!
-//! # Why a second file
-//!
-//! Nextcloud connections are independent of mail accounts — see the
-//! doc comment on `NextcloudAccount`. Keeping them in their own file
-//! means removing a mail account can never accidentally nuke a
-//! Nextcloud connection, and users can back them up separately.
-
-use std::path::PathBuf;
+//! Connections remain a separate top-level record from mail
+//! accounts because one Nextcloud often backs several mail
+//! identities — see the doc comment on `NextcloudAccount`.
 
 use nimbus_core::NimbusError;
-use nimbus_core::models::NextcloudAccount;
+use nimbus_core::models::{NextcloudAccount, NextcloudCapabilities};
+use rusqlite::params;
 use tracing::{debug, info};
 
-fn file_path() -> Result<PathBuf, NimbusError> {
-    let data_dir = dirs::config_dir()
-        .ok_or_else(|| NimbusError::Storage("cannot determine config directory".into()))?;
-    Ok(data_dir.join("nimbus-mail").join("nextcloud_accounts.json"))
-}
+use crate::Cache;
 
-/// Load all saved Nextcloud connections. Empty list on first run.
-pub fn load_accounts() -> Result<Vec<NextcloudAccount>, NimbusError> {
-    let path = file_path()?;
-    if !path.exists() {
-        debug!("No Nextcloud accounts file at {}", path.display());
-        return Ok(Vec::new());
+/// Load all saved Nextcloud connections.  Empty list on first run.
+pub fn load_accounts(cache: &Cache) -> Result<Vec<NextcloudAccount>, NimbusError> {
+    let conn = cache
+        .conn()
+        .map_err(|e| NimbusError::Storage(format!("nextcloud load: {e}")))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, server_url, username, display_name, capabilities_json
+             FROM nextcloud_accounts
+             ORDER BY rowid",
+        )
+        .map_err(|e| NimbusError::Storage(format!("prepare nextcloud_accounts read: {e}")))?;
+    let rows = stmt
+        .query_map([], |r| {
+            let caps_json: Option<String> = r.get(4)?;
+            let capabilities = caps_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str::<NextcloudCapabilities>(s).ok());
+            Ok(NextcloudAccount {
+                id: r.get(0)?,
+                server_url: r.get(1)?,
+                username: r.get(2)?,
+                display_name: r.get(3)?,
+                capabilities,
+            })
+        })
+        .map_err(|e| NimbusError::Storage(format!("query nextcloud_accounts: {e}")))?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.map_err(|e| NimbusError::Storage(format!("row nextcloud_accounts: {e}")))?);
     }
-    let data = std::fs::read_to_string(&path)
-        .map_err(|e| NimbusError::Storage(format!("read nextcloud_accounts.json: {e}")))?;
-    let accts: Vec<NextcloudAccount> = serde_json::from_str(&data)
-        .map_err(|e| NimbusError::Storage(format!("parse nextcloud_accounts.json: {e}")))?;
-    info!("Loaded {} Nextcloud connection(s)", accts.len());
-    Ok(accts)
-}
-
-fn save_accounts(accts: &[NextcloudAccount]) -> Result<(), NimbusError> {
-    let path = file_path()?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| NimbusError::Storage(format!("create config dir: {e}")))?;
-    }
-    let json = serde_json::to_string_pretty(accts)
-        .map_err(|e| NimbusError::Storage(format!("serialize nextcloud accounts: {e}")))?;
-    std::fs::write(&path, json)
-        .map_err(|e| NimbusError::Storage(format!("write nextcloud_accounts.json: {e}")))?;
-    debug!("Saved {} Nextcloud connection(s)", accts.len());
-    Ok(())
+    debug!("Loaded {} Nextcloud connection(s)", out.len());
+    Ok(out)
 }
 
 /// Add a new Nextcloud connection, or overwrite one with the same id.
@@ -59,34 +57,55 @@ fn save_accounts(accts: &[NextcloudAccount]) -> Result<(), NimbusError> {
 /// Overwrite semantics are deliberate: re-running Login Flow v2 for the
 /// same logical server/user produces a fresh app password; we want to
 /// update in place rather than accumulating stale rows.
-pub fn upsert_account(acct: NextcloudAccount) -> Result<(), NimbusError> {
-    let mut accts = load_accounts()?;
-    if let Some(existing) = accts.iter_mut().find(|a| a.id == acct.id) {
-        info!(
-            "Updating Nextcloud connection '{}' ({}@{})",
-            acct.id, acct.username, acct.server_url
-        );
-        *existing = acct;
-    } else {
-        info!(
-            "Adding Nextcloud connection '{}' ({}@{})",
-            acct.id, acct.username, acct.server_url
-        );
-        accts.push(acct);
-    }
-    save_accounts(&accts)
+pub fn upsert_account(cache: &Cache, acct: NextcloudAccount) -> Result<(), NimbusError> {
+    let conn = cache
+        .conn()
+        .map_err(|e| NimbusError::Storage(format!("nextcloud upsert: {e}")))?;
+    let caps_json = match &acct.capabilities {
+        Some(c) => Some(
+            serde_json::to_string(c)
+                .map_err(|e| NimbusError::Storage(format!("serialise capabilities: {e}")))?,
+        ),
+        None => None,
+    };
+    conn.execute(
+        "INSERT INTO nextcloud_accounts
+            (id, server_url, username, display_name, capabilities_json)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(id) DO UPDATE SET
+            server_url        = excluded.server_url,
+            username          = excluded.username,
+            display_name      = excluded.display_name,
+            capabilities_json = excluded.capabilities_json",
+        params![
+            acct.id,
+            acct.server_url,
+            acct.username,
+            acct.display_name,
+            caps_json,
+        ],
+    )
+    .map_err(|e| NimbusError::Storage(format!("upsert nextcloud_accounts: {e}")))?;
+    info!(
+        "Stored Nextcloud connection '{}' ({}@{})",
+        acct.id, acct.username, acct.server_url
+    );
+    Ok(())
 }
 
 /// Remove a Nextcloud connection by id.
-pub fn remove_account(id: &str) -> Result<(), NimbusError> {
-    let mut accts = load_accounts()?;
-    let before = accts.len();
-    accts.retain(|a| a.id != id);
-    if accts.len() == before {
+pub fn remove_account(cache: &Cache, id: &str) -> Result<(), NimbusError> {
+    let conn = cache
+        .conn()
+        .map_err(|e| NimbusError::Storage(format!("nextcloud remove: {e}")))?;
+    let removed = conn
+        .execute("DELETE FROM nextcloud_accounts WHERE id = ?1", params![id])
+        .map_err(|e| NimbusError::Storage(format!("delete nextcloud_accounts: {e}")))?;
+    if removed == 0 {
         return Err(NimbusError::Storage(format!(
             "no Nextcloud connection with id '{id}'"
         )));
     }
     info!("Removed Nextcloud connection '{id}'");
-    save_accounts(&accts)
+    Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -431,14 +431,14 @@ async fn poll_nextcloud_login(
         display_name: None,
         capabilities,
     };
-    nextcloud_store::upsert_account(account.clone())?;
+    nextcloud_store::upsert_account(global_cache()?, account.clone())?;
     Ok(Some(account))
 }
 
 /// List all saved Nextcloud connections.
 #[tauri::command]
 fn get_nextcloud_accounts() -> Result<Vec<NextcloudAccount>, NimbusError> {
-    nextcloud_store::load_accounts()
+    nextcloud_store::load_accounts(global_cache()?)
 }
 
 /// Re-probe `/ocs/v2.php/cloud/capabilities` for one account and
@@ -456,7 +456,7 @@ async fn refresh_nextcloud_capabilities(nc_id: String) -> Result<NextcloudAccoun
     match fetch_capabilities(&account.server_url, &account.username, &app_password).await {
         Ok(caps) => {
             account.capabilities = Some(caps);
-            nextcloud_store::upsert_account(account.clone())?;
+            nextcloud_store::upsert_account(global_cache()?, account.clone())?;
         }
         Err(e) => {
             tracing::warn!("refresh_nextcloud_capabilities for {nc_id}: {e}");
@@ -513,7 +513,7 @@ fn remove_nextcloud_account(id: String, cache: State<'_, Cache>) -> Result<(), N
     if let Err(e) = cache.wipe_nextcloud_calendars(&id) {
         tracing::warn!("failed to wipe calendars for NC account '{id}': {e}");
     }
-    nextcloud_store::remove_account(&id)
+    nextcloud_store::remove_account(&cache, &id)
 }
 
 /// Open an arbitrary URL in the system's default browser.
@@ -1527,7 +1527,7 @@ async fn sync_nextcloud_contacts(
     nc_id: String,
     cache: State<'_, Cache>,
 ) -> Result<SyncContactsReport, NimbusError> {
-    let account = nextcloud_store::load_accounts()?
+    let account = nextcloud_store::load_accounts(&cache)?
         .into_iter()
         .find(|a| a.id == nc_id)
         .ok_or_else(|| NimbusError::Other(format!("no Nextcloud account with id '{nc_id}'")))?;
@@ -2760,7 +2760,7 @@ fn humanize_nc_group_name(raw: &str) -> String {
 async fn list_nextcloud_groups(
     cache: State<'_, Cache>,
 ) -> Result<Vec<NextcloudGroupView>, NimbusError> {
-    let accounts = nextcloud_store::load_accounts().unwrap_or_default();
+    let accounts = nextcloud_store::load_accounts(&cache).unwrap_or_default();
     let mut out: Vec<NextcloudGroupView> = Vec::new();
     // Build a uid → email fallback map from the local CardDAV
     // cache.  Most NC instances sync the system addressbook into
@@ -4618,8 +4618,20 @@ fn row_to_contact(nc_account_id: &str, addressbook: &str, row: &ContactRow) -> C
     }
 }
 
+/// Process-wide handle to the encrypted cache.  Populated once in
+/// `main()` after `Cache::open_default`, so non-IPC helpers can
+/// reach the pool without every call site having to extract
+/// `State<'_, Cache>` and thread `&Cache` through itself.
+static GLOBAL_CACHE: std::sync::OnceLock<Cache> = std::sync::OnceLock::new();
+
+fn global_cache() -> Result<&'static Cache, NimbusError> {
+    GLOBAL_CACHE
+        .get()
+        .ok_or_else(|| NimbusError::Storage("cache not initialised yet".into()))
+}
+
 fn load_nextcloud_account(nc_id: &str) -> Result<NextcloudAccount, NimbusError> {
-    nextcloud_store::load_accounts()?
+    nextcloud_store::load_accounts(global_cache()?)?
         .into_iter()
         .find(|a| a.id == nc_id)
         .ok_or_else(|| NimbusError::Other(format!("no Nextcloud account with id '{nc_id}'")))
@@ -6526,8 +6538,8 @@ async fn check_talk_reminders_inner(app: &AppHandle) -> Result<(), NimbusError> 
     // connected NC account.  Mirrors the visibility the user
     // already chose for the agenda grid; muting a calendar there
     // also silences its Talk reminders.
-    let nc_accounts = nextcloud_store::load_accounts().unwrap_or_default();
     let cache = app.state::<Cache>();
+    let nc_accounts = nextcloud_store::load_accounts(&cache).unwrap_or_default();
     let mut calendar_ids: Vec<String> = Vec::new();
     for acc in &nc_accounts {
         if let Ok(list) = cache.list_calendars(&acc.id) {
@@ -7629,6 +7641,12 @@ fn main() {
     // A failure here is fatal: without the cache the write-through path
     // is broken, and the user would silently lose offline capability.
     let cache = Cache::open_default().expect("failed to open local mail cache");
+    // Stash a clone for the small set of helpers (e.g. `load_nextcloud_account`)
+    // that fan out across many call sites and would otherwise need `&Cache`
+    // threaded through 30+ functions.  `Cache` is a cheap `Arc`-clone, so this
+    // doesn't duplicate the pool — just gives non-IPC code paths a way to
+    // reach it without a State extractor.
+    let _ = GLOBAL_CACHE.set(cache.clone());
 
     // Scrub orphan cache rows left behind by removed accounts.
     // `cache.wipe_account(...)` runs on account removal, but if it ever


### PR DESCRIPTION
Closes #155.

## Summary
The SQLCipher cache was already encrypting mail bodies, accounts, contacts, and calendars — but `nextcloud_accounts.json` sat next to it in plaintext, exposing every connected server URL + login name to anyone with config-dir read access. This PR moves Nextcloud connection metadata into the same encrypted store and drops a related dead-code migration left over from #60.

## What does NOT change (deliberately)
After auditing all on-disk writes:
- `app_settings.json` — stays plaintext. No secrets, and the lock screen needs to read the theme name *before* unlock.
- `system_fonts.json` — stays. It's the #142 follow-up that eliminated first-Compose lag from font-kit's catalogue walk; dropping it would regress that.
- Print temps in `$TMPDIR/nimbus-print-<uuid>/` — stay. Already auto-deleted after 10 minutes; replacing with an in-memory write would need an OS print pipeline rewrite.
- Passwords — already keychain-only. Logs — already stdout-only.

So `nextcloud_accounts.json` was the only remaining plaintext leak worth closing.

## What changed

**Schema** (`crates/nimbus-store/src/cache/schema.rs`)
- v20 → v21 migration creates `nextcloud_accounts (id, server_url, username, display_name, capabilities_json)`. `capabilities_json` is the `NextcloudCapabilities` struct as a single TEXT column — the UI deserialises the whole thing, splitting per-cap would just mean re-serialising on the way out.

**Store** (`crates/nimbus-store/src/nextcloud_store.rs`)
- Rewritten end-to-end against the encrypted cache. Public API shape preserved; each fn just gains a `&Cache` arg:
  - `load_accounts(&Cache) -> Vec<NextcloudAccount>`
  - `upsert_account(&Cache, NextcloudAccount)`
  - `remove_account(&Cache, &str)`
- App password unchanged — still in the OS keychain under `nimbus-mail-nextcloud`.

**Glue** (`src-tauri/src/main.rs`)
- New `GLOBAL_CACHE: OnceLock<Cache>` populated once in `main()` after `Cache::open_default`. `Cache` is a cheap Arc-clone, so this doesn't duplicate the pool — it gives the small set of non-IPC helpers (notably `load_nextcloud_account`, called from 30+ places) a way to reach the pool without `&Cache` threaded through every intermediate function.
- All 8 `nextcloud_store::*` call sites updated. Four of them already had `cache: State<'_, Cache>` in scope; the rest go through `global_cache()`.

**Cleanup that came along for the ride** (`account_store.rs`)
- The legacy `accounts.json` → SQLCipher migration from #60 + `.bak` rename rollback path was dead code — landed in the same dev cycle as the encrypted table, only the developers ever ran it, and the rollback hatch can't realistically save anyone. Removed (~120 lines): `migrate_from_legacy_json`, `legacy_json_path`, the `cfg(not(test))` imports, and the `# Migration` doc paragraph.
- Stale "Accounts: still in `accounts.json`" comment in `cache/mod.rs` removed.

## Migration
**None.** This codebase has no users outside Nick + Jannik. Existing `nextcloud_accounts.json` is harmless (just stale plaintext) — delete by hand and re-run Login Flow v2 once. Same call we made for the FIDO PR's `.bak` cleanup.

## Test plan
- [x] Fresh install: connect a Nextcloud account → verify it appears in the cache (`SELECT * FROM nextcloud_accounts;`) and not on disk as JSON.
- [ ] Reconnect same NC: row is updated in place, not duplicated.
- [ ] Disconnect: row is removed, app password is gone from keychain, contacts + calendars wiped.
- [x] Restart Nimbus: connection survives, capabilities chips render correctly.
- [x] `Settings → Refresh capabilities`: persists the fresh snapshot.
- [x] Confirm no `nextcloud_accounts.json` is created during normal use (`ls -la ~/.config/nimbus-mail/`).
- [x] With Key Encryption on: locked launch shows lock screen, unlock works, NC connection still readable post-unlock.
- [x] Existing dev install with stale JSON: app ignores it, fresh table is empty until reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)