### PR TITLE
Improve mail navigation: visual-first account, cross-view jump, calm refresh hint (#161)

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -82,6 +82,10 @@
         special-use / keyword rules in `folderIcon`. Optional for
         the same back-compat reason as `folder_icons`. */
     folder_icon_overrides?: Record<string, string>
+    /** Display order in the IconRail; lower = top.  Lets us pick
+     *  the visually-first account on launch instead of the one
+     *  that happens to be first in the DB's insertion order. */
+    sort_order?: number
   }
   let accounts = $state<Account[]>([])
   let activeAccountId = $state<string | null>(null)
@@ -161,6 +165,15 @@
     account_id: string
   }
   let mailListEnvelopes = $state<MailListEnvelope[]>([])
+
+  // Network-refresh state for the IconRail's active-account
+  // avatar spinner (#161).  Each child component (MailList,
+  // MailView) flips its own flag while a post-cache fetch is
+  // in flight; we OR them so a refresh in either pane lights
+  // the same indicator.
+  let mailListRefreshing = $state(false)
+  let mailViewRefreshing = $state(false)
+  const mailRefreshing = $derived(mailListRefreshing || mailViewRefreshing)
 
   // ── Search state ────────────────────────────────────────────
   // `searchQuery` drives the mail-list column: non-empty query OR
@@ -531,11 +544,19 @@
       accounts = list
       if (list.length > 0) {
         // Keep the current selection if it still exists (e.g. after
-        // adding another account); otherwise fall back to the first.
-        // This also handles the "active account was just removed"
-        // case from AccountSettings.
+        // adding another account); otherwise fall back to the
+        // visually-first account.  `list` is in insertion order; the
+        // IconRail and sidebar render by `sort_order`, so we sort
+        // here to match — otherwise the auto-picked account isn't
+        // the one the user sees at the top of the rail (#161).
         if (!activeAccountId || !list.some((a) => a.id === activeAccountId)) {
-          activeAccountId = list[0].id
+          const sorted = [...list].sort((a, b) => {
+            const ao = a.sort_order ?? 0
+            const bo = b.sort_order ?? 0
+            if (ao !== bo) return ao - bo
+            return a.id.localeCompare(b.id)
+          })
+          activeAccountId = sorted[0].id
         }
         currentView = 'inbox'
       } else {
@@ -575,8 +596,16 @@
    * id automatically turns unified mode off.
    */
   function selectAccount(id: string) {
+    // Picking an account from the IconRail always means "show me
+    // mail for this account" — even from calendar / contacts /
+    // settings, where the rail is still visible.  Flip the view
+    // before any of the early-return paths so a click from
+    // another view always lands you in the inbox (#161).
+    const wasOnMail = currentView === 'inbox'
+    if (currentView !== 'inbox') currentView = 'inbox'
+
     if (id === '__all__') {
-      if (unifiedMode) return
+      if (unifiedMode && wasOnMail) return
       unifiedMode = true
       selectedFolder = 'INBOX'
       selectedUid = null
@@ -587,7 +616,7 @@
       refreshToken++
       return
     }
-    if (!unifiedMode && id === activeAccountId) return
+    if (!unifiedMode && id === activeAccountId && wasOnMail) return
     unifiedMode = false
     activeAccountId = id
     selectedFolder = 'INBOX'
@@ -1096,6 +1125,7 @@
       accountId={activeAccountId}
       unified={unifiedMode}
       currentView={currentView}
+      mailRefreshing={mailRefreshing}
       onselectaccount={selectAccount}
       onselectview={onSelectView}
     />
@@ -1180,6 +1210,7 @@
               refreshToken={refreshToken}
               onselect={selectMessage}
               bind:envelopes={mailListEnvelopes}
+              bind:refreshing={mailListRefreshing}
               onmessagemoved={onMessageRemoved}
             />
           {/if}
@@ -1201,6 +1232,7 @@
         oneditdraft={onEditDraft}
         onmessageremoved={onMessageRemoved}
         onmailto={(init) => openCompose(init)}
+        bind:refreshing={mailViewRefreshing}
       />
     {/if}
 

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -269,6 +269,11 @@
         ></span>
       {/if}
     </button>
+    <!-- Sub-divider between the All-inboxes bubble and the
+         individual account avatars.  Visually groups "aggregate"
+         vs. "single account" without making the rail noisier
+         than the main divider below the avatar stack. -->
+    <div class="w-6 h-px my-1 bg-surface-300 dark:bg-surface-600" aria-hidden="true"></div>
   {/if}
   {#each sortedAccounts as a (a.id)}
     <!-- The active ring only paints while we're actually on the

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -206,8 +206,11 @@
     label: string
     icon: string
   }
+  // No 'inbox' entry here (#161 follow-up): the account avatars
+  // above the divider already navigate to mail, so a dedicated
+  // mail icon would be redundant.  Use `onselectaccount` (with the
+  // `'__all__'` sentinel for unified mode) to land in the inbox.
   const MAIN_NAV: NavEntry[] = [
-    { match: 'inbox', label: 'Mail', icon: '\u{1F4E7}' },        // 📧
     { match: 'contacts', label: 'Contacts', icon: '\u{1F464}' }, // 👤
     { match: 'calendar', label: 'Calendar', icon: '\u{1F4C5}' }, // 📅
     { match: 'files', label: 'Files', icon: '\u{1F4C1}' },       // 📁

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -75,6 +75,12 @@
      *  old Sidebar dropdown used. */
     onselectaccount: (id: string) => void
     onselectview: (view: RailView) => void
+    /** True while a network refresh is in flight in the active
+     *  mail pane (MailList or MailView).  Drives a calm spinner
+     *  ring overlay on the active account's avatar so the
+     *  "Refreshing…" hint lives somewhere persistent rather
+     *  than as a buggy strip inside the list (#161). */
+    mailRefreshing?: boolean
   }
   let {
     accounts,
@@ -83,6 +89,7 @@
     currentView,
     onselectaccount,
     onselectview,
+    mailRefreshing = false,
   }: Props = $props()
 
   /** First-letter / initial-pair fallback for the avatar bubble.
@@ -250,6 +257,13 @@
           title={`${totalUnread} unread across all inboxes`}
         >{totalUnread > 99 ? '99+' : totalUnread}</span>
       {/if}
+      {#if unified && mailRefreshing}
+        <span
+          class="pointer-events-none absolute inset-0 rounded-full border-2 border-transparent border-t-white/80 animate-spin"
+          aria-hidden="true"
+          title="Refreshing"
+        ></span>
+      {/if}
     </button>
   {/if}
   {#each sortedAccounts as a (a.id)}
@@ -279,6 +293,18 @@
         <span
           class="absolute -top-0.5 -right-0.5 min-w-4 h-4 px-1 text-[10px] rounded-full bg-red-500 text-white flex items-center justify-center font-semibold ring-2 ring-surface-100 dark:ring-surface-800"
         >{unread > 99 ? '99+' : unread}</span>
+      {/if}
+      {#if active && mailRefreshing}
+        <!-- Calm refresh hint (#161): a thin spinner ring
+             overlaid on the active avatar replaces the inline
+             "Refreshing…" strip that used to live in MailList /
+             MailView.  Only renders for the active account so
+             it doesn't compete with the avatar's content. -->
+        <span
+          class="pointer-events-none absolute inset-0 rounded-full border-2 border-transparent border-t-white/80 animate-spin"
+          aria-hidden="true"
+          title="Refreshing"
+        ></span>
       {/if}
     </button>
   {/each}

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -227,10 +227,11 @@
        has more than one account — for a single-account setup it's
        chrome with no distinct behaviour. -->
   {#if accounts.length > 1}
+    {@const allActive = unified && currentView === 'inbox'}
     <button
       class="relative w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
              transition-colors
-             {unified
+             {allActive
                ? 'bg-primary-500 text-white ring-2 ring-offset-2 ring-offset-surface-100 dark:ring-offset-surface-800 ring-primary-500'
                : 'bg-surface-300 dark:bg-surface-700 text-surface-700 dark:text-surface-300 hover:bg-surface-400 dark:hover:bg-surface-600'}"
       title="All inboxes (unified)"
@@ -270,7 +271,12 @@
     </button>
   {/if}
   {#each sortedAccounts as a (a.id)}
-    {@const active = !unified && accountId === a.id}
+    <!-- The active ring only paints while we're actually on the
+         mail view (#161 follow-up).  When the user is in
+         calendar / contacts / settings, the avatars stay quiet
+         so the rail clearly says "click an account to see its
+         mail" rather than "this account is selected." -->
+    {@const active = !unified && accountId === a.id && currentView === 'inbox'}
     {@const unread = unreadFor(a.id)}
     <button
       class="relative w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -67,6 +67,12 @@
         envelope and run the auto-advance flow when the moved row
         was the currently-open one. */
     onmessagemoved?: (removedUid: number) => void
+    /** Bindable hint to the parent that the network refresh after
+     *  the cache-paint is still in flight.  `App.svelte` ORs this
+     *  with MailView's flag and surfaces it as a calm spinner on
+     *  the active-account avatar in the IconRail (#161) — the
+     *  inline "Refreshing…" strip used to live here. */
+    refreshing?: boolean
   }
   let {
     accounts = [],
@@ -78,6 +84,7 @@
     onselect,
     envelopes = $bindable([]),
     onmessagemoved,
+    refreshing = $bindable(false),
   }: Props = $props()
 
   /** Short label for the per-row account chip in unified mode. We
@@ -99,7 +106,6 @@
   // after the cache has rendered, so the UI can show a subtle hint
   // without blanking the list.
   let loading = $state(true)
-  let refreshing = $state(false)
   let error = $state('')
 
   // ── Multi-select (#89, follow-up) ─────────────────────────────
@@ -426,11 +432,6 @@
 </script>
 
 <div class="flex-1 flex flex-col min-w-0">
-  {#if refreshing}
-    <div class="px-3 py-1 text-[11px] text-surface-500 border-b border-surface-100 dark:border-surface-800">
-      Refreshing…
-    </div>
-  {/if}
 
   <!-- Email list -->
   <div class="flex-1 overflow-y-auto">

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -105,6 +105,12 @@
         cc/bcc/subject/body) — used when the user clicks a
         `mailto:` link inside a rendered email. */
     onmailto?: (init: { to?: string; cc?: string; bcc?: string; subject?: string; body?: string }) => void
+    /** Bindable refresh hint — see the equivalent prop on
+     *  `MailList`.  The network re-fetch after the cache paint
+     *  flips this true; `App.svelte` aggregates it with
+     *  MailList's flag and shows a calm spinner on the
+     *  IconRail's active-account avatar (#161). */
+    refreshing?: boolean
   }
   let {
     accountId,
@@ -123,11 +129,11 @@
     inStandaloneWindow = false,
     forceWhiteBackground = true,
     onmailto,
+    refreshing = $bindable(false),
   }: Props = $props()
 
   let email = $state<Email | null>(null)
   let loading = $state(false)
-  let refreshing = $state(false)
   let error = $state('')
 
   /** Pre-fetch persisted thumbnails for one message and seed
@@ -1151,9 +1157,6 @@
       <div class="flex items-start justify-between mb-2 gap-4">
         <h2 class="text-xl font-semibold">{email.subject || '(no subject)'}</h2>
         <div class="flex items-center gap-3 shrink-0">
-          {#if refreshing}
-            <span class="text-xs text-surface-500">Refreshing…</span>
-          {/if}
           <span class="text-sm text-surface-500">{formatFullDate(email.date)}</span>
         </div>
       </div>


### PR DESCRIPTION
Closes #161.

## Summary
Three small UX fixes that smooth out how users move around the mail surface.

## What changed

**Auto-pick the visually-first account on launch**
`checkAccounts` used `list[0]` from `get_accounts`, which is DB-insertion order. Once accounts are reordered via the IconRail's up/down arrows, that's not the account you see at the top of the rail. Now sorts by `sort_order` (with `id` tiebreak — same logic IconRail uses) before falling back. Added `sort_order?: number` to the local `Account` interface so TS picks it up.

**Account click from any view → land in mail**
`selectAccount` previously only set `activeAccountId`, so clicking an account from calendar / contacts / settings moved the active marker without switching the view. Now flips `currentView = 'inbox'` first thing, and the early-return guards check `account-id equality && wasOnMail` — clicking the already-active account from another view still pulls you back to the inbox. Unified-mode picker behaves the same way.

**"Refreshing…" → calm avatar spinner**
- Removed the inline strip at the top of MailList.
- Removed the inline span next to the date in MailView.
- Made `refreshing` `$bindable` on both components — App.svelte now ORs them into a `$derived` `mailRefreshing` flag.
- IconRail accepts `mailRefreshing` and renders a thin `border-t-white/80 animate-spin` ring overlay on the active avatar (or the All-inboxes bubble when in unified mode). Only the active account gets the spinner so the rail stays quiet.

## Test plan
- [ ] Reorder accounts via IconRail arrows; restart app → first account in the rail is auto-selected, not the one inserted first.
- [ ] On launch into inbox, the active account's avatar briefly shows a spinning ring while envelopes are pulled, then clears.
- [ ] Click into Calendar, then click another account in the rail → snaps to inbox for that account, no need to click the Mail icon.
- [ ] Click into Settings, click the *currently-active* account → snaps back to inbox (was a no-op before).
- [ ] In unified-inbox mode, the spinner appears on the All bubble while a fetch is in flight.
- [ ] Selecting a message in MailView → MailView's spinner adds onto the active avatar; no inline "Refreshing…" anywhere in the reading area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)