### PR TITLE
v5 sun + add-folder / delete-folder icon registrations + UI swaps (#179)

### DIFF
--- a/icons/icons-v5/svelte/icons/AddFolder.svelte
+++ b/icons/icons-v5/svelte/icons/AddFolder.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+  <path d="M12 11v6"/>
+  <path d="M9 14h6"/>
+</svg>

--- a/icons/icons-v5/svelte/icons/DeleteFolder.svelte
+++ b/icons/icons-v5/svelte/icons/DeleteFolder.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+  <path d="M10 12l4 4"/>
+  <path d="M14 12l-4 4"/>
+</svg>

--- a/icons/icons-v5/svelte/icons/Sun.svelte
+++ b/icons/icons-v5/svelte/icons/Sun.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <circle cx="12" cy="12" r="3.5"/>
+  <path d="M12 3v2"/>
+  <path d="M12 19v2"/>
+  <path d="M3 12h2"/>
+  <path d="M19 12h2"/>
+  <path d="M5.6 5.6l1.4 1.4"/>
+  <path d="M17 17l1.4 1.4"/>
+  <path d="M5.6 18.4l1.4-1.4"/>
+  <path d="M17 7l1.4-1.4"/>
+</svg>

--- a/icons/icons-v5/svg/add-folder.svg
+++ b/icons/icons-v5/svg/add-folder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+  <path d="M12 11v6"/>
+  <path d="M9 14h6"/>
+</svg>

--- a/icons/icons-v5/svg/delete-folder.svg
+++ b/icons/icons-v5/svg/delete-folder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+  <path d="M10 12l4 4"/>
+  <path d="M14 12l-4 4"/>
+</svg>

--- a/icons/icons-v5/svg/sun.svg
+++ b/icons/icons-v5/svg/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="3.5"/>
+  <path d="M12 3v2"/>
+  <path d="M12 19v2"/>
+  <path d="M3 12h2"/>
+  <path d="M19 12h2"/>
+  <path d="M5.6 5.6l1.4 1.4"/>
+  <path d="M17 17l1.4 1.4"/>
+  <path d="M5.6 18.4l1.4-1.4"/>
+  <path d="M17 7l1.4-1.4"/>
+</svg>

--- a/ui/src/lib/Icon.svelte
+++ b/ui/src/lib/Icon.svelte
@@ -47,8 +47,9 @@
     | 'quote' | 'text-color' | 'highlight-text'
     | 'undo' | 'redo'
     | 'passphrase' | 'security-key'
-    // v5 — people categories + map + time
+    // v5 — people categories + map + time + folder ops
     | 'group' | 'address-book' | 'team' | 'location' | 'time' | 'sun'
+    | 'add-folder' | 'delete-folder'
 </script>
 
 <script lang="ts">
@@ -160,6 +161,8 @@
   import Location from './icons/Location.svelte'
   import Time from './icons/Time.svelte'
   import Sun from './icons/Sun.svelte'
+  import AddFolder from './icons/AddFolder.svelte'
+  import DeleteFolder from './icons/DeleteFolder.svelte'
   import type { Component } from 'svelte'
 
   interface Props {
@@ -277,6 +280,8 @@
     'location': Location,
     'time': Time,
     'sun': Sun,
+    'add-folder': AddFolder,
+    'delete-folder': DeleteFolder,
   }
   const Cmp = $derived(map[name])
 </script>

--- a/ui/src/lib/Icon.svelte
+++ b/ui/src/lib/Icon.svelte
@@ -48,7 +48,7 @@
     | 'undo' | 'redo'
     | 'passphrase' | 'security-key'
     // v5 — people categories + map + time
-    | 'group' | 'address-book' | 'team' | 'location' | 'time'
+    | 'group' | 'address-book' | 'team' | 'location' | 'time' | 'sun'
 </script>
 
 <script lang="ts">
@@ -159,6 +159,7 @@
   import Team from './icons/Team.svelte'
   import Location from './icons/Location.svelte'
   import Time from './icons/Time.svelte'
+  import Sun from './icons/Sun.svelte'
   import type { Component } from 'svelte'
 
   interface Props {
@@ -275,6 +276,7 @@
     'team': Team,
     'location': Location,
     'time': Time,
+    'sun': Sun,
   }
   const Cmp = $derived(map[name])
 </script>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1253,16 +1253,19 @@
       {/if}
       {#if email.body_html}
         <!-- Per-message background toggle — flips the white-canvas
-             default just for the open mail.  Kept text-only because
-             the family has no "page background" glyph; the label is
-             short and tells the user where a click will take them. -->
+             default just for the open mail.  Icon-only: `sun` for
+             "switch to white" (bright canvas), `design-palette` for
+             "switch to the app's theme" (whatever palette the user
+             picked).  Title carries the action so hover tooltips
+             still spell it out. -->
         <button
-          class="btn btn-sm preset-outlined-surface-500"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
           onclick={() => (whiteBackgroundOverride = !effectiveWhiteBackground)}
           title={effectiveWhiteBackground
             ? "Switch this mail to the app's theme background"
             : 'Switch this mail to a white background'}
-        >{effectiveWhiteBackground ? 'Use mail theme' : 'White background'}</button>
+          aria-label={effectiveWhiteBackground ? 'Use mail theme' : 'White background'}
+        ><Icon name={effectiveWhiteBackground ? 'design-palette' : 'sun'} size={16} /></button>
       {/if}
       <!-- Move to folder (#89) — single button that opens the
            `MoveFolderPicker` modal.  Picker presents folders with
@@ -1281,7 +1284,7 @@
         aria-label="Archive"
       ><Icon name="archive" size={16} /></button>
       <button
-        class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+        class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-red-500/15 hover:text-red-500 hover:border-red-500/40"
         onclick={deleteMessage}
         title="Move this message to Trash (permanently deletes if already in Trash or if the account has no Trash folder)"
         aria-label="Delete"

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -344,10 +344,11 @@
       <div class="flex-1"></div>
       {#if !creatingFolder}
         <button
-          class="text-primary-500 hover:underline"
+          class="text-primary-500 hover:bg-primary-500/10 rounded-md p-1 inline-flex items-center justify-center"
           onclick={startCreateFolder}
           title="Create a new folder in this directory"
-        >+ New folder</button>
+          aria-label="New folder"
+        ><Icon name="add-folder" size={16} /></button>
       {/if}
     </nav>
 

--- a/ui/src/lib/icons/AddFolder.svelte
+++ b/ui/src/lib/icons/AddFolder.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+  <path d="M12 11v6"/>
+  <path d="M9 14h6"/>
+</svg>

--- a/ui/src/lib/icons/DeleteFolder.svelte
+++ b/ui/src/lib/icons/DeleteFolder.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z"/>
+  <path d="M10 12l4 4"/>
+  <path d="M14 12l-4 4"/>
+</svg>

--- a/ui/src/lib/icons/Sun.svelte
+++ b/ui/src/lib/icons/Sun.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <circle cx="12" cy="12" r="3.5"/>
+  <path d="M12 3v2"/>
+  <path d="M12 19v2"/>
+  <path d="M3 12h2"/>
+  <path d="M19 12h2"/>
+  <path d="M5.6 5.6l1.4 1.4"/>
+  <path d="M17 17l1.4 1.4"/>
+  <path d="M5.6 18.4l1.4-1.4"/>
+  <path d="M17 7l1.4-1.4"/>
+</svg>


### PR DESCRIPTION
Final follow-up to #179.  Two commits that landed on `feature/179-svg-icon-system` after PR #181 was already merged.

## What's in here
1. **`v5 sun`** + UI use:
   - Drop `Sun.svelte` into `ui/src/lib/icons/`, register `'sun'` in `Icon.svelte`.
   - MailView's "White background" toggle goes icon-only — `sun` when the user can switch *to* white, `design-palette` when they can switch back to the app's theme.  Title + `aria-label` still carry the verbose action.
   - MailView's trash button picks up `hover:bg-red-500/15 hover:text-red-500 hover:border-red-500/40` so it matches the red-hover treatment the MailList row's quick-delete already uses.

2. **`v5 add-folder` + `delete-folder`** registrations + first consumer:
   - Drop both components into `ui/src/lib/icons/`, register both in `Icon.svelte` (`'add-folder'`, `'delete-folder'`).  Total reaches 107 icons.
   - `NextcloudFileBrowser`'s `+ New folder` text link → icon-only button using `add-folder` (rounded primary hover).  Same affordance shows up in both surfaces that mount the browser (the standalone Files view and the Compose attach picker).
   - `delete-folder` is registered for future use; not wired yet to keep this PR focused.

## Why this needed its own PR
PR #181 merged earlier in the session via rebase-merge with 14 of the icon-family follow-ups.  These two commits arrived after the merge and stayed on the branch unmerged.  Branch is rebased clean onto current main; only the two commits above remain.

## Test plan
- [ ] MailView reading pane: white-background toggle shows the sun icon when on theme, palette icon when on white.
- [ ] MailView toolbar: hovering Trash flashes red, matches the MailList row's quick-delete hover.
- [ ] FilesView (left-rail Files) and Compose's NC Files picker both show the new circular `add-folder` icon in place of the `+ New folder` text link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)