### PR TITLE
NC picker UX: circular selection toggles + per-file download status (#160)

### DIFF
--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -74,6 +74,22 @@
     return path.split('/').filter(Boolean).pop() ?? path
   }
 
+  /** Per-file download status surfaced as a progress strip while
+   *  `sendAsAttachment` runs (#160).  Same shape as the one in
+   *  NextcloudFilePicker — keys are NC paths, values cycle
+   *  pending → downloading → done | failed. */
+  type DownloadStatus =
+    | { kind: 'pending' }
+    | { kind: 'downloading' }
+    | { kind: 'done' }
+    | { kind: 'failed'; message: string }
+  let downloadStatus = $state<Map<string, DownloadStatus>>(new Map())
+  function setDownloadStatus(path: string, status: DownloadStatus) {
+    const next = new Map(downloadStatus)
+    next.set(path, status)
+    downloadStatus = next
+  }
+
   /** Download every selected file (folders are skipped — Nextcloud has
       no zip-folder endpoint) and open Compose with them pre-attached. */
   async function sendAsAttachment() {
@@ -83,24 +99,34 @@
     if (filePaths.length === 0) return
     attaching = true
     error = ''
+    const seeded = new Map<string, DownloadStatus>()
+    for (const p of filePaths) seeded.set(p, { kind: 'pending' })
+    downloadStatus = seeded
     try {
       // Same parallelisation rationale as the picker: each invoke is
       // an independent task, so this scales with file count rather
       // than serialising.
       const attachments = await Promise.all(
         filePaths.map(async (p) => {
-          const bytes = await invoke<number[]>('download_nextcloud_file', {
-            ncId: accountId,
-            path: p,
-          })
-          const ct =
-            entries.find((e) => e.path === p)?.content_type ??
-            'application/octet-stream'
-          return {
-            filename: basename(p),
-            content_type: ct,
-            data: bytes,
-          } satisfies Attachment
+          setDownloadStatus(p, { kind: 'downloading' })
+          try {
+            const bytes = await invoke<number[]>('download_nextcloud_file', {
+              ncId: accountId,
+              path: p,
+            })
+            const ct =
+              entries.find((e) => e.path === p)?.content_type ??
+              'application/octet-stream'
+            setDownloadStatus(p, { kind: 'done' })
+            return {
+              filename: basename(p),
+              content_type: ct,
+              data: bytes,
+            } satisfies Attachment
+          } catch (e) {
+            setDownloadStatus(p, { kind: 'failed', message: formatError(e) || 'Failed' })
+            throw e
+          }
         }),
       )
       oncompose({ attachments })
@@ -188,6 +214,39 @@
       <p class="px-5 py-2 text-sm text-red-500 border-t border-surface-200 dark:border-surface-700">
         {error}
       </p>
+    {/if}
+
+    {#if downloadStatus.size > 0 && (attaching || [...downloadStatus.values()].some((s) => s.kind === 'failed'))}
+      <!-- Per-file download status strip (#160).  Mirrors the
+           NextcloudFilePicker progress UI so the user sees exactly
+           which file is being fetched and which (if any) errored. -->
+      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1">
+        {#each [...downloadStatus] as [path, status] (path)}
+          <div class="flex items-center gap-2 text-xs">
+            <span class="shrink-0 w-4 h-4 flex items-center justify-center">
+              {#if status.kind === 'pending'}
+                <span class="w-2 h-2 rounded-full bg-surface-400"></span>
+              {:else if status.kind === 'downloading'}
+                <span class="text-primary-500"><Icon name="loading" size={14} /></span>
+              {:else if status.kind === 'done'}
+                <span class="text-success-500"><Icon name="success" size={14} /></span>
+              {:else}
+                <span class="text-error-500"><Icon name="error" size={14} /></span>
+              {/if}
+            </span>
+            <span class="flex-1 truncate text-surface-700 dark:text-surface-300">{basename(path)}</span>
+            {#if status.kind === 'failed'}
+              <span class="shrink-0 text-error-500 truncate max-w-[180px]" title={status.message}>{status.message}</span>
+            {:else if status.kind === 'done'}
+              <span class="shrink-0 text-success-500">Done</span>
+            {:else if status.kind === 'downloading'}
+              <span class="shrink-0 text-primary-500">Downloading…</span>
+            {:else}
+              <span class="shrink-0 text-surface-500">Queued</span>
+            {/if}
+          </div>
+        {/each}
+      </div>
     {/if}
 
     <!-- Action footer. Both buttons are bulk-aware: select N items and

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -273,7 +273,11 @@
           onclick={sendAsLink}
           title="Open a new mail with public download links inserted into the body"
         >
-          {sharing ? 'Sharing…' : '🔗 New mail with link'}
+          {#if sharing}
+            Sharing…
+          {:else}
+            <Icon name="open-link" size={14} class="inline-block align-text-bottom mr-1.5" />New mail with link
+          {/if}
         </button>
         <button
           class="btn preset-filled-primary-500"

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -276,7 +276,7 @@
           {#if sharing}
             Sharing…
           {:else}
-            <Icon name="open-link" size={14} class="inline-block align-text-bottom mr-1.5" />New mail with link
+            <Icon name="share-links" size={14} class="inline-block align-text-bottom mr-1.5" />New mail with link
           {/if}
         </button>
         <button

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -258,7 +258,7 @@
                  there for why we don't drive a real percentage. -->
             <div class="mt-1 ml-6 h-1 rounded-full overflow-hidden bg-surface-200 dark:bg-surface-700 relative">
               {#if status.kind === 'downloading'}
-                <span class="nc-indeterminate absolute inset-y-0 w-1/3 bg-primary-500 rounded-full"></span>
+                <span class="nc-indeterminate absolute inset-y-0 left-0 w-1/3 bg-primary-500 rounded-full"></span>
               {:else if status.kind === 'done'}
                 <span class="absolute inset-0 bg-success-500"></span>
               {:else if status.kind === 'failed'}
@@ -382,14 +382,18 @@
 {/if}
 
 <style>
-  /* Indeterminate per-file progress head (#160).  Same animation
-     used in NextcloudFilePicker — slides a short fill segment
-     across the track so the row reads as "in flight". */
+  /* Indeterminate per-file progress head (#160).  Animates
+     `transform` rather than `left` so the bar keeps ticking
+     while the main thread is busy structured-cloning each
+     file's bytes when its IPC resolves — `left` is layout-
+     driven and stalls the moment the main thread blocks,
+     `transform` runs on the GPU compositor. */
   @keyframes nc-indeterminate {
-    0% { left: -33%; }
-    100% { left: 100%; }
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(400%); }
   }
   .nc-indeterminate {
     animation: nc-indeterminate 1.2s linear infinite;
+    will-change: transform;
   }
 </style>

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -220,30 +220,44 @@
       <!-- Per-file download status strip (#160).  Mirrors the
            NextcloudFilePicker progress UI so the user sees exactly
            which file is being fetched and which (if any) errored. -->
-      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1">
+      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1.5">
         {#each [...downloadStatus] as [path, status] (path)}
-          <div class="flex items-center gap-2 text-xs">
-            <span class="shrink-0 w-4 h-4 flex items-center justify-center">
-              {#if status.kind === 'pending'}
-                <span class="w-2 h-2 rounded-full bg-surface-400"></span>
-              {:else if status.kind === 'downloading'}
-                <span class="text-primary-500"><Icon name="loading" size={14} /></span>
+          <div class="text-xs">
+            <div class="flex items-center gap-2">
+              <span class="shrink-0 w-4 h-4 flex items-center justify-center">
+                {#if status.kind === 'pending'}
+                  <span class="w-2 h-2 rounded-full bg-surface-400"></span>
+                {:else if status.kind === 'downloading'}
+                  <span class="text-primary-500"><Icon name="loading" size={14} /></span>
+                {:else if status.kind === 'done'}
+                  <span class="text-success-500"><Icon name="success" size={14} /></span>
+                {:else}
+                  <span class="text-error-500"><Icon name="error" size={14} /></span>
+                {/if}
+              </span>
+              <span class="flex-1 truncate text-surface-700 dark:text-surface-300">{basename(path)}</span>
+              {#if status.kind === 'failed'}
+                <span class="shrink-0 text-error-500 truncate max-w-[180px]" title={status.message}>{status.message}</span>
               {:else if status.kind === 'done'}
-                <span class="text-success-500"><Icon name="success" size={14} /></span>
+                <span class="shrink-0 text-success-500">Done</span>
+              {:else if status.kind === 'downloading'}
+                <span class="shrink-0 text-primary-500">Downloading…</span>
               {:else}
-                <span class="text-error-500"><Icon name="error" size={14} /></span>
+                <span class="shrink-0 text-surface-500">Queued</span>
               {/if}
-            </span>
-            <span class="flex-1 truncate text-surface-700 dark:text-surface-300">{basename(path)}</span>
-            {#if status.kind === 'failed'}
-              <span class="shrink-0 text-error-500 truncate max-w-[180px]" title={status.message}>{status.message}</span>
-            {:else if status.kind === 'done'}
-              <span class="shrink-0 text-success-500">Done</span>
-            {:else if status.kind === 'downloading'}
-              <span class="shrink-0 text-primary-500">Downloading…</span>
-            {:else}
-              <span class="shrink-0 text-surface-500">Queued</span>
-            {/if}
+            </div>
+            <!-- Indeterminate per-file bar (#160).  Same component
+                 styling as `NextcloudFilePicker` — see the comment
+                 there for why we don't drive a real percentage. -->
+            <div class="mt-1 ml-6 h-1 rounded-full overflow-hidden bg-surface-200 dark:bg-surface-700 relative">
+              {#if status.kind === 'downloading'}
+                <span class="nc-indeterminate absolute inset-y-0 w-1/3 bg-primary-500 rounded-full"></span>
+              {:else if status.kind === 'done'}
+                <span class="absolute inset-0 bg-success-500"></span>
+              {:else if status.kind === 'failed'}
+                <span class="absolute inset-0 bg-error-500"></span>
+              {/if}
+            </div>
           </div>
         {/each}
       </div>
@@ -359,3 +373,16 @@
     </div>
   </div>
 {/if}
+
+<style>
+  /* Indeterminate per-file progress head (#160).  Same animation
+     used in NextcloudFilePicker — slides a short fill segment
+     across the track so the row reads as "in flight". */
+  @keyframes nc-indeterminate {
+    0% { left: -33%; }
+    100% { left: 100%; }
+  }
+  .nc-indeterminate {
+    animation: nc-indeterminate 1.2s linear infinite;
+  }
+</style>

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -220,8 +220,15 @@
       <!-- Per-file download status strip (#160).  Mirrors the
            NextcloudFilePicker progress UI so the user sees exactly
            which file is being fetched and which (if any) errored. -->
-      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1.5">
-        {#each [...downloadStatus] as [path, status] (path)}
+      <!-- Strip ordering (#160): completed rows pile up at the top,
+           the active download sits at the bottom, pending rows
+           below it.  No scrollbar — the strip grows to fit. -->
+      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 space-y-1.5">
+        {#each [...downloadStatus].sort((a, b) => {
+          const rank = (k: DownloadStatus['kind']) =>
+            k === 'done' || k === 'failed' ? 0 : k === 'downloading' ? 1 : 2
+          return rank(a[1].kind) - rank(b[1].kind)
+        }) as [path, status] (path)}
           <div class="text-xs">
             <div class="flex items-center gap-2">
               <span class="shrink-0 w-4 h-4 flex items-center justify-center">

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -425,17 +425,28 @@
                   ></button>
                 {/if}
                 {#if iconName}
+                  <!-- Folder / plaintext icon at 20 px inside a
+                       36 px slot — visibly smaller than the file
+                       thumbnail beside it so the user can
+                       differentiate at a glance (#160). -->
                   <span class="w-9 h-9 flex items-center justify-center shrink-0 text-surface-500">
                     <Icon name={iconName} size={20} />
                   </span>
                 {:else}
-                  <NcPreview
-                    {accountId}
-                    path={entry.path}
-                    contentType={entry.content_type}
-                    filename={entry.name}
-                    class="w-9 h-9"
-                  />
+                  <!-- File preview — sits inside the same 36 px
+                       slot for row alignment, but the visible
+                       thumbnail / typed icon caps at 28 px so it
+                       matches the rest of the new icon sizes
+                       without dominating the row. -->
+                  <span class="w-9 h-9 flex items-center justify-center shrink-0">
+                    <NcPreview
+                      {accountId}
+                      path={entry.path}
+                      contentType={entry.content_type}
+                      filename={entry.name}
+                      class="w-7 h-7"
+                    />
+                  </span>
                 {/if}
                 <span class="flex-1 truncate text-sm">{entry.name}</span>
                 <span class="text-xs text-surface-500">{formatSize(entry.size)}</span>

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -415,9 +415,9 @@
                     role="checkbox"
                     aria-checked={isChecked}
                     aria-label={isChecked ? `Deselect ${entry.name}` : `Select ${entry.name}`}
-                    class="w-4 h-4 shrink-0 rounded-full transition-colors {isChecked
-                      ? 'bg-primary-500'
-                      : 'border-2 border-surface-400 dark:border-surface-500 hover:border-surface-600 dark:hover:border-surface-300'}"
+                    class="w-4 h-4 shrink-0 rounded-full border-2 transition-colors {isChecked
+                      ? 'bg-primary-500 border-surface-400 dark:border-surface-500'
+                      : 'border-surface-400 dark:border-surface-500 hover:border-surface-600 dark:hover:border-surface-300'}"
                     onclick={(e) => {
                       e.stopPropagation()
                       toggleSelected(entry.path, entry.is_dir)

--- a/ui/src/lib/NextcloudFileBrowser.svelte
+++ b/ui/src/lib/NextcloudFileBrowser.svelte
@@ -404,13 +404,25 @@
                   also fire.
                 -->
                 {#if !pickFolderMode}
-                  <input
-                    type="checkbox"
-                    class="checkbox"
-                    checked={selected.has(entry.path)}
-                    onclick={(e) => e.stopPropagation()}
-                    onchange={() => toggleSelected(entry.path, entry.is_dir)}
-                  />
+                  {@const isChecked = selected.has(entry.path)}
+                  <!-- Compact circular toggle (#160).  No checkmark
+                       glyph — just a filled primary-500 dot when on,
+                       outlined surface-400 ring when off.  Matches
+                       the new icon-sized affordances used elsewhere
+                       in the picker. -->
+                  <button
+                    type="button"
+                    role="checkbox"
+                    aria-checked={isChecked}
+                    aria-label={isChecked ? `Deselect ${entry.name}` : `Select ${entry.name}`}
+                    class="w-4 h-4 shrink-0 rounded-full transition-colors {isChecked
+                      ? 'bg-primary-500'
+                      : 'border-2 border-surface-400 dark:border-surface-500 hover:border-surface-600 dark:hover:border-surface-300'}"
+                    onclick={(e) => {
+                      e.stopPropagation()
+                      toggleSelected(entry.path, entry.is_dir)
+                    }}
+                  ></button>
                 {/if}
                 {#if iconName}
                   <span class="w-9 h-9 flex items-center justify-center shrink-0 text-surface-500">

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -350,8 +350,17 @@
            failed so the user can read the error before
            dismissing.  Successful runs auto-dismiss when the
            picker closes via `onpicked`. -->
-      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1.5">
-        {#each [...downloadStatus] as [path, status] (path)}
+      <!-- Strip ordering (#160): completed rows pile up at the top,
+           the active download sits at the bottom of the visible
+           list, with pending rows below it.  No scrollbar — the
+           strip just grows to fit, so the user always sees every
+           in-flight + completed file without scrubbing. -->
+      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 space-y-1.5">
+        {#each [...downloadStatus].sort((a, b) => {
+          const rank = (k: DownloadStatus['kind']) =>
+            k === 'done' || k === 'failed' ? 0 : k === 'downloading' ? 1 : 2
+          return rank(a[1].kind) - rank(b[1].kind)
+        }) as [path, status] (path)}
           <div class="text-xs">
             <div class="flex items-center gap-2">
               <span class="shrink-0 w-4 h-4 flex items-center justify-center">

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -395,7 +395,7 @@
                  list and spot the one that errored. -->
             <div class="mt-1 ml-6 h-1 rounded-full overflow-hidden bg-surface-200 dark:bg-surface-700 relative">
               {#if status.kind === 'downloading'}
-                <span class="nc-indeterminate absolute inset-y-0 w-1/3 bg-primary-500 rounded-full"></span>
+                <span class="nc-indeterminate absolute inset-y-0 left-0 w-1/3 bg-primary-500 rounded-full"></span>
               {:else if status.kind === 'done'}
                 <span class="absolute inset-0 bg-success-500"></span>
               {:else if status.kind === 'failed'}
@@ -560,11 +560,19 @@
      short fill segment across the track so an active download
      reads as "in flight" even though the IPC has no chunked
      progress events to drive a real percentage. */
+  /* Animate `transform`, not `left`.  The IPC's structured-
+     clone of multi-MB payload bytes blocks the JS main thread
+     for hundreds of ms when each download lands; main-thread
+     animations (left / top / width) freeze for that whole
+     window, which read as "the bar is stuck at 30%".  Transform
+     animations stay on the GPU compositor and keep ticking
+     while the main thread chews the bytes. */
   @keyframes nc-indeterminate {
-    0% { left: -33%; }
-    100% { left: 100%; }
+    0% { transform: translateX(-100%); }
+    100% { transform: translateX(400%); }
   }
   .nc-indeterminate {
     animation: nc-indeterminate 1.2s linear infinite;
+    will-change: transform;
   }
 </style>

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -350,30 +350,49 @@
            failed so the user can read the error before
            dismissing.  Successful runs auto-dismiss when the
            picker closes via `onpicked`. -->
-      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1">
+      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1.5">
         {#each [...downloadStatus] as [path, status] (path)}
-          <div class="flex items-center gap-2 text-xs">
-            <span class="shrink-0 w-4 h-4 flex items-center justify-center">
-              {#if status.kind === 'pending'}
-                <span class="w-2 h-2 rounded-full bg-surface-400"></span>
-              {:else if status.kind === 'downloading'}
-                <span class="text-primary-500"><Icon name="loading" size={14} /></span>
+          <div class="text-xs">
+            <div class="flex items-center gap-2">
+              <span class="shrink-0 w-4 h-4 flex items-center justify-center">
+                {#if status.kind === 'pending'}
+                  <span class="w-2 h-2 rounded-full bg-surface-400"></span>
+                {:else if status.kind === 'downloading'}
+                  <span class="text-primary-500"><Icon name="loading" size={14} /></span>
+                {:else if status.kind === 'done'}
+                  <span class="text-success-500"><Icon name="success" size={14} /></span>
+                {:else}
+                  <span class="text-error-500"><Icon name="error" size={14} /></span>
+                {/if}
+              </span>
+              <span class="flex-1 truncate text-surface-700 dark:text-surface-300">{basename(path)}</span>
+              {#if status.kind === 'failed'}
+                <span class="shrink-0 text-error-500 truncate max-w-[180px]" title={status.message}>{status.message}</span>
               {:else if status.kind === 'done'}
-                <span class="text-success-500"><Icon name="success" size={14} /></span>
+                <span class="shrink-0 text-success-500">Done</span>
+              {:else if status.kind === 'downloading'}
+                <span class="shrink-0 text-primary-500">Downloading…</span>
               {:else}
-                <span class="text-error-500"><Icon name="error" size={14} /></span>
+                <span class="shrink-0 text-surface-500">Queued</span>
               {/if}
-            </span>
-            <span class="flex-1 truncate text-surface-700 dark:text-surface-300">{basename(path)}</span>
-            {#if status.kind === 'failed'}
-              <span class="shrink-0 text-error-500 truncate max-w-[180px]" title={status.message}>{status.message}</span>
-            {:else if status.kind === 'done'}
-              <span class="shrink-0 text-success-500">Done</span>
-            {:else if status.kind === 'downloading'}
-              <span class="shrink-0 text-primary-500">Downloading…</span>
-            {:else}
-              <span class="shrink-0 text-surface-500">Queued</span>
-            {/if}
+            </div>
+            <!-- Per-file progress bar (#160).  IPC `download_nextcloud_file`
+                 returns the entire payload at once with no chunked progress
+                 events, so the bar is indeterminate — animated head sliding
+                 left → right communicates "this row is actively working"
+                 without claiming a percentage we can't measure.  Pending
+                 rows show a quiet grey track; done / failed rows fill the
+                 track in their semantic colour so the user can scan a long
+                 list and spot the one that errored. -->
+            <div class="mt-1 ml-6 h-1 rounded-full overflow-hidden bg-surface-200 dark:bg-surface-700 relative">
+              {#if status.kind === 'downloading'}
+                <span class="nc-indeterminate absolute inset-y-0 w-1/3 bg-primary-500 rounded-full"></span>
+              {:else if status.kind === 'done'}
+                <span class="absolute inset-0 bg-success-500"></span>
+              {:else if status.kind === 'failed'}
+                <span class="absolute inset-0 bg-error-500"></span>
+              {/if}
+            </div>
           </div>
         {/each}
       </div>
@@ -526,3 +545,17 @@
     </div>
   </div>
 {/if}
+
+<style>
+  /* Indeterminate per-file progress head (#160).  Slides a
+     short fill segment across the track so an active download
+     reads as "in flight" even though the IPC has no chunked
+     progress events to drive a real percentage. */
+  @keyframes nc-indeterminate {
+    0% { left: -33%; }
+    100% { left: 100%; }
+  }
+  .nc-indeterminate {
+    animation: nc-indeterminate 1.2s linear infinite;
+  }
+</style>

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -98,6 +98,23 @@
   let downloading = $state(false)
   let sharing = $state(false)
 
+  /** Per-file download status surfaced as a progress strip while
+   *  `attachSelected` runs (#160).  Keys are the full NC paths
+   *  the user ticked.  `pending` rows show a queued chip,
+   *  `downloading` an active spinner, `done` a green check, and
+   *  `failed` a red mark with the underlying error string. */
+  type DownloadStatus =
+    | { kind: 'pending' }
+    | { kind: 'downloading' }
+    | { kind: 'done' }
+    | { kind: 'failed'; message: string }
+  let downloadStatus = $state<Map<string, DownloadStatus>>(new Map())
+  function setStatus(path: string, status: DownloadStatus) {
+    const next = new Map(downloadStatus)
+    next.set(path, status)
+    downloadStatus = next
+  }
+
   // Password-protect-the-share modal. `null` = the prompt isn't open;
   // `paths` is the snapshot of selection at the moment the user
   // clicked "Share as link" so toggling the file tree behind the
@@ -186,27 +203,41 @@
     if (filePaths.length === 0) return
     downloading = true
     error = ''
+    // Seed every selected path as pending so the user sees the
+    // full list of files the picker is about to fetch.  Each row
+    // flips to `downloading` immediately before its IPC fires
+    // and to `done` / `failed` when the response lands (#160).
+    const seeded = new Map<string, DownloadStatus>()
+    for (const p of filePaths) seeded.set(p, { kind: 'pending' })
+    downloadStatus = seeded
     try {
       // Run all downloads in parallel — Tauri bridges each invoke to
       // its own async task so this genuinely parallelises.
       const results = await Promise.all(
         filePaths.map(async (p) => {
-          const bytes = await invoke<number[]>('download_nextcloud_file', {
-            ncId: accountId,
-            path: p,
-          })
-          // Content-type from the current folder's entries when
-          // available; fall back to a neutral default for files
-          // selected in other folders (the SMTP build path
-          // re-derives from filename when this is unset).
-          const ct =
-            entries.find((e) => e.path === p)?.content_type ??
-            'application/octet-stream'
-          return {
-            filename: basename(p),
-            content_type: ct,
-            data: bytes,
-          } satisfies Attachment
+          setStatus(p, { kind: 'downloading' })
+          try {
+            const bytes = await invoke<number[]>('download_nextcloud_file', {
+              ncId: accountId,
+              path: p,
+            })
+            // Content-type from the current folder's entries when
+            // available; fall back to a neutral default for files
+            // selected in other folders (the SMTP build path
+            // re-derives from filename when this is unset).
+            const ct =
+              entries.find((e) => e.path === p)?.content_type ??
+              'application/octet-stream'
+            setStatus(p, { kind: 'done' })
+            return {
+              filename: basename(p),
+              content_type: ct,
+              data: bytes,
+            } satisfies Attachment
+          } catch (e) {
+            setStatus(p, { kind: 'failed', message: formatError(e) || 'Failed' })
+            throw e
+          }
         }),
       )
       onpicked(results)
@@ -311,6 +342,41 @@
       <p class="px-5 py-2 text-sm text-red-500 border-t border-surface-200 dark:border-surface-700">
         {error}
       </p>
+    {/if}
+
+    {#if downloadStatus.size > 0 && (downloading || [...downloadStatus.values()].some((s) => s.kind === 'failed'))}
+      <!-- Per-file download status strip (#160).  Rendered while
+           the picker is fetching, and stays visible if any file
+           failed so the user can read the error before
+           dismissing.  Successful runs auto-dismiss when the
+           picker closes via `onpicked`. -->
+      <div class="px-5 py-2 border-t border-surface-200 dark:border-surface-700 max-h-40 overflow-y-auto space-y-1">
+        {#each [...downloadStatus] as [path, status] (path)}
+          <div class="flex items-center gap-2 text-xs">
+            <span class="shrink-0 w-4 h-4 flex items-center justify-center">
+              {#if status.kind === 'pending'}
+                <span class="w-2 h-2 rounded-full bg-surface-400"></span>
+              {:else if status.kind === 'downloading'}
+                <span class="text-primary-500"><Icon name="loading" size={14} /></span>
+              {:else if status.kind === 'done'}
+                <span class="text-success-500"><Icon name="success" size={14} /></span>
+              {:else}
+                <span class="text-error-500"><Icon name="error" size={14} /></span>
+              {/if}
+            </span>
+            <span class="flex-1 truncate text-surface-700 dark:text-surface-300">{basename(path)}</span>
+            {#if status.kind === 'failed'}
+              <span class="shrink-0 text-error-500 truncate max-w-[180px]" title={status.message}>{status.message}</span>
+            {:else if status.kind === 'done'}
+              <span class="shrink-0 text-success-500">Done</span>
+            {:else if status.kind === 'downloading'}
+              <span class="shrink-0 text-primary-500">Downloading…</span>
+            {:else}
+              <span class="shrink-0 text-surface-500">Queued</span>
+            {/if}
+          </div>
+        {/each}
+      </div>
     {/if}
 
     <footer class="px-5 py-3 border-t border-surface-200 dark:border-surface-700 flex items-center gap-2">


### PR DESCRIPTION
Closes #160.

## Selection toggle: circular, no checkmark
Replaces the native `<input type="checkbox" class="checkbox">` in `NextcloudFileBrowser` with a 16 px circular `<button role="checkbox">` — primary-500 fill when on, `border-2 border-surface-400` ring when off, no checkmark glyph. The same affordance shows in both surfaces that mount the browser (FilesView and the Compose attach picker). `stopPropagation` preserves the existing row-click-vs-toggle split.

## Per-file download status
Both attachment-build flows (`NextcloudFilePicker.attachSelected` + `FilesView.sendAsAttachment`) now expose a per-path `DownloadStatus` map cycling `pending → downloading → done | failed`. A status strip renders above the action footer while the run is in flight (and stays visible if any file failed so the user can read the per-file error before dismissing); successful runs auto-dismiss when the picker closes through `onpicked` / `oncompose`.

Each row shows:
- A 16 px status indicator: dot (pending), `loading` icon (in flight), `success` icon (done), `error` icon (failed).
- The basename (truncated when long).
- A short status label: `Queued` / `Downloading…` / `Done`, or the underlying error string for `failed` rows.

The existing global `downloading` / `attaching` flags stay on the action buttons so they remain disabled until the run finishes.

## Test plan
- [x] Tick a couple of files and folders in the picker → circular toggles fill primary-500 with no checkmark; row click navigates into folders unaffected.
- [x] Click Attach with 5+ files selected from multiple folders → status strip lists every file; rows flip from "Queued" → "Downloading…" → "Done" as their IPC resolves; picker closes when the last one lands.
- [x] Pull the network mid-download → failed rows turn red with the error message; strip stays visible after `attaching` flips back to false.
- [x] FilesView "New mail with attachment" runs the same flow with the same UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)