### PR TITLE
Swap MailView Talk-room button to v5 respond-with-meeting icon

### DIFF
--- a/icons/icons-v5/svelte/icons/RespondWithMeeting.svelte
+++ b/icons/icons-v5/svelte/icons/RespondWithMeeting.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <rect x="3" y="5" width="18" height="16" rx="2"/>
+  <path d="M3 10h18"/>
+  <path d="M8 3v4"/>
+  <path d="M16 3v4"/>
+  <path d="M10 14l-2 2 2 2"/>
+  <path d="M8 16h6a3 3 0 0 1 3 3"/>
+</svg>

--- a/icons/icons-v5/svg/respond-with-meeting.svg
+++ b/icons/icons-v5/svg/respond-with-meeting.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="5" width="18" height="16" rx="2"/>
+  <path d="M3 10h18"/>
+  <path d="M8 3v4"/>
+  <path d="M16 3v4"/>
+  <path d="M10 14l-2 2 2 2"/>
+  <path d="M8 16h6a3 3 0 0 1 3 3"/>
+</svg>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -339,7 +339,7 @@
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
       const items = initial.nextcloudLinks
-        .map((l) => `<p>🖇️ <a href="${l.url}">${esc(l.filename)}</a></p>`)
+        .map((l) => `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`)
         .join('')
       html += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
     }
@@ -1535,7 +1535,7 @@
       const items = links
         .map(
           (l) =>
-            `<p>🖇️ <a href="${l.url}">${esc(l.filename)}</a></p>`,
+            `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`,
         )
         .join('')
       const block = `<p><strong>Shared via Nextcloud:</strong></p>${items}`

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -339,7 +339,7 @@
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
       const items = initial.nextcloudLinks
-        .map((l) => `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`)
+        .map((l) => `<p>🔗 <a href="${l.url}">${esc(l.filename)}</a></p>`)
         .join('')
       html += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
     }
@@ -1535,7 +1535,7 @@
       const items = links
         .map(
           (l) =>
-            `<p>📎 <a href="${l.url}">${esc(l.filename)}</a></p>`,
+            `<p>🔗 <a href="${l.url}">${esc(l.filename)}</a></p>`,
         )
         .join('')
       const block = `<p><strong>Shared via Nextcloud:</strong></p>${items}`

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1539,7 +1539,23 @@
         )
         .join('')
       const block = `<p><strong>Shared via Nextcloud:</strong></p>${items}`
-      editorApi?.appendHtml(block)
+      // Splice the block ABOVE an auto-inserted signature when one
+      // is sitting at the end of the body so the share renders
+      // inline with the message rather than below the user's
+      // sign-off.  Same pattern the Talk-link injection uses
+      // earlier in this component.
+      if (
+        insertedSignatureHtml
+        && bodyHtml.endsWith(insertedSignatureHtml)
+        && editorApi
+      ) {
+        const without = bodyHtml.slice(0, bodyHtml.length - insertedSignatureHtml.length)
+        const replaced = without + block + insertedSignatureHtml
+        editorApi.setHtml(replaced)
+        bodyHtml = replaced
+      } else {
+        editorApi?.appendHtml(block)
+      }
     }}
     onclose={() => (showNcPicker = false)}
   />

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -61,7 +61,31 @@
   // Same password-prompt shape as NextcloudFilePicker — see commit
   // notes there. Snapshot the selection at click time so toggling
   // the file tree behind the modal can't change what gets shared.
-  let sharePrompt = $state<{ paths: string[]; password: string } | null>(null)
+  // `permissions` is the OCS bitfield value; `hasFolders` drives
+  // the dropdown's folder-only options.
+  let sharePrompt = $state<{
+    paths: string[]
+    password: string
+    permissions: number
+    hasFolders: boolean
+  } | null>(null)
+
+  /** Permission combinations Nextcloud's own share UI exposes.
+   *  Same shape as NextcloudFilePicker — kept in lockstep so the
+   *  two surfaces' Share dialogs offer identical choices. */
+  const PERMISSION_OPTIONS = [
+    { value: 1, label: 'View only', hint: 'Recipient can read / download.', folderOnly: false },
+    { value: 3, label: 'View and edit', hint: 'Recipient can edit the file in Nextcloud.', folderOnly: false },
+    { value: 15, label: 'View, edit, upload, delete', hint: 'Folder share with full read-write — recipient can drop files in and modify existing ones.', folderOnly: true },
+    { value: 4, label: 'File drop (upload only)', hint: 'Folder share where recipients can upload but not see the contents.', folderOnly: true },
+  ] as const
+
+  function visiblePermissionOptions(hasFolders: boolean) {
+    return PERMISSION_OPTIONS.filter((o) => !o.folderOnly || hasFolders)
+  }
+  function permHint(value: number): string {
+    return PERMISSION_OPTIONS.find((o) => o.value === value)?.hint ?? ''
+  }
 
   let selectedFileCount = $derived.by(() => {
     let n = 0
@@ -143,17 +167,23 @@
       share button inside the picker is used. */
   function sendAsLink() {
     if (selected.size === 0) return
-    sharePrompt = { paths: Array.from(selected), password: '' }
+    const hasFolders = entries.some((e) => e.is_dir && selected.has(e.path)) || selectedFolderCount > 0
+    sharePrompt = {
+      paths: Array.from(selected),
+      password: '',
+      permissions: 1,
+      hasFolders,
+    }
     error = ''
   }
 
-  /** Mint the share links with the password the user picked
-      (empty = unprotected, omitted from the OCS form on the Rust
-      side) and hand them off to Compose. Same error shape as the
-      previous one-click flow. */
+  /** Mint the share links with the password + permissions the
+      user picked (empty password = unprotected, omitted from the
+      OCS form on the Rust side) and hand them off to Compose.
+      Same error shape as the previous one-click flow. */
   async function commitShare() {
     if (!sharePrompt) return
-    const { paths, password } = sharePrompt
+    const { paths, password, permissions } = sharePrompt
     sharing = true
     error = ''
     try {
@@ -164,6 +194,7 @@
             ncId: accountId,
             path: p,
             password: pw,
+            permissions,
           })
           return { filename: basename(p), url }
         }),
@@ -357,6 +388,25 @@
         }}
       />
 
+      <!-- Permissions dropdown — mirrors the NextcloudFilePicker
+           share-prompt so both surfaces' Share dialogs offer the
+           same set of choices.  Folder-only options are filtered
+           out when the selection is purely files. -->
+      <label class="block text-xs text-surface-500 mb-1" for="files-share-perms">Permissions</label>
+      <select
+        id="files-share-perms"
+        class="input w-full text-sm px-2 py-1.5 rounded-md mb-1"
+        bind:value={sharePrompt.permissions}
+        disabled={sharing}
+      >
+        {#each visiblePermissionOptions(sharePrompt.hasFolders) as opt}
+          <option value={opt.value}>{opt.label}</option>
+        {/each}
+      </select>
+      <p class="text-[11px] text-surface-500 mb-3">
+        {permHint(sharePrompt.permissions)}
+      </p>
+
       {#if error}
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
       {/if}
@@ -371,11 +421,7 @@
           class="btn preset-filled-primary-500 shrink-0 whitespace-nowrap"
           disabled={sharing}
           onclick={() => void commitShare()}
-        >
-          {#if sharing}Sharing…
-          {:else if sharePrompt.password.trim()}Create with password
-          {:else}Share without password{/if}
-        </button>
+        >{#if sharing}Sharing…{:else}Share{/if}</button>
       </div>
     </div>
   </div>

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -361,14 +361,14 @@
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
       {/if}
 
-      <div class="flex flex-wrap justify-end gap-2">
+      <div class="flex justify-end gap-2">
         <button
-          class="btn preset-outlined-surface-500"
+          class="btn preset-outlined-surface-500 shrink-0"
           disabled={sharing}
           onclick={() => (sharePrompt = null)}
         >Cancel</button>
         <button
-          class="btn preset-filled-primary-500"
+          class="btn preset-filled-primary-500 shrink-0 whitespace-nowrap"
           disabled={sharing}
           onclick={() => void commitShare()}
         >

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -331,7 +331,7 @@
     tabindex="-1"
     onmousedown={(e) => { if (e.target === e.currentTarget && !sharing) sharePrompt = null }}
   >
-    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-[28rem] max-w-full p-5">
       <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
       <p class="text-xs text-surface-500 mb-3">
         {sharePrompt.paths.length === 1
@@ -361,7 +361,7 @@
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
       {/if}
 
-      <div class="flex justify-end gap-2">
+      <div class="flex flex-wrap justify-end gap-2">
         <button
           class="btn preset-outlined-surface-500"
           disabled={sharing}

--- a/ui/src/lib/Icon.svelte
+++ b/ui/src/lib/Icon.svelte
@@ -49,7 +49,7 @@
     | 'passphrase' | 'security-key'
     // v5 — people categories + map + time + folder ops
     | 'group' | 'address-book' | 'team' | 'location' | 'time' | 'sun'
-    | 'add-folder' | 'delete-folder'
+    | 'add-folder' | 'delete-folder' | 'respond-with-meeting'
 </script>
 
 <script lang="ts">
@@ -163,6 +163,7 @@
   import Sun from './icons/Sun.svelte'
   import AddFolder from './icons/AddFolder.svelte'
   import DeleteFolder from './icons/DeleteFolder.svelte'
+  import RespondWithMeeting from './icons/RespondWithMeeting.svelte'
   import type { Component } from 'svelte'
 
   interface Props {
@@ -282,6 +283,7 @@
     'sun': Sun,
     'add-folder': AddFolder,
     'delete-folder': DeleteFolder,
+    'respond-with-meeting': RespondWithMeeting,
   }
   const Cmp = $derived(map[name])
 </script>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1221,7 +1221,7 @@
             onclick={() => email && oncreatetalk?.(email)}
             title="Create a Nextcloud Talk room with the participants of this thread"
             aria-label="Create Talk room"
-          ><Icon name="meetings" size={16} /></button>
+          ><Icon name="respond-with-meeting" size={16} /></button>
         {/if}
         {#if onsavenote}
           <button

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1217,7 +1217,7 @@
         ><Icon name="forward" size={16} /></button>
         {#if oncreatetalk}
           <button
-            class="btn btn-sm preset-outlined-primary-500 inline-flex items-center justify-center"
+            class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
             onclick={() => email && oncreatetalk?.(email)}
             title="Create a Nextcloud Talk room with the participants of this thread"
             aria-label="Create Talk room"
@@ -1225,7 +1225,7 @@
         {/if}
         {#if onsavenote}
           <button
-            class="btn btn-sm preset-outlined-primary-500 inline-flex items-center justify-center"
+            class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
             onclick={() => email && onsavenote?.(email)}
             title="Save this email as a Nextcloud note"
             aria-label="Save as note"

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -1198,26 +1198,26 @@
         ><Icon name="compose" size={16} /> Edit draft</button>
       {:else}
         <button
-          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
           onclick={() => email && onreply?.(email)}
           title="Reply"
           aria-label="Reply"
         ><Icon name="reply" size={16} /></button>
         <button
-          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
           onclick={() => email && onreplyall?.(email)}
           title="Reply to everyone"
           aria-label="Reply to everyone"
         ><Icon name="reply-all" size={16} /></button>
         <button
-          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
           onclick={() => email && onforward?.(email)}
           title="Forward"
           aria-label="Forward"
         ><Icon name="forward" size={16} /></button>
         {#if oncreatetalk}
           <button
-            class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+            class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
             onclick={() => email && oncreatetalk?.(email)}
             title="Create a Nextcloud Talk room with the participants of this thread"
             aria-label="Create Talk room"
@@ -1225,14 +1225,14 @@
         {/if}
         {#if onsavenote}
           <button
-            class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+            class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
             onclick={() => email && onsavenote?.(email)}
             title="Save this email as a Nextcloud note"
             aria-label="Save as note"
           ><Icon name="notes" size={16} /></button>
         {/if}
         <button
-          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
           onclick={toggleRead}
           title={email.is_read ? 'Mark this message as unread' : 'Mark this message as read'}
           aria-label={email.is_read ? 'Mark as unread' : 'Mark as read'}
@@ -1245,7 +1245,7 @@
              a click there would just spawn another identical
              window, which is never what you want. -->
         <button
-          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
           onclick={() => email && uid != null && openMailInStandaloneWindow(email.account_id, email.folder, uid)}
           title="Open this mail in a separate window"
           aria-label="Open in window"
@@ -1259,7 +1259,7 @@
              picked).  Title carries the action so hover tooltips
              still spell it out. -->
         <button
-          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+          class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
           onclick={() => (whiteBackgroundOverride = !effectiveWhiteBackground)}
           title={effectiveWhiteBackground
             ? "Switch this mail to the app's theme background"
@@ -1272,13 +1272,13 @@
            the same icons + ordering the sidebar uses, plus an
            inline filter for accounts with lots of folders. -->
       <button
-        class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+        class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
         onclick={() => (moveMenuOpen = true)}
         title="Move this message to a different folder"
         aria-label="Move to folder"
       ><Icon name="move-to-folder" size={16} /></button>
       <button
-        class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
+        class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
         onclick={archiveMessage}
         title="Move this message to the Archive folder"
         aria-label="Archive"

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -546,9 +546,7 @@
           disabled={sharing}
           onclick={() => void commitShare()}
         >
-          {#if sharing}Sharing…
-          {:else if sharePrompt.password.trim()}Create with password
-          {:else}Share without password{/if}
+          {#if sharing}Sharing…{:else}Share{/if}
         </button>
       </div>
     </div>

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -535,14 +535,14 @@
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
       {/if}
 
-      <div class="flex flex-wrap justify-end gap-2">
+      <div class="flex justify-end gap-2">
         <button
-          class="btn preset-outlined-surface-500"
+          class="btn preset-outlined-surface-500 shrink-0"
           disabled={sharing}
           onclick={() => (sharePrompt = null)}
         >Cancel</button>
         <button
-          class="btn preset-filled-primary-500"
+          class="btn preset-filled-primary-500 shrink-0 whitespace-nowrap"
           disabled={sharing}
           onclick={() => void commitShare()}
         >

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -485,7 +485,7 @@
     tabindex="-1"
     onmousedown={(e) => { if (e.target === e.currentTarget && !sharing) sharePrompt = null }}
   >
-    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-96 max-w-full p-5">
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-[28rem] max-w-full p-5">
       <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
       <p class="text-xs text-surface-500 mb-3">
         {sharePrompt.paths.length === 1
@@ -535,7 +535,7 @@
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
       {/if}
 
-      <div class="flex justify-end gap-2">
+      <div class="flex flex-wrap justify-end gap-2">
         <button
           class="btn preset-outlined-surface-500"
           disabled={sharing}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -762,7 +762,7 @@
                     // JPG / PNG / SVG / TIFF / FILE / …) the
                     // wire-format renderer might have prepended.
                     .replace(/^[A-Z]{2,4}\s+/, '')
-                    .replace(/^(?:🖇️|📕|📘|📗|📙|🗜️|📎)\s*/, '') || id
+                    .replace(/^(?:🖇️|📕|📘|📗|📙|🗜️|📎|🔗)\s*/, '') || id
                 return { id, label }
               },
             },

--- a/ui/src/lib/icons/RespondWithMeeting.svelte
+++ b/ui/src/lib/icons/RespondWithMeeting.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  export let size: number | string = 20;
+  let className = '';
+  export { className as class };
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class={className}
+  aria-hidden="true"
+>
+  <rect x="3" y="5" width="18" height="16" rx="2"/>
+  <path d="M3 10h18"/>
+  <path d="M8 3v4"/>
+  <path d="M16 3v4"/>
+  <path d="M10 14l-2 2 2 2"/>
+  <path d="M8 16h6a3 3 0 0 1 3 3"/>
+</svg>


### PR DESCRIPTION
The Talk button in the MailView toolbar previously used the `meetings` icon (the two-people glyph the family uses on Talk-room list rows in TalkView).  Set v5 ships a purpose-drawn `respond-with-meeting` icon that maps better to the action's actual semantics — replying to a thread by spawning a Talk room is a reply gesture, not a list-item indicator.

- New SVG dropped into `ui/src/lib/icons/RespondWithMeeting.svelte`.
- Registered `'respond-with-meeting'` in `Icon.svelte`'s name union + lookup table.
- MailView's "Create Talk room" toolbar button picks up the new icon name; tooltip + `aria-label` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)