### PR TITLE
Respond with meeting: open full EventEditor with Talk link prefilled

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1043,15 +1043,15 @@
   /** Round a Date up to the next half-hour boundary.  Mirrors what
       a user would type when scheduling a fresh meeting "now-ish":
       11:07 → 11:30, 11:30 → 12:00. */
-  /** Prefix the email subject with "RE: " to mark the event as a
+  /** Prefix the email subject with "Re: " to mark the event as a
       response to the thread.  Skips the prefix when the subject
-      already starts with RE:/AW:/SV: (case-insensitive) so we don't
-      stack "RE: RE: RE:" on a long reply chain. */
+      already starts with Re:/Aw:/Sv: (case-insensitive) so we don't
+      stack "Re: Re: Re:" on a long reply chain. */
   function meetingSubject(subject: string): string {
     const s = subject.trim()
-    if (!s) return 'RE: Meeting'
+    if (!s) return 'Re: Meeting'
     if (/^(re|aw|sv)\s*:/i.test(s)) return s
-    return `RE: ${s}`
+    return `Re: ${s}`
   }
 
   function nextHalfHour(d: Date): Date {

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1043,6 +1043,17 @@
   /** Round a Date up to the next half-hour boundary.  Mirrors what
       a user would type when scheduling a fresh meeting "now-ish":
       11:07 → 11:30, 11:30 → 12:00. */
+  /** Prefix the email subject with "RE: " to mark the event as a
+      response to the thread.  Skips the prefix when the subject
+      already starts with RE:/AW:/SV: (case-insensitive) so we don't
+      stack "RE: RE: RE:" on a long reply chain. */
+  function meetingSubject(subject: string): string {
+    const s = subject.trim()
+    if (!s) return 'RE: Meeting'
+    if (/^(re|aw|sv)\s*:/i.test(s)) return s
+    return `RE: ${s}`
+  }
+
   function nextHalfHour(d: Date): Date {
     const out = new Date(d)
     out.setSeconds(0, 0)
@@ -1120,7 +1131,7 @@
         calendarId: initialCalendarId,
         start,
         end,
-        summary: mail.subject || 'Meeting',
+        summary: meetingSubject(mail.subject),
         requiredAttendees: required,
         optionalAttendees: optional,
         createTalkRoom: true,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -34,7 +34,7 @@
   import FilesView from './lib/FilesView.svelte'
   import TalkView from './lib/TalkView.svelte'
   import NotesView from './lib/NotesView.svelte'
-  import CreateTalkRoomModal, { type TalkRoom } from './lib/CreateTalkRoomModal.svelte'
+  import EventEditor, { type SavedEvent } from './lib/EventEditor.svelte'
   import SearchBar, {
     type SearchScope,
     type SearchFilters,
@@ -1003,20 +1003,33 @@
     })
   }
 
-  // ── "Create Talk room from this thread" flow ────────────────
-  // Triggered from MailView's 💬 Talk button. Opens a modal seeded
-  // with the email's subject and the thread's participants; on
-  // create, chains into Compose with the room link in the body and
-  // the same recipients in the To field, satisfying issue #13's
-  // "create a Talk room from an email thread" task in one user
-  // gesture.
-  let talkRoomDraft = $state<{
-    ncId: string
-    initialName: string
-    initialParticipants: string[]
-    /** Pre-fills Compose's `To` after the room is created — kept on
-        the draft so we don't have to re-derive it from the email. */
-    composeTo: string
+  // ── "Respond with meeting" flow ────────────────────────────
+  // Triggered from MailView's meeting button. Opens the full
+  // EventEditor pre-filled with the email subject as the title, the
+  // thread's From/To as required attendees, Cc as optional, and
+  // (via `createTalkRoom: true`) auto-creates a Nextcloud Talk room
+  // whose join URL lands in the event's location.  One gesture
+  // turns an email into a calendar invite plus a meeting link.
+  interface CalendarSummary {
+    id: string
+    nextcloud_account_id: string
+    display_name: string
+    color: string | null
+    last_synced_at: string | null
+    hidden?: boolean
+    muted?: boolean
+  }
+  let meetingDraft = $state<{
+    calendars: CalendarSummary[]
+    draft: {
+      calendarId: string
+      start: Date
+      end: Date
+      summary: string
+      requiredAttendees: string[]
+      optionalAttendees: string[]
+      createTalkRoom: boolean
+    }
   } | null>(null)
 
   /** Strip an `"Name" <addr>` wrapper down to the bare email. */
@@ -1027,9 +1040,18 @@
     return m ? m[1].trim() : t
   }
 
-  async function onCreateTalkFromMail(mail: OpenMail) {
-    // For the MVP we use the first connected Nextcloud account. A
-    // multi-account picker can land later — most users have one NC.
+  /** Round a Date up to the next half-hour boundary.  Mirrors what
+      a user would type when scheduling a fresh meeting "now-ish":
+      11:07 → 11:30, 11:30 → 12:00. */
+  function nextHalfHour(d: Date): Date {
+    const out = new Date(d)
+    out.setSeconds(0, 0)
+    const m = out.getMinutes()
+    out.setMinutes(m < 30 ? 30 : 60)
+    return out
+  }
+
+  async function onRespondWithMeeting(mail: OpenMail) {
     let ncId = ''
     try {
       const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
@@ -1043,47 +1065,74 @@
       return
     }
 
-    // Build the participant set: From + To + Cc, deduped, minus the
-    // current user (who's already in the room as the creator).
+    let calendars: CalendarSummary[] = []
+    try {
+      calendars = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
+    } catch (e) {
+      alert(`Failed to load calendars: ${e}`)
+      return
+    }
+    const visible = calendars.filter((c) => !c.hidden)
+    if (visible.length === 0) {
+      alert('No writable calendars found on your Nextcloud account.')
+      return
+    }
+    let initialCalendarId = visible[0].id
+    try {
+      const s = await invoke<{ default_calendar_id: string | null }>('get_app_settings')
+      if (s.default_calendar_id && visible.some((c) => c.id === s.default_calendar_id)) {
+        initialCalendarId = s.default_calendar_id!
+      }
+    } catch {}
+
+    // Split the thread's participants — From + To go required,
+    // Cc goes optional.  Skip the active account (the user is the
+    // organizer; the editor adds them as CHAIR).  De-dupe across
+    // buckets so an address that appears in both To and Cc only
+    // shows up once in the higher-priority bucket.
+    const self = activeAccountEmail.toLowerCase()
     const seen = new Set<string>()
-    const participants: string[] = []
-    for (const piece of [mail.from, ...mail.to, ...mail.cc]) {
+    const required: string[] = []
+    for (const piece of [mail.from, ...mail.to]) {
       const addr = bareEmail(piece)
       if (!addr) continue
       const key = addr.toLowerCase()
-      if (key === activeAccountEmail.toLowerCase()) continue
-      if (seen.has(key)) continue
+      if (key === self || seen.has(key)) continue
       seen.add(key)
-      participants.push(addr)
+      required.push(piece)
+    }
+    const optional: string[] = []
+    for (const piece of mail.cc) {
+      const addr = bareEmail(piece)
+      if (!addr) continue
+      const key = addr.toLowerCase()
+      if (key === self || seen.has(key)) continue
+      seen.add(key)
+      optional.push(piece)
     }
 
-    // The Compose `To` field happily accepts the original
-    // `"Name" <addr>` strings, so display names round-trip into the
-    // sent invite without us having to re-format.
-    const composeTo = [mail.from, ...mail.to, ...mail.cc]
-      .filter((a) => {
-        const e = bareEmail(a)
-        return e && e.toLowerCase() !== activeAccountEmail.toLowerCase()
-      })
-      .join(', ')
+    const start = nextHalfHour(new Date())
+    const end = new Date(start.getTime() + 30 * 60 * 1000)
 
-    talkRoomDraft = {
-      ncId,
-      initialName: mail.subject || 'Talk',
-      initialParticipants: participants,
-      composeTo,
+    meetingDraft = {
+      calendars: visible,
+      draft: {
+        calendarId: initialCalendarId,
+        start,
+        end,
+        summary: mail.subject || 'Meeting',
+        requiredAttendees: required,
+        optionalAttendees: optional,
+        createTalkRoom: true,
+      },
     }
   }
 
-  function onTalkRoomCreatedFromMail(room: TalkRoom) {
-    const draft = talkRoomDraft
-    talkRoomDraft = null
-    if (!draft) return
-    openCompose({
-      to: draft.composeTo,
-      subject: `Join Talk: ${room.display_name}`,
-      talkLink: { name: room.display_name, url: room.web_url },
-    })
+  function onMeetingEditorClose() {
+    meetingDraft = null
+  }
+  function onMeetingEditorSaved(_saved?: SavedEvent) {
+    meetingDraft = null
   }
 
   /** "Save as note" handler — issue #67's email→note bridge. Builds
@@ -1295,7 +1344,7 @@
         onreply={onReply}
         onreplyall={onReplyAll}
         onforward={onForward}
-        oncreatetalk={onCreateTalkFromMail}
+        onrespondwithmeeting={onRespondWithMeeting}
         onsavenote={onSaveMailAsNote}
         isDraftsFolder={isDraftsFolder}
         isSentFolder={isSentFolder}
@@ -1322,16 +1371,17 @@
   </div>
 {/if}
 
-<!-- Talk-room creation modal — mounted at the app level so it can
-     overlay any view. Driven entirely by `talkRoomDraft`: setting it
-     opens the modal pre-filled, clearing it (or `oncreated`)
-     dismisses. -->
-{#if talkRoomDraft}
-  <CreateTalkRoomModal
-    ncId={talkRoomDraft.ncId}
-    initialName={talkRoomDraft.initialName}
-    initialParticipants={talkRoomDraft.initialParticipants}
-    onclose={() => (talkRoomDraft = null)}
-    oncreated={onTalkRoomCreatedFromMail}
+<!-- "Respond with meeting" event editor — mounted at the app level
+     so it can overlay any view. Driven entirely by `meetingDraft`:
+     setting it opens the editor pre-filled (subject as title,
+     From/To as required attendees, Cc as optional, auto-created
+     Talk room), clearing it dismisses. -->
+{#if meetingDraft}
+  <EventEditor
+    mode="create"
+    calendars={meetingDraft.calendars}
+    draft={meetingDraft.draft}
+    onclose={onMeetingEditorClose}
+    onsaved={onMeetingEditorSaved}
   />
 {/if}

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -119,8 +119,21 @@
       location?: string
       url?: string
       /** Each entry is a bare address or `"Name" <addr>` — same
-          shape `parseAddress` accepts everywhere else. */
+          shape `parseAddress` accepts everywhere else.  All seeded
+          here land as REQ-PARTICIPANT.  Use the per-role fields
+          below when the caller wants a more nuanced split (e.g.
+          MailView's "Respond with meeting" puts From / To in
+          `requiredAttendees` and Cc in `optionalAttendees`). */
       attendees?: string[]
+      requiredAttendees?: string[]
+      optionalAttendees?: string[]
+      chairAttendees?: string[]
+      /** When true, the editor auto-creates a Talk room as soon as it
+          mounts — same effect as clicking "Add Talk link", but the
+          user doesn't have to.  Used by MailView's "Respond with
+          meeting" so the meeting starts life with a join URL already
+          attached. */
+      createTalkRoom?: boolean
     } | null
     /** edit-mode subject: the existing event being edited. */
     event?: CalendarEvent | null
@@ -205,6 +218,17 @@
         }
       })
       .catch(() => {})
+      .finally(() => {
+        // Auto-mint a Talk room once the calendar selection has
+        // settled — used by "Respond with meeting" so the event
+        // mounts with a join URL pre-attached.  Mirrors the manual
+        // "Add Talk link" button so all the save-time wiring
+        // (participant invites, public/private downgrade) reuses
+        // the same path.
+        if (draft?.createTalkRoom && !pendingTalkRoom && !creatingTalkRoom) {
+          void addTalkLink()
+        }
+      })
   })
 
   // svelte-ignore state_referenced_locally
@@ -244,18 +268,31 @@
     if (r === 'CHAIR') return 'CHAIR'
     return 'REQ-PARTICIPANT'
   }
+  function seedRole(list: string[] | undefined, role: Role): EventAttendee[] {
+    return (list ?? [])
+      .map((s) => parseAddressToAttendee(s, role))
+      .filter((a): a is EventAttendee => !!a)
+  }
   // svelte-ignore state_referenced_locally
   let requiredAttendees = $state<EventAttendee[]>(
-    event ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'REQ-PARTICIPANT')
-          : (draft?.attendees ?? []).map((s) => parseAddressToAttendee(s, 'REQ-PARTICIPANT')).filter((a): a is EventAttendee => !!a),
+    event
+      ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'REQ-PARTICIPANT')
+      : [
+          ...seedRole(draft?.attendees, 'REQ-PARTICIPANT'),
+          ...seedRole(draft?.requiredAttendees, 'REQ-PARTICIPANT'),
+        ],
   )
   // svelte-ignore state_referenced_locally
   let optionalAttendees = $state<EventAttendee[]>(
-    event ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'OPT-PARTICIPANT') : [],
+    event
+      ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'OPT-PARTICIPANT')
+      : seedRole(draft?.optionalAttendees, 'OPT-PARTICIPANT'),
   )
   // svelte-ignore state_referenced_locally
   let chairAttendees = $state<EventAttendee[]>(
-    event ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'CHAIR') : [],
+    event
+      ? (event.attendees ?? []).filter((a) => bucketFor(a) === 'CHAIR')
+      : seedRole(draft?.chairAttendees, 'CHAIR'),
   )
 
   /** Lower-cased addresses we consider "the user" — the union

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -197,11 +197,38 @@
         return
       }
       e.preventDefault()
-      onclose()
+      void cancel()
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
   })
+
+  /** Cancel = onclose + best-effort cleanup of any Talk room we
+      created during this session.  Only relevant in create-mode:
+      the event was never saved, so the room would otherwise
+      linger empty on the server.  Edit-mode keeps existing rooms
+      untouched (the user might have created the room days ago and
+      just opened the event to tweak the time). */
+  async function cancel() {
+    const room = pendingTalkRoom
+    pendingTalkRoom = null
+    if (mode === 'create' && room) {
+      const cal = calendars.find((c) => c.id === calendarId)
+      if (cal) {
+        try {
+          await invoke('delete_talk_room', {
+            ncId: cal.nextcloud_account_id,
+            roomToken: room.token,
+          })
+        } catch {
+          // Best-effort — leaving an empty room behind is annoying
+          // but not user-blocking, and the user can delete it from
+          // TalkView if they care.
+        }
+      }
+    }
+    onclose()
+  }
 
   // Async-load the default-calendar setting and switch to it if the
   // user hasn't manually changed the picker yet.  In create-mode
@@ -1227,7 +1254,7 @@
     ) {
       return
     }
-    onclose()
+    void cancel()
   }}
 >
   <div class="w-[640px] max-h-[90vh] bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl flex flex-col">
@@ -1237,7 +1264,7 @@
       </h2>
       <button
         class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100"
-        onclick={onclose}
+        onclick={() => void cancel()}
         aria-label="Close"
       >✕</button>
     </header>
@@ -1718,7 +1745,7 @@
         </button>
       {/if}
       <div class="flex-1"></div>
-      <button class="btn preset-outlined-surface-500" disabled={saving || deleting} onclick={onclose}>
+      <button class="btn preset-outlined-surface-500" disabled={saving || deleting} onclick={() => void cancel()}>
         Cancel
       </button>
     </footer>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -65,7 +65,7 @@
     /** Open the "Create Talk room" flow seeded from this email's
         subject + thread participants. Wired from `App.svelte` so the
         resulting Compose window stacks on top of the inbox view. */
-    oncreatetalk?: (mail: Email) => void
+    onrespondwithmeeting?: (mail: Email) => void
     /** Save the email as a Nextcloud note. The handler in
         `App.svelte` picks the NC account and POSTs to the Notes
         API — we just hand over the email so the title/body are
@@ -121,7 +121,7 @@
     onreply,
     onreplyall,
     onforward,
-    oncreatetalk,
+    onrespondwithmeeting,
     onsavenote,
     isDraftsFolder = false,
     isSentFolder = false,
@@ -1215,12 +1215,12 @@
           title="Forward"
           aria-label="Forward"
         ><Icon name="forward" size={16} /></button>
-        {#if oncreatetalk}
+        {#if onrespondwithmeeting}
           <button
             class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
-            onclick={() => email && oncreatetalk?.(email)}
-            title="Create a Nextcloud Talk room with the participants of this thread"
-            aria-label="Create Talk room"
+            onclick={() => email && onrespondwithmeeting?.(email)}
+            title="Create a calendar event with a Talk link and the thread's participants as attendees"
+            aria-label="Respond with meeting"
           ><Icon name="respond-with-meeting" size={16} /></button>
         {/if}
         {#if onsavenote}


### PR DESCRIPTION
## Summary
- The MailView meeting button now opens the full EventEditor instead of just a Talk-room modal
- Title is seeded from the email subject, From/To become required attendees, Cc become optional, and a Nextcloud Talk room is auto-minted on mount so the join URL lands in the event location
- All existing EventEditor wiring (per-attendee Talk participants on save, public/private downgrade, iMIP invites) reuses the same code path as the manual "Add Talk link" button

## Implementation notes
- `EventEditor` draft type gains `requiredAttendees` / `optionalAttendees` / `chairAttendees` for nuanced role splits (existing `attendees` bulk array still works) and a `createTalkRoom` flag that calls `addTalkLink()` once the calendar selection has settled
- `MailView` prop renamed `oncreatetalk` → `onrespondwithmeeting` and tooltip/aria updated to reflect the new behaviour
- `App.svelte` drops the `CreateTalkRoomModal`-driven flow in favour of a `meetingDraft` state cell that mounts the EventEditor with the prefilled seed; participant split is From + To → required, Cc → optional, with the active account filtered out so the user stays the organizer
- The active calendar defaults to the user's `default_calendar_id` setting when set, otherwise the first non-hidden calendar on the first connected NC account

## Test plan
- [x] Open a mail with multiple recipients in To and Cc, click the "Respond with meeting" button, confirm the editor opens with subject as title, From/To in Required, Cc in Optional
- [x] Confirm a Talk room is auto-created (location field populated, "Add Talk link" button switches to "Talk room created")
- [x] Save the event and confirm an iMIP invite goes out and the Talk room gets the right participants
- [x] Cancel the editor and confirm no event was created (room may linger; same as the manual flow)
- [ ] No connected Nextcloud account → friendly alert
- [ ] No writable calendars → friendly alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)