### PR TITLE
Improve Talk: delete button in TalkView + auto-tear-down on event delete (#172)

### DIFF
--- a/crates/nimbus-nextcloud/src/talk.rs
+++ b/crates/nimbus-nextcloud/src/talk.rs
@@ -98,6 +98,13 @@ pub struct TalkRoom {
     /// doesn't have to reconstruct it on every render and so the
     /// "Share link in email" action has a single value to drop.
     pub web_url: String,
+    /// Talk 21+ "archived" flag.  Archived rooms still exist on the
+    /// server (and the user can still join + read history) but the
+    /// web UI dims them and pushes them to the bottom of the list.
+    /// Older Nextcloud / Talk versions don't send this field; serde
+    /// defaults it to `false`, which matches their UX (everything
+    /// active).
+    pub is_archived: bool,
 }
 
 /// Source of a new participant. Talk distinguishes between adding a
@@ -155,6 +162,8 @@ struct WireRoom {
     unread_mention: bool,
     #[serde(rename = "lastActivity", default)]
     last_activity: i64,
+    #[serde(rename = "isArchived", default)]
+    is_archived: bool,
 }
 
 impl WireRoom {
@@ -171,6 +180,7 @@ impl WireRoom {
             unread_messages: self.unread_messages,
             unread_mention: self.unread_mention,
             last_activity: self.last_activity,
+            is_archived: self.is_archived,
         }
     }
 }

--- a/ui/src/lib/CreateTalkRoomModal.svelte
+++ b/ui/src/lib/CreateTalkRoomModal.svelte
@@ -31,6 +31,8 @@
     unread_mention: boolean
     last_activity: number
     web_url: string
+    /** Talk 21+ "archived" flag.  Older servers default to false. */
+    is_archived?: boolean
   }
 
   interface Props {

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -1213,6 +1213,19 @@
     }
   }
 
+  /** Pull a `/call/<token>` token out of an arbitrary string.
+      Matches both pretty (`/call/abc`) and ugly (`/index.php/call/abc`)
+      URLs — Talk uses one or the other depending on the server's
+      `htaccess` setup.  Returns null when nothing looks like a Talk
+      URL, or when the token wouldn't be a valid identifier
+      (length-bounded so a stray `/call/` followed by junk doesn't
+      get treated as a real token). */
+  function extractTalkToken(s: string | null | undefined): string | null {
+    if (!s) return null
+    const m = s.match(/\/call\/([A-Za-z0-9]{4,32})\b/)
+    return m ? m[1] : null
+  }
+
   async function remove() {
     if (mode !== 'edit' || !event) return
     if (!confirm(`Delete "${event.summary || '(no title)'}"?`)) return
@@ -1220,6 +1233,33 @@
     error = ''
     try {
       await invoke('delete_calendar_event', { eventId: event.id })
+
+      // Best-effort tear down the associated Talk room (#172).
+      // Nextcloud doesn't auto-delete rooms attached to a deleted
+      // event, so without this the user accumulates dangling
+      // meeting rooms in their Talk list.  We look for a `/call/`
+      // token in LOCATION first (where Nimbus + NC Calendar both
+      // write the join URL), falling back to URL / DESCRIPTION
+      // for events created elsewhere.  A 404 (room already gone)
+      // or 403 (not the owner) is normal — log + move on.
+      const token =
+        extractTalkToken(event.location) ??
+        extractTalkToken(event.url) ??
+        extractTalkToken(event.description)
+      if (token) {
+        const cal = calendars.find((c) => c.id === calendarId)
+        if (cal) {
+          try {
+            await invoke('delete_talk_room', {
+              ncId: cal.nextcloud_account_id,
+              roomToken: token,
+            })
+          } catch (e) {
+            console.warn('delete_talk_room (event remove cleanup) failed:', e)
+          }
+        }
+      }
+
       onsaved()
       onclose()
     } catch (e) {

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -42,6 +42,15 @@
   let loading = $state(false)
   let error = $state('')
   let showCreate = $state(false)
+  /** Archived rooms live behind a collapsible header at the bottom
+      of the list — most users rarely care about them, so we default
+      to collapsed and let them expand on demand.  Persisted only
+      for the lifetime of the view (no localStorage); reopening
+      TalkView starts collapsed again, which matches what NC's
+      web UI does. */
+  let showArchived = $state(false)
+  const activeRooms = $derived(rooms.filter((r) => !r.is_archived))
+  const archivedRooms = $derived(rooms.filter((r) => r.is_archived))
 
   // Periodic refresh — 30s is the same cadence the Nextcloud web UI
   // polls at. Long enough to be cheap, short enough that the unread
@@ -93,16 +102,10 @@
     if (!opts.silent) error = ''
     try {
       const list = await invoke<TalkRoom[]>('list_talk_rooms', { ncId: accountId })
-      // Sort: active rooms first, archived rooms grouped at the
-      // bottom — same UX Nextcloud's web Talk surfaces.  Within each
-      // group, newest activity wins so the freshest conversation
-      // floats to the top.
-      list.sort((a, b) => {
-        const aArch = a.is_archived ? 1 : 0
-        const bArch = b.is_archived ? 1 : 0
-        if (aArch !== bArch) return aArch - bArch
-        return b.last_activity - a.last_activity
-      })
+      // Sort by last activity desc within each group; the template
+      // splits active vs. archived into two visual sections so we
+      // don't need to interleave them here.
+      list.sort((a, b) => b.last_activity - a.last_activity)
       rooms = list
     } catch (e) {
       if (!opts.silent) error = formatError(e) || 'Failed to load Talk rooms'
@@ -238,49 +241,80 @@
         No Talk rooms yet. Click <strong>+ New room</strong> to start your first conversation.
       </div>
     {:else}
-      <ul class="flex-1 overflow-y-auto divide-y divide-surface-200 dark:divide-surface-800">
-        {#each rooms as room (room.token)}
-          <li class="px-5 py-3 flex items-center gap-3 hover:bg-surface-100 dark:hover:bg-surface-800 {room.is_archived ? 'opacity-60' : ''}">
-            <span class="flex-shrink-0 text-surface-600 dark:text-surface-300"><Icon name={roomTypeIcon(room.room_type)} size={20} /></span>
+      {#snippet roomRow(room: TalkRoom)}
+        <li class="px-5 py-3 flex items-center gap-3 hover:bg-surface-100 dark:hover:bg-surface-800 {room.is_archived ? 'opacity-60' : ''}">
+          <span class="flex-shrink-0 text-surface-600 dark:text-surface-300"><Icon name={roomTypeIcon(room.room_type)} size={20} /></span>
 
-            <div class="flex-1 min-w-0">
-              <div class="flex items-center gap-2">
-                <span class="font-medium truncate">{room.display_name}</span>
-                {#if room.is_archived}
-                  <span class="badge text-xs flex-shrink-0 preset-tonal-surface" title="This Talk room is archived">Archived</span>
-                {/if}
-                {#if room.unread_messages > 0}
-                  <span
-                    class="badge text-xs flex-shrink-0
-                           {room.unread_mention ? 'preset-filled-error-500' : 'preset-filled-primary-500'}"
-                    title={room.unread_mention ? 'You were mentioned' : 'Unread messages'}
-                  >{room.unread_messages}</span>
-                {/if}
-              </div>
-              <p class="text-xs text-surface-500 truncate">
-                {formatRelative(room.last_activity)}
-              </p>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="font-medium truncate">{room.display_name}</span>
+              {#if room.unread_messages > 0}
+                <span
+                  class="badge text-xs flex-shrink-0
+                         {room.unread_mention ? 'preset-filled-error-500' : 'preset-filled-primary-500'}"
+                  title={room.unread_mention ? 'You were mentioned' : 'Unread messages'}
+                >{room.unread_messages}</span>
+              {/if}
             </div>
+            <p class="text-xs text-surface-500 truncate">
+              {formatRelative(room.last_activity)}
+            </p>
+          </div>
 
-            <button
-              class="btn preset-outlined-surface-500 text-xs inline-flex items-center gap-1.5"
-              onclick={() => shareRoom(room)}
-              title="Open a new mail with this room's join link"
-            ><Icon name="share-links" size={14} /> Share link</button>
-            <button
-              class="btn preset-filled-primary-500 text-xs inline-flex items-center gap-1.5"
-              onclick={() => openRoom(room)}
-              title="Open this Talk room in your browser"
-            >Open <Icon name="open-link" size={14} /></button>
-            <button
-              class="btn preset-outlined-error-500 text-xs inline-flex items-center gap-1.5 hover:bg-error-500/15 hover:text-error-500"
-              disabled={deletingToken === room.token}
-              onclick={() => void deleteRoom(room)}
-              title="Delete this Talk room for everyone"
-            ><Icon name={deletingToken === room.token ? 'loading' : 'trash'} size={14} /> {deletingToken === room.token ? 'Deleting…' : 'Delete'}</button>
-          </li>
-        {/each}
-      </ul>
+          <button
+            class="btn preset-outlined-surface-500 text-xs inline-flex items-center gap-1.5"
+            onclick={() => shareRoom(room)}
+            title="Open a new mail with this room's join link"
+          ><Icon name="share-links" size={14} /> Share link</button>
+          <button
+            class="btn preset-filled-primary-500 text-xs inline-flex items-center gap-1.5"
+            onclick={() => openRoom(room)}
+            title="Open this Talk room in your browser"
+          >Open <Icon name="open-link" size={14} /></button>
+          <button
+            class="btn preset-outlined-error-500 text-xs inline-flex items-center gap-1.5 hover:bg-error-500/15 hover:text-error-500"
+            disabled={deletingToken === room.token}
+            onclick={() => void deleteRoom(room)}
+            title="Delete this Talk room for everyone"
+          ><Icon name={deletingToken === room.token ? 'loading' : 'trash'} size={14} /> {deletingToken === room.token ? 'Deleting…' : 'Delete'}</button>
+        </li>
+      {/snippet}
+      <div class="flex-1 overflow-y-auto flex flex-col">
+        <ul class="divide-y divide-surface-200 dark:divide-surface-800">
+          {#each activeRooms as room (room.token)}
+            {@render roomRow(room)}
+          {/each}
+        </ul>
+        {#if archivedRooms.length > 0}
+          <!-- Collapsible archived divider — clicking the header
+               toggles a section that lists every archived room.
+               Defaults collapsed; the chevron + count tells the
+               user there's something hidden without forcing
+               them to scroll past dimmed rows they rarely
+               touch. -->
+          <button
+            type="button"
+            class="w-full px-5 py-2 flex items-center gap-2 text-sm border-t border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 text-surface-700 dark:text-surface-200"
+            onclick={() => (showArchived = !showArchived)}
+            aria-expanded={showArchived}
+          >
+            <span
+              class="inline-block transition-transform text-surface-500"
+              style="transform: rotate({showArchived ? 90 : 0}deg)"
+              aria-hidden="true"
+            >▸</span>
+            <span class="font-medium">Archived</span>
+            <span class="text-xs text-surface-500">({archivedRooms.length})</span>
+          </button>
+          {#if showArchived}
+            <ul class="divide-y divide-surface-200 dark:divide-surface-800">
+              {#each archivedRooms as room (room.token)}
+                {@render roomRow(room)}
+              {/each}
+            </ul>
+          {/if}
+        {/if}
+      </div>
     {/if}
   {/if}
 </div>

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -93,10 +93,16 @@
     if (!opts.silent) error = ''
     try {
       const list = await invoke<TalkRoom[]>('list_talk_rooms', { ncId: accountId })
-      // Sort by last activity desc so the freshest conversation is on
-      // top. Rooms with zero last_activity (newly created, no messages
-      // yet) sink to the bottom.
-      list.sort((a, b) => b.last_activity - a.last_activity)
+      // Sort: active rooms first, archived rooms grouped at the
+      // bottom — same UX Nextcloud's web Talk surfaces.  Within each
+      // group, newest activity wins so the freshest conversation
+      // floats to the top.
+      list.sort((a, b) => {
+        const aArch = a.is_archived ? 1 : 0
+        const bArch = b.is_archived ? 1 : 0
+        if (aArch !== bArch) return aArch - bArch
+        return b.last_activity - a.last_activity
+      })
       rooms = list
     } catch (e) {
       if (!opts.silent) error = formatError(e) || 'Failed to load Talk rooms'
@@ -234,12 +240,15 @@
     {:else}
       <ul class="flex-1 overflow-y-auto divide-y divide-surface-200 dark:divide-surface-800">
         {#each rooms as room (room.token)}
-          <li class="px-5 py-3 flex items-center gap-3 hover:bg-surface-100 dark:hover:bg-surface-800">
+          <li class="px-5 py-3 flex items-center gap-3 hover:bg-surface-100 dark:hover:bg-surface-800 {room.is_archived ? 'opacity-60' : ''}">
             <span class="flex-shrink-0 text-surface-600 dark:text-surface-300"><Icon name={roomTypeIcon(room.room_type)} size={20} /></span>
 
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2">
                 <span class="font-medium truncate">{room.display_name}</span>
+                {#if room.is_archived}
+                  <span class="badge text-xs flex-shrink-0 preset-tonal-surface" title="This Talk room is archived">Archived</span>
+                {/if}
                 {#if room.unread_messages > 0}
                   <span
                     class="badge text-xs flex-shrink-0

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -122,6 +122,30 @@
     })
   }
 
+  /** Confirm + delete a room.  Talk's API tears the room down server-
+      side for everyone — there's no per-user "leave" semantic for an
+      owner — so we gate behind a confirm prompt to keep accidental
+      clicks from nuking a busy conversation.  Optimistically remove
+      from the list on success; the next periodic refresh reconciles
+      any drift. */
+  let deletingToken = $state<string | null>(null)
+  async function deleteRoom(room: TalkRoom) {
+    if (!accountId) return
+    const ok = window.confirm(
+      `Delete "${room.display_name}"?\n\nThis removes the room for every participant — there's no undo.`,
+    )
+    if (!ok) return
+    deletingToken = room.token
+    try {
+      await invoke('delete_talk_room', { ncId: accountId, roomToken: room.token })
+      rooms = rooms.filter((r) => r.token !== room.token)
+    } catch (e) {
+      error = formatError(e) || 'Failed to delete Talk room'
+    } finally {
+      deletingToken = null
+    }
+  }
+
   function onRoomCreated(room: TalkRoom) {
     // Optimistically prepend the new room — the next periodic refresh
     // (or the user's manual refresh) will reconcile any drift.
@@ -239,6 +263,12 @@
               onclick={() => openRoom(room)}
               title="Open this Talk room in your browser"
             >Open <Icon name="open-link" size={14} /></button>
+            <button
+              class="btn preset-outlined-error-500 text-xs inline-flex items-center gap-1.5 hover:bg-error-500/15 hover:text-error-500"
+              disabled={deletingToken === room.token}
+              onclick={() => void deleteRoom(room)}
+              title="Delete this Talk room for everyone"
+            ><Icon name={deletingToken === room.token ? 'loading' : 'trash'} size={14} /> {deletingToken === room.token ? 'Deleting…' : 'Delete'}</button>
           </li>
         {/each}
       </ul>

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -304,7 +304,7 @@
                 style="transform: rotate({showArchived ? 90 : 0}deg)"
                 aria-hidden="true"
               >▸</span>
-              <span class="font-medium tracking-wide uppercase text-xs">Archived</span>
+              <span class="font-medium">Archived</span>
               <span class="text-xs">({archivedRooms.length})</span>
             </span>
             <span class="flex-1 h-px bg-surface-200 dark:bg-surface-700 group-hover:bg-surface-300 dark:group-hover:bg-surface-600 transition-colors"></span>

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -294,17 +294,21 @@
                touch. -->
           <button
             type="button"
-            class="w-full px-5 py-2 flex items-center gap-2 text-sm border-t border-b border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 hover:bg-surface-200 dark:hover:bg-surface-700 text-surface-700 dark:text-surface-200"
+            class="w-full px-5 py-3 flex items-center gap-3 text-sm text-surface-500 hover:text-surface-700 dark:hover:text-surface-200 group"
             onclick={() => (showArchived = !showArchived)}
             aria-expanded={showArchived}
           >
-            <span
-              class="inline-block transition-transform text-surface-500"
-              style="transform: rotate({showArchived ? 90 : 0}deg)"
-              aria-hidden="true"
-            >▸</span>
-            <span class="font-medium">Archived</span>
-            <span class="text-xs text-surface-500">({archivedRooms.length})</span>
+            <span class="flex-1 h-px bg-surface-200 dark:bg-surface-700 group-hover:bg-surface-300 dark:group-hover:bg-surface-600 transition-colors"></span>
+            <span class="inline-flex items-center gap-1.5 shrink-0">
+              <span
+                class="inline-block transition-transform text-xs"
+                style="transform: rotate({showArchived ? 90 : 0}deg)"
+                aria-hidden="true"
+              >▸</span>
+              <span class="font-medium tracking-wide uppercase text-xs">Archived</span>
+              <span class="text-xs">({archivedRooms.length})</span>
+            </span>
+            <span class="flex-1 h-px bg-surface-200 dark:bg-surface-700 group-hover:bg-surface-300 dark:group-hover:bg-surface-600 transition-colors"></span>
           </button>
           {#if showArchived}
             <ul class="divide-y divide-surface-200 dark:divide-surface-800">

--- a/ui/src/lib/TalkView.svelte
+++ b/ui/src/lib/TalkView.svelte
@@ -298,10 +298,9 @@
             onclick={() => (showArchived = !showArchived)}
             aria-expanded={showArchived}
           >
-            <span class="flex-1 h-px bg-surface-200 dark:bg-surface-700 group-hover:bg-surface-300 dark:group-hover:bg-surface-600 transition-colors"></span>
-            <span class="inline-flex items-center gap-1.5 shrink-0">
+            <span class="inline-flex items-center gap-2 shrink-0">
               <span
-                class="inline-block transition-transform text-xs"
+                class="inline-block transition-transform text-lg leading-none"
                 style="transform: rotate({showArchived ? 90 : 0}deg)"
                 aria-hidden="true"
               >▸</span>


### PR DESCRIPTION
Closes #172.

## Summary
- **TalkView**: every room row now carries a red-outlined "Delete" button right after Share / Open. Confirmed before firing (Talk's delete tears the room down for every participant — no per-user leave path for an owner), optimistic list removal on success.
- **EventEditor**: deleting an event with a Talk URL in LOCATION (or URL / DESCRIPTION as fallback) now best-effort `delete_talk_room`s the matching `/call/<token>`. Nextcloud doesn't auto-clean event-bound rooms, so without this the user accumulates dangling meeting rooms. 404 / 403 are tolerated — logged and skipped — so the event delete itself never blocks on a missing-or-not-mine room.

## Test plan
- [x] TalkView → click Delete on a test room → confirm prompt appears, room disappears from the list
- [x] Cancel the confirm → room stays
- [ ] Delete an event with a Talk link in its location → matching room disappears from Nextcloud Talk
- [ ] Delete an event with no Talk link → nothing extra happens
- [ ] Delete an event whose Talk room was already deleted server-side → event still deletes cleanly (warning logged)
- [ ] Delete a Talk room that isn't owned by you → friendly error in the row strip, list unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)