### PR TITLE
Branding: app-icon style picker in Settings → Design

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -81,6 +81,21 @@ pub struct AppSettings {
     /// with the stock catalogue.
     #[serde(default)]
     pub custom_themes: Vec<CustomTheme>,
+    /// User-selected app-icon style (taskbar / tray / window).  One
+    /// of the slugs known to the runtime (`storm`, `dawn`, `mint`,
+    /// `sky`, `twilight`, `monochrome-black`, `monochrome-white`).
+    /// `set_logo_style` swaps the running tray and main-window icon
+    /// to this style and persists it; on next boot the chosen icon
+    /// is reapplied before the window is shown.  Note: the .exe icon
+    /// shown in Windows Explorer / macOS Finder *before launch* is
+    /// baked into the binary at build time and is not affected by
+    /// this setting — only what the user sees while the app runs.
+    #[serde(default = "default_logo_style")]
+    pub logo_style: String,
+}
+
+fn default_logo_style() -> String {
+    "storm".to_string()
 }
 
 /// One user-imported Skeleton theme — the metadata the picker
@@ -144,6 +159,7 @@ impl Default for AppSettings {
             talk_reminder_enabled: true,
             autostart_enabled: false,
             custom_themes: Vec::new(),
+            logo_style: default_logo_style(),
         }
     }
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,18 @@
 fn main() {
+    // Tauri embeds the .exe / .app icon as a Windows resource (or
+    // macOS bundle asset) at build time. When only the icon bytes
+    // change — e.g. running `cargo tauri icon` after a logo
+    // refresh — Cargo's incremental compilation has no Rust-source
+    // signal to rerun this script, so the old icon stays baked into
+    // the cached binary and surfaces in Task Manager / Finder until
+    // the next clean rebuild. Adding explicit `rerun-if-changed`
+    // hints fixes that — Cargo will re-run `tauri_build::build()`
+    // (which re-embeds the resource) the moment any icon file's
+    // mtime changes.
+    println!("cargo:rerun-if-changed=icons/icon.ico");
+    println!("cargo:rerun-if-changed=icons/icon.icns");
+    println!("cargo:rerun-if-changed=icons/icon.png");
+    println!("cargo:rerun-if-changed=tauri.conf.json");
+
     tauri_build::build();
 }

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -42,8 +42,11 @@ pub fn render_tray_icon(
         let badge_size = ((dim * 22) / 100).max(8);
         let inset = (dim / 16).max(2);
 
+        // Bottom-right corner — matches where Windows places the
+        // taskbar overlay, so the indicator sits at the same spot
+        // relative to the icon on both surfaces.
         let bx = width.saturating_sub(badge_size + inset);
-        let by = inset;
+        let by = height.saturating_sub(badge_size + inset);
 
         draw_filled_circle(&mut p, width, height, bx, by, badge_size, BADGE_RGBA);
         p
@@ -171,13 +174,12 @@ mod tests {
     fn nonzero_unread_paints_reddish() {
         let base = vec![0u8; 32 * 32 * 4];
         let img = render_tray_icon(&base, 32, 32, 5);
-        // Alpha-blending red onto transparent black scales each
-        // channel down by the source alpha (230). We just want to
-        // see "this pixel is dominated by red" somewhere in the
-        // top-right quadrant where the dot lives.
+        // We just want to see "this pixel is dominated by red"
+        // somewhere in the bottom-right quadrant where the dot
+        // lives.
         let pixels = img.rgba();
         let mut found_red = false;
-        for y in 0..16 {
+        for y in 16..32 {
             for x in 16..32 {
                 let idx = (y * 32 + x) * 4;
                 let (r, g, b, a) = (

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -6,17 +6,10 @@
 //! "you have something to read" at a glance, and reaches for the
 //! actual count from inside the app where typography is legible.
 //!
-//! The disc has two visual tricks:
-//!
-//! 1. **Alpha-blended red.** Tailwind red-500 at ~90% alpha
-//!    (`230/255`), composited via proper src-over-dst blending so
-//!    the underlying tray icon shows faintly through the disc.
-//!    Reads as a translucent overlay, not a flat sticker.
-//!
-//! 2. **2×2 supersampled circle edge.** Each pixel along the
-//!    circumference samples 4 sub-pixel positions; the fraction
-//!    inside the circle becomes the pixel's coverage. Smooth
-//!    boundary with no FFT-grade AA stack.
+//! The disc uses a 2×2 supersampled edge: each pixel along the
+//! circumference samples 4 sub-pixel positions; the fraction
+//! inside the circle becomes the pixel's coverage. Smooth
+//! boundary with no FFT-grade AA stack.
 //!
 //! The tray icon is the base PNG composited with the dot in the
 //! bottom-right corner. The Windows taskbar overlay is the dot
@@ -24,16 +17,8 @@
 
 use tauri::image::Image;
 
-/// Tailwind red-500, fully opaque. The thin halo around it (drawn
-/// first, see below) gives the disc its breathing room so we don't
-/// need translucency to keep it from looking like a sticker.
+/// Tailwind red-500, fully opaque.
 const BADGE_RGBA: [u8; 4] = [239, 68, 68, 255];
-
-/// Soft white ring drawn underneath the red disc. Same trick
-/// macOS/iOS notification badges use: separates the badge from a
-/// busy underlying icon at any background colour. Slightly
-/// translucent so it doesn't read as a hard cutout.
-const HALO_RGBA: [u8; 4] = [255, 255, 255, 220];
 
 /// Composite the unread dot onto a copy of `base_pixels` and
 /// return it as an owned Tauri image. When `unread == 0` the
@@ -56,19 +41,10 @@ pub fn render_tray_icon(
         // base icon still produces a visible disc.
         let badge_size = ((dim * 22) / 100).max(8);
         let inset = (dim / 16).max(2);
-        // 2 px (or 1.25%-of-icon, whichever is bigger) white ring
-        // around the disc — separates it from a busy underlying
-        // icon at any colour, the same trick macOS / iOS
-        // notification badges use.
-        let ring = (dim / 80).max(2);
-        let halo_size = badge_size + 2 * ring;
 
         let bx = width.saturating_sub(badge_size + inset);
         let by = inset;
-        let hx = bx.saturating_sub(ring);
-        let hy = by.saturating_sub(ring);
 
-        draw_filled_circle(&mut p, width, height, hx, hy, halo_size, HALO_RGBA);
         draw_filled_circle(&mut p, width, height, bx, by, badge_size, BADGE_RGBA);
         p
     };
@@ -96,18 +72,13 @@ pub fn render_taskbar_overlay(unread: u32) -> Option<Image<'static>> {
     }
     const W: u32 = 16;
     const H: u32 = 16;
-    // 10×10 disc with a 1px white halo, centered in the 16×16
-    // canvas (3px transparent padding all around). Leaves the
-    // visible badge ~half the taskbar overlay slot — modern
-    // dock-indicator proportions.
+    // 10×10 disc centered in the 16×16 canvas (3 px transparent
+    // padding all around). Leaves the visible badge ~half the
+    // taskbar overlay slot — modern dock-indicator proportions.
     const BADGE_SIZE: u32 = 10;
-    const RING: u32 = 1;
-    const HALO_SIZE: u32 = BADGE_SIZE + 2 * RING;
     let badge_pos = (W - BADGE_SIZE) / 2;
-    let halo_pos = (W - HALO_SIZE) / 2;
 
     let mut pixels = vec![0u8; (W * H * 4) as usize];
-    draw_filled_circle(&mut pixels, W, H, halo_pos, halo_pos, HALO_SIZE, HALO_RGBA);
     draw_filled_circle(&mut pixels, W, H, badge_pos, badge_pos, BADGE_SIZE, BADGE_RGBA);
     Some(Image::new_owned(pixels, W, H))
 }

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -50,21 +50,17 @@ pub fn render_tray_icon(
     } else {
         let mut p = base_pixels.to_vec();
         let dim = width.min(height);
-        // Indicator-style: ~14% of the icon's short side and well
-        // inset from the corner. This is the proportion modern
-        // dock badges (Slack, Discord, Apple Mail without a count)
-        // actually use; the earlier 22-30% sizes read as a sticker.
-        // Floor of 4 px so a tiny tray icon still shows something
-        // visible.
-        let badge_size = ((dim * 14) / 100).max(4);
-        // Inset by ~10% of the icon side so the dot sits inside
-        // the visible mark, not in the canvas's transparent
-        // padding.
-        let inset = (dim / 10).max(2);
-        // 1 px halo — just enough separation against a busy mark
-        // at full size, vanishes acceptably when the OS downscales
-        // for a 16 / 32 px tray render.
-        let ring: u32 = 1;
+        // ~22% of the icon's short side, inset from the corner.
+        // Reads as an indicator at the system-tray render size
+        // without dominating the icon. Floor of 8 px so a tiny
+        // base icon still produces a visible disc.
+        let badge_size = ((dim * 22) / 100).max(8);
+        let inset = (dim / 16).max(2);
+        // 2 px (or 1.25%-of-icon, whichever is bigger) white ring
+        // around the disc — separates it from a busy underlying
+        // icon at any colour, the same trick macOS / iOS
+        // notification badges use.
+        let ring = (dim / 80).max(2);
         let halo_size = badge_size + 2 * ring;
 
         let bx = width.saturating_sub(badge_size + inset);
@@ -83,6 +79,14 @@ pub fn render_tray_icon(
 /// (16×16). Returns `None` when there's nothing to show so the
 /// caller can clear the overlay with `set_overlay_icon(None)`.
 ///
+/// Windows places the entire 16×16 overlay at the bottom-right of
+/// the taskbar entry, then scales it for the user's DPI. Drawing
+/// the disc at the full 16×16 produced a chunky red ball; instead
+/// we paint a smaller disc inside transparent padding so the
+/// visible badge in the taskbar reads as an indicator, not a
+/// sticker. Same halo trick the tray badge uses for separation
+/// against a busy underlying icon.
+///
 /// Called from the `#[cfg(windows)]` branch in `main.rs`; on other
 /// platforms the call site is compiled away.
 #[cfg_attr(not(windows), allow(dead_code))]
@@ -92,8 +96,19 @@ pub fn render_taskbar_overlay(unread: u32) -> Option<Image<'static>> {
     }
     const W: u32 = 16;
     const H: u32 = 16;
+    // 10×10 disc with a 1px white halo, centered in the 16×16
+    // canvas (3px transparent padding all around). Leaves the
+    // visible badge ~half the taskbar overlay slot — modern
+    // dock-indicator proportions.
+    const BADGE_SIZE: u32 = 10;
+    const RING: u32 = 1;
+    const HALO_SIZE: u32 = BADGE_SIZE + 2 * RING;
+    let badge_pos = (W - BADGE_SIZE) / 2;
+    let halo_pos = (W - HALO_SIZE) / 2;
+
     let mut pixels = vec![0u8; (W * H * 4) as usize];
-    draw_filled_circle(&mut pixels, W, H, 0, 0, W, BADGE_RGBA);
+    draw_filled_circle(&mut pixels, W, H, halo_pos, halo_pos, HALO_SIZE, HALO_RGBA);
+    draw_filled_circle(&mut pixels, W, H, badge_pos, badge_pos, BADGE_SIZE, BADGE_RGBA);
     Some(Image::new_owned(pixels, W, H))
 }
 

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -42,11 +42,9 @@ pub fn render_tray_icon(
         let badge_size = ((dim * 22) / 100).max(8);
         let inset = (dim / 16).max(2);
 
-        // Bottom-right corner — matches where Windows places the
-        // taskbar overlay, so the indicator sits at the same spot
-        // relative to the icon on both surfaces.
+        // Top-right corner of the icon canvas.
         let bx = width.saturating_sub(badge_size + inset);
-        let by = height.saturating_sub(badge_size + inset);
+        let by = inset;
 
         draw_filled_circle(&mut p, width, height, bx, by, badge_size, BADGE_RGBA);
         p
@@ -175,11 +173,11 @@ mod tests {
         let base = vec![0u8; 32 * 32 * 4];
         let img = render_tray_icon(&base, 32, 32, 5);
         // We just want to see "this pixel is dominated by red"
-        // somewhere in the bottom-right quadrant where the dot
+        // somewhere in the top-right quadrant where the dot
         // lives.
         let pixels = img.rgba();
         let mut found_red = false;
-        for y in 16..32 {
+        for y in 0..16 {
             for x in 16..32 {
                 let idx = (y * 32 + x) * 4;
                 let (r, g, b, a) = (

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -24,10 +24,16 @@
 
 use tauri::image::Image;
 
-/// Tailwind red-500 with ~90% alpha. Soft enough that the icon
-/// underneath reads through, saturated enough to register as a
-/// "new" indicator at a glance.
-const BADGE_RGBA: [u8; 4] = [239, 68, 68, 230];
+/// Tailwind red-500, fully opaque. The thin halo around it (drawn
+/// first, see below) gives the disc its breathing room so we don't
+/// need translucency to keep it from looking like a sticker.
+const BADGE_RGBA: [u8; 4] = [239, 68, 68, 255];
+
+/// Soft white ring drawn underneath the red disc. Same trick
+/// macOS/iOS notification badges use: separates the badge from a
+/// busy underlying icon at any background colour. Slightly
+/// translucent so it doesn't read as a hard cutout.
+const HALO_RGBA: [u8; 4] = [255, 255, 255, 220];
 
 /// Composite the unread dot onto a copy of `base_pixels` and
 /// return it as an owned Tauri image. When `unread == 0` the
@@ -44,14 +50,24 @@ pub fn render_tray_icon(
     } else {
         let mut p = base_pixels.to_vec();
         let dim = width.min(height);
-        // ~30% of the icon's short side, never below 8 px. Sized to
-        // read as an indicator rather than a sticker, and small
-        // enough that the whole disc fits inside the canvas without
-        // clipping at the right edge.
-        let badge_size = ((dim * 3) / 10).max(8).min(dim);
-        // Top-right corner, fully inside the canvas.
-        let bx = width - badge_size;
-        let by = 0;
+        // Modern dock-badge sizing: ~22% of the icon's short side,
+        // not flush against the edge. The previous 30%/0-inset
+        // combo read as a sticker pasted on the corner; this
+        // matches the size + insetting macOS / iOS use.
+        let badge_size = ((dim * 22) / 100).max(8);
+        let inset = (dim / 16).max(2);
+        // Halo is the badge plus a 2px (or 1.25%-of-icon, whichever
+        // is bigger) ring on every side so it pops without looking
+        // dipped in white-out.
+        let ring = (dim / 80).max(2);
+        let halo_size = badge_size + 2 * ring;
+
+        let bx = width.saturating_sub(badge_size + inset);
+        let by = inset;
+        let hx = bx.saturating_sub(ring);
+        let hy = by.saturating_sub(ring);
+
+        draw_filled_circle(&mut p, width, height, hx, hy, halo_size, HALO_RGBA);
         draw_filled_circle(&mut p, width, height, bx, by, badge_size, BADGE_RGBA);
         p
     };

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -50,16 +50,21 @@ pub fn render_tray_icon(
     } else {
         let mut p = base_pixels.to_vec();
         let dim = width.min(height);
-        // Modern dock-badge sizing: ~22% of the icon's short side,
-        // not flush against the edge. The previous 30%/0-inset
-        // combo read as a sticker pasted on the corner; this
-        // matches the size + insetting macOS / iOS use.
-        let badge_size = ((dim * 22) / 100).max(8);
-        let inset = (dim / 16).max(2);
-        // Halo is the badge plus a 2px (or 1.25%-of-icon, whichever
-        // is bigger) ring on every side so it pops without looking
-        // dipped in white-out.
-        let ring = (dim / 80).max(2);
+        // Indicator-style: ~14% of the icon's short side and well
+        // inset from the corner. This is the proportion modern
+        // dock badges (Slack, Discord, Apple Mail without a count)
+        // actually use; the earlier 22-30% sizes read as a sticker.
+        // Floor of 4 px so a tiny tray icon still shows something
+        // visible.
+        let badge_size = ((dim * 14) / 100).max(4);
+        // Inset by ~10% of the icon side so the dot sits inside
+        // the visible mark, not in the canvas's transparent
+        // padding.
+        let inset = (dim / 10).max(2);
+        // 1 px halo — just enough separation against a busy mark
+        // at full size, vanishes acceptably when the OS downscales
+        // for a 16 / 32 px tray render.
+        let ring: u32 = 1;
         let halo_size = badge_size + 2 * ring;
 
         let bx = width.saturating_sub(badge_size + inset);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8194,15 +8194,22 @@ fn main() {
                     }
                 });
 
-                // Honour `start_minimized`: hide the window right away
-                // so the app boots straight into the tray.
+                // The main window starts hidden (`visible: false` in
+                // tauri.conf.json) so we don't paint it with the
+                // bundled storm icon for a frame before the user's
+                // chosen logo style is applied above.  Now that the
+                // icon is in place, decide whether to show it:
+                //   - `start_minimized` true → leave it hidden, app
+                //     boots straight into the tray.
+                //   - otherwise → show the window with the correct
+                //     icon already painted in the titlebar / taskbar.
                 let should_hide_on_start = app
                     .state::<SharedSettings>()
                     .inner()
                     .blocking_read()
                     .start_minimized;
-                if should_hide_on_start {
-                    let _ = main_window.hide();
+                if !should_hide_on_start {
+                    let _ = main_window.show();
                 }
             } else {
                 tracing::warn!("main window not found at setup time");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,14 +54,76 @@ type SharedSettings = Arc<RwLock<AppSettings>>;
 /// `app_settings.json` DOSing the user's mail server.
 const MIN_SYNC_INTERVAL_SECS: u64 = 30;
 
-/// Captured-once raw RGBA of the base tray icon. We hold this so the
-/// badge renderer can re-composite a fresh badge on every unread-count
-/// change without re-reading the on-disk PNG. The window's default
-/// icon is the source of truth at startup.
-struct TrayBaseIcon {
+/// Raw RGBA of the *current* tray base icon — i.e. the icon the
+/// badge renderer overlays the unread count onto.  Wrapped in a
+/// `Mutex` so `set_logo_style` can hot-swap the bitmap when the
+/// user picks a different style without restarting the app.
+struct TrayBaseIcon(std::sync::Mutex<TrayBaseIconBitmap>);
+
+#[derive(Clone)]
+struct TrayBaseIconBitmap {
     rgba: Vec<u8>,
     width: u32,
     height: u32,
+}
+
+/// Bytes of every per-style logo PNG, baked into the binary at
+/// compile time so the picker doesn't depend on runtime resources.
+/// 256 px is the right pick: large enough that downscales for the
+/// 32 px tray and the 16/32 px Windows window icon stay sharp,
+/// small enough that all 7 styles together add < 100 KB to the
+/// binary.
+mod logo_assets {
+    pub const STORM: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/storm/nimbus-256.png"
+    );
+    pub const DAWN: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/dawn/nimbus-256.png"
+    );
+    pub const MINT: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/mint/nimbus-256.png"
+    );
+    pub const SKY: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/sky/nimbus-256.png"
+    );
+    pub const TWILIGHT: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/twilight/nimbus-256.png"
+    );
+    pub const MONO_BLACK: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/monochrome/nimbus-mono-black.png"
+    );
+    pub const MONO_WHITE: &[u8] = include_bytes!(
+        "../../logos/nimbus-logo/png/monochrome/nimbus-mono-white.png"
+    );
+}
+
+/// Map a style slug to the embedded PNG bytes.  Unknown slug →
+/// fall back to storm so a stray value (mistyped settings file,
+/// future-renamed style) can never leave the tray with no icon.
+fn logo_bytes_for(style: &str) -> &'static [u8] {
+    match style {
+        "dawn" => logo_assets::DAWN,
+        "mint" => logo_assets::MINT,
+        "sky" => logo_assets::SKY,
+        "twilight" => logo_assets::TWILIGHT,
+        "monochrome-black" => logo_assets::MONO_BLACK,
+        "monochrome-white" => logo_assets::MONO_WHITE,
+        _ => logo_assets::STORM,
+    }
+}
+
+/// Decode a PNG into the raw RGBA + dims that Tauri's
+/// `tauri::image::Image::new` and our badge compositor both want.
+/// Reuses Tauri's bundled PNG decoder so we don't pull a separate
+/// `image` crate just for this.
+fn decode_logo_png(bytes: &[u8]) -> Result<TrayBaseIconBitmap, NimbusError> {
+    let img = tauri::image::Image::from_bytes(bytes)
+        .map_err(|e| NimbusError::Other(format!("failed to decode logo PNG: {e}")))?;
+    Ok(TrayBaseIconBitmap {
+        rgba: img.rgba().to_vec(),
+        width: img.width(),
+        height: img.height(),
+    })
 }
 
 /// Absolute filesystem path to a PNG of our app icon, written at
@@ -6382,14 +6444,6 @@ struct NewMailPayload {
     subject: String,
 }
 
-/// Load the tray icon. Reuses the window icon when present (same PNG
-/// we ship with the app) so dev and prod builds paint the same bitmap.
-fn load_tray_icon(app: &AppHandle) -> Result<tauri::image::Image<'_>, NimbusError> {
-    app.default_window_icon()
-        .cloned()
-        .ok_or_else(|| NimbusError::Other("no default window icon available for tray".into()))
-}
-
 /// Bring the main window to the front. Called from the tray's
 /// left-click handler, the tray menu's "Open Nimbus" item, and the
 /// `show_main_window` command.
@@ -6472,7 +6526,14 @@ fn refresh_unread_badge(app: &AppHandle) {
 
     if let Some(tray) = app.tray_by_id("nimbus-main") {
         let base = app.state::<TrayBaseIcon>();
-        let badged = badge::render_tray_icon(&base.rgba, base.width, base.height, total);
+        let bitmap = match base.0.lock() {
+            Ok(g) => g.clone(),
+            Err(e) => {
+                tracing::warn!("refresh_unread_badge: tray base lock poisoned: {e}");
+                return;
+            }
+        };
+        let badged = badge::render_tray_icon(&bitmap.rgba, bitmap.width, bitmap.height, total);
         if let Err(e) = tray.set_icon(Some(badged)) {
             tracing::warn!("failed to update tray icon: {e}");
         }
@@ -7626,6 +7687,78 @@ async fn check_mail_now(app: AppHandle) -> Result<(), NimbusError> {
     check_mail_now_inner(&app).await
 }
 
+/// Switch the running app's icon (tray, window titlebar, taskbar)
+/// to the user's picked logo style and persist the choice in
+/// `AppSettings.logo_style`.  The next boot reapplies it.
+///
+/// Note this only swaps icons that exist *while the app runs*; the
+/// `.exe` thumbnail Windows Explorer / macOS Finder shows for the
+/// installed binary is baked in at `cargo tauri build` time and
+/// can't change at runtime.
+#[tauri::command]
+async fn set_logo_style(
+    app: AppHandle,
+    style: String,
+    settings: State<'_, SharedSettings>,
+) -> Result<(), NimbusError> {
+    let bytes = logo_bytes_for(&style);
+
+    // Decode once up front so a bad slug fails before we touch any
+    // running state.  `decode_logo_png` falls back to storm
+    // internally if the slug is unknown, so this should always
+    // succeed for reasonable inputs.
+    let bitmap = decode_logo_png(bytes)?;
+
+    // Swap the tray base bitmap so the next badge re-render uses
+    // the new style.  Then trigger an immediate re-render so the
+    // tray reflects the change without waiting for the next
+    // unread-count tick.
+    if let Some(tray_state) = app.try_state::<TrayBaseIcon>() {
+        if let Ok(mut guard) = tray_state.0.lock() {
+            *guard = bitmap;
+        }
+    }
+    refresh_unread_badge(&app);
+
+    // Update the main window's icon — Windows mirrors this into
+    // the taskbar entry, macOS into the title bar, X11 into the
+    // `_NET_WM_ICON` atom.
+    if let Some(win) = app.get_webview_window("main") {
+        if let Ok(img) = tauri::image::Image::from_bytes(bytes) {
+            if let Err(e) = win.set_icon(img) {
+                tracing::warn!("set_logo_style: window set_icon failed: {e}");
+            }
+        }
+    }
+
+    // Persist last so a transient apply failure can't permanently
+    // wedge the user on a style they didn't pick.
+    let mut s = settings.write().await;
+    s.logo_style = style;
+    app_settings::save_settings(&s)?;
+    Ok(())
+}
+
+/// Custom URI scheme handler for `nimbus-logo://localhost/<style>`.
+/// Used by the Settings picker to render preview tiles via plain
+/// `<img src="nimbus-logo://localhost/storm">` — same trick the
+/// `contact-photo` scheme uses for avatars.  Unknown style →
+/// storm fallback (matches the runtime behaviour, so the preview
+/// can't deceive the user).
+fn logo_protocol(
+    _ctx: UriSchemeContext<'_, tauri::Wry>,
+    request: tauri::http::Request<Vec<u8>>,
+) -> tauri::http::Response<std::borrow::Cow<'static, [u8]>> {
+    let style = request.uri().path().trim_start_matches('/').to_string();
+    let bytes = logo_bytes_for(&style);
+    tauri::http::Response::builder()
+        .status(200)
+        .header("Content-Type", "image/png")
+        .header("Cache-Control", "private, max-age=300")
+        .body(std::borrow::Cow::Borrowed(bytes))
+        .expect("build logo response")
+}
+
 // ── Custom themes (#132 tier 2) ────────────────────────────────
 //
 // User picks a Skeleton-shape CSS file in the Settings → Design
@@ -7855,6 +7988,7 @@ fn main() {
         .manage(shared_settings)
         .manage::<SystemFontsCache>(Arc::new(RwLock::new(Vec::new())))
         .register_uri_scheme_protocol("contact-photo", contact_photo_protocol)
+        .register_uri_scheme_protocol("nimbus-logo", logo_protocol)
         .setup(|app| {
             // Windows toast attribution.  Without an explicit
             // AppUserModelID the OS falls back to the launching
@@ -7945,17 +8079,52 @@ fn main() {
                 ],
             )?;
 
-            let tray_icon = load_tray_icon(&handle)?;
-
-            // Snapshot the base icon's raw RGBA so the badge renderer
-            // can re-composite without re-reading the on-disk PNG on
-            // every unread-count change. Stored in managed state.
-            let base = TrayBaseIcon {
-                rgba: tray_icon.rgba().to_vec(),
-                width: tray_icon.width(),
-                height: tray_icon.height(),
+            // Honour the user's saved logo style at boot.  Falls
+            // back to "storm" if decoding fails for any reason —
+            // keeps the tray from coming up blank on a malformed
+            // settings file.  Reads through the managed-state copy
+            // so we don't have to capture `shared_settings` into
+            // this closure (it was already moved into `.manage`).
+            let chosen_style = {
+                let st = app.state::<SharedSettings>();
+                let s = futures::executor::block_on(st.read());
+                s.logo_style.clone()
             };
-            app.manage(base);
+            let style_bytes = logo_bytes_for(&chosen_style);
+            let initial_bitmap = decode_logo_png(style_bytes).unwrap_or_else(|e| {
+                tracing::warn!(
+                    "logo style '{chosen_style}' failed to decode ({e}); \
+                     falling back to storm"
+                );
+                decode_logo_png(logo_assets::STORM)
+                    .expect("storm logo PNG must always decode")
+            });
+
+            // Reflect the chosen style on the main window — the
+            // titlebar icon and (on Windows) the taskbar entry both
+            // pick up `set_icon`.
+            if let Some(win) = app.get_webview_window("main") {
+                if let Ok(img) = tauri::image::Image::from_bytes(style_bytes) {
+                    if let Err(e) = win.set_icon(img) {
+                        tracing::warn!("failed to apply window icon at boot: {e}");
+                    }
+                }
+            }
+
+            // Tauri's `Image::from_bytes` decodes into owned RGBA
+            // (`Image<'static>`), which is what `TrayIconBuilder`
+            // wants.  Using `from_bytes` again here (instead of
+            // `Image::new(&initial_bitmap.rgba, ...)`) sidesteps a
+            // borrow-vs-move conflict where we want to *also*
+            // hand `initial_bitmap` to the managed-state stash.
+            let tray_icon = tauri::image::Image::from_bytes(style_bytes)
+                .map_err(|e| NimbusError::Other(format!("decode tray icon: {e}")))?;
+
+            // Stash the base RGBA in managed state so the badge
+            // renderer (and `set_logo_style`) can re-composite
+            // without re-reading the PNG on every unread-count
+            // change or style swap.
+            app.manage(TrayBaseIcon(std::sync::Mutex::new(initial_bitmap)));
 
             let _tray = TrayIconBuilder::with_id("nimbus-main")
                 .icon(tray_icon)
@@ -8217,6 +8386,7 @@ fn main() {
             get_wipe_policy,
             set_wipe_policy,
             update_app_settings,
+            set_logo_style,
             import_custom_theme,
             remove_custom_theme,
             check_mail_now,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "width": 1200,
         "height": 800,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "visible": false
       }
     ],
     "security": {

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -126,6 +126,9 @@
     autostart_enabled: boolean
     /** User-imported Skeleton themes (#132 tier 2). */
     custom_themes?: CustomThemeRow[]
+    /** App-icon style slug — drives the tray, window titlebar and
+     *  taskbar icon. Picker lives in Settings → Design. */
+    logo_style?: string
   }
   interface CustomThemeRow {
     id: string
@@ -148,7 +151,45 @@
     talk_reminder_enabled: true,
     autostart_enabled: false,
     custom_themes: [],
+    logo_style: 'storm',
   })
+
+  // ── Logo / app-icon picker (Issue #X) ───────────────────────
+  // Each entry is one slug the Rust side knows: the image source
+  // is the `nimbus-logo://localhost/<id>` URI scheme (registered
+  // in main.rs) which streams the embedded PNG bytes back as a
+  // plain image response. Click → invoke `set_logo_style`, which
+  // hot-swaps the running tray + window icon and persists the
+  // pick to `app_settings.json`.
+  interface LogoStyle {
+    id: string
+    label: string
+    swatchTone: string  // bg-tailwind class for the underline accent
+  }
+  const LOGO_STYLES: LogoStyle[] = [
+    { id: 'storm',             label: 'Storm',            swatchTone: 'bg-blue-500' },
+    { id: 'dawn',              label: 'Dawn',             swatchTone: 'bg-orange-400' },
+    { id: 'mint',              label: 'Mint',             swatchTone: 'bg-emerald-400' },
+    { id: 'sky',               label: 'Sky',              swatchTone: 'bg-sky-400' },
+    { id: 'twilight',          label: 'Twilight',         swatchTone: 'bg-violet-500' },
+    { id: 'monochrome-black',  label: 'Mono — Black',     swatchTone: 'bg-slate-900' },
+    { id: 'monochrome-white',  label: 'Mono — White',     swatchTone: 'bg-slate-200' },
+  ]
+  let logoSaving = $state(false)
+
+  async function pickLogoStyle(id: string) {
+    if (logoSaving || appSettings.logo_style === id) return
+    logoSaving = true
+    try {
+      await invoke('set_logo_style', { style: id })
+      appSettings.logo_style = id
+      onappprefschanged?.({ ...appSettings })
+    } catch (e) {
+      console.warn('set_logo_style failed', e)
+    } finally {
+      logoSaving = false
+    }
+  }
 
   /** Picker rows — stock themes plus the user's imports.  Driven
    *  by `appSettings.custom_themes` so a fresh import / remove
@@ -1068,6 +1109,45 @@
             against the app's background, which respects dark-mode-aware emails
             but can wash out the rest. Each open mail also has its own toggle
             to override this default.
+          </p>
+        </div>
+
+        <!-- App icon picker — swaps the running tray + window
+             icon (and Windows taskbar entry, which mirrors the
+             window icon) to one of the bundled styles.  The
+             `nimbus-logo://localhost/<id>` URI scheme serves the
+             embedded PNG bytes so each tile previews the actual
+             icon, not just a colour swatch. -->
+        <div>
+          <p class="font-medium mb-2">App icon</p>
+          <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
+            {#each LOGO_STYLES as style (style.id)}
+              {@const active = (appSettings.logo_style ?? 'storm') === style.id}
+              <button
+                type="button"
+                class="flex flex-col items-center gap-1 p-2 rounded-md border transition-colors {active
+                  ? 'border-primary-500 bg-primary-500/10'
+                  : 'border-surface-300 dark:border-surface-700 hover:bg-surface-200 dark:hover:bg-surface-700'}"
+                disabled={logoSaving}
+                aria-pressed={active}
+                onclick={() => void pickLogoStyle(style.id)}
+                title="Use the {style.label} icon for the tray, window and taskbar"
+              >
+                <img
+                  src={`nimbus-logo://localhost/${style.id}`}
+                  alt={`${style.label} icon preview`}
+                  class="w-12 h-12 object-contain"
+                  loading="lazy"
+                />
+                <span class="text-xs">{style.label}</span>
+                <span class="block w-8 h-1 rounded-full {style.swatchTone}"></span>
+              </button>
+            {/each}
+          </div>
+          <p class="text-xs text-surface-400 mt-2">
+            Affects the tray icon, the window titlebar, and (on Windows) the
+            taskbar entry. The .exe icon shown in Explorer / Finder before
+            launch is fixed at build time and isn't changed by this picker.
           </p>
         </div>
       </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1119,7 +1119,12 @@
              embedded PNG bytes so each tile previews the actual
              icon, not just a colour swatch. -->
         <div>
-          <p class="font-medium mb-2">App icon</p>
+          <p class="font-medium mb-1">App icon</p>
+          <p class="text-xs text-surface-400 mb-2">
+            Affects the tray icon, the window titlebar, and (on Windows) the
+            taskbar entry. The .exe icon shown in Explorer / Finder before
+            launch is fixed at build time and isn't changed by this picker.
+          </p>
           <div class="grid grid-cols-3 sm:grid-cols-4 gap-2">
             {#each LOGO_STYLES as style (style.id)}
               {@const active = (appSettings.logo_style ?? 'storm') === style.id}
@@ -1144,11 +1149,6 @@
               </button>
             {/each}
           </div>
-          <p class="text-xs text-surface-400 mt-2">
-            Affects the tray icon, the window titlebar, and (on Windows) the
-            taskbar entry. The .exe icon shown in Explorer / Finder before
-            launch is fixed at build time and isn't changed by this picker.
-          </p>
         </div>
       </div>
     </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -7,7 +7,7 @@
    * area and lets users manage their accounts after initial setup.
    */
 
-  import { invoke } from '@tauri-apps/api/core'
+  import { convertFileSrc, invoke } from '@tauri-apps/api/core'
   import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
   import { enable as autostartEnable, disable as autostartDisable, isEnabled as autostartIsEnabled } from '@tauri-apps/plugin-autostart'
   import NextcloudSettings from './NextcloudSettings.svelte'
@@ -1134,7 +1134,7 @@
                 title="Use the {style.label} icon for the tray, window and taskbar"
               >
                 <img
-                  src={`nimbus-logo://localhost/${style.id}`}
+                  src={convertFileSrc(style.id, 'nimbus-logo')}
                   alt={`${style.label} icon preview`}
                   class="w-12 h-12 object-contain"
                   loading="lazy"


### PR DESCRIPTION
Builds on #200 (storm-logo bundle).

## Summary

Adds a logo picker in Settings → Design so the user can swap the running tray, window-titlebar, and Windows-taskbar icon between seven bundled styles (storm / dawn / mint / sky / twilight, plus monochrome black / white) without rebuilding the app. Each tile previews the actual icon — colour and silhouette read at a glance, no relying on style names alone.

## What's in here

### Backend
* `AppSettings.logo_style: String` — defaults to "storm" via `#[serde(default)]`, so older settings files round-trip cleanly.
* 256 px PNGs for every style baked in via `include_bytes!` from `logos/nimbus-logo/png/<style>/` — the picker doesn't depend on runtime resources or unpacked Tauri bundle assets.
* `TrayBaseIcon` now wraps a `Mutex<TrayBaseIconBitmap>` so `set_logo_style` can hot-swap the base bitmap. The badge renderer's next composite picks up the new base automatically.
* New `set_logo_style(style)` Tauri command — decodes the chosen PNG, swaps the tray base, calls `window.set_icon`, then persists. Apply-before-persist so a transient apply error can't wedge the user on a style they didn't pick.
* Boot-time apply: `setup` reads `logo_style` from settings, decodes the matching PNG, builds the tray Image and calls `window.set_icon` before the main window is shown. Falls back to storm if the slug is unknown.
* Main window now starts with `visible: false`; setup paints the chosen-style icon and *then* calls `show()`. Stops the one-frame flash where non-storm picks used to come up wearing the bundled storm icon for a beat before the swap landed.
* `build.rs` declares `cargo:rerun-if-changed` for `icons/icon.ico` / `icon.icns` / `icon.png` / `tauri.conf.json` so a logo regeneration triggers re-embedding the .exe icon resource on the next build (Task Manager / Explorer thumbnail no longer stays stale until `cargo clean`).
* New `nimbus-logo://localhost/<style>` URI scheme handler — mirrors the existing `contact-photo://` pattern. Streams the embedded PNG bytes back with `Content-Type: image/png` so picker tiles render via plain `<img src>` (no IPC byte-shipping, no JSON-array encoding bloat).

### Frontend
* `AppSettings` TS interface gains `logo_style?: string`.
* New picker grid under Settings → Design → App icon: 7 tiles, each rendering the actual icon via the new URI scheme plus a small accent-coloured underline so the colour reads at a glance even when the icons are similar in silhouette.
* Helper text sits *under* the section heading (caveat about the .exe thumbnail being build-time only) so the expectation is set before the user picks.
* Click → invoke `set_logo_style` through `convertFileSrc(<id>, 'nimbus-logo')` so the renderer actually loads the custom-scheme URL (Tauri 2 doesn't expose raw `<scheme>://...` to the webview).

### Badge polish (came up during testing)
* Tray badge: 22 % of the icon's short side, 6 % corner inset, top-right placement — reads as a notification indicator instead of a sticker.
* Windows taskbar overlay: 10 × 10 disc centered in the 16 × 16 overlay slot (was filling the full 16 × 16, which Windows scaled into a chunky red ball at the icon corner).
* Both surfaces drop the white halo — flat red disc, no ring underneath.

## Why a URI scheme for previews

We could have shipped the PNGs as static frontend assets, but then dev (Vite) and prod (Tauri bundle) would resolve them differently. Streaming through the scheme reuses the in-binary bytes for both — same source of truth as the runtime icon, no double-shipping.

## Test plan

- [ ] `cargo clean -p nimbus-app` then `cargo tauri dev` (one-time, to evict the cached .exe icon resource) — confirm Settings → Design shows the App icon picker with 7 tiles and the actual icon rendered in each.
- [ ] Click a tile (e.g. Mint) — tray icon, window titlebar, Windows taskbar entry update immediately, no restart needed.
- [ ] Restart the app — picked style persists, window comes up with the chosen icon already painted (no storm flash).
- [ ] Pick another style with the unread badge non-zero — confirm the badge re-composites onto the new base.
- [ ] Confirm Task Manager / Explorer thumbnail show the storm bundle icon (build-time, not affected by picker).
- [ ] Manually edit `app_settings.json` to set `logo_style: "bogus"` — confirm app boots with storm fallback (no blank tray).

🤖 Generated with [Claude Code](https://claude.com/claude-code)