### PR TITLE
Compose: dismiss the table picker on outside click (closes #199)

### DIFF
--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1111,7 +1111,32 @@
   let showTablePicker = $state(false)
   let tableHoverRows = $state(0)
   let tableHoverCols = $state(0)
+  let tablePickerAnchor = $state<HTMLDivElement | null>(null)
   const TABLE_GRID = 8  // 8x8 picker like Outlook
+
+  /** Outside-click dismissal for the table picker (#199).  Mirrors
+   *  the project-wide idiom from CLAUDE.md: register the listener
+   *  inside an `$effect` keyed on the open state, defer one tick
+   *  so the click that opened the picker doesn't immediately
+   *  close it, tear down on close. */
+  $effect(() => {
+    if (!showTablePicker) return
+    const onMouseDown = (e: MouseEvent) => {
+      if (tablePickerAnchor && !tablePickerAnchor.contains(e.target as Node)) {
+        showTablePicker = false
+        tableHoverRows = 0
+        tableHoverCols = 0
+      }
+    }
+    const id = setTimeout(
+      () => document.addEventListener('mousedown', onMouseDown),
+      0,
+    )
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('mousedown', onMouseDown)
+    }
+  })
 
   /** Selection (cursor position) snapshotted when the user opens
    *  the table picker.  We restore it before inserting so the
@@ -1657,7 +1682,7 @@
         <span class="rt-divider"></span>
 
         <!-- Table picker -->
-        <div class="relative inline-block">
+        <div class="relative inline-block" bind:this={tablePickerAnchor}>
           <button class="rt-btn" title="Insert table at cursor" onclick={openTablePicker}>
             <span class="rt-btn-icon"><Icon name="table" size={16} /></span>
             <span class="rt-btn-label">Table</span>
@@ -1667,6 +1692,7 @@
             <div
               class="absolute left-0 top-full mt-1 z-50 p-2 bg-white dark:bg-surface-800 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg"
               onmouseleave={() => { tableHoverRows = 0; tableHoverCols = 0 }}
+              onkeydown={(e) => e.key === 'Escape' && (showTablePicker = false)}
             >
               <div class="text-xs text-surface-500 mb-1 text-center">
                 {tableHoverRows > 0 ? `${tableHoverRows} × ${tableHoverCols}` : 'Pick size'}


### PR DESCRIPTION
Closes #199.

## Summary

The table-grid popover in the rich-text toolbar only closed when the user picked a cell or toggled the toolbar button again — clicking anywhere else in Compose left it sitting open over the body. Now it dismisses on outside click and on Escape, matching the project's other popovers.

## What's in here

* `bind:this={tablePickerAnchor}` on the picker's wrapping div so the dismiss handler can do an ancestor check on the click target.
* `$effect` keyed on `showTablePicker` (RichTextEditor.svelte): registers a `mousedown` listener inside a `setTimeout(0)` so the click that opened the picker doesn't immediately close it; tears down on close / unmount. Mirrors the project-wide idiom in CLAUDE.md and the existing `Select.svelte` reference.
* `onkeydown` on the popover handles Escape, same affordance the emoji picker already has.
* Hover state is reset on dismiss so a re-open starts at "Pick size" instead of whatever cell the cursor last hovered.

## Test plan

- [ ] In Compose, click Insert → Table — picker opens.
- [ ] Click anywhere outside the picker (body, another toolbar button, the email subject field) — picker closes without inserting a table.
- [ ] Click inside the picker grid — closes and inserts the table at the picked size.
- [ ] Press Escape while the picker is open — closes without inserting.
- [ ] Open the picker, hover a cell, dismiss via outside click, reopen — picker shows "Pick size", not the previous hover state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)