### PR TITLE
Infinite scroll for older messages in MailList (closes #194)

### DIFF
--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -1323,6 +1323,142 @@ impl ImapClient {
         Ok(envelopes)
     }
 
+    /// Fetch up to `limit` envelopes whose UIDs are strictly less than
+    /// `before_uid`, sorted newest-first.  Used by MailList's
+    /// infinite-scroll "load older" path (#194): the cold-cache
+    /// `fetch_envelopes("newest N")` only walks the tail of the
+    /// folder, so anything older than the Nth-newest message never
+    /// reaches the local cache. This method runs `UID SEARCH UID
+    /// 1:<before_uid-1>` to get every older UID, sorts descending,
+    /// truncates to `limit`, and fetches just those envelopes.
+    ///
+    /// Returns the freshly-fetched envelopes; the caller is
+    /// responsible for writing them through to the cache. An empty
+    /// return means there's nothing older — frontend can stop
+    /// asking.
+    ///
+    /// Two round trips (SEARCH then FETCH) on purpose: a single
+    /// `UID FETCH 1:<before_uid-1>` would parse envelope metadata
+    /// for every older message in the folder, even though we only
+    /// want the newest `limit` of them. SEARCH returns just UIDs
+    /// (small payload), FETCH then asks for the slice we keep.
+    pub async fn fetch_older_envelopes(
+        &mut self,
+        folder: &str,
+        before_uid: u32,
+        limit: u32,
+    ) -> Result<EnvelopeBatch, NimbusError> {
+        let (_total, uidvalidity) = self.select_folder(folder).await?;
+        if before_uid == 0 || before_uid == 1 {
+            // Nothing can be older than UID 1.  (Some servers don't
+            // assign UID 0 at all, others reserve it; either way an
+            // empty response here is correct.)
+            return Ok(EnvelopeBatch {
+                uidvalidity,
+                envelopes: Vec::new(),
+            });
+        }
+
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        let criterion = format!("UID 1:{}", before_uid - 1);
+        debug!("UID SEARCH for older in '{folder}': {criterion}");
+        let mut uids: Vec<u32> = session
+            .uid_search(&criterion)
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID SEARCH (older) failed: {e}")))?
+            .into_iter()
+            .collect();
+
+        if uids.is_empty() {
+            return Ok(EnvelopeBatch {
+                uidvalidity,
+                envelopes: Vec::new(),
+            });
+        }
+
+        // Top `limit` by descending UID — those are the newest
+        // among "older than before_uid".
+        uids.sort_unstable_by(|a, b| b.cmp(a));
+        uids.truncate(limit as usize);
+
+        let set = uids
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let fetches: Vec<_> = session
+            .uid_fetch(set, "(UID FLAGS INTERNALDATE ENVELOPE)")
+            .await
+            .map_err(|e| {
+                NimbusError::Protocol(format!("UID FETCH (older) failed: {e}"))
+            })?
+            .try_collect()
+            .await
+            .map_err(|e| {
+                NimbusError::Protocol(format!("Failed to read older FETCH: {e}"))
+            })?;
+
+        let mut envelopes: Vec<EmailEnvelope> = fetches
+            .iter()
+            .filter_map(|fetch| {
+                let uid = fetch.uid?;
+                let envelope = fetch.envelope()?;
+
+                let subject = envelope
+                    .subject
+                    .as_ref()
+                    .map(|s| decode_header(s))
+                    .unwrap_or_default();
+                let from = envelope
+                    .from
+                    .as_ref()
+                    .and_then(|addrs| addrs.first())
+                    .map(format_address)
+                    .unwrap_or_default();
+                let date = envelope
+                    .date
+                    .as_ref()
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .and_then(parse_rfc2822)
+                    .or_else(|| fetch.internal_date().map(|dt| dt.with_timezone(&Utc)))
+                    .unwrap_or_else(Utc::now);
+
+                let mut is_read = false;
+                let mut is_starred = false;
+                for flag in fetch.flags() {
+                    match flag {
+                        async_imap::types::Flag::Seen => is_read = true,
+                        async_imap::types::Flag::Flagged => is_starred = true,
+                        _ => {}
+                    }
+                }
+
+                Some(EmailEnvelope {
+                    uid,
+                    folder: folder.to_string(),
+                    from,
+                    subject,
+                    date,
+                    is_read,
+                    is_starred,
+                    account_id: String::new(),
+                })
+            })
+            .collect();
+        envelopes.sort_unstable_by_key(|e| std::cmp::Reverse(e.date));
+
+        info!(
+            "Fetched {} older envelopes in '{folder}' before UID {before_uid}",
+            envelopes.len()
+        );
+        Ok(EnvelopeBatch { uidvalidity, envelopes })
+    }
+
     /// Log out from the IMAP server and close the connection cleanly.
     ///
     /// Always call this when you're done — it sends the LOGOUT command

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -1323,6 +1323,116 @@ impl ImapClient {
         Ok(envelopes)
     }
 
+    /// Server-side search variant of `search_envelopes` that returns
+    /// only matches with UIDs strictly less than `before_uid`. Used
+    /// by SearchResults' infinite-scroll path (#194 follow-up): when
+    /// the user has clicked "Search server too" and wants to keep
+    /// loading deeper into the server's results.
+    ///
+    /// Same SEARCH-then-FETCH shape as `search_envelopes`: the UID
+    /// criterion is AND'd into the query so the server-side filter
+    /// runs as part of one SEARCH instead of two; we then sort the
+    /// returned UIDs descending and FETCH just the top `limit`.
+    pub async fn search_envelopes_older(
+        &mut self,
+        folder: &str,
+        criterion: &str,
+        before_uid: u32,
+        limit: u32,
+    ) -> Result<Vec<EmailEnvelope>, NimbusError> {
+        if before_uid <= 1 {
+            return Ok(Vec::new());
+        }
+        let _ = self.select_folder(folder).await?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        // AND the user's query with `UID 1:<before_uid-1>` so the
+        // server returns only matches strictly older than the
+        // anchor — saves us a client-side filter pass.
+        let combined = format!("UID 1:{} {}", before_uid - 1, criterion);
+        debug!("UID SEARCH (older) in '{folder}': {combined}");
+        let mut uids: Vec<u32> = session
+            .uid_search(&combined)
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID SEARCH (older) failed: {e}")))?
+            .into_iter()
+            .collect();
+
+        if uids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        uids.sort_unstable_by(|a, b| b.cmp(a));
+        uids.truncate(limit as usize);
+
+        let set = uids
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let fetches: Vec<_> = session
+            .uid_fetch(set, "(UID FLAGS INTERNALDATE ENVELOPE)")
+            .await
+            .map_err(|e| {
+                NimbusError::Protocol(format!("UID FETCH (older search) failed: {e}"))
+            })?
+            .try_collect()
+            .await
+            .map_err(|e| {
+                NimbusError::Protocol(format!("Failed to read older SEARCH FETCH: {e}"))
+            })?;
+
+        let mut envelopes: Vec<EmailEnvelope> = fetches
+            .iter()
+            .filter_map(|fetch| {
+                let uid = fetch.uid?;
+                let envelope = fetch.envelope()?;
+                let subject = envelope
+                    .subject
+                    .as_ref()
+                    .map(|s| decode_header(s))
+                    .unwrap_or_default();
+                let from = envelope
+                    .from
+                    .as_ref()
+                    .and_then(|addrs| addrs.first())
+                    .map(format_address)
+                    .unwrap_or_default();
+                let date = envelope
+                    .date
+                    .as_ref()
+                    .and_then(|bytes| std::str::from_utf8(bytes).ok())
+                    .and_then(parse_rfc2822)
+                    .or_else(|| fetch.internal_date().map(|dt| dt.with_timezone(&Utc)))
+                    .unwrap_or_else(Utc::now);
+                let mut is_read = false;
+                let mut is_starred = false;
+                for flag in fetch.flags() {
+                    match flag {
+                        async_imap::types::Flag::Seen => is_read = true,
+                        async_imap::types::Flag::Flagged => is_starred = true,
+                        _ => {}
+                    }
+                }
+                Some(EmailEnvelope {
+                    uid,
+                    folder: folder.to_string(),
+                    from,
+                    subject,
+                    date,
+                    is_read,
+                    is_starred,
+                    account_id: String::new(),
+                })
+            })
+            .collect();
+        envelopes.sort_unstable_by_key(|e| std::cmp::Reverse(e.date));
+        Ok(envelopes)
+    }
+
     /// Fetch up to `limit` envelopes whose UIDs are strictly less than
     /// `before_uid`, sorted newest-first.  Used by MailList's
     /// infinite-scroll "load older" path (#194): the cold-cache

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6489,6 +6489,47 @@ async fn search_imap_server(
     Ok(hits)
 }
 
+/// "Load older server-search results" — same shape as
+/// `search_imap_server` but takes a `before_uid` cursor so
+/// SearchResults can paginate the IMAP search hits past the
+/// initial round (#194 follow-up). The frontend tracks the
+/// smallest UID it currently has from a previous server-search
+/// call and passes it here; we return up to `limit` envelopes
+/// matching the same criterion with UID < before_uid.
+///
+/// JMAP returns empty (same posture as `search_imap_server`,
+/// since the JMAP cache-first path covers the user's needs
+/// without server pagination).
+#[tauri::command]
+async fn search_imap_server_older(
+    account_id: String,
+    folder: String,
+    query: String,
+    before_uid: u32,
+    limit: u32,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, NimbusError> {
+    let account = load_account(&cache, &account_id)?;
+    if uses_jmap(&account) {
+        return Ok(Vec::new());
+    }
+    let criterion = imap_search_criterion(&query);
+    if criterion.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut client = connect_imap(&account).await?;
+    let hits = client
+        .search_envelopes_older(&folder, &criterion, before_uid, limit)
+        .await?;
+    let _ = client.logout().await;
+
+    if !hits.is_empty() {
+        cache.upsert_envelopes_for_account(&account_id, &hits)?;
+    }
+    Ok(hits)
+}
+
 /// Translate a user query into an IMAP SEARCH criterion string.
 ///
 /// We keep this much simpler than the FTS parser — IMAP SEARCH
@@ -8445,6 +8486,7 @@ fn main() {
             detect_jmap,
             search_emails,
             search_imap_server,
+            search_imap_server_older,
             start_nextcloud_login,
             poll_nextcloud_login,
             get_nextcloud_accounts,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4840,6 +4840,121 @@ async fn fetch_envelopes_inner(
         .map_err(Into::into)
 }
 
+/// "Load older messages" — fetch up to `limit` envelopes whose UIDs
+/// are strictly less than `before_uid`, used by MailList's
+/// infinite-scroll path (#194). The cold-cache `fetch_envelopes`
+/// path only walks the tail of a folder, so this is the surface
+/// the UI calls when the user scrolls past the loaded set and
+/// wants to keep going.
+///
+/// IMAP path runs `UID SEARCH UID 1:<before_uid-1>`, slices the
+/// top `limit` UIDs (newest among the older), then fetches just
+/// those envelopes. The result is written through to the SQLite
+/// cache so subsequent loads are instant. Empty return = nothing
+/// older exists; the frontend stops asking.
+///
+/// JMAP isn't wired here yet — we tracing-warn and return an
+/// empty batch so the frontend simply stops paginating.
+#[tauri::command]
+async fn fetch_older_envelopes(
+    account_id: String,
+    folder: String,
+    before_uid: u32,
+    limit: u32,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, NimbusError> {
+    let account = load_account(&cache, &account_id)?;
+    if uses_jmap(&account) {
+        tracing::warn!(
+            "fetch_older_envelopes: JMAP older-pagination not implemented for '{account_id}'/'{folder}'"
+        );
+        return Ok(Vec::new());
+    }
+
+    let mut client = connect_imap(&account).await?;
+    let batch = client
+        .fetch_older_envelopes(&folder, before_uid, limit)
+        .await?;
+    let _ = client.logout().await;
+
+    if !batch.envelopes.is_empty() {
+        if let Err(e) = cache.upsert_envelopes_for_account(&account_id, &batch.envelopes) {
+            tracing::warn!("cache.upsert_envelopes (older) failed: {e}");
+        }
+    }
+
+    // Stamp the account_id into the returned envelopes so the
+    // frontend's grouping logic (unified inbox uses
+    // `account_id` to route per-row clicks) keeps working —
+    // the IMAP method leaves it empty since it doesn't know
+    // which account it's serving.
+    let mut envelopes = batch.envelopes;
+    for env in &mut envelopes {
+        env.account_id = account_id.clone();
+    }
+    Ok(envelopes)
+}
+
+/// Unified-inbox version of `fetch_older_envelopes`. Each account
+/// has its own UID space, so the frontend passes a per-account
+/// `before_uid` map. We poll each account's folder with its own
+/// anchor and merge the results. Same JMAP caveat as the
+/// per-account version.
+#[tauri::command]
+async fn fetch_older_unified_envelopes(
+    folder: String,
+    before_uid_per_account: std::collections::HashMap<String, u32>,
+    limit: u32,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, NimbusError> {
+    let accounts = account_store::load_accounts(&cache).unwrap_or_default();
+    let mut merged: Vec<EmailEnvelope> = Vec::new();
+    for account in &accounts {
+        let Some(&before_uid) = before_uid_per_account.get(&account.id) else {
+            continue;
+        };
+        if uses_jmap(account) {
+            tracing::warn!(
+                "fetch_older_unified_envelopes: JMAP not implemented for '{}'",
+                account.id
+            );
+            continue;
+        }
+        let mut client = match connect_imap(account).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("unified older: connect failed for '{}': {e}", account.id);
+                continue;
+            }
+        };
+        match client.fetch_older_envelopes(&folder, before_uid, limit).await {
+            Ok(batch) => {
+                if let Err(e) =
+                    cache.upsert_envelopes_for_account(&account.id, &batch.envelopes)
+                {
+                    tracing::warn!("cache.upsert_envelopes (unified older) failed: {e}");
+                }
+                for mut env in batch.envelopes {
+                    env.account_id = account.id.clone();
+                    merged.push(env);
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "unified older fetch failed for '{}'/'{folder}': {e}",
+                    account.id
+                );
+            }
+        }
+        let _ = client.logout().await;
+    }
+    // Newest-first, capped at the unified `limit` so a single
+    // chatty account doesn't crowd the page.
+    merged.sort_unstable_by_key(|e| std::cmp::Reverse(e.date));
+    merged.truncate(limit as usize);
+    Ok(merged)
+}
+
 /// Unified-inbox version of `fetch_envelopes`: polls every configured
 /// account's `folder` (sequentially — keeps the SMTP/IMAP server load
 /// predictable) and then returns the merged newest-`limit` view from
@@ -8303,6 +8418,8 @@ fn main() {
             test_connection,
             fetch_envelopes,
             fetch_unified_envelopes,
+            fetch_older_envelopes,
+            fetch_older_unified_envelopes,
             fetch_message,
             download_email_attachment,
             put_attachment_preview,

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -316,6 +316,38 @@
     void load(accountId, folder, unified)
   })
 
+  /** Merge a fresh batch of envelopes (newest N from the cache or
+   *  the server) into the current rendered list.  Crucial for
+   *  preserving infinite-scroll state (#194 follow-up): the old
+   *  "envelopes = fresh" pattern wiped out any older pages the
+   *  user had scrolled to whenever `refreshToken` bumped (clicking
+   *  the IconRail avatar, marking read, etc.), which collapsed the
+   *  list back to 50 rows and reset scroll position to wherever
+   *  it could no longer reach.
+   *
+   *  Strategy: dedupe by `(account_id, uid)`. Fresh entries win on
+   *  collision so flag changes (read/starred/etc.) from the
+   *  refresh propagate. Older paginated entries the fresh batch
+   *  doesn't touch stay in place. Result is sorted newest-first by
+   *  date so a freshly-arrived envelope appears at the top.
+   *
+   *  Trade-off: if a message was expunged server-side between
+   *  paginated load and refresh, it stays stale in the UI until
+   *  the user switches folders. Acceptable — far better than the
+   *  alternative of losing pagination on every keystroke. */
+  function mergeEnvelopes(
+    existing: EmailEnvelope[],
+    fresh: EmailEnvelope[],
+  ): EmailEnvelope[] {
+    if (existing.length === 0) return fresh
+    const byKey = new Map<string, EmailEnvelope>()
+    for (const e of existing) byKey.set(`${e.account_id}:${e.uid}`, e)
+    for (const e of fresh) byKey.set(`${e.account_id}:${e.uid}`, e) // fresh wins
+    const merged = Array.from(byKey.values())
+    merged.sort((a, b) => b.date.localeCompare(a.date))
+    return merged
+  }
+
   async function load(id: string, f: string, isUnified: boolean) {
     loading = true
     refreshing = false
@@ -336,8 +368,8 @@
           : { accountId: id, folder: f, limit: PAGE_SIZE },
       )
       if (stillCurrent()) {
-        envelopes = cached
-        if (cached.length > 0) loading = false
+        envelopes = mergeEnvelopes(envelopes, cached)
+        if (envelopes.length > 0) loading = false
       }
     } catch (e: any) {
       // Cache miss is not an error — just ignore and wait for network.
@@ -355,7 +387,7 @@
           : { accountId: id, folder: f, limit: PAGE_SIZE },
       )
       if (stillCurrent()) {
-        envelopes = fresh
+        envelopes = mergeEnvelopes(envelopes, fresh)
       }
     } catch (e: any) {
       if (envelopes.length === 0) {

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -304,13 +304,31 @@
   let olderExhausted = $state(false)
   let scrollContainer = $state<HTMLDivElement | null>(null)
 
+  /** Snapshot of the (account, folder, unified) tuple the last
+   *  time the load effect ran.  Used to distinguish "folder /
+   *  account changed" (envelopes from the previous view must be
+   *  cleared so they don't leak into the new folder) from
+   *  "refreshToken bumped while folder unchanged" (envelopes
+   *  must be PRESERVED so any older pages the user paginated to
+   *  via infinite scroll survive — the merge path in `load()`
+   *  handles that case). Without this distinction the previous
+   *  fix to the refresh-clobber bug also caused mails from one
+   *  folder to leak into the next on folder switch. */
+  let lastFolderKey = $state('')
+
   // Re-fetch whenever the account, folder, unified flag, or
-  // refreshToken changes.  Also resets the pagination flags so a
-  // freshly-opened folder starts with a clean "load older"
-  // affordance — the previous folder's exhausted flag must not
-  // leak into the new one.
+  // refreshToken changes.  Resets the pagination flags every
+  // round and clears the rendered envelope list IF the
+  // (account, folder, unified) tuple changed — the merge path
+  // in `load()` only does the right thing within a single
+  // folder.
   $effect(() => {
     refreshToken
+    const key = `${unified ? '__all__' : accountId}::${folder}`
+    if (key !== lastFolderKey) {
+      envelopes = []
+      lastFolderKey = key
+    }
     loadingOlder = false
     olderExhausted = false
     void load(accountId, folder, unified)

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -294,10 +294,25 @@
     e.dataTransfer.effectAllowed = 'move'
   }
 
+  // Infinite-scroll pagination state (#194). Each (account, folder)
+  // pair has its own "older fetch" lifecycle: a flag to prevent
+  // double-loads while a request is in flight, and an "exhausted"
+  // flag set once the IMAP server returns nothing older — that's
+  // the signal to stop trying.
+  const PAGE_SIZE = 50
+  let loadingOlder = $state(false)
+  let olderExhausted = $state(false)
+  let scrollContainer = $state<HTMLDivElement | null>(null)
+
   // Re-fetch whenever the account, folder, unified flag, or
-  // refreshToken changes.
+  // refreshToken changes.  Also resets the pagination flags so a
+  // freshly-opened folder starts with a clean "load older"
+  // affordance — the previous folder's exhausted flag must not
+  // leak into the new one.
   $effect(() => {
     refreshToken
+    loadingOlder = false
+    olderExhausted = false
     void load(accountId, folder, unified)
   })
 
@@ -317,8 +332,8 @@
       const cached = await invoke<EmailEnvelope[]>(
         isUnified ? 'get_unified_cached_envelopes' : 'get_cached_envelopes',
         isUnified
-          ? { folder: f, limit: 50 }
-          : { accountId: id, folder: f, limit: 50 },
+          ? { folder: f, limit: PAGE_SIZE }
+          : { accountId: id, folder: f, limit: PAGE_SIZE },
       )
       if (stillCurrent()) {
         envelopes = cached
@@ -336,8 +351,8 @@
       const fresh = await invoke<EmailEnvelope[]>(
         isUnified ? 'fetch_unified_envelopes' : 'fetch_envelopes',
         isUnified
-          ? { folder: f, limit: 50 }
-          : { accountId: id, folder: f, limit: 50 },
+          ? { folder: f, limit: PAGE_SIZE }
+          : { accountId: id, folder: f, limit: PAGE_SIZE },
       )
       if (stillCurrent()) {
         envelopes = fresh
@@ -351,6 +366,114 @@
     } finally {
       loading = false
       refreshing = false
+    }
+  }
+
+  /** Compute the smallest UID per account in the currently-rendered
+   *  envelope list — the anchor for the next "load older" round.
+   *  Returned as a Map<accountId, smallestUid> for the unified mode,
+   *  or as a single number for single-account mode. */
+  function smallestUidPerAccount(): Map<string, number> {
+    const out = new Map<string, number>()
+    for (const e of envelopes) {
+      const prev = out.get(e.account_id)
+      if (prev === undefined || e.uid < prev) {
+        out.set(e.account_id, e.uid)
+      }
+    }
+    return out
+  }
+
+  /** Fetch the next page of older envelopes via the
+   *  `fetch_older_envelopes` Tauri command (#194). Appends to
+   *  `envelopes` and persists in cache server-side. Triggered by
+   *  the scroll-near-bottom handler below; also safe to call
+   *  manually from a "Load older" button if we ever add one. */
+  async function loadOlder() {
+    if (loadingOlder || olderExhausted || envelopes.length === 0) return
+    if (loading) return  // initial paint still in flight
+
+    const idAtCall = accountId
+    const folderAtCall = folder
+    const unifiedAtCall = unified
+    loadingOlder = true
+    try {
+      let older: EmailEnvelope[]
+      if (unifiedAtCall) {
+        const map = smallestUidPerAccount()
+        if (map.size === 0) {
+          olderExhausted = true
+          return
+        }
+        // Tauri serialises Map → JSON object via Object.fromEntries.
+        const beforeUidPerAccount: Record<string, number> = {}
+        for (const [k, v] of map) beforeUidPerAccount[k] = v
+        older = await invoke<EmailEnvelope[]>('fetch_older_unified_envelopes', {
+          folder: folderAtCall,
+          beforeUidPerAccount,
+          limit: PAGE_SIZE,
+        })
+      } else {
+        const smallest = envelopes.reduce<number | null>(
+          (acc, e) => (acc === null || e.uid < acc ? e.uid : acc),
+          null,
+        )
+        if (smallest === null) {
+          olderExhausted = true
+          return
+        }
+        older = await invoke<EmailEnvelope[]>('fetch_older_envelopes', {
+          accountId: idAtCall,
+          folder: folderAtCall,
+          beforeUid: smallest,
+          limit: PAGE_SIZE,
+        })
+      }
+
+      // Stale-response guard — same shape as `load`.
+      const stillCurrent =
+        unifiedAtCall === unified
+        && (unifiedAtCall || (idAtCall === accountId && folderAtCall === folder))
+      if (!stillCurrent) return
+
+      if (older.length === 0) {
+        olderExhausted = true
+        return
+      }
+
+      // De-dupe in case the server includes a UID we already have
+      // (UID-search overlaps are rare but possible if a poll arrives
+      // mid-pagination). Newest-first ordering preserved by sorting
+      // the merged list by date descending.
+      const seen = new Set(envelopes.map((e) => `${e.account_id}:${e.uid}`))
+      const fresh = older.filter((e) => !seen.has(`${e.account_id}:${e.uid}`))
+      const merged = [...envelopes, ...fresh]
+      merged.sort((a, b) => b.date.localeCompare(a.date))
+      envelopes = merged
+
+      // If the server returned fewer than we asked for, there's
+      // probably nothing left — stop asking. (A folder with
+      // exactly PAGE_SIZE older messages will trigger one extra
+      // empty round, which is fine.)
+      if (older.length < PAGE_SIZE) olderExhausted = true
+    } catch (e) {
+      console.warn('fetch_older_envelopes failed:', e)
+    } finally {
+      loadingOlder = false
+    }
+  }
+
+  /** Scroll handler — fires whenever the list scrolls.  When the
+   *  user is within ~400 px of the bottom we kick off the next
+   *  "load older" round.  The 400 px threshold gives the network
+   *  fetch time to land before the user actually hits the bottom,
+   *  so the list keeps growing smoothly instead of pausing on each
+   *  page boundary. */
+  function onListScroll(e: Event) {
+    const el = e.currentTarget as HTMLDivElement
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    if (distanceFromBottom < 400) {
+      void loadOlder()
     }
   }
 
@@ -483,7 +606,11 @@
 <div class="flex-1 flex flex-col min-w-0">
 
   <!-- Email list -->
-  <div class="flex-1 overflow-y-auto">
+  <div
+    class="flex-1 overflow-y-auto"
+    bind:this={scrollContainer}
+    onscroll={onListScroll}
+  >
     {#if loading}
       <div class="p-6 text-center text-sm text-surface-500">Loading…</div>
     {:else if error}
@@ -584,6 +711,23 @@
           </div>
         </div>
       {/each}
+
+      <!-- Infinite-scroll status row (#194). Sits at the bottom of
+           the list to give the user a calm signal of the
+           pagination state — a thin loading hint while the next
+           page is in flight, a quiet "end of folder" line once
+           the IMAP server has told us there's nothing older. The
+           scroll handler keeps fetching automatically. -->
+      {#if loadingOlder}
+        <div class="px-4 py-3 text-center text-xs text-surface-500 inline-flex items-center justify-center gap-2 w-full">
+          <Icon name="loading" size={14} />
+          Loading older messages…
+        </div>
+      {:else if olderExhausted && envelopes.length > 0}
+        <div class="px-4 py-3 text-center text-[11px] text-surface-400 uppercase tracking-wider">
+          End of folder
+        </div>
+      {/if}
     {/if}
   </div>
 </div>

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -463,19 +463,42 @@
     }
   }
 
-  /** Scroll handler — fires whenever the list scrolls.  When the
-   *  user is within ~400 px of the bottom we kick off the next
-   *  "load older" round.  The 400 px threshold gives the network
-   *  fetch time to land before the user actually hits the bottom,
-   *  so the list keeps growing smoothly instead of pausing on each
-   *  page boundary. */
+  /** How far above the bottom we trigger the next "load older"
+   *  round.  Generous (~2 viewports' worth of buffer) so the
+   *  network round-trip lands well before the user actually
+   *  scrolls into the unloaded region — they never see the
+   *  spinner unless they're scrolling at hard-flick speed. */
+  const PAGER_PREFETCH_PX = 1500
+
+  /** Scroll handler — fires the next "load older" round as soon
+   *  as the user is within `PAGER_PREFETCH_PX` of the bottom. */
   function onListScroll(e: Event) {
     const el = e.currentTarget as HTMLDivElement
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    if (distanceFromBottom < 400) {
+    if (distanceFromBottom < PAGER_PREFETCH_PX) {
       void loadOlder()
     }
   }
+
+  /** Eager prefetch (#194 follow-up): as soon as the initial
+   *  load lands, kick off the next page in the background so
+   *  the user can scroll past the first 50 rows without ever
+   *  hitting a "Loading older messages…" pause. Re-fires when
+   *  the folder / account / unified flag changes — each fresh
+   *  open prefetches its own next page. The flag below stops
+   *  it from looping past the first prefetch on any given
+   *  folder; subsequent pages still come via the scroll-based
+   *  trigger. */
+  let prefetchedFor = $state<string | null>(null)
+  $effect(() => {
+    const key = `${unified ? '__all__' : accountId}::${folder}`
+    if (prefetchedFor === key) return
+    if (loading || loadingOlder) return
+    if (envelopes.length === 0) return
+    if (olderExhausted) return
+    prefetchedFor = key
+    void loadOlder()
+  })
 
   // Render dates compactly: today → time, otherwise short date.
   function formatDate(iso: string): string {

--- a/ui/src/lib/SearchResults.svelte
+++ b/ui/src/lib/SearchResults.svelte
@@ -238,17 +238,46 @@
     }
   }
 
-  /** Scroll handler — fires `loadServerOlder` when the user is
-   *  within ~400 px of the bottom of the results list, mirroring
-   *  the MailList infinite-scroll trigger. No-op until the user
-   *  has clicked "Search server too" at least once. */
+  /** How far above the bottom we trigger the next "load older
+   *  server matches" round. Generous (~2 viewports' worth) so
+   *  the network round-trip lands before the user actually
+   *  scrolls into the unloaded region. Mirrors MailList's
+   *  PAGER_PREFETCH_PX. */
+  const PAGER_PREFETCH_PX = 1500
+
+  /** Scroll handler — fires `loadServerOlder` as soon as the
+   *  user is within `PAGER_PREFETCH_PX` of the bottom of the
+   *  results list. No-op until the user has clicked "Search
+   *  server too" at least once. */
   function onListScroll(e: Event) {
     const el = e.currentTarget as HTMLDivElement
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    if (distanceFromBottom < 400) {
+    if (distanceFromBottom < PAGER_PREFETCH_PX) {
       void loadServerOlder()
     }
   }
+
+  /** Eager prefetch after the user kicks off "Search server
+   *  too" (#194 follow-up): as soon as that first server round
+   *  lands, fire one more `loadServerOlder` in the background
+   *  so the user can scroll past the first 100 results without
+   *  ever hitting a "Loading older server matches…" pause.
+   *  Subsequent pages keep coming via the scroll-based trigger.
+   *  Reset on every fresh query so each search has its own
+   *  prefetch lifecycle. */
+  let serverPrefetchedFor = $state<string | null>(null)
+  $effect(() => {
+    // Re-key on the user's query + folder so each fresh search
+    // gets its own prefetch round.
+    const key = `${query}::${scope.folder ?? currentFolder}`
+    if (!serverSearched) return
+    if (loadingServerOlder) return
+    if (serverOlderExhausted) return
+    if (hits.length === 0) return
+    if (serverPrefetchedFor === key) return
+    serverPrefetchedFor = key
+    void loadServerOlder()
+  })
 
   function formatDate(iso: string): string {
     const d = new Date(iso)

--- a/ui/src/lib/SearchResults.svelte
+++ b/ui/src/lib/SearchResults.svelte
@@ -14,6 +14,7 @@
   import { invoke } from '@tauri-apps/api/core'
   import type { SearchScope, SearchFilters } from './SearchBar.svelte'
   import { formatError } from './errors'
+  import Icon from './Icon.svelte'
 
   interface SearchHit {
     accountId: string
@@ -54,15 +55,27 @@
   let serverSearching = $state(false)
   let serverSearched = $state(false)
 
+  // Server-side infinite-scroll state (#194 follow-up). Only the
+  // server path paginates — local FTS5 returns up to 200 hits in
+  // one round which is plenty. Once "Search server too" has been
+  // clicked, scrolling near the bottom auto-loads the next batch
+  // of older server-side matches.
+  const SERVER_PAGE_SIZE = 100
+  let loadingServerOlder = $state(false)
+  let serverOlderExhausted = $state(false)
+
   // Re-run whenever the query / scope / filters change. We also
   // reset the "server search already done" flag so the button is
-  // offered again for the new query.
+  // offered again for the new query.  Pagination flags reset too
+  // so a fresh query starts with a clean lifecycle.
   $effect(() => {
     // Touch the reactive inputs so Svelte re-runs this effect.
     query
     scope
     filters
     serverSearched = false
+    loadingServerOlder = false
+    serverOlderExhausted = false
     void runLocal()
   })
 
@@ -131,10 +144,109 @@
       )
       hits = merged
       serverSearched = true
+      // First server round returned fewer than the page size →
+      // server has no more matches, stop the scroll-paginator.
+      serverOlderExhausted = serverHits.length < SERVER_PAGE_SIZE
     } catch (e: any) {
       error = formatError(e) || 'Server search failed'
     } finally {
       serverSearching = false
+    }
+  }
+
+  /** Smallest UID currently held among server-search hits — the
+   *  cursor for the next "load older server matches" round.
+   *  Local-only hits are excluded since they may live in folders
+   *  we haven't searched server-side. */
+  function smallestServerUid(): number | null {
+    let smallest: number | null = null
+    for (const h of hits) {
+      if (smallest === null || h.uid < smallest) smallest = h.uid
+    }
+    return smallest
+  }
+
+  /** Fetch the next page of server-side matches via
+   *  `search_imap_server_older`. Triggered automatically by the
+   *  scroll-near-bottom handler once the user has run a server
+   *  search and there are more matches to load. */
+  async function loadServerOlder() {
+    if (loadingServerOlder || serverOlderExhausted) return
+    if (!serverSearched) return  // user hasn't kicked off server search yet
+    if (!query.trim()) return
+    const smallest = smallestServerUid()
+    if (smallest === null) {
+      serverOlderExhausted = true
+      return
+    }
+
+    loadingServerOlder = true
+    try {
+      const folder = scope.folder ?? currentFolder
+      const more = await invoke<
+        Array<{
+          uid: number
+          folder: string
+          from: string
+          subject: string
+          date: string
+          is_read: boolean
+          is_starred: boolean
+        }>
+      >('search_imap_server_older', {
+        accountId,
+        folder,
+        query,
+        beforeUid: smallest,
+        limit: SERVER_PAGE_SIZE,
+      })
+
+      if (more.length === 0) {
+        serverOlderExhausted = true
+        return
+      }
+
+      const seen = new Set(hits.map((h) => `${h.folder}:${h.uid}`))
+      const merged = [...hits]
+      for (const s of more) {
+        const key = `${s.folder}:${s.uid}`
+        if (seen.has(key)) continue
+        merged.push({
+          accountId,
+          folder: s.folder,
+          uid: s.uid,
+          from: s.from,
+          subject: s.subject,
+          date: s.date,
+          isRead: s.is_read,
+          isStarred: s.is_starred,
+          hasAttachments: false,
+          snippet: '',
+        })
+      }
+      merged.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      )
+      hits = merged
+      // Server returned fewer than we asked for → no more older
+      // matches.
+      if (more.length < SERVER_PAGE_SIZE) serverOlderExhausted = true
+    } catch (e) {
+      console.warn('search_imap_server_older failed:', e)
+    } finally {
+      loadingServerOlder = false
+    }
+  }
+
+  /** Scroll handler — fires `loadServerOlder` when the user is
+   *  within ~400 px of the bottom of the results list, mirroring
+   *  the MailList infinite-scroll trigger. No-op until the user
+   *  has clicked "Search server too" at least once. */
+  function onListScroll(e: Event) {
+    const el = e.currentTarget as HTMLDivElement
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    if (distanceFromBottom < 400) {
+      void loadServerOlder()
     }
   }
 
@@ -191,7 +303,7 @@
     {/if}
   </div>
 
-  <div class="flex-1 overflow-y-auto">
+  <div class="flex-1 overflow-y-auto" onscroll={onListScroll}>
     {#if error}
       <div class="p-4 text-sm text-red-500">{error}</div>
     {:else if !loading && hits.length === 0}
@@ -235,6 +347,20 @@
           </div>
         </button>
       {/each}
+
+      <!-- Server-search infinite-scroll status row (#194 follow-up).
+           Only renders once "Search server too" has run and there's
+           something to paginate. -->
+      {#if loadingServerOlder}
+        <div class="px-4 py-3 text-center text-xs text-surface-500 inline-flex items-center justify-center gap-2 w-full">
+          <Icon name="loading" size={14} />
+          Loading older server matches…
+        </div>
+      {:else if serverSearched && serverOlderExhausted && hits.length > 0}
+        <div class="px-4 py-3 text-center text-[11px] text-surface-400 uppercase tracking-wider">
+          End of server results
+        </div>
+      {/if}
     {/if}
   </div>
 </div>

--- a/ui/src/lib/SearchResults.svelte
+++ b/ui/src/lib/SearchResults.svelte
@@ -307,8 +307,35 @@
     {#if error}
       <div class="p-4 text-sm text-red-500">{error}</div>
     {:else if !loading && hits.length === 0}
-      <div class="p-6 text-center text-sm text-surface-500">
-        No messages match.
+      <!-- Empty-state.  When local FTS5 returned no hits and the
+           user hasn't yet asked the server, we explain *why*
+           (only cached messages were searched) and surface the
+           server-search button prominently — without that nudge
+           a "no results" outcome can be misleading: the server
+           may have matches the cache hasn't seen yet (#194). -->
+      <div class="p-8 text-center max-w-md mx-auto">
+        {#if !query.trim()}
+          <p class="text-sm text-surface-500">No messages match.</p>
+        {:else if serverSearched}
+          <p class="text-sm text-surface-500">No messages match on this device or on the server.</p>
+        {:else}
+          <div class="inline-flex items-center justify-center w-12 h-12 mb-3 rounded-full bg-surface-200 dark:bg-surface-800 text-surface-500">
+            <Icon name="search" size={22} />
+          </div>
+          <p class="text-base font-medium mb-1">No cached messages match</p>
+          <p class="text-sm text-surface-500 mb-4">
+            Only messages already on this device were searched. Older mail you haven't opened or scrolled to yet may live on the server.
+          </p>
+          <button
+            type="button"
+            class="btn preset-filled-primary-500 inline-flex items-center gap-2"
+            disabled={serverSearching}
+            onclick={runServer}
+          >
+            <Icon name={serverSearching ? 'loading' : 'sync'} size={14} />
+            {serverSearching ? 'Searching server…' : 'Search server too'}
+          </button>
+        {/if}
       </div>
     {:else}
       {#each hits as hit (`${hit.folder}:${hit.uid}`)}


### PR DESCRIPTION
Closes #194.

## Problem

Folders that exceed the 50-message cap (Trash, Sent, high-volume INBOXes, etc.) only ever showed their newest 50 envelopes. Three layers of clipping all converged on `limit = 50`:

1. **Frontend** ([ui/src/lib/MailList.svelte](ui/src/lib/MailList.svelte)) — hardcoded `limit: 50` on every IPC call. No pagination, no "load more", no scroll-to-fetch.
2. **Backend cold-cache fetch** ([crates/nimbus-imap/src/client.rs:375-389](crates/nimbus-imap/src/client.rs#L375-L389)) — "newest N by sequence number". If Trash had 200 messages and `limit=50`, only sequences 151–200 ever entered the cache. The oldest 150 were never fetched.
3. **Cache read** ([crates/nimbus-store/src/cache/mod.rs:572-606](crates/nimbus-store/src/cache/mod.rs#L572-L606)) — `SELECT … ORDER BY internal_date DESC LIMIT ?3`. Even if older messages were cached, the read clipped at `limit`.

Trash is the reproducible case because the [background sync loop](src-tauri/src/main.rs#L6508) only polls INBOX — Trash never warms in the background, so the on-demand fetch happens against a cold cache and all three caps stack.

## Approach — Option C: infinite scroll

Initial paint stays at 50 envelopes (folder open is still instant), no risk of OOM on huge folders, scales to any folder size.

### Backend

* New `ImapClient::fetch_older_envelopes(folder, before_uid, limit)` — runs `UID SEARCH UID 1:<before_uid-1>` to get every older UID, sorts descending, truncates to `limit`, then `UID FETCH`es just that slice. Two round trips (SEARCH then FETCH) on purpose: a single `UID FETCH 1:<before_uid-1>` would parse envelope metadata for every older message in a 10k-mail folder when we only want the newest N.
* New Tauri commands `fetch_older_envelopes` (per-account) and `fetch_older_unified_envelopes` (takes `before_uid_per_account: HashMap<String, u32>`, merges newest-first, caps at `limit`). Both write results through to the SQLite cache so subsequent loads are instant. JMAP path returns empty with a tracing-warn — older-pagination over JMAP isn't wired yet (easy follow-up).

### Frontend

* `PAGE_SIZE = 50` constant replaces the literal limits the initial-load path was using.
* `loadingOlder` / `olderExhausted` state per folder. Reset on every folder/account change so a freshly-opened folder starts with a clean pagination lifecycle.
* `loadOlder()` computes the smallest UID per account from the rendered envelope set and calls the right command. De-dupes against existing rows on merge (a concurrent poll might lap the result), sorts by date descending. Sets `olderExhausted` when the response is empty OR shorter than `PAGE_SIZE`.
* Scroll handler on the list container fires `loadOlder` when the user is within 400 px of the bottom — gives the network fetch time to land before the user actually hits the floor, so the list keeps growing smoothly.
* Calm bottom-of-list status row: **"Loading older messages…"** with the loading icon while in flight, **"End of folder"** microcopy once exhausted.

## Test plan

- [x] Open a folder with > 50 messages (Trash with old deletions, or any high-volume INBOX). Confirm the initial 50 paint instantly.
- [x] Scroll to within ~400 px of the bottom — list should auto-extend with the next 50 older. Loading hint visible briefly.
- [x] Keep scrolling until the IMAP server has nothing older. Confirm "End of folder" appears.
- [x] Switch folders (Trash → INBOX → back to Trash). Confirm each folder's pagination state resets cleanly — re-scrolling Trash starts a fresh pagination cycle without stale flags from the previous session.
- [x] Unified mode (multi-account All Inboxes): scroll to bottom. Confirm older messages from every account show up in the merged list, sorted newest-first.
- [x] Right-click context-menu actions (mark read, move, delete) still work on rows that came from a `fetch_older` round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)