### PR TITLE
CI: fix all 5 failing pipeline jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,10 +844,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1204,6 +1219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "email-encoding"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,18 +1274,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enumflags2"
@@ -2039,23 +2048,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -2063,22 +2072,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "system-configuration",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2477,6 +2511,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2550,6 +2587,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2762,12 +2829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,15 +2854,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "lru-slab"
@@ -2930,6 +2982,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3419,6 +3488,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -3922,6 +3995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,6 +4029,17 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
 
 [[package]]
 name = "prettyplease"
@@ -4585,9 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5012,6 +5102,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5260,6 +5366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tao"
 version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5276,7 +5388,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5332,7 +5444,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5531,7 +5643,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5554,7 +5666,7 @@ checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -7205,7 +7317,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ uuid = { version = "1", features = ["v4"] }
 # autoconfiguration (`_imaps._tcp.<domain>` etc.) when a provider
 # doesn't expose a Mozilla autoconfig endpoint. Pure Rust, no
 # system-resolver dependency.
-hickory-resolver = "0.24"
+hickory-resolver = "0.26"
 # System font enumeration for the compose toolbar's font picker
 # (#142).  font-kit walks the OS font catalogue (DirectWrite on
 # Windows, Core Text on macOS, fontconfig on Linux) and gives

--- a/SBOM.md
+++ b/SBOM.md
@@ -113,7 +113,7 @@ strong-copyleft licence stronger than what we already have (e.g.
 AGPL-3.0) is a project-level decision, not a routine PR. See
 [CLAUDE.md](CLAUDE.md) for the AI-assistant version of this rule.
 
-Last manual reconciliation: 2026-05-02 (PR # following #211).
+Last manual reconciliation: 2026-05-02 (CI pipeline fixes — `hickory-resolver` 0.24→0.26 and transitive `rustls-webpki` 0.103.11→0.103.13 security bumps; both keep their existing MIT-OR-Apache-2.0 licences, no new direct deps).
 
 ---
 

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,43 @@
+# Configuration for `cargo audit` and the rustsec/audit-check GitHub Action.
+#
+# Each ID listed below is a `cargo audit` warning we are *intentionally*
+# accepting because the affected crate is pulled in transitively by an
+# upstream we cannot upgrade past.  Revisit this list whenever upstream
+# releases land — the goal is to keep it shrinking.
+
+[advisories]
+ignore = [
+  # ── GTK3 chain pulled in transitively by `font-kit` ─────────────
+  # font-kit's Linux fontconfig backend depends on the GTK3 family,
+  # which the maintainers have flagged as unmaintained in favour of
+  # GTK4 bindings.  We use font-kit for system font enumeration in
+  # `src-tauri/src/main.rs`; switching enumerators would mean
+  # platform-specific code on each OS.  Revisit when font-kit
+  # releases a GTK4-based build.
+  "RUSTSEC-2024-0413", # atk
+  "RUSTSEC-2024-0416", # atk-sys
+  "RUSTSEC-2025-0057", # fxhash
+  "RUSTSEC-2024-0412", # gdk
+  "RUSTSEC-2024-0418", # gdk-sys
+  "RUSTSEC-2024-0411", # gdkwayland-sys
+  "RUSTSEC-2024-0417", # gdkx11
+  "RUSTSEC-2024-0414", # gdkx11-sys
+  "RUSTSEC-2024-0415", # gtk
+  "RUSTSEC-2024-0420", # gtk-sys
+  "RUSTSEC-2024-0419", # gtk3-macros
+  "RUSTSEC-2024-0429", # glib (unsound)
+
+  # ── unic-* chain (transitive via rrule / chrono-tz) ──────────────
+  # The unic family is unmaintained.  Pulled in transitively by our
+  # recurrence-rule and timezone deps; no direct API surface for us.
+  "RUSTSEC-2025-0081", # unic-char-property
+  "RUSTSEC-2025-0075", # unic-char-range
+  "RUSTSEC-2025-0080", # unic-common
+  "RUSTSEC-2025-0100", # unic-ucd-ident
+  "RUSTSEC-2025-0098", # unic-ucd-version
+
+  # ── Other transitive unmaintained / unsound deps ─────────────────
+  "RUSTSEC-2025-0052", # async-std (transitive build dep)
+  "RUSTSEC-2024-0370", # proc-macro-error (transitive build-time)
+  "RUSTSEC-2026-0097", # rand 0.7 + 0.8 — unsound; transitive only
+]

--- a/crates/nimbus-carddav/src/vcard.rs
+++ b/crates/nimbus-carddav/src/vcard.rs
@@ -239,7 +239,7 @@ pub fn parse_vcard(raw: &str) -> Result<ParsedVcard, NimbusError> {
                 // the same property, preserve cross-property
                 // accumulation in case a card has CATEGORIES
                 // listed twice.
-                for raw in value.split(|c| c == ',' || c == ';') {
+                for raw in value.split([',', ';']) {
                     let t = raw.trim();
                     if !t.is_empty() && !categories.iter().any(|c| c == t) {
                         categories.push(t.to_string());

--- a/crates/nimbus-discovery/src/srv.rs
+++ b/crates/nimbus-discovery/src/srv.rs
@@ -14,8 +14,10 @@
 
 use std::time::Duration;
 
-use hickory_resolver::TokioAsyncResolver;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+use hickory_resolver::TokioResolver;
+use hickory_resolver::config::ResolverConfig;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::proto::rr::RData;
 use tracing::debug;
 
 use crate::{DiscoveredAccount, DiscoveryError, DiscoverySource};
@@ -24,13 +26,18 @@ use crate::{DiscoveredAccount, DiscoveryError, DiscoverySource};
 /// (IMAP, SMTP) pair we manage to put together; `Err(NotFound)` if
 /// no usable records exist.
 pub async fn discover(domain: &str) -> Result<DiscoveredAccount, DiscoveryError> {
-    let mut opts = ResolverOpts::default();
+    let mut builder = TokioResolver::builder_with_config(
+        ResolverConfig::default(),
+        TokioRuntimeProvider::default(),
+    );
     // Default DNS timeout is 5s per attempt × 2 attempts = 10s — too
     // long when the wizard is waiting on us. Cap it at 4s total.
-    opts.timeout = Duration::from_secs(2);
-    opts.attempts = 2;
+    builder.options_mut().timeout = Duration::from_secs(2);
+    builder.options_mut().attempts = 2;
 
-    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), opts);
+    let resolver = builder
+        .build()
+        .map_err(|e| DiscoveryError::Network(format!("DNS resolver init failed: {e}")))?;
 
     // Implicit-TLS first.
     let imap_tls = lookup_first_srv(&resolver, "_imaps._tcp", domain).await;
@@ -79,24 +86,27 @@ struct SrvEndpoint {
 /// answer is fine because providers rarely publish multiple servers
 /// here, and the user can always override.
 async fn lookup_first_srv(
-    resolver: &TokioAsyncResolver,
+    resolver: &TokioResolver,
     service: &str,
     domain: &str,
 ) -> Option<SrvEndpoint> {
     let name = format!("{service}.{domain}.");
     match resolver.srv_lookup(&name).await {
-        Ok(records) => {
+        Ok(lookup) => {
             let mut best: Option<(u16, u16, SrvEndpoint)> = None;
-            for r in records.iter() {
-                let host = r.target().to_ascii().trim_end_matches('.').to_string();
+            for record in lookup.answers() {
+                let RData::SRV(ref srv) = record.data else {
+                    continue;
+                };
+                let host = srv.target.to_ascii().trim_end_matches('.').to_string();
                 if host.is_empty() {
                     continue;
                 }
                 let candidate = SrvEndpoint {
                     host,
-                    port: r.port(),
+                    port: srv.port,
                 };
-                let key = (r.priority(), u16::MAX - r.weight());
+                let key = (srv.priority, u16::MAX - srv.weight);
                 if best.as_ref().map(|(p, _, _)| key < (*p, 0)).unwrap_or(true) {
                     best = Some((key.0, key.1, candidate));
                 }

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -1376,9 +1376,7 @@ impl ImapClient {
         let fetches: Vec<_> = session
             .uid_fetch(set, "(UID FLAGS INTERNALDATE ENVELOPE)")
             .await
-            .map_err(|e| {
-                NimbusError::Protocol(format!("UID FETCH (older search) failed: {e}"))
-            })?
+            .map_err(|e| NimbusError::Protocol(format!("UID FETCH (older search) failed: {e}")))?
             .try_collect()
             .await
             .map_err(|e| {
@@ -1504,14 +1502,10 @@ impl ImapClient {
         let fetches: Vec<_> = session
             .uid_fetch(set, "(UID FLAGS INTERNALDATE ENVELOPE)")
             .await
-            .map_err(|e| {
-                NimbusError::Protocol(format!("UID FETCH (older) failed: {e}"))
-            })?
+            .map_err(|e| NimbusError::Protocol(format!("UID FETCH (older) failed: {e}")))?
             .try_collect()
             .await
-            .map_err(|e| {
-                NimbusError::Protocol(format!("Failed to read older FETCH: {e}"))
-            })?;
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read older FETCH: {e}")))?;
 
         let mut envelopes: Vec<EmailEnvelope> = fetches
             .iter()
@@ -1566,7 +1560,10 @@ impl ImapClient {
             "Fetched {} older envelopes in '{folder}' before UID {before_uid}",
             envelopes.len()
         );
-        Ok(EnvelopeBatch { uidvalidity, envelopes })
+        Ok(EnvelopeBatch {
+            uidvalidity,
+            envelopes,
+        })
     }
 
     /// Log out from the IMAP server and close the connection cleanly.

--- a/crates/nimbus-jmap/tests/mock_server.rs
+++ b/crates/nimbus-jmap/tests/mock_server.rs
@@ -404,6 +404,8 @@ async fn test_send_email() {
         body_text: Some("Hello from JMAP tests!".into()),
         body_html: None,
         attachments: vec![],
+        calendar_part: None,
+        skip_sent_copy: false,
     };
 
     client

--- a/crates/nimbus-store/src/cache/calendars.rs
+++ b/crates/nimbus-store/src/cache/calendars.rs
@@ -1047,15 +1047,10 @@ fn row_to_calendar_event(r: &rusqlite::Row<'_>) -> rusqlite::Result<CalendarEven
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::{pool, schema};
     use chrono::Duration;
 
     fn open_test_cache() -> Cache {
-        let pool = pool::open_memory_pool().expect("open memory pool");
-        let mut conn = pool.get().expect("checkout");
-        schema::run_migrations(&mut conn).expect("migrate");
-        drop(conn);
-        Cache { pool }
+        Cache::open_in_memory().expect("open in-memory cache")
     }
 
     fn cal(path: &str, name: &str) -> CalendarRow {

--- a/crates/nimbus-store/src/cache/contacts.rs
+++ b/crates/nimbus-store/src/cache/contacts.rs
@@ -962,14 +962,8 @@ fn decode_emails(json: &str) -> Vec<ContactEmail> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::{pool, schema};
-
     fn open_test_cache() -> Cache {
-        let pool = pool::open_memory_pool().expect("open memory pool");
-        let mut conn = pool.get().expect("checkout");
-        schema::run_migrations(&mut conn).expect("migrate");
-        drop(conn);
-        Cache { pool }
+        Cache::open_in_memory().expect("open in-memory cache")
     }
 
     fn row(uid: &str, name: &str, email: &str) -> ContactRow {

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -266,10 +266,7 @@ impl Cache {
     /// in-memory test cache.  Used by `disable_fido_only_mode`
     /// to restore `envelope.plain_key` without re-prompting.
     pub fn master_key_hex(&self) -> Option<String> {
-        self.master_key_hex
-            .read()
-            .ok()
-            .and_then(|g| g.clone())
+        self.master_key_hex.read().ok().and_then(|g| g.clone())
     }
 
     /// Delete the cache DB and its WAL sidecars from disk.  Used
@@ -288,9 +285,7 @@ impl Cache {
     /// state propagates uniformly.  `pub(crate)` so sibling
     /// modules (`account_store`, …) can reuse it instead of
     /// duplicating the lock-and-checkout dance.
-    pub(crate) fn conn(
-        &self,
-    ) -> Result<PooledConnection<SqliteConnectionManager>, CacheError> {
+    pub(crate) fn conn(&self) -> Result<PooledConnection<SqliteConnectionManager>, CacheError> {
         let guard = self.pool.read().expect("Cache pool RwLock poisoned");
         let pool = guard.as_ref().ok_or(CacheError::Locked)?;
         Ok(pool.get()?)
@@ -1371,19 +1366,14 @@ mod tests {
     }
 
     fn open_test_cache() -> Cache {
-        let pool = pool::open_memory_pool().expect("open memory pool");
-        let mut conn = pool.get().expect("checkout");
-        schema::run_migrations(&mut conn).expect("migrate");
-        // Drop the conn before the Cache uses the pool.
-        drop(conn);
-        Cache { pool }
+        Cache::open_in_memory().expect("open in-memory cache")
     }
 
     #[test]
     fn migrations_are_idempotent() {
         let cache = open_test_cache();
         // Running again against the same pool should be a no-op.
-        let mut conn = cache.pool.get().unwrap();
+        let mut conn = cache.conn().expect("checkout");
         schema::run_migrations(&mut conn).expect("second migrate");
     }
 

--- a/crates/nimbus-store/src/cache/search.rs
+++ b/crates/nimbus-store/src/cache/search.rs
@@ -442,16 +442,12 @@ fn fts_column(column: &str, value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::{Cache, pool, schema};
+    use crate::cache::Cache;
     use chrono::Duration;
     use nimbus_core::models::Email;
 
     fn open() -> Cache {
-        let pool = pool::open_memory_pool().unwrap();
-        let mut conn = pool.get().unwrap();
-        schema::run_migrations(&mut conn).unwrap();
-        drop(conn);
-        Cache { pool }
+        Cache::open_in_memory().expect("open in-memory cache")
     }
 
     fn email(uid: u32, folder: &str, subject: &str, body: &str, from: &str) -> Email {

--- a/crates/nimbus-store/src/fido.rs
+++ b/crates/nimbus-store/src/fido.rs
@@ -21,7 +21,9 @@
 //! WebAuthn's PRF extension (RFC-bound; backed by CTAP2's
 //! `hmac-secret`) lets us evaluate
 //!
-//!     prf_output = HMAC-SHA-256(per-credential-secret, salt)
+//! ```text
+//! prf_output = HMAC-SHA-256(per-credential-secret, salt)
+//! ```
 //!
 //! The per-credential secret never leaves the authenticator.  Same
 //! `(credential_id, salt)` always produces the same 32-byte output,
@@ -343,8 +345,13 @@ pub fn derive_passphrase_key(passphrase: &str, salt: &[u8]) -> Result<[u8; PRF_L
         return Err(NimbusError::Other("passphrase must not be empty".into()));
     }
     let mut out = [0u8; PRF_LEN];
-    pbkdf2::<Hmac<Sha256>>(passphrase.as_bytes(), salt, PASSPHRASE_PBKDF2_ITERS, &mut out)
-        .map_err(|e| NimbusError::Storage(format!("pbkdf2 derive: {e}")))?;
+    pbkdf2::<Hmac<Sha256>>(
+        passphrase.as_bytes(),
+        salt,
+        PASSPHRASE_PBKDF2_ITERS,
+        &mut out,
+    )
+    .map_err(|e| NimbusError::Storage(format!("pbkdf2 derive: {e}")))?;
     Ok(out)
 }
 
@@ -360,10 +367,7 @@ pub fn generate_passphrase_id() -> Result<[u8; 16], NimbusError> {
 
 /// Open a single wrap with the FIDO PRF output computed at unlock
 /// time.  Returns the recovered master key bytes (32 bytes).
-pub fn unwrap_master_key(
-    wrap: &WrappedKey,
-    prf_output: &[u8],
-) -> Result<Vec<u8>, NimbusError> {
+pub fn unwrap_master_key(wrap: &WrappedKey, prf_output: &[u8]) -> Result<Vec<u8>, NimbusError> {
     if prf_output.len() != PRF_LEN {
         return Err(NimbusError::Storage(format!(
             "unwrap_master_key: prf_output must be {PRF_LEN} bytes, got {}",
@@ -434,8 +438,7 @@ mod tests {
         let cred = b"fake-credential-id";
         let salt = generate_salt().unwrap();
         let wrap =
-            wrap_master_key(WrapKind::FidoPrf, &master, &prf, cred, &salt, "Test".into())
-                .unwrap();
+            wrap_master_key(WrapKind::FidoPrf, &master, &prf, cred, &salt, "Test".into()).unwrap();
         let recovered = unwrap_master_key(&wrap, &prf).unwrap();
         assert_eq!(recovered, master);
     }
@@ -446,11 +449,16 @@ mod tests {
         let salt = generate_salt().unwrap();
         let id = generate_passphrase_id().unwrap();
         let key = derive_passphrase_key("correct horse battery staple", &salt).unwrap();
-        let wrap =
-            wrap_master_key(WrapKind::Passphrase, &master, &key, &id, &salt, "Recovery".into())
-                .unwrap();
-        let derived =
-            derive_passphrase_key("correct horse battery staple", &salt).unwrap();
+        let wrap = wrap_master_key(
+            WrapKind::Passphrase,
+            &master,
+            &key,
+            &id,
+            &salt,
+            "Recovery".into(),
+        )
+        .unwrap();
+        let derived = derive_passphrase_key("correct horse battery staple", &salt).unwrap();
         let recovered = unwrap_master_key(&wrap, &derived).unwrap();
         assert_eq!(recovered, master);
     }
@@ -462,8 +470,7 @@ mod tests {
         let id = generate_passphrase_id().unwrap();
         let key = derive_passphrase_key("right answer", &salt).unwrap();
         let wrap =
-            wrap_master_key(WrapKind::Passphrase, &master, &key, &id, &salt, "X".into())
-                .unwrap();
+            wrap_master_key(WrapKind::Passphrase, &master, &key, &id, &salt, "X".into()).unwrap();
         let wrong = derive_passphrase_key("wrong answer", &salt).unwrap();
         assert!(unwrap_master_key(&wrap, &wrong).is_err());
     }

--- a/src-tauri/src/badge.rs
+++ b/src-tauri/src/badge.rs
@@ -80,7 +80,15 @@ pub fn render_taskbar_overlay(unread: u32) -> Option<Image<'static>> {
     let badge_pos = (W - BADGE_SIZE) / 2;
 
     let mut pixels = vec![0u8; (W * H * 4) as usize];
-    draw_filled_circle(&mut pixels, W, H, badge_pos, badge_pos, BADGE_SIZE, BADGE_RGBA);
+    draw_filled_circle(
+        &mut pixels,
+        W,
+        H,
+        badge_pos,
+        badge_pos,
+        BADGE_SIZE,
+        BADGE_RGBA,
+    );
     Some(Image::new_owned(pixels, W, H))
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,53 +74,32 @@ struct TrayBaseIconBitmap {
 /// small enough that all 7 styles together add < 100 KB to the
 /// binary.
 mod logo_assets {
-    pub const STORM: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/storm/nimbus-256.png"
-    );
-    pub const DAWN: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/dawn/nimbus-256.png"
-    );
-    pub const MINT: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/mint/nimbus-256.png"
-    );
-    pub const SKY: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/sky/nimbus-256.png"
-    );
-    pub const TWILIGHT: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/twilight/nimbus-256.png"
-    );
-    pub const MONO_BLACK: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/monochrome/nimbus-mono-black.png"
-    );
-    pub const MONO_WHITE: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo/png/monochrome/nimbus-mono-white.png"
-    );
+    pub const STORM: &[u8] = include_bytes!("../../logos/nimbus-logo/png/storm/nimbus-256.png");
+    pub const DAWN: &[u8] = include_bytes!("../../logos/nimbus-logo/png/dawn/nimbus-256.png");
+    pub const MINT: &[u8] = include_bytes!("../../logos/nimbus-logo/png/mint/nimbus-256.png");
+    pub const SKY: &[u8] = include_bytes!("../../logos/nimbus-logo/png/sky/nimbus-256.png");
+    pub const TWILIGHT: &[u8] =
+        include_bytes!("../../logos/nimbus-logo/png/twilight/nimbus-256.png");
+    pub const MONO_BLACK: &[u8] =
+        include_bytes!("../../logos/nimbus-logo/png/monochrome/nimbus-mono-black.png");
+    pub const MONO_WHITE: &[u8] =
+        include_bytes!("../../logos/nimbus-logo/png/monochrome/nimbus-mono-white.png");
 
     // ── v2 logo set (added in #197 follow-up) ────────────────────
     // Same 256 px naming convention as v1; lives under the
     // separate `nimbus-logo-v2` folder so the original art and
     // the new pack stay independently swappable.
-    pub const COPPER: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/copper/nimbus-256.png"
-    );
-    pub const FOREST: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/forest/nimbus-256.png"
-    );
-    pub const MIDNIGHT: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/midnight/nimbus-256.png"
-    );
-    pub const OCEAN: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/ocean/nimbus-256.png"
-    );
-    pub const ROSE: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/rose/nimbus-256.png"
-    );
-    pub const SLATE: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/slate/nimbus-256.png"
-    );
-    pub const SUNSET: &[u8] = include_bytes!(
-        "../../logos/nimbus-logo-v2/png/sunset/nimbus-256.png"
-    );
+    pub const COPPER: &[u8] =
+        include_bytes!("../../logos/nimbus-logo-v2/png/copper/nimbus-256.png");
+    pub const FOREST: &[u8] =
+        include_bytes!("../../logos/nimbus-logo-v2/png/forest/nimbus-256.png");
+    pub const MIDNIGHT: &[u8] =
+        include_bytes!("../../logos/nimbus-logo-v2/png/midnight/nimbus-256.png");
+    pub const OCEAN: &[u8] = include_bytes!("../../logos/nimbus-logo-v2/png/ocean/nimbus-256.png");
+    pub const ROSE: &[u8] = include_bytes!("../../logos/nimbus-logo-v2/png/rose/nimbus-256.png");
+    pub const SLATE: &[u8] = include_bytes!("../../logos/nimbus-logo-v2/png/slate/nimbus-256.png");
+    pub const SUNSET: &[u8] =
+        include_bytes!("../../logos/nimbus-logo-v2/png/sunset/nimbus-256.png");
 }
 
 /// Map a style slug to the embedded PNG bytes.  Unknown slug →
@@ -4877,10 +4856,10 @@ async fn fetch_older_envelopes(
         .await?;
     let _ = client.logout().await;
 
-    if !batch.envelopes.is_empty() {
-        if let Err(e) = cache.upsert_envelopes_for_account(&account_id, &batch.envelopes) {
-            tracing::warn!("cache.upsert_envelopes (older) failed: {e}");
-        }
+    if !batch.envelopes.is_empty()
+        && let Err(e) = cache.upsert_envelopes_for_account(&account_id, &batch.envelopes)
+    {
+        tracing::warn!("cache.upsert_envelopes (older) failed: {e}");
     }
 
     // Stamp the account_id into the returned envelopes so the
@@ -4927,11 +4906,12 @@ async fn fetch_older_unified_envelopes(
                 continue;
             }
         };
-        match client.fetch_older_envelopes(&folder, before_uid, limit).await {
+        match client
+            .fetch_older_envelopes(&folder, before_uid, limit)
+            .await
+        {
             Ok(batch) => {
-                if let Err(e) =
-                    cache.upsert_envelopes_for_account(&account.id, &batch.envelopes)
-                {
+                if let Err(e) = cache.upsert_envelopes_for_account(&account.id, &batch.envelopes) {
                     tracing::warn!("cache.upsert_envelopes (unified older) failed: {e}");
                 }
                 for mut env in batch.envelopes {
@@ -5482,7 +5462,7 @@ async fn delete_message(
             if let Err(c) = cache.clear_message_pending(&account_id, &folder, uid) {
                 tracing::warn!("clear_message_pending after connect failure: {c}");
             }
-            return Err(e.into());
+            return Err(e);
         }
     };
     let result = match destination.as_deref() {
@@ -5621,7 +5601,7 @@ async fn archive_message(
             if let Err(c) = cache.clear_message_pending(&account_id, &folder, uid) {
                 tracing::warn!("clear_message_pending after archive connect failure: {c}");
             }
-            return Err(e.into());
+            return Err(e);
         }
     };
     let result = client.move_message(&folder, uid, &archive).await;
@@ -5693,7 +5673,7 @@ async fn move_message(
             if let Err(c) = cache.clear_message_pending(&account_id, &folder, uid) {
                 tracing::warn!("clear_message_pending after connect failure: {c}");
             }
-            return Err(e.into());
+            return Err(e);
         }
     };
     let result = client.move_message(&folder, uid, &dest_folder).await;
@@ -5778,7 +5758,7 @@ async fn move_messages(
                     tracing::warn!("clear_message_pending after batch connect failure: {c}");
                 }
             }
-            return Err(e.into());
+            return Err(e);
         }
     };
     let result = client
@@ -7004,7 +6984,7 @@ async fn check_talk_reminders_inner(app: &AppHandle) -> Result<(), NimbusError> 
             // do allow a tick's worth of catch-up so a slightly
             // late tick still lands.
             let elapsed = (now - fire_at).num_seconds();
-            if elapsed < 0 || elapsed > TALK_REMINDER_FIRE_TOLERANCE_SECS {
+            if !(0..=TALK_REMINDER_FIRE_TOLERANCE_SECS).contains(&elapsed) {
                 continue;
             }
 
@@ -7106,7 +7086,8 @@ async fn prerender_inboxes_on_launch(app: &AppHandle) {
         let app = app.clone();
         handles.push(tauri::async_runtime::spawn(async move {
             let cache = app.state::<Cache>();
-            let uids = match cache.get_envelopes_missing_body(&account.id, "INBOX", PRERENDER_LIMIT) {
+            let uids = match cache.get_envelopes_missing_body(&account.id, "INBOX", PRERENDER_LIMIT)
+            {
                 Ok(v) => v,
                 Err(e) => {
                     tracing::warn!(
@@ -7196,7 +7177,7 @@ fn enumerate_system_fonts() -> Vec<String> {
         .into_iter()
         .filter(|f| !f.starts_with('.') && !f.trim().is_empty())
         .collect();
-    out.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    out.sort_by_key(|a| a.to_lowercase());
     out.dedup();
     out
 }
@@ -7515,10 +7496,7 @@ fn fido_verify_passphrase(passphrase: String) -> Result<bool, NimbusError> {
 /// here.  Phase 1B's lock screen will use this; today it lets
 /// you sanity-check that a registered hardware key still works.
 #[tauri::command]
-fn fido_verify_prf(
-    credential_id_b64: String,
-    prf_output_b64: String,
-) -> Result<bool, NimbusError> {
+fn fido_verify_prf(credential_id_b64: String, prf_output_b64: String) -> Result<bool, NimbusError> {
     use nimbus_store::fido::{self, WrapKind};
     let env = nimbus_store::cache::key::load_envelope()?;
     let prf = fido::decode_b64(&prf_output_b64)?;
@@ -7639,9 +7617,7 @@ fn note_unlock_failure(cache: &Cache, label: &str) -> NimbusError {
     };
     let tampered = nimbus_store::cache::key::envelope_tampered(&env);
     if tampered {
-        tracing::warn!(
-            "Keychain envelope MAC mismatch — treating this attempt as terminal."
-        );
+        tracing::warn!("Keychain envelope MAC mismatch — treating this attempt as terminal.");
     }
     env.failed_attempts = env.failed_attempts.saturating_add(1);
     let attempts = env.failed_attempts;
@@ -7661,7 +7637,8 @@ fn note_unlock_failure(cache: &Cache, label: &str) -> NimbusError {
             }
             perform_wipe(cache);
             return NimbusError::Auth(if tampered {
-                "Keychain envelope was modified outside Nimbus. The encrypted cache has been wiped.".to_string()
+                "Keychain envelope was modified outside Nimbus. The encrypted cache has been wiped."
+                    .to_string()
             } else {
                 format!(
                     "Too many failed attempts ({attempts}/{max}). The encrypted cache has been wiped."
@@ -7689,10 +7666,7 @@ fn note_unlock_success() {
 /// Unlock the cache from a passphrase.  Tries every passphrase
 /// wrap in the envelope, returns the first match.
 #[tauri::command]
-fn unlock_with_passphrase(
-    passphrase: String,
-    cache: State<'_, Cache>,
-) -> Result<(), NimbusError> {
+fn unlock_with_passphrase(passphrase: String, cache: State<'_, Cache>) -> Result<(), NimbusError> {
     use nimbus_store::fido::{self, WrapKind};
     let env = nimbus_store::cache::key::load_envelope()?;
     for wrap in &env.wraps {
@@ -7703,7 +7677,9 @@ fn unlock_with_passphrase(
         let aes_key = fido::derive_passphrase_key(&passphrase, &salt)?;
         if let Ok(master) = fido::unwrap_master_key(wrap, &aes_key) {
             let hex = hex::encode(&master);
-            cache.unlock_with_master_key(hex).map_err(NimbusError::from)?;
+            cache
+                .unlock_with_master_key(hex)
+                .map_err(NimbusError::from)?;
             note_unlock_success();
             return Ok(());
         }
@@ -7733,7 +7709,9 @@ fn unlock_with_prf(
             Err(_) => return Err(note_unlock_failure(&cache, "hardware key PRF output")),
         };
         let hex = hex::encode(&master);
-        cache.unlock_with_master_key(hex).map_err(NimbusError::from)?;
+        cache
+            .unlock_with_master_key(hex)
+            .map_err(NimbusError::from)?;
         note_unlock_success();
         return Ok(());
     }
@@ -7842,9 +7820,7 @@ fn disable_fido_only_mode(cache: State<'_, Cache>) -> Result<(), NimbusError> {
 /// yet), runs the enumeration once on a blocking thread and
 /// memoises the result before returning.
 #[tauri::command]
-async fn list_system_fonts(
-    cache: State<'_, SystemFontsCache>,
-) -> Result<Vec<String>, NimbusError> {
+async fn list_system_fonts(cache: State<'_, SystemFontsCache>) -> Result<Vec<String>, NimbusError> {
     {
         let snap = cache.read().await;
         if !snap.is_empty() {
@@ -7905,22 +7881,21 @@ async fn set_logo_style(
     // the new style.  Then trigger an immediate re-render so the
     // tray reflects the change without waiting for the next
     // unread-count tick.
-    if let Some(tray_state) = app.try_state::<TrayBaseIcon>() {
-        if let Ok(mut guard) = tray_state.0.lock() {
-            *guard = bitmap;
-        }
+    if let Some(tray_state) = app.try_state::<TrayBaseIcon>()
+        && let Ok(mut guard) = tray_state.0.lock()
+    {
+        *guard = bitmap;
     }
     refresh_unread_badge(&app);
 
     // Update the main window's icon — Windows mirrors this into
     // the taskbar entry, macOS into the title bar, X11 into the
     // `_NET_WM_ICON` atom.
-    if let Some(win) = app.get_webview_window("main") {
-        if let Ok(img) = tauri::image::Image::from_bytes(bytes) {
-            if let Err(e) = win.set_icon(img) {
-                tracing::warn!("set_logo_style: window set_icon failed: {e}");
-            }
-        }
+    if let Some(win) = app.get_webview_window("main")
+        && let Ok(img) = tauri::image::Image::from_bytes(bytes)
+        && let Err(e) = win.set_icon(img)
+    {
+        tracing::warn!("set_logo_style: window set_icon failed: {e}");
     }
 
     // Persist last so a transient apply failure can't permanently
@@ -7994,12 +7969,11 @@ fn extract_theme_slug(css: &str, fallback: &str) -> String {
         if let Some(rest) = trimmed
             .strip_prefix('"')
             .or_else(|| trimmed.strip_prefix('\''))
+            && let Some(end) = rest.find(['"', '\''])
         {
-            if let Some(end) = rest.find(['"', '\'']) {
-                let slug = rest[..end].trim();
-                if !slug.is_empty() {
-                    return slug.to_string();
-                }
+            let slug = rest[..end].trim();
+            if !slug.is_empty() {
+                return slug.to_string();
             }
         }
     }
@@ -8288,19 +8262,17 @@ fn main() {
                     "logo style '{chosen_style}' failed to decode ({e}); \
                      falling back to storm"
                 );
-                decode_logo_png(logo_assets::STORM)
-                    .expect("storm logo PNG must always decode")
+                decode_logo_png(logo_assets::STORM).expect("storm logo PNG must always decode")
             });
 
             // Reflect the chosen style on the main window — the
             // titlebar icon and (on Windows) the taskbar entry both
             // pick up `set_icon`.
-            if let Some(win) = app.get_webview_window("main") {
-                if let Ok(img) = tauri::image::Image::from_bytes(style_bytes) {
-                    if let Err(e) = win.set_icon(img) {
-                        tracing::warn!("failed to apply window icon at boot: {e}");
-                    }
-                }
+            if let Some(win) = app.get_webview_window("main")
+                && let Ok(img) = tauri::image::Image::from_bytes(style_bytes)
+                && let Err(e) = win.set_icon(img)
+            {
+                tracing::warn!("failed to apply window icon at boot: {e}");
             }
 
             // Tauri's `Image::from_bytes` decodes into owned RGBA

--- a/ui/src/lib/AttachmentThumb.svelte
+++ b/ui/src/lib/AttachmentThumb.svelte
@@ -81,14 +81,14 @@
       if (imageBlobGet(key)) return
       let ct = contentType ?? ''
       if (!ct) ct = 'image/png'
-      const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+      const u8 = new Uint8Array(bytes)
       const url = URL.createObjectURL(new Blob([u8], { type: ct }))
       imageBlobPut(key, url)
     } else if (isVideoGuess(contentType, filename)) {
       if (cacheGet(key)) return
       let ct = contentType ?? ''
       if (!ct) ct = 'video/mp4'
-      const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+      const u8 = new Uint8Array(bytes)
       const url = URL.createObjectURL(new Blob([u8], { type: ct }))
       extractionChain = extractionChain
         .then(async () => {
@@ -385,7 +385,7 @@
   function makeBlobUrl(b: Uint8Array | number[]): string {
     let ct = contentType ?? ''
     if (!ct) ct = isVideo() ? 'video/mp4' : 'image/png'
-    const u8 = b instanceof Uint8Array ? b : new Uint8Array(b)
+    const u8 = new Uint8Array(b)
     return URL.createObjectURL(new Blob([u8], { type: ct }))
   }
 

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -22,7 +22,7 @@
 
   import { onDestroy } from 'svelte'
   import { createEditor, EditorContent } from 'svelte-tiptap'
-  import { Node, mergeAttributes } from '@tiptap/core'
+  import { Node as TiptapNode, mergeAttributes } from '@tiptap/core'
   import StarterKit from '@tiptap/starter-kit'
   import Underline from '@tiptap/extension-underline'
   import Link from '@tiptap/extension-link'
@@ -330,7 +330,7 @@
   // the inline data URI versions, leaving recipients with a
   // broken-icon. Brand header is typography-only now, so the
   // editor and the recipient see exactly the same thing.)
-  const NimbusBlock = Node.create({
+  const NimbusBlock = TiptapNode.create({
     name: 'nimbusBlock',
     group: 'block',
     atom: true,

--- a/ui/src/lib/webauthnPrf.ts
+++ b/ui/src/lib/webauthnPrf.ts
@@ -26,7 +26,7 @@ function bufToB64(buf: ArrayBuffer | Uint8Array): string {
   return btoa(bin)
 }
 
-function b64ToBuf(s: string): Uint8Array {
+function b64ToBuf(s: string): Uint8Array<ArrayBuffer> {
   const bin = atob(s)
   const out = new Uint8Array(bin.length)
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)


### PR DESCRIPTION
## Summary

All five CI jobs on `main` were red. This PR makes the pipeline green again. Each fix is minimal and scoped to its job.

- **rust-fmt** — `cargo fmt --all` on a few drifted call layouts.
- **rust-clippy** — fixes broken `Cache { pool }` test helpers in `nimbus-store` (the cache struct grew `master_key_hex` + `path` and wrapped `pool` in `Arc<RwLock<Option<…>>>` for the FIDO unlock flow; the four test helpers now route through `Cache::open_in_memory()` which already exists). Also clears a `manual_pattern_char_comparison` in CardDAV's vCard parser, plus a batch of collapsible-`if` / `useless_conversion` / `manual_range_contains` / `unnecessary_sort_by` lints flagged by clippy 1.95 in `main.rs`. Marks `fido.rs`'s PRF protocol pseudo-code as a `text` fenced doctest (was being interpreted as Rust).
- **rust-test** — completes the `OutgoingEmail` literal in the JMAP mock-server test with the `calendar_part` / `skip_sent_copy` fields added in #58.
- **rust-audit** — patch-bumps `rustls-webpki` (0.103.11 → 0.103.13) for RUSTSEC-2026-0098/-99/-104, and minor-bumps `hickory-resolver` (0.24 → 0.26) for RUSTSEC-2026-0119. Hickory's API changed in 0.26 (`TokioAsyncResolver::tokio` → `TokioResolver::builder_with_config`), so the SRV-discovery file needed a small refactor. Adds `audit.toml` listing 20 transitive unmaintained / unsound advisories we accept — every one is upstream-blocked (GTK3 chain via `font-kit`, unic-* via `rrule`, `async-std`, `proc-macro-error`, `rand` 0.7/0.8) with a brief comment explaining the source.
- **frontend-lint** — `lib.dom`'s `Uint8Array<ArrayBufferLike>` split was failing `BlobPart`/`BufferSource` checks in 4 sites: `b64ToBuf` now returns `Uint8Array<ArrayBuffer>`, and `AttachmentThumb`'s blob constructions go through a fresh `new Uint8Array(bytes)` (always `ArrayBuffer`-backed). Aliases the Tiptap `Node` import to `TiptapNode` so the table-picker outside-click handler's `as Node` cast still resolves to the DOM `Node`.

SBOM: only the reconciliation note moved — licences for both upgraded crates are unchanged, no new direct deps.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` all green (46 + many lib tests)
- [x] `npm run check` 0 errors / 0 warnings
- [x] `npm run build` succeeds
- [x] CI on this branch — all 5 jobs green
- [x] Verify SRV autoconfig (`nimbus-discovery`) still works against a real domain after the hickory bump