### PR TITLE
CI hardening: Dependabot, cargo-deny, CodeQL, npm audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,82 @@
+# Dependabot configuration.
+#
+# Dependabot does three jobs for us:
+#   1. Watches the Cargo + npm + GitHub-Actions dependency trees and
+#      opens PRs to bump versions.
+#   2. Auto-fast-tracks PRs that fix a known security advisory
+#      (RustSec, GitHub Advisory Database).
+#   3. Honours a *cooldown* window so newly published versions sit on
+#      the registry for a few days before we pick them up — see the
+#      block at the bottom.  This is our main mitigation for npm
+#      supply-chain attacks: most poisoned versions of a popular
+#      package are caught and yanked within hours, so deferring the
+#      bump by a few days keeps us off the bleeding edge.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot/
+
+version: 2
+
+updates:
+  # ── Cargo (Rust) workspace ──────────────────────────────────────
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    # Group non-security updates into a single PR per week so we
+    # don't drown in noise.  Security patches still come as their
+    # own (high-priority) PRs.
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    # Cooldown: do not bump a Cargo crate to a freshly-published
+    # version until it has been on crates.io for at least N days.
+    # cargo-audit + the RustSec DB usually flag malicious or
+    # unsound releases within hours; a week of soak time means
+    # we skip nearly all such releases.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 5
+    # Keep the PR volume manageable.  Security PRs are not capped.
+    open-pull-requests-limit: 5
+
+  # ── npm (frontend) ──────────────────────────────────────────────
+  # The npm ecosystem has been the target of multiple high-profile
+  # supply-chain attacks (event-stream, ua-parser-js, ctx, the 2024
+  # `shai-hulud` worm).  The cooldown below is the single most
+  # important setting in this file — most poisoned npm versions are
+  # detected and yanked within 24-72 hours, so a 7-day cooldown
+  # keeps us off them entirely.
+  - package-ecosystem: npm
+    directory: /ui
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 5
+    open-pull-requests-limit: 5
+
+  # ── GitHub Actions ─────────────────────────────────────────────
+  # Pin-bump Action versions so we don't silently drift onto a
+  # compromised tag (the `tj-actions/changed-files` 2025 incident
+  # shipped a credential-harvesting payload via a re-tagged release).
+  # We pin to major versions in the workflow files; Dependabot opens
+  # PRs when a new major is available so we can review the diff
+  # before adopting.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # `cargo-deny` complements `cargo audit`: in addition to advisory
+  # scanning it enforces our licence allow-list and — most
+  # importantly for supply-chain hygiene — bans crates from
+  # unknown registries or git URLs.  See `deny.toml` at the
+  # workspace root for the policy.
+  rust-deny:
+    name: Supply-chain policy (cargo-deny)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans licenses sources advisories
+
   # ── Frontend checks ─────────────────────────────────────────
   frontend-lint:
     name: Frontend lint & type check
@@ -89,5 +103,19 @@ jobs:
           cache: npm
           cache-dependency-path: ui/package-lock.json
       - run: npm ci
+      # Belt-and-suspenders supply-chain check on the lockfile:
+      # `lockfile-lint` rejects any dep whose resolved URL points
+      # somewhere other than the official npm registry, catching a
+      # whole class of attacks where a poisoned tarball is wedged
+      # into `package-lock.json` directly.
+      - name: Validate npm lockfile sources
+        run: npx --yes lockfile-lint --path package-lock.json
+          --validate-https
+          --allowed-hosts npm
+      # `npm audit` is the npm-side counterpart of `cargo audit`.
+      # We only fail on `high` or `critical` so noisy `low`/`moderate`
+      # advisories on dev-only deps don't block merges.
+      - name: npm audit (high+ severity)
+        run: npm audit --audit-level=high
       - run: npm run check
       - run: npm run build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# CodeQL is GitHub's static-analysis scanner.  It looks for
+# injection patterns, dangerous APIs, hardcoded credentials,
+# unsafe deserialisation, path-traversal — the kind of thing
+# `clippy` and `eslint` don't catch because they're linters,
+# not security analysers.  Findings appear in the "Security"
+# tab of the repo (Code scanning alerts).
+#
+# We scan two languages:
+#   * `javascript-typescript` — covers our Svelte / TS frontend
+#     and any JS in node_modules-imported tooling.
+#   * `rust` — CodeQL added Rust support in 2024 (still in
+#     beta but already useful for the obvious patterns).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Re-scan weekly so newly-discovered query patterns hit our
+    # codebase even when we're not pushing.  Sunday 03:00 UTC
+    # avoids the weekday peak.
+    - cron: "0 3 * * 0"
+
+jobs:
+  analyse:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to the Security tab.
+      security-events: write
+      # Required to read the contents of the repository.
+      contents: read
+      # Required to resolve workflow caches.
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, rust]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # `security-extended` adds higher-precision security
+          # queries on top of the default set; `security-and-quality`
+          # would also catch maintainability issues but is noisier.
+          queries: security-extended
+
+      # CodeQL needs to *see* compiled code for compiled languages.
+      # For Rust we let its autobuild step run cargo for us.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,13 @@ version = "0.1.0"
 edition = "2024"
 license = "GPL-3.0"
 repository = "https://github.com/Videothek/nimbus-mail"
+# We never publish individual `nimbus-*` crates to crates.io —
+# they're internal building blocks of the desktop app.  Marking
+# them `publish = false` lets cargo-deny treat them as private
+# (so `private = { ignore = true }` in deny.toml takes effect)
+# and lets the `allow-wildcard-paths` flag exempt our internal
+# path-deps from the wildcard ban.
+publish = false
 
 [workspace.dependencies]
 # Async runtime

--- a/crates/nimbus-caldav/Cargo.toml
+++ b/crates/nimbus-caldav/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-caldav"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-carddav/Cargo.toml
+++ b/crates/nimbus-carddav/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-carddav"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-core/Cargo.toml
+++ b/crates/nimbus-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-core"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/nimbus-discovery/Cargo.toml
+++ b/crates/nimbus-discovery/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-discovery"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-imap/Cargo.toml
+++ b/crates/nimbus-imap/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-imap"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-jmap/Cargo.toml
+++ b/crates/nimbus-jmap/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-jmap"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-nextcloud/Cargo.toml
+++ b/crates/nimbus-nextcloud/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-nextcloud"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-smtp/Cargo.toml
+++ b/crates/nimbus-smtp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-smtp"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/crates/nimbus-store/Cargo.toml
+++ b/crates/nimbus-store/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-store"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -55,6 +55,14 @@ ignore = [
 [licenses]
 version = 2
 confidence-threshold = 0.8
+# Skip licence checks for crates that aren't published anywhere
+# (i.e. our own workspace crates).  Without this, cargo-deny
+# fails on every `nimbus-*` crate because it can't infer a
+# licence from the manifest — and inheriting `license.workspace`
+# would still leave the per-crate manifest ambiguous to
+# cargo-deny's parser.  The `SBOM.md` / `License.md` pair is
+# our authoritative source for what licence Nimbus ships under.
+private = { ignore = true }
 allow = [
   # Permissive
   "MIT",
@@ -87,10 +95,25 @@ allow = [
 ]
 exceptions = []
 
+# Some crates declare their licence via `license-file = "./LICENSE"`
+# rather than the `license = "..."` SPDX field, which cargo-deny
+# can't auto-resolve.  We hand it the SPDX expression here, with
+# the upstream LICENSE file as the source of truth.
+[[licenses.clarify]]
+crate = "ical"
+expression = "Apache-2.0"
+license-files = []
+
 # ── Bans ────────────────────────────────────────────────────────
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+# Workspace path-deps (`nimbus-core = { path = "../nimbus-core" }`)
+# look like wildcard version requirements to cargo-deny.  This
+# flag exempts intra-workspace path links from the wildcard ban
+# without weakening the ban for *external* deps, which is what
+# we actually care about.
+allow-wildcard-paths = true
 # Crates explicitly off-limits.  Empty for now; revisit if a
 # specific package needs to be banned (e.g. a confirmed-malicious
 # typosquatter, or a crate with a forced-unsound API).

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,112 @@
+# Configuration for `cargo-deny` — our supply-chain firewall on top
+# of `cargo audit`.  Whereas `cargo audit` only checks for known
+# CVEs in published crates, `cargo-deny` also enforces:
+#
+#   * which licences are allowed
+#   * which crate sources are allowed (only crates.io by default —
+#     no rogue git URLs, no alternative registries)
+#   * banned crates / version pins
+#   * detection of yanked or duplicate-version crates
+#
+# Run locally with `cargo deny check`; CI runs the same.
+
+[graph]
+all-features = true
+
+# ── Advisories ─────────────────────────────────────────────────
+# `cargo audit` already runs as its own CI job, but cargo-deny
+# checks the same RustSec DB so a single workflow can gate both.
+# We keep the existing audit.toml ignore list authoritative and
+# just refer to the same RUSTSEC IDs here.
+[advisories]
+version = 2
+yanked = "deny"
+ignore = [
+  # GTK3 chain via font-kit (transitive, upstream-blocked)
+  "RUSTSEC-2024-0413",
+  "RUSTSEC-2024-0416",
+  "RUSTSEC-2025-0057",
+  "RUSTSEC-2024-0412",
+  "RUSTSEC-2024-0418",
+  "RUSTSEC-2024-0411",
+  "RUSTSEC-2024-0417",
+  "RUSTSEC-2024-0414",
+  "RUSTSEC-2024-0415",
+  "RUSTSEC-2024-0420",
+  "RUSTSEC-2024-0419",
+  "RUSTSEC-2024-0429",
+  # unic-* chain via rrule
+  "RUSTSEC-2025-0081",
+  "RUSTSEC-2025-0075",
+  "RUSTSEC-2025-0080",
+  "RUSTSEC-2025-0100",
+  "RUSTSEC-2025-0098",
+  # Other transitive deps
+  "RUSTSEC-2025-0052", # async-std
+  "RUSTSEC-2024-0370", # proc-macro-error
+  "RUSTSEC-2026-0097", # rand 0.7 / 0.8
+]
+
+# ── Licences ────────────────────────────────────────────────────
+# Allow-list mirrors `SBOM.md`'s "what licences ship with Nimbus"
+# section.  Adding a new licence here is the same project-level
+# decision as adding a row to the SBOM — surface it in the PR
+# description, don't slip it in.
+[licenses]
+version = 2
+confidence-threshold = 0.8
+allow = [
+  # Permissive
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Zlib",
+  "0BSD",
+  "BSL-1.0",
+  "Unlicense",
+  "WTFPL",
+  "CC0-1.0",
+  # Data / font / Unicode licences
+  "Unicode-DFS-2016",
+  "Unicode-3.0",
+  "OFL-1.1",
+  "CDLA-Permissive-2.0",
+  # Weak copyleft (file-level)
+  "MPL-2.0",
+  "EPL-2.0",
+  # Strong copyleft — we already ship under GPL-3.0 because of `rrule`.
+  "GPL-3.0",
+  "GPL-3.0-or-later",
+  "LGPL-3.0",
+  "LGPL-3.0-or-later",
+  # OpenSSL is statically linked via vendored-openssl
+  "OpenSSL",
+]
+exceptions = []
+
+# ── Bans ────────────────────────────────────────────────────────
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+# Crates explicitly off-limits.  Empty for now; revisit if a
+# specific package needs to be banned (e.g. a confirmed-malicious
+# typosquatter, or a crate with a forced-unsound API).
+deny = []
+# When two versions of the same crate end up in the tree, prefer
+# the older one if it's already there (reduces churn).
+skip = []
+skip-tree = []
+
+# ── Sources ─────────────────────────────────────────────────────
+# This is the headline supply-chain protection.  Anyone trying to
+# add a Cargo dep from a non-crates.io source (a private registry,
+# a git URL, a tarball) will fail CI.  Closes off the easiest way
+# to slip a backdoored crate into the tree.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nimbus-app"
 version.workspace = true
 edition.workspace = true
+publish.workspace = true
 
 [dependencies]
 nimbus-core.workspace = true


### PR DESCRIPTION
## Summary

Adds five layers of supply-chain / vuln coverage on top of the existing pipeline. None of these block local development — they only run in CI, with one Dependabot config that opens PRs in the background.

- **Dependabot** (`.github/dependabot.yml`) — weekly bumps for Cargo, npm, and the GitHub Actions tree. The headline supply-chain mitigation lives here: a **`cooldown`** of 5–14 days per ecosystem so freshly-published versions sit on the registry before we pick them up. Most poisoned npm versions are flagged and yanked within 24–72 hours, so a 7-day cooldown skips nearly all of them.
- **cargo-deny** (new `rust-deny` job, `deny.toml`) — supply-chain firewall on top of `cargo audit`. Denies any crate from a source other than crates.io (no rogue git URLs, no private registries), enforces the licence allow-list mirrored from `SBOM.md`, and re-runs the advisory scan with the same RUSTSEC ignores `audit.toml` already lists.
- **CodeQL** (`.github/workflows/codeql.yml`) — GitHub's static analyser. Scans Rust + the JS/TS frontend with the `security-extended` pack, on push / PR / weekly cron. Findings appear in the repo's Security tab.
- **`lockfile-lint`** (new step in `frontend-lint`) — rejects any npm dep whose resolved URL points outside the official npm registry. Catches a whole class of attacks where a poisoned tarball URL is wedged into `package-lock.json` directly.
- **`npm audit --audit-level=high`** (new step in `frontend-lint`) — the npm-side counterpart to `cargo audit`. Currently 1 moderate-severity advisory in the tree (`postcss` < 8.5.10) which is below the `high` threshold and won't block.

## Manual steps (Nick — repo owner)

After merging this PR, two GitHub UI toggles need to flip on. Both are free for public repos.

1. **Repo → Settings → Code security**
   - Enable **Dependabot alerts**
   - Enable **Dependabot security updates** (auto-PRs for vulnerabilities)
   - Enable **Dependabot version updates** (reads our new `dependabot.yml`)
   - Enable **Secret scanning** + **Push protection** (blocks accidental commits of API keys / tokens)
2. **Repo → Settings → Code security → Code scanning** — should auto-detect the new `codeql.yml` workflow. If a banner offers "Set up CodeQL," dismiss it (the workflow file already does it). Verify alerts start appearing in the Security tab after the first run.

## On the npm supply-chain question

Yes — the cooldown setting in `dependabot.yml` is specifically the mitigation for the recent attacks (event-stream, ua-parser-js, ctx, the `shai-hulud` worm). Combined with `lockfile-lint` (rejects non-npm sources) + `npm audit` (CVE feed) + Dependabot itself (auto-PR for known-bad versions), we cover most of what's automatable without buying into a third-party scanner like Snyk or Socket. The class of attack we still can't catch — a long-game maintainer takeover that ships a stealth payload (xz-style) — is unfixable by tooling alone; the defences there are minimising the dep tree, reviewing every lockfile diff, and keeping cooldown windows generous.

## Test plan

- [ ] CI on this branch — all jobs green (5 existing + 1 new `rust-deny` + CodeQL on its own workflow)
- [x] After merge, verify Dependabot opens a small PR within a week
- [x] After merge, verify CodeQL alerts populate the Security tab
- [ ] Verify (manually) the four Settings toggles in the description above