### PR TITLE
CI: add OSV-Scanner and Semgrep, plus Socket install instructions

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,37 @@
+name: OSV-Scanner
+
+# Google's OSV-Scanner reads our Cargo.lock + package-lock.json and
+# checks every dep against the unified Open Source Vulnerabilities
+# database (osv.dev).  This catches advisories from sources beyond
+# the RustSec / GHSA feeds that `cargo audit` and `npm audit`
+# already cover — the OSV DB unifies CVE, GHSA, RustSec, PyPA,
+# Go DB, OSS-Fuzz, and others into one shape.
+#
+# Apache-2.0 licensed, run by Google, free for any project
+# regardless of whether the downstream binary is sold.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Re-scan twice a week so newly-disclosed advisories that
+    # affect already-merged code surface even when no PRs are open.
+    - cron: "0 4 * * 1,4"
+
+permissions:
+  # SARIF upload to the Security tab.
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  scan:
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.2.4
+    with:
+      # Recursively scan every lockfile in the repo (Cargo.lock at
+      # workspace root + ui/package-lock.json).
+      scan-args: |-
+        --lockfile=./Cargo.lock
+        --lockfile=./ui/package-lock.json

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,58 @@
+name: Semgrep
+
+# Semgrep is a fast pattern-based static analyser that complements
+# CodeQL.  Where CodeQL does deep dataflow analysis, Semgrep is
+# good for pattern-style rules: "no `eval` here", "every call to
+# this function must pass through `validate()` first", etc.
+#
+# We run the official `p/security-audit` ruleset (curated security
+# patterns), plus the Rust- and TypeScript-specific packs.  These
+# are public rule packs distributed by Semgrep — no account or
+# token required.  The Semgrep CLI itself is LGPL-2.1, free for
+# any usage including commercial / sold downstream apps.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Weekly cron so newly-published rule patterns hit our codebase
+    # even when we're not pushing.
+    - cron: "0 5 * * 1"
+
+permissions:
+  contents: read
+  # SARIF upload to the Security tab.
+  security-events: write
+
+jobs:
+  semgrep:
+    name: Semgrep scan
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    # Skip the scheduled run on forks to save CI minutes — the
+    # Security tab on the upstream repo is the authoritative view.
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Semgrep
+        # `--config p/security-audit` is the cross-language default
+        # security pack.  We add the Rust + TS-specific packs on
+        # top.  `--sarif` writes findings in the GitHub-Code-Scanning
+        # format so they appear in the Security tab.
+        run: |
+          semgrep scan \
+            --config p/security-audit \
+            --config p/rust \
+            --config p/typescript \
+            --sarif --output=semgrep.sarif \
+            --error \
+            --metrics=off
+      - name: Upload SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -3553,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,73 @@
+# Configuration for Google's OSV-Scanner.
+#
+# Mirrors the ignore list in `audit.toml` (cargo-audit) and the
+# `[advisories.ignore]` block in `deny.toml` (cargo-deny).  The
+# three sources need to stay in sync — every advisory we accept is
+# upstream-blocked: a transitive dep we can't bump until its own
+# maintainers cut a release.
+
+# ── GTK3 chain pulled in transitively by `font-kit` ─────────────
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0413"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0416"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0057"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0412"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0418"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0411"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0417"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0414"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0415"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0420"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0419"
+reason = "transitive via font-kit / GTK3 — no upstream fix yet"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0429"
+reason = "glib unsoundness — transitive via font-kit / GTK3"
+
+# ── unic-* chain (transitive via rrule / chrono-tz) ──────────────
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0081"
+reason = "unic-* family is unmaintained — transitive via rrule"
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0075"
+reason = "unic-* family is unmaintained — transitive via rrule"
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0080"
+reason = "unic-* family is unmaintained — transitive via rrule"
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0100"
+reason = "unic-* family is unmaintained — transitive via rrule"
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0098"
+reason = "unic-* family is unmaintained — transitive via rrule"
+
+# ── Other transitive unmaintained / unsound deps ─────────────────
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0052"
+reason = "async-std unmaintained — transitive build dep"
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0370"
+reason = "proc-macro-error unmaintained — transitive build-time"
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.7 / 0.8 unsoundness — transitive only, not exposed in our API"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -159,6 +159,11 @@ const NOTIFICATION_ICON_PNG: &[u8] = include_bytes!("../icons/icon.png");
 /// Idempotent — overwriting on every launch is cheap (~10 KB) and
 /// keeps the file in sync with whatever's currently bundled.
 fn install_notification_icon() -> Result<std::path::PathBuf, NimbusError> {
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir
+    // The file is the bundled app icon (a static asset, identical
+    // for all installs).  Predictable name in the per-user temp
+    // dir is intentional — Windows' notification API needs a
+    // stable on-disk path to reference.  No secret data here.
     let dir = std::env::temp_dir().join("nimbus-mail");
     std::fs::create_dir_all(&dir)
         .map_err(|e| NimbusError::Other(format!("notification icon mkdir failed: {e}")))?;
@@ -239,6 +244,7 @@ fn set_app_user_model_id() {
     // SAFETY: the function takes a PCWSTR derived from a live
     // HSTRING; the call has no preconditions beyond a valid
     // null-terminated wide string, which `HSTRING` guarantees.
+    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
     if let Err(e) = unsafe { SetCurrentProcessExplicitAppUserModelID(&aumid) } {
         tracing::warn!("SetCurrentProcessExplicitAppUserModelID failed: {e}");
     }
@@ -1093,6 +1099,9 @@ async fn office_sweep_temp(nc_id: String) -> Result<u32, NimbusError> {
 /// to actually print before we clean up.
 #[tauri::command]
 async fn print_attachment(file_name: String, bytes: Vec<u8>) -> Result<(), NimbusError> {
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir
+    // Per-call subdir name is a UUID v4 — not a predictable
+    // path, which is exactly what the lint is meant to catch.
     let mut dir = std::env::temp_dir();
     dir.push(format!("nimbus-print-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -159,11 +159,11 @@ const NOTIFICATION_ICON_PNG: &[u8] = include_bytes!("../icons/icon.png");
 /// Idempotent — overwriting on every launch is cheap (~10 KB) and
 /// keeps the file in sync with whatever's currently bundled.
 fn install_notification_icon() -> Result<std::path::PathBuf, NimbusError> {
-    // nosemgrep: rust.lang.security.temp-dir.temp-dir
     // The file is the bundled app icon (a static asset, identical
     // for all installs).  Predictable name in the per-user temp
     // dir is intentional — Windows' notification API needs a
     // stable on-disk path to reference.  No secret data here.
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir
     let dir = std::env::temp_dir().join("nimbus-mail");
     std::fs::create_dir_all(&dir)
         .map_err(|e| NimbusError::Other(format!("notification icon mkdir failed: {e}")))?;
@@ -244,8 +244,10 @@ fn set_app_user_model_id() {
     // SAFETY: the function takes a PCWSTR derived from a live
     // HSTRING; the call has no preconditions beyond a valid
     // null-terminated wide string, which `HSTRING` guarantees.
-    // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
-    if let Err(e) = unsafe { SetCurrentProcessExplicitAppUserModelID(&aumid) } {
+    if let Err(e) =
+        // nosemgrep: rust.lang.security.unsafe-usage.unsafe-usage
+        unsafe { SetCurrentProcessExplicitAppUserModelID(&aumid) }
+    {
         tracing::warn!("SetCurrentProcessExplicitAppUserModelID failed: {e}");
     }
 }
@@ -1099,9 +1101,9 @@ async fn office_sweep_temp(nc_id: String) -> Result<u32, NimbusError> {
 /// to actually print before we clean up.
 #[tauri::command]
 async fn print_attachment(file_name: String, bytes: Vec<u8>) -> Result<(), NimbusError> {
-    // nosemgrep: rust.lang.security.temp-dir.temp-dir
     // Per-call subdir name is a UUID v4 — not a predictable
     // path, which is exactly what the lint is meant to catch.
+    // nosemgrep: rust.lang.security.temp-dir.temp-dir
     let mut dir = std::env::temp_dir();
     dir.push(format!("nimbus-print-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2673,9 +2673,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Adds two more free security scanners to the pipeline. Both run on push / PR / cron and post findings to the **Security** tab via SARIF. Neither requires an account or paid plan, and **both stay free even if Nimbus Mail itself is sold downstream** — important since we may eventually monetise the binaries.

- **OSV-Scanner** (`.github/workflows/osv-scanner.yml`) — Google's Apache-2.0 scanner that reads `Cargo.lock` + `ui/package-lock.json` and checks every dep against [osv.dev](https://osv.dev). The OSV database unifies advisories from CVE, GHSA, RustSec, PyPA, Go DB, and OSS-Fuzz — broader than what `cargo audit` / `npm audit` see on their own.
- **Semgrep** (`.github/workflows/semgrep.yml`) — LGPL-2.1 pattern-based analyser, complements CodeQL's dataflow analysis. Runs the official `p/security-audit` + `p/rust` + `p/typescript` rule packs. Fast (seconds, not minutes), and findings appear next to CodeQL's in the Security tab.

## Manual step (one-time)

There's a third tool worth adding that does **not** ship as a CI workflow — **Socket** is a GitHub App that comments on every dep-bump PR with a behavioural diff: new postinstall scripts, new network calls, new `eval`/`fs`/env-var reads. It's the strongest single mitigation for the npm-supply-chain class (event-stream / shai-hulud / ua-parser-js style) because it actively analyses what's *in* the new version rather than just whether anyone has reported it as bad yet.

To install:

1. Go to https://socket.dev/
2. Click "Sign in with GitHub" → install the **Socket Security** app on the `Videothek/nimbus-mail` repo
3. Free for public / open-source repos. Stays free even if we sell binaries downstream — the qualifying criterion is the *repo* being public, not the project's monetisation model.

After install, Socket will leave a status check + PR comment on Dependabot's bumps. No further config needed; defaults are sensible.

## Pipeline state after this merges

| Layer | Tool | Catches |
|---|---|---|
| Format | rustfmt | Whitespace |
| Lint | clippy + svelte-check | Bug patterns, type errors |
| Tests | cargo test | Behaviour |
| Build | npm run build | Frontend bundle |
| **Dep CVEs (Rust)** | cargo audit + cargo-deny | RustSec advisories + licence + source firewall |
| **Dep CVEs (npm)** | npm audit + lockfile-lint | GHSA advisories + lockfile source check |
| **Dep CVEs (unified)** | OSV-Scanner | osv.dev cross-DB |
| **Dep updates** | Dependabot + cooldown | Auto-PR with 5-14 day soak window |
| **SAST (deep)** | CodeQL | Dataflow injection / unsafe API |
| **SAST (pattern)** | Semgrep | Pattern rules, fast |
| **Supply chain (npm behavioural)** | Socket (manual install) | Postinstall / network / eval diffs |

## Test plan

- [ ] CI on this branch — all jobs green (existing 8 + 2 new)
- [ ] Verify OSV-Scanner findings (if any) appear in the Security tab
- [ ] Verify Semgrep findings (if any) appear in the Security tab
- [ ] Manually install Socket on the repo and confirm it adds a status check