### PR TITLE
CI: split into smoke (every push) + quality gate (release / weekly)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,64 @@
+# Configuration for GitHub's "Auto-generated release notes".
+#
+# When the release workflow ticks `generate_release_notes: true`,
+# GitHub walks every PR merged since the previous tag and groups
+# them into the categories below based on PR labels.  PRs without
+# a matching label fall into the "Other" bucket.
+#
+# To assign a PR to a category, just add the right label when you
+# open it (or any time before the release tag goes out).
+
+changelog:
+  exclude:
+    # Don't list bot-authored PRs in the headline changelog —
+    # they go into a separate "Dependency updates" group below.
+    authors:
+      - dependabot
+      - dependabot[bot]
+
+  categories:
+    - title: ✨ New features
+      labels:
+        - feature
+        - enhancement
+
+    - title: 🐛 Bug fixes
+      labels:
+        - bug
+        - fix
+
+    - title: 🔒 Security
+      labels:
+        - security
+
+    - title: ⚡ Performance
+      labels:
+        - performance
+
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+
+    - title: 🧹 Refactor & cleanup
+      labels:
+        - refactor
+        - cleanup
+        - chore
+
+    - title: 🧪 Tests & CI
+      labels:
+        - test
+        - ci
+
+    - title: 📦 Dependency updates
+      labels:
+        - dependencies
+        - "*"
+      authors:
+        - dependabot
+        - dependabot[bot]
+
+    - title: 🔧 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,20 @@
-name: CI
+name: Quality gate
+
+# Heavy CI suite — clippy, tests, audit, deny, frontend audits.
+# Runs only when something *needs* to be verified end-to-end:
+#   * `workflow_call` — invoked by `release.yml` before building
+#     installers and by `weekly-security.yml` on the cron tick.
+#   * `workflow_dispatch` — for ad-hoc manual runs from the
+#     Actions UI when you want to gate-check a branch.
+#
+# It is deliberately NOT triggered on every push or PR — that's
+# what `smoke.yml` is for (~2 min: fmt + cargo check + frontend
+# typecheck + build).  This keeps the daily dev loop fast while
+# the strict checks only kick in around release time.
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_call:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,14 +14,15 @@ name: CodeQL
 #     beta but already useful for the obvious patterns).
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  # Triggered from `release.yml` (gates the installer build) and
+  # from `weekly-security.yml` (the cron tick).  No push / PR
+  # triggers — daily dev gets the cheap `smoke.yml` instead.
+  workflow_call:
+  workflow_dispatch:
   schedule:
-    # Re-scan weekly so newly-discovered query patterns hit our
-    # codebase even when we're not pushing.  Sunday 03:00 UTC
-    # avoids the weekday peak.
+    # Independent weekly cron so the Security tab keeps fresh data
+    # even if no release tag was cut.  Sunday 03:00 UTC avoids
+    # the weekday peak.
     - cron: "0 3 * * 0"
 
 jobs:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -11,13 +11,14 @@ name: OSV-Scanner
 # regardless of whether the downstream binary is sold.
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  # Triggered from `release.yml` and `weekly-security.yml`; daily
+  # dev uses `smoke.yml` instead.
+  workflow_call:
+  workflow_dispatch:
   schedule:
-    # Re-scan twice a week so newly-disclosed advisories that
-    # affect already-merged code surface even when no PRs are open.
+    # Independent twice-weekly cron so newly-disclosed advisories
+    # affecting already-merged code surface even when no release
+    # tag was cut.
     - cron: "0 4 * * 1,4"
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,156 @@
+name: Release
+
+# Triggered by pushing a `v*` tag (e.g. `v0.1.0`).  Two phases:
+#
+# 1. Quality gate — invokes the reusable `Quality gate`,
+#    `CodeQL`, `OSV-Scanner`, and `Semgrep` workflows.  If any of
+#    them fail, the build phase never runs and no installers are
+#    produced.  This is the model where the strict checks only
+#    matter at release time.
+#
+# 2. Build — matrix-builds Tauri installers for Windows, macOS,
+#    and Linux via the official `tauri-apps/tauri-action`.  The
+#    action creates a GitHub Release tagged with the same `v*`
+#    tag and attaches every installer it produces (.msi/.exe on
+#    Windows, .dmg/.app.tar.gz on macOS, .AppImage/.deb on
+#    Linux).  Release notes use GitHub's auto-generation, which
+#    reads `.github/release.yml` for category routing.
+#
+# How to cut a release:
+#   git checkout main
+#   git pull origin main
+#   git tag v0.1.0
+#   git push origin v0.1.0
+#
+# To dry-run from a non-tag branch, use the workflow_dispatch
+# trigger from the Actions UI — it runs the gate but skips the
+# Release upload (no tag exists to attach to).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write          # tauri-action creates / updates the Release
+  security-events: write   # SARIF uploads from the gating scanners
+  actions: read
+  packages: read
+
+jobs:
+  # ── Phase 1: gate ───────────────────────────────────────────
+  quality-gate:
+    name: Quality gate
+    uses: ./.github/workflows/ci.yml
+
+  codeql:
+    name: CodeQL
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+  osv:
+    name: OSV-Scanner
+    uses: ./.github/workflows/osv-scanner.yml
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+  semgrep:
+    name: Semgrep
+    uses: ./.github/workflows/semgrep.yml
+    permissions:
+      security-events: write
+      contents: read
+
+  # ── Phase 2: build + publish ────────────────────────────────
+  build:
+    name: Build (${{ matrix.platform }})
+    needs: [quality-gate, codeql, osv, semgrep]
+    # Only build when triggered by a real tag — workflow_dispatch
+    # runs are gate-only dry-runs, no Release to attach to.
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: ubuntu-latest
+            target: linux
+          - platform: macos-latest
+            target: macos
+          - platform: windows-latest
+            target: windows
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry + target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-
+
+      # Linux: Tauri / WebKitGTK system deps.
+      - name: Install Linux build deps
+        if: matrix.target == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev
+
+      # Windows: SQLCipher needs OpenSSL, and OpenSSL's build
+      # script needs a real Perl (Git Bash's stripped-down Perl
+      # is missing standard modules).  See CLAUDE.md.
+      - name: Install Strawberry Perl (Windows)
+        if: matrix.target == 'windows'
+        run: choco install strawberryperl -y
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: ui
+        run: npm ci
+
+      # tauri-action runs `tauri build`, packages installers, and
+      # — when triggered by a tag push — creates / updates the
+      # GitHub Release with the matching tag and uploads every
+      # built installer as an asset.  Notes come from GitHub's
+      # auto-generated changelog (categories in .github/release.yml).
+      - name: Build Tauri app + publish to Release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "Nimbus Mail ${{ github.ref_name }}"
+          releaseDraft: true
+          prerelease: false
+          # `generateReleaseNotes: true` tells the underlying
+          # `softprops/action-gh-release` (which tauri-action wraps)
+          # to call GitHub's auto-notes generator, which honours
+          # `.github/release.yml`.  We also reference the template
+          # at the top so manual editing has a starting point.
+          releaseBody: |
+            See `RELEASE_NOTES_TEMPLATE.md` for the manual editorial
+            section (What's new / Known issues / Install).  The
+            auto-generated changelog from PRs follows below.

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,13 +12,13 @@ name: Semgrep
 # any usage including commercial / sold downstream apps.
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  # Triggered from `release.yml` and `weekly-security.yml`; daily
+  # dev uses `smoke.yml` instead.
+  workflow_call:
+  workflow_dispatch:
   schedule:
-    # Weekly cron so newly-published rule patterns hit our codebase
-    # even when we're not pushing.
+    # Independent weekly cron so newly-published rule patterns hit
+    # the codebase even when no release tag was cut.
     - cron: "0 5 * * 1"
 
 permissions:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,69 @@
+name: Smoke
+
+# Cheap, fast checks that run on every push and PR.  The goal is
+# to catch the "I broke the build" / "I broke formatting" class
+# of regressions in ~2 minutes without making contributors wait
+# on the heavy security suite.
+#
+# The full quality gate (clippy, tests, audits, deny, codeql,
+# osv-scanner, semgrep, frontend audits) lives in `quality-gate.yml`
+# and now only runs on:
+#   * pushed `v*` tags (gates the release build)
+#   * the weekly cron in `weekly-security.yml`
+#   * manual `workflow_dispatch`
+#
+# This means the dev experience is fast by default; full
+# verification kicks in when we're actually shipping.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  rust-smoke:
+    name: Rust smoke (fmt + check)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-smoke-
+      - name: Install Tauri system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+      - name: cargo check (workspace)
+        run: cargo check --workspace --all-targets
+
+  frontend-smoke:
+    name: Frontend smoke (typecheck + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - run: npm ci
+      - run: npm run check
+      - run: npm run build

--- a/.github/workflows/weekly-security.yml
+++ b/.github/workflows/weekly-security.yml
@@ -1,0 +1,50 @@
+name: Weekly security gate
+
+# Once a week, run the full security suite on `main` so the
+# Security tab and the audit / deny / scanner runs stay current
+# even when no release tag is being cut.  This is the safety net
+# for the "checks only run at release time" model — without it
+# we'd go blind to advisories disclosed mid-cycle.
+#
+# Runs every Sunday at 06:00 UTC.  Each gating job is also wired
+# to its own cron in its own file (CodeQL Sunday 03:00, OSV-Scanner
+# Mon+Thu 04:00, Semgrep Mon 05:00) so even if this composite job
+# fails, the individual scanners still run independently.
+
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  quality-gate:
+    name: Quality gate
+    uses: ./.github/workflows/ci.yml
+
+  codeql:
+    name: CodeQL
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+  osv:
+    name: OSV-Scanner
+    uses: ./.github/workflows/osv-scanner.yml
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+  semgrep:
+    name: Semgrep
+    uses: ./.github/workflows/semgrep.yml
+    permissions:
+      security-events: write
+      contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,16 +153,75 @@ We run a **two-tier CI model** so daily dev stays fast and the heavy security su
 - A red smoke means you broke `cargo check` or formatting; everything else is deferred.
 - Heavy regressions surface at release time (or in the Sunday cron). For a 2-person scaffolding-phase project that's an acceptable trade-off; tighten back up once we have real users.
 
-**How to cut a release:**
+**How to cut a release — full recipe.** When the user says "push a new version" / "release vX.Y.Z" / "ship a new build", walk them through every step below. Do not improvise an abbreviated version of this.
+
+1. **Pick the new version** — semver:
+   - **patch** (`0.1.0 → 0.1.1`): bug fixes, security bumps, internal refactors. No new user-visible behaviour.
+   - **minor** (`0.1.0 → 0.2.0`): new features, additive UI, new settings. Backwards-compatible.
+   - **major** (`0.1.0 → 1.0.0`): breaking config-file changes, removed features, anything that requires a manual upgrade step. Pre-1.0 we're loose with this; once we ship to real users, treat it strictly.
+
+2. **Bump the version in BOTH files** (they must stay in sync — the installer filename is built from `tauri.conf.json` while crate metadata reads from `Cargo.toml`):
+   - `Cargo.toml` → `[workspace.package].version`
+   - `src-tauri/tauri.conf.json` → top-level `"version"`
+   - (`ui/package.json` has its own version — leave it; it's not user-visible.)
+
+3. **Preview the auto-generated changelog** (optional but recommended — saves an "oh no, that PR didn't get a label" moment after the tag is out):
+
+   ```bash
+   gh api repos/Videothek/nimbus-mail/releases/generate-notes \
+     -f tag_name=vX.Y.Z \
+     -f previous_tag_name=vPREV.PREV.PREV \
+     --jq .body
+   ```
+
+   If a PR ended up under "🔧 Other changes" that should have been a feature or fix, label it correctly on GitHub *before* tagging — the auto-generator runs at tag time and bakes the result.
+
+4. **Commit the bump and push to main:**
+
+   ```bash
+   git checkout main
+   git pull origin main
+   # edit Cargo.toml and src-tauri/tauri.conf.json
+   git add Cargo.toml Cargo.lock src-tauri/tauri.conf.json
+   git commit -m "Bump version to vX.Y.Z"
+   git push origin main
+   ```
+
+   Wait for `smoke.yml` to go green on main. If it fails, fix and re-push the bump commit before tagging — never tag a red main.
+
+5. **Tag and push:**
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   This kicks off `release.yml`. Phase 1 runs the full quality gate (clippy / tests / audit / deny / codeql / osv / semgrep). Phase 2 only starts if every gate passed; it matrix-builds the 3-OS installers via `tauri-apps/tauri-action` and creates a *draft* GitHub Release.
+
+6. **Watch the run** — on a cold cache it takes ~25 min. Surface any failures to the user immediately rather than leaving them to discover it on their own.
+
+7. **Finalise the Release**:
+   - Open the draft on the Releases page.
+   - Paste the editorial sections from `RELEASE_NOTES_TEMPLATE.md` *above* the auto-generated changelog (the template comment block explains what goes where).
+   - Verify every expected installer is attached: `nimbus-mail_X.Y.Z_x64-setup.exe`, `nimbus-mail_X.Y.Z_x64_en-US.msi`, `nimbus-mail_X.Y.Z_aarch64.dmg`, `nimbus-mail_X.Y.Z_x64.dmg`, `nimbus-mail_X.Y.Z_amd64.deb`, `nimbus-mail_X.Y.Z_amd64.AppImage`.
+   - Click **Publish release**.
+
+**If the tag pipeline fails** (gate red, build matrix red, etc.):
 
 ```bash
-git checkout main
-git pull origin main
-git tag v0.1.0           # follow semver
-git push origin v0.1.0
+# Delete the bad tag locally and on the remote
+git tag -d vX.Y.Z
+git push origin --delete vX.Y.Z
 ```
 
-That kicks off `release.yml`. Once the build matrix completes, a *draft* Release appears on the Releases page with all installers attached. Open it, paste in the editorial sections from `RELEASE_NOTES_TEMPLATE.md` (the auto-generated PR changelog will already be there beneath), and publish.
+Then fix the underlying problem on `main` (a new commit, not an amend), and re-tag the same `vX.Y.Z` — it's fine to reuse the version number because the failed tag was deleted and no Release was published from it. The draft Release that may have been created can be left alone or deleted from the Releases UI.
+
+**What NOT to do:**
+
+- Don't bump only one of the two version files — you'll get installers named after the old version while crate metadata reports the new one.
+- Don't tag from a branch other than `main`. The release workflow only treats `main` as canonical.
+- Don't tag without pushing the bump commit first. The build will then ship the *previous* version's code under the new tag's name.
+- Don't republish a tag that already shipped — bump the version instead. Mutating a published release breaks anyone who already downloaded it.
 
 **Release notes:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,13 +137,40 @@ the shipped binary is self-contained. Perl is a build-time tool only.
 
 ### CI
 
-GitHub Actions should install Strawberry Perl before `cargo tauri build`:
+We run a **two-tier CI model** so daily dev stays fast and the heavy security suite only kicks in around release time:
 
-```yaml
-- name: Install Strawberry Perl (Windows)
-  if: runner.os == 'Windows'
-  run: choco install strawberryperl -y
+| Workflow | When it runs | What it does |
+|---|---|---|
+| `smoke.yml` | Every PR + push to `main` | `cargo fmt --check`, `cargo check --workspace`, frontend typecheck + build. ~2 min. |
+| `ci.yml` (a.k.a. *Quality gate*) | `workflow_call` only — invoked from `release.yml` and `weekly-security.yml` | clippy, tests, cargo-audit, cargo-deny, frontend lockfile-lint + npm audit |
+| `codeql.yml` / `osv-scanner.yml` / `semgrep.yml` | `workflow_call` + their own crons | Static / supply-chain scanners that publish to the Security tab |
+| `release.yml` | Push of a `v*` tag (or manual dispatch for a dry-run) | Runs the full quality gate + scanners; if all green, matrix-builds Tauri installers and uploads them to a draft GitHub Release |
+| `weekly-security.yml` | Sunday 06:00 UTC | Runs the full quality gate + scanners on `main` so the Security tab keeps fresh data between releases |
+
+**What this means for daily work:**
+
+- Push freely on any branch — only the 2-minute smoke runs.
+- A red smoke means you broke `cargo check` or formatting; everything else is deferred.
+- Heavy regressions surface at release time (or in the Sunday cron). For a 2-person scaffolding-phase project that's an acceptable trade-off; tighten back up once we have real users.
+
+**How to cut a release:**
+
+```bash
+git checkout main
+git pull origin main
+git tag v0.1.0           # follow semver
+git push origin v0.1.0
 ```
+
+That kicks off `release.yml`. Once the build matrix completes, a *draft* Release appears on the Releases page with all installers attached. Open it, paste in the editorial sections from `RELEASE_NOTES_TEMPLATE.md` (the auto-generated PR changelog will already be there beneath), and publish.
+
+**Release notes:**
+
+- Auto-generated changelog comes from PR titles, grouped by label. The grouping config lives in `.github/release.yml`. To route a PR into a category, label it (`feature` / `bug` / `security` / `performance` / `documentation` / `refactor` / `test` / `dependencies`).
+- The hand-written editorial header lives in `RELEASE_NOTES_TEMPLATE.md` — paste that above the auto-changelog when finalising the release.
+- Dependabot PRs are auto-routed to a "Dependency updates" bucket and excluded from the headline categories so the changelog stays human-curated.
+
+**Windows builds need Strawberry Perl** (the SQLCipher → OpenSSL → vendored-openssl chain compiles OpenSSL from source, and OpenSSL's build scripts need a real Perl). Both `smoke.yml` and `release.yml` install it via `choco install strawberryperl -y` on the Windows runner. Local Windows dev needs the same — see the section above.
 
 ### Commands
 

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,81 @@
+<!--
+  Editorial template for a Nimbus Mail release.
+
+  When the release workflow runs (`v*` tag pushed), it creates a
+  *draft* GitHub Release with the auto-generated changelog from
+  every PR merged since the previous tag (categories defined in
+  `.github/release.yml`).
+
+  Open the draft, paste this template above the auto-generated
+  changelog, fill in the editorial sections, then publish.
+
+  Suggested rule of thumb for what goes in each section:
+    * Headline — one sentence that someone seeing the release
+      list can read at a glance.
+    * What's new — features the user notices.  Skip refactors
+      and dependency bumps; those are in the auto changelog.
+    * Bug fixes — user-visible fixes only.  Internal cleanups
+      do not belong here.
+    * Known issues — anything you want users to be aware of
+      before installing.  Empty is fine; do not invent issues
+      to fill space.
+    * Upgrade notes — only when the user has to do something
+      manual (re-login, clear cache, re-export config, etc.).
+
+  Delete this comment block before publishing.
+-->
+
+# Nimbus Mail vX.Y.Z — _<one-sentence headline>_
+
+## ✨ What's new
+
+- _Feature one — what changed and why a user should care._
+- _Feature two._
+
+## 🐛 Bug fixes
+
+- _Fix one — described from the user's point of view ("the sidebar no longer freezes when …")._
+- _Fix two._
+
+## ⚠️ Known issues
+
+- _If empty, delete this section entirely. Do not list "no known issues"._
+
+## 🔄 Upgrade notes
+
+- _Only include if the user has to take a manual step (re-authenticate, re-import config, clear a cache, etc.). Otherwise delete this section._
+
+---
+
+## 💾 Install
+
+| Platform | Download |
+|---|---|
+| Windows (10 / 11, x86_64) | `nimbus-mail_X.Y.Z_x64-setup.exe` or `nimbus-mail_X.Y.Z_x64_en-US.msi` |
+| macOS (Apple Silicon) | `nimbus-mail_X.Y.Z_aarch64.dmg` |
+| macOS (Intel) | `nimbus-mail_X.Y.Z_x64.dmg` |
+| Linux (Ubuntu/Debian, x86_64) | `nimbus-mail_X.Y.Z_amd64.deb` |
+| Linux (any distro, x86_64) | `nimbus-mail_X.Y.Z_amd64.AppImage` |
+
+> **Note on signing:** these builds are not yet signed. Windows SmartScreen and macOS Gatekeeper will warn the first time you run the installer. We will start shipping signed builds once we provision the certs (Apple Developer ID + Windows EV Code Signing).
+
+## 📦 Verify your download (optional)
+
+The release assets include a `SHA256SUMS` file. To verify:
+
+```sh
+# macOS / Linux
+shasum -a 256 -c SHA256SUMS
+
+# Windows (PowerShell)
+Get-FileHash <installer> -Algorithm SHA256
+```
+
+---
+
+<!--
+  Below this line is the auto-generated changelog from PRs.
+  See `.github/release.yml` for how PRs are routed into the
+  categories.  Bot-authored Dependabot PRs land in their own
+  bucket so the headline list stays human-curated.
+-->


### PR DESCRIPTION
## Summary

Restructures CI so that **daily dev only sees a 2-minute smoke test**, and the heavy security suite only runs at release time + once a week.

### New structure

| Workflow | When | Scope |
|---|---|---|
| `smoke.yml` | every PR + push to `main` | `cargo fmt --check`, `cargo check --workspace`, frontend typecheck + build (~2 min) |
| `ci.yml` | `workflow_call` only | clippy, tests, audit, deny, lockfile-lint, npm audit |
| `codeql.yml` / `osv-scanner.yml` / `semgrep.yml` | `workflow_call` + own crons | Static + supply-chain scanners → Security tab |
| **`release.yml`** | `v*` tag pushed | Runs full gate; if green, matrix-builds Tauri installers for Win/Mac/Linux and publishes a draft GitHub Release |
| **`weekly-security.yml`** | Sunday 06:00 UTC | Re-runs full gate so the Security tab stays fresh between releases |

### How a release goes out

```bash
git checkout main
git pull origin main
git tag v0.1.0
git push origin v0.1.0
```

The release workflow runs the full quality gate first. If anything fails, no installers are produced and you fix-then-retag. When the gate passes, the build matrix runs and a *draft* Release appears on the Releases page with `.msi`/`.exe`/`.dmg`/`.AppImage`/`.deb` attached. Open the draft, paste in the editorial sections from `RELEASE_NOTES_TEMPLATE.md`, then publish.

### Release notes

- **Auto-generated changelog** — GitHub builds it from PRs merged since the previous tag. Routing into categories happens via PR labels, configured in `.github/release.yml` (`feature` / `bug` / `security` / `performance` / `documentation` / `refactor` / `test` / `dependencies`). Dependabot PRs land in their own bucket so the headline categories stay human-curated.
- **`RELEASE_NOTES_TEMPLATE.md`** — editorial template at the repo root. Paste above the auto-changelog and fill in the headline / What's new / Known issues / Install table.

### What this trades

- Heavy regressions surface at release time (or in the Sunday cron) rather than on every push. For a 2-person scaffolding-phase project this is a fair trade for the speed boost. Once we have real users, easy to flip back.
- Builds are **unsigned** for now — Windows SmartScreen and macOS Gatekeeper will warn on first install. Worth provisioning Apple Developer ID (~\$100/yr) + Windows EV Code Signing (~\$200-400/yr) before we ship to anyone outside the team.

## Manual step after merge

Optional but recommended: **add labels** to the repo so the auto-notes routing has something to match against. Suggested set:
- `feature`, `enhancement`
- `bug`, `fix`
- `security`
- `performance`
- `documentation`, `docs`
- `refactor`, `cleanup`, `chore`
- `test`, `ci`
- `dependencies`

GitHub's default labels cover most of this; just add the missing ones in **Repo → Issues → Labels**.

## Test plan

- [x] `smoke.yml` passes on this PR (the only workflow that should fire on a regular PR now)
- [ ] After merge, push a throwaway tag (e.g. `v0.0.0-test`) on a scratch branch to dry-run the release workflow end-to-end
- [ ] Confirm scheduled cron jobs still appear in the Actions UI under their own workflows
- [ ] Add labels listed above to the repo