### PR TITLE
Security alert cleanup: ensure_https() guard + CodeQL test exclusion

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,31 @@
+# CodeQL scan configuration.
+#
+# Referenced from `.github/workflows/codeql.yml` via the `config-file`
+# input.  The default analysis scans every source file in the repo;
+# we narrow that here so test fixtures don't generate
+# `hard-coded-cryptographic-value` alerts on obvious test passwords
+# like `"password123"`, and so vendored / generated assets don't
+# pollute the Security tab.
+
+paths-ignore:
+  # Test code carries its own conventions — fake creds in mock
+  # servers, hard-coded fixtures, deliberately unsafe call patterns
+  # to test error paths.  CodeQL scans `src/` for the real code.
+  - "**/tests/**"
+  - "**/test/**"
+  - "**/*_test.rs"
+  - "**/*_tests.rs"
+  # Frontend test surfaces (vitest / jest / playwright) likewise.
+  - "**/*.spec.ts"
+  - "**/*.test.ts"
+  - "**/*.spec.js"
+  - "**/*.test.js"
+  # Generated / vendored assets that are not our code to fix.
+  - "ui/dist/**"
+  - "target/**"
+  - "node_modules/**"
+
+# Use the same query packs as the workflow does — `security-extended`
+# for the higher-precision security pack on top of the default set.
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,10 +49,10 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          # `security-extended` adds higher-precision security
-          # queries on top of the default set; `security-and-quality`
-          # would also catch maintainability issues but is noisier.
-          queries: security-extended
+          # See `.github/codeql/codeql-config.yml` for the path
+          # exclusions (test fixtures, generated assets) and the
+          # `security-extended` query pack.
+          config-file: ./.github/codeql/codeql-config.yml
 
       # CodeQL needs to *see* compiled code for compiled languages.
       # For Rust we let its autobuild step run cargo for us.

--- a/crates/nimbus-caldav/src/client.rs
+++ b/crates/nimbus-caldav/src/client.rs
@@ -10,6 +10,7 @@ use reqwest::{Client, Method, Response};
 use std::time::Duration;
 
 use nimbus_core::NimbusError;
+use nimbus_core::url::ensure_https;
 
 /// Build the shared HTTP client.
 pub fn build() -> Result<Client, NimbusError> {
@@ -34,6 +35,7 @@ pub async fn propfind(
     depth: u32,
     body: &str,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let method = Method::from_bytes(b"PROPFIND")
         .map_err(|e| NimbusError::Other(format!("PROPFIND method: {e}")))?;
     http.request(method, url)
@@ -56,6 +58,7 @@ pub async fn report(
     app_password: &str,
     body: &str,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let method = Method::from_bytes(b"REPORT")
         .map_err(|e| NimbusError::Other(format!("REPORT method: {e}")))?;
     http.request(method, url)
@@ -83,6 +86,7 @@ pub async fn put_ics(
     if_match: Option<&str>,
     if_none_match_star: bool,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let mut req = http
         .put(url)
         .basic_auth(username, Some(app_password))
@@ -145,6 +149,7 @@ async fn delete_resource_inner(
     if_match: Option<&str>,
     suppress_itip: bool,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let mut req = http.delete(url).basic_auth(username, Some(app_password));
     if let Some(etag) = if_match {
         let v = if etag.starts_with('"') {

--- a/crates/nimbus-carddav/src/client.rs
+++ b/crates/nimbus-carddav/src/client.rs
@@ -9,6 +9,7 @@ use reqwest::{Client, Method, Response};
 use std::time::Duration;
 
 use nimbus_core::NimbusError;
+use nimbus_core::url::ensure_https;
 
 /// Build the shared HTTP client.
 ///
@@ -36,6 +37,7 @@ pub async fn propfind(
     depth: u32,
     body: &str,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let method = Method::from_bytes(b"PROPFIND")
         .map_err(|e| NimbusError::Other(format!("PROPFIND method: {e}")))?;
     http.request(method, url)
@@ -57,6 +59,7 @@ pub async fn report(
     app_password: &str,
     body: &str,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let method = Method::from_bytes(b"REPORT")
         .map_err(|e| NimbusError::Other(format!("REPORT method: {e}")))?;
     http.request(method, url)
@@ -85,6 +88,7 @@ pub async fn put_vcard(
     if_match: Option<&str>,
     if_none_match_star: bool,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let mut req = http
         .put(url)
         .basic_auth(username, Some(app_password))
@@ -118,6 +122,7 @@ pub async fn delete_resource(
     app_password: &str,
     if_match: Option<&str>,
 ) -> Result<Response, NimbusError> {
+    ensure_https(url)?;
     let mut req = http.delete(url).basic_auth(username, Some(app_password));
     if let Some(etag) = if_match {
         let v = if etag.starts_with('"') {

--- a/crates/nimbus-core/src/lib.rs
+++ b/crates/nimbus-core/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod error;
 pub mod models;
 pub mod tls;
+pub mod url;
 
 pub use error::NimbusError;

--- a/crates/nimbus-core/src/url.rs
+++ b/crates/nimbus-core/src/url.rs
@@ -1,0 +1,100 @@
+//! Small URL guards used by the protocol crates.
+//!
+//! These exist to make sure we never accidentally send credentials
+//! over an unencrypted transport.  IMAP, SMTP, JMAP, CalDAV and
+//! CardDAV all carry HTTP Basic auth (or comparable) headers in the
+//! request itself; if the URL turned out to be `http://` instead
+//! of `https://` (server misconfig, autoconfig fallback bug, a
+//! freshly-typed account where the user dropped the `s`) we'd leak
+//! the password in cleartext.  Calling `ensure_https()` before any
+//! authenticated request short-circuits with a clear error instead
+//! of trusting the URL.
+
+use crate::NimbusError;
+
+/// Reject any URL that doesn't carry the `https://` scheme — with a
+/// narrow exemption for HTTP loopback (`127.0.0.1`, `[::1]`,
+/// `localhost`).
+///
+/// This is a defence-in-depth guard.  Account discovery and the
+/// autoconfig flow already filter out HTTP endpoints, so under
+/// normal use this never trips — but a misconfigured Nextcloud
+/// instance, a typo in a manually-entered server URL, or a future
+/// regression in discovery would otherwise silently put credentials
+/// over plaintext HTTP.  Refuse to proceed instead.
+///
+/// The loopback exemption exists because:
+///   * mock servers in `tests/` bind to `http://127.0.0.1:<port>`
+///     and the integration tests pass real credentials to them.
+///     Loopback never leaves the machine, so cleartext is safe.
+///   * Developers running a local Nextcloud instance for testing
+///     also commonly do so over plain HTTP on localhost.
+pub fn ensure_https(url: &str) -> Result<(), NimbusError> {
+    if url.starts_with("https://") {
+        return Ok(());
+    }
+    if let Some(rest) = url.strip_prefix("http://") {
+        // Cheap host extraction — everything up to the first `/`,
+        // `?`, `#`, or end of string.  Strip an `userinfo@` prefix
+        // and a `:port` suffix on the way through.
+        let host_with_port = rest
+            .split(|c| c == '/' || c == '?' || c == '#')
+            .next()
+            .unwrap_or("");
+        let host_with_port = host_with_port.rsplit('@').next().unwrap_or(host_with_port);
+        // IPv6 literals come bracketed: `[::1]:8080`.
+        let host = if let Some(end) = host_with_port.strip_prefix('[') {
+            end.split(']').next().unwrap_or("")
+        } else {
+            host_with_port.split(':').next().unwrap_or("")
+        };
+        if matches!(host, "127.0.0.1" | "::1" | "localhost") {
+            return Ok(());
+        }
+    }
+    Err(NimbusError::Network(format!(
+        "refusing to send credentials over a non-HTTPS URL: {url}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn https_passes() {
+        assert!(ensure_https("https://example.com/path").is_ok());
+    }
+
+    #[test]
+    fn http_loopback_passes() {
+        assert!(ensure_https("http://127.0.0.1:8080/path").is_ok());
+        assert!(ensure_https("http://localhost:3000/").is_ok());
+        assert!(ensure_https("http://[::1]:8080/api").is_ok());
+    }
+
+    #[test]
+    fn http_public_rejected() {
+        let err = ensure_https("http://example.com/path").unwrap_err();
+        assert!(format!("{err}").contains("non-HTTPS"));
+    }
+
+    #[test]
+    fn http_userinfo_does_not_spoof_loopback() {
+        // `userinfo@host` — the userinfo is `127.0.0.1`, host is
+        // `evil.com`.  Must reject.
+        assert!(ensure_https("http://127.0.0.1@evil.com/path").is_err());
+    }
+
+    #[test]
+    fn other_schemes_rejected() {
+        assert!(ensure_https("ftp://example.com").is_err());
+        assert!(ensure_https("ws://example.com").is_err());
+        assert!(ensure_https("file:///etc/passwd").is_err());
+    }
+
+    #[test]
+    fn empty_rejected() {
+        assert!(ensure_https("").is_err());
+    }
+}

--- a/crates/nimbus-jmap/src/client.rs
+++ b/crates/nimbus-jmap/src/client.rs
@@ -5,6 +5,7 @@
 use chrono::{DateTime, Utc};
 use nimbus_core::error::NimbusError;
 use nimbus_core::models::{Email, EmailEnvelope, Folder, OutgoingEmail};
+use nimbus_core::url::ensure_https;
 use reqwest::Client;
 use serde_json::{Value, json};
 use std::collections::HashMap;
@@ -140,6 +141,7 @@ impl JmapClient {
     /// Send a JMAP request and return the response.
     async fn call(&self, method_calls: Vec<MethodCall>) -> Result<JmapResponse, NimbusError> {
         let api_url = self.resolve_url(&self.session.api_url)?;
+        ensure_https(&api_url)?;
 
         let request = JmapRequest {
             using: CAPABILITIES.iter().map(|s| s.to_string()).collect(),


### PR DESCRIPTION
## Summary

Cleans up the open Security tab alerts. **8 of 13 are addressed in code**; the remaining 5 are dismissed via API after this merges (justifications below).

### Code fixes

- **5 × CodeQL `cleartext-transmission` (high)** on JMAP / CalDAV / CardDAV authenticated request sites: added a `nimbus_core::url::ensure_https()` guard, called before every `basic_auth(...)` site. The helper:
  - Accepts `https://` URLs.
  - Exempts HTTP loopback (`127.0.0.1`, `[::1]`, `localhost`) so the JMAP `mock_server` tests and local-Nextcloud dev setups still work — credentials over loopback never leave the machine.
  - Rejects `userinfo@host` spoof attempts (`http://127.0.0.1@evil.com/...`).
  - Lives in `crates/nimbus-core/src/url.rs` with 6 unit tests.
  - Wired into all authenticated entry points (PROPFIND / REPORT / PUT / DELETE for CalDAV+CardDAV, plus the JMAP `call()` method).

- **4 × CodeQL `hard-coded-cryptographic-value` (critical)** in `crates/nimbus-jmap/tests/mock_server.rs`: those are test fixtures (`"password123"`, `"pass"`). Added `.github/codeql/codeql-config.yml` with `paths-ignore` covering `**/tests/**`, `**/test/**`, generated assets, and frontend test specs. Once CodeQL re-runs from this config, those 4 alerts won't be re-found and will auto-resolve.

### Manual dismissals (after merge)

| Alert | Count | Why dismissable |
|---|---|---|
| Semgrep `temp-dir` / `unsafe-usage` | 3 | `// nosemgrep:` annotations are already in code; alerts are stale because Semgrep hasn't re-scanned since the fix landed |
| CodeQL `hard-coded-cryptographic-value` on `main.rs:8432` | 1 | False positive — col 25-49 is the `tauri::generate_handler!` macro name itself, not a real key |
| Dependabot `rand` (low) / `glib` (medium) | 2 | Already in our `audit.toml` / `deny.toml` / `osv-scanner.toml` ignore lists. Transitive via font-kit/GTK3 chain, upstream-blocked |

I'll clear all 6 via the GitHub API once this merges, with the dismissal reason recorded on each alert so the audit trail is intact.

## Test plan

- [x] `cargo test -p nimbus-core` — 6 new tests on `ensure_https`, all green
- [ ] CI smoke (this PR) green
- [ ] After merge, trigger a manual `Semgrep` + `CodeQL` workflow_dispatch to confirm the 7 in-code alerts disappear
- [ ] Dismiss the remaining 6 via API with documented reasons