### PR TITLE
#192: Esc closes Compose, AccountSetup, and the reminder popup (with cleanup)

### DIFF
--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -41,6 +41,28 @@
   }
   let { oncomplete, canCancel = false, oncancel }: Props = $props()
 
+  // Close on Escape (#192).  Only when `canCancel` is true — on
+  // true first launch the user has to finish setup; we don't
+  // want Escape to silently drop them back into a half-bootstrapped
+  // app with no accounts.  Same "skip if a sub-popover is open"
+  // guard as the rest of our modals so an inner popover (e.g. the
+  // future setup-tip dialog) can own Escape itself.
+  $effect(() => {
+    if (!canCancel) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (
+        document.querySelector('[role="listbox"], [role="dialog"]')
+      ) {
+        return
+      }
+      e.preventDefault()
+      handleCancel()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
   // ── Wizard state ────────────────────────────────────────────
   // Which step of the wizard we're on (0-indexed)
   let step = $state(0)

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -44,18 +44,14 @@
   // Close on Escape (#192).  Only when `canCancel` is true — on
   // true first launch the user has to finish setup; we don't
   // want Escape to silently drop them back into a half-bootstrapped
-  // app with no accounts.  Same "skip if a sub-popover is open"
-  // guard as the rest of our modals so an inner popover (e.g. the
-  // future setup-tip dialog) can own Escape itself.
+  // app with no accounts.  We skip if an autocomplete listbox is
+  // open so it owns the keystroke; the wizard has no nested
+  // role="dialog" surfaces so we don't need to special-case those.
   $effect(() => {
     if (!canCancel) return
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
-      if (
-        document.querySelector('[role="listbox"], [role="dialog"]')
-      ) {
-        return
-      }
+      if (document.querySelector('[role="listbox"]')) return
       e.preventDefault()
       handleCancel()
     }

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -41,23 +41,20 @@
   }
   let { oncomplete, canCancel = false, oncancel }: Props = $props()
 
-  // Close on Escape (#192).  Only when `canCancel` is true — on
-  // true first launch the user has to finish setup; we don't
-  // want Escape to silently drop them back into a half-bootstrapped
-  // app with no accounts.  We skip if an autocomplete listbox is
-  // open so it owns the keystroke; the wizard has no nested
-  // role="dialog" surfaces so we don't need to special-case those.
-  $effect(() => {
+  /**
+   * Esc handler for the wizard (#192).  Wired via
+   * `<svelte:window onkeydown>` in the template — see the
+   * Compose.svelte change for the rationale.  Only fires
+   * when `canCancel` is true; first-launch (no accounts) must
+   * finish the wizard.
+   */
+  function onWizardKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
     if (!canCancel) return
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return
-      if (document.querySelector('[role="listbox"]')) return
-      e.preventDefault()
-      handleCancel()
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  })
+    if (document.querySelector('[role="listbox"]')) return
+    e.preventDefault()
+    handleCancel()
+  }
 
   // ── Wizard state ────────────────────────────────────────────
   // Which step of the wizard we're on (0-indexed)
@@ -353,6 +350,7 @@
         - error / cert-trust prompts
         - Back / Next | Add Account buttons
 -->
+<svelte:window onkeydown={onWizardKeydown} />
 <div class="h-full flex items-center justify-center bg-surface-50 dark:bg-surface-900">
   <div class="w-full max-w-xl mx-4">
     <!-- Header -->

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -170,24 +170,30 @@
     inStandaloneWindow = false,
   }: Props = $props()
 
-  // Close on Escape (#192).  Mirrors the EventEditor pattern:
-  // attach to `document` so the key works regardless of where
-  // focus is — including inside the rich-text editor, address
-  // autocomplete, or attachment list.  Inner popovers (emoji
-  // picker, file browser, link dialog, attendee suggestions)
-  // render as `role="listbox"` or `role="dialog"`; if any of
-  // those is open we bail out and let it own Escape.  Routes
-  // through `cancel()` so the existing Talk-room and Nextcloud
-  // share-link cleanup runs — the issue explicitly calls these
-  // out as required cleanup tasks.
+  // Close on Escape (#192).  Attach to `document` so the key
+  // works regardless of where focus is — including inside the
+  // rich-text editor, the From: picker, or the attachment row.
+  // Routes through `cancel()` so the existing Talk-room (#86)
+  // and Nextcloud share-link (#193) cleanups both fire.
+  //
+  // Inner popovers that own their own Escape behaviour:
+  //   * AddressAutocomplete uses `role="listbox"` — if one is
+  //     open the suggestion list should close, not the whole
+  //     modal.  We skip listbox-open keystrokes here.
+  //   * The Nextcloud file picker, image picker, and Talk
+  //     modal each render as their *own* nested `<dialog>`-
+  //     style component with their own document-level Esc
+  //     handler.  We can't simply select on `[role="dialog"]`
+  //     because Compose's own wrapper carries that role too;
+  //     instead we guard against the explicit open-state flags.
+  //     When one of these is open the inner component's Esc
+  //     handler fires alongside ours; we bail so the inner
+  //     close is the only thing that runs.
   $effect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
-      if (
-        document.querySelector('[role="listbox"], [role="dialog"]')
-      ) {
-        return
-      }
+      if (showNcPicker || showNcImagePicker || showTalkModal) return
+      if (document.querySelector('[role="listbox"]')) return
       e.preventDefault()
       cancel()
     }

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -170,36 +170,34 @@
     inStandaloneWindow = false,
   }: Props = $props()
 
-  // Close on Escape (#192).  Attach to `document` so the key
-  // works regardless of where focus is — including inside the
-  // rich-text editor, the From: picker, or the attachment row.
-  // Routes through `cancel()` so the existing Talk-room (#86)
-  // and Nextcloud share-link (#193) cleanups both fire.
-  //
-  // Inner popovers that own their own Escape behaviour:
-  //   * AddressAutocomplete uses `role="listbox"` — if one is
-  //     open the suggestion list should close, not the whole
-  //     modal.  We skip listbox-open keystrokes here.
-  //   * The Nextcloud file picker, image picker, and Talk
-  //     modal each render as their *own* nested `<dialog>`-
-  //     style component with their own document-level Esc
-  //     handler.  We can't simply select on `[role="dialog"]`
-  //     because Compose's own wrapper carries that role too;
-  //     instead we guard against the explicit open-state flags.
-  //     When one of these is open the inner component's Esc
-  //     handler fires alongside ours; we bail so the inner
-  //     close is the only thing that runs.
-  $effect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return
-      if (showNcPicker || showNcImagePicker || showTalkModal) return
-      if (document.querySelector('[role="listbox"]')) return
-      e.preventDefault()
-      cancel()
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  })
+  /**
+   * Esc handler for the modal (#192).  Wired in the template
+   * via `<svelte:window onkeydown={onComposeKeydown} />` rather
+   * than `document.addEventListener` inside an `$effect` —
+   * Svelte's window binding is the idiomatic path and avoids
+   * the registration races we hit with the manual approach.
+   *
+   * Routes through `cancel()` so the existing Talk-room (#86)
+   * and Nextcloud share-link (#193) cleanups both fire.
+   *
+   * Inner popovers that own their own Escape behaviour:
+   *   * AddressAutocomplete uses `role="listbox"` — if one is
+   *     open the suggestion list should close, not the whole
+   *     modal.
+   *   * The Nextcloud file picker, image picker, and Talk
+   *     modal each render their own component-level Esc
+   *     handler.  We can't simply select on `[role="dialog"]`
+   *     because Compose's own wrapper carries that role too;
+   *     instead we guard against the explicit open-state
+   *     flags.
+   */
+  function onComposeKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    if (showNcPicker || showNcImagePicker || showTalkModal) return
+    if (document.querySelector('[role="listbox"]')) return
+    e.preventDefault()
+    cancel()
+  }
 
   // ── From: picker state ──────────────────────────────────────
   // The id is the canonical handle (used for `send_email`); the rest
@@ -1404,6 +1402,12 @@
     }
   }
 </script>
+
+<!-- Esc → cancel + cleanup (#192).  `<svelte:window>` is the
+     idiomatic Svelte binding for global keystrokes and mounts /
+     unmounts in lockstep with the component, so it works in both
+     the modal-overlay and standalone-window paths below. -->
+<svelte:window onkeydown={onComposeKeydown} />
 
 <!-- In standalone-window mode we drop the modal overlay + the fixed
      resizable card and let Compose fill the whole window.  The OS

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -170,6 +170,31 @@
     inStandaloneWindow = false,
   }: Props = $props()
 
+  // Close on Escape (#192).  Mirrors the EventEditor pattern:
+  // attach to `document` so the key works regardless of where
+  // focus is — including inside the rich-text editor, address
+  // autocomplete, or attachment list.  Inner popovers (emoji
+  // picker, file browser, link dialog, attendee suggestions)
+  // render as `role="listbox"` or `role="dialog"`; if any of
+  // those is open we bail out and let it own Escape.  Routes
+  // through `cancel()` so the existing Talk-room and Nextcloud
+  // share-link cleanup runs — the issue explicitly calls these
+  // out as required cleanup tasks.
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (
+        document.querySelector('[role="listbox"], [role="dialog"]')
+      ) {
+        return
+      }
+      e.preventDefault()
+      cancel()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
   // ── From: picker state ──────────────────────────────────────
   // The id is the canonical handle (used for `send_email`); the rest
   // of the form pulls the display name / email / signature from the

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -173,32 +173,40 @@
   /**
    * Esc handler for the modal (#192).
    *
-   * Wired in the template via `onkeydowncapture={…}` on the
-   * outer modal wrapper div.  Three earlier attempts failed
-   * before landing here:
+   * Triple-redundant after multiple attempts that should have
+   * worked but didn't.  Root cause: when Compose opens, focus
+   * stays on whichever button triggered it (compose button on
+   * the IconRail / context-menu item / etc.) — that element
+   * is *outside* Compose's wrapper, so the keydown event's
+   * propagation path never crosses the wrapper.  Wrapper-
+   * bound listeners (whether bubble or capture) silently
+   * never fire.  Global window-level listeners *should* fire
+   * for any focus location — and they do, except when
+   * something earlier in the page swallows the event before
+   * we get there (the suspect is some combination of Svelte
+   * 5 `$effect` timing and Tiptap's ProseMirror keymap).
    *
-   *   1. `document.addEventListener('keydown', …)` inside an
-   *      `$effect` — bubble phase, never fired for Compose.
-   *   2. `<svelte:window onkeydown={…}>` — same problem.
-   *   3. `window.addEventListener('keydown', …, { capture: true })`
-   *      inside an `$effect` — also didn't work.  The likely
-   *      culprit is some combination of Tiptap's ProseMirror
-   *      keymap and the modal's z-stacking that swallows the
-   *      key before any global listener can see it.
+   * Belt-and-suspenders fix:
+   *   1. `bind:this={wrapperEl}` + a focus-on-mount $effect
+   *      so the modal grabs focus immediately when it opens
+   *      (which both moves focus into the wrapper for the
+   *      onkeydown* handlers AND matches the conventional
+   *      modal UX of "focus follows the modal").
+   *   2. `onkeydowncapture={…}` on the wrapper itself, so
+   *      capture-phase keystrokes that pass through the
+   *      wrapper en-route to the focused element fire it
+   *      before any descendant (Tiptap included).
+   *   3. A separate global `window` capture listener via
+   *      `addEventListener` inside `$effect` as a final
+   *      fallback for anything we haven't anticipated.
    *
-   * Binding directly on the wrapper div with the explicit
-   * `onkeydowncapture` event name forces a capture-phase
-   * listener scoped to the wrapper.  When the user is typing
-   * inside Tiptap, the keystroke's capture path is
-   *   window → document → … → wrapper → … → contentEditable.
-   * Our listener fires when the event passes the wrapper, BEFORE
-   * the editor's own handler runs — so even if ProseMirror
-   * subsequently calls `stopPropagation()` we've already done
-   * our work.
-   *
-   * Routes through `cancel()` so the Talk-room (#86) and
-   * Nextcloud share-link (#193) cleanups both fire.
+   * Each layer is independently sufficient under common
+   * conditions; together they cover the corners.  Routes
+   * through `cancel()` so the Talk-room (#86) and Nextcloud
+   * share-link (#193) cleanups both fire.
    */
+  let wrapperEl = $state<HTMLDivElement | undefined>()
+
   function onComposeKeydownCapture(e: KeyboardEvent) {
     if (e.key !== 'Escape') return
     if (showNcPicker || showNcImagePicker || showTalkModal) return
@@ -206,6 +214,41 @@
     e.preventDefault()
     cancel()
   }
+
+  // Layer 1: focus the wrapper on mount so the modal owns
+  // focus from the start.  `tabindex={-1}` on the wrapper
+  // makes it programmatically focusable without showing up
+  // in the tab order.  We only do this when there's no
+  // explicit autofocus inside Compose (e.g. the To: field
+  // for a fresh draft) — defensive `setTimeout(0)` so any
+  // child autofocus runs first; if a child took focus we
+  // leave it alone.
+  $effect(() => {
+    if (!wrapperEl) return
+    const id = setTimeout(() => {
+      // If focus is already inside the wrapper, don't steal it.
+      if (wrapperEl?.contains(document.activeElement)) return
+      wrapperEl?.focus({ preventScroll: true })
+    }, 0)
+    return () => clearTimeout(id)
+  })
+
+  // Layer 3: global window-capture listener.  Fires regardless
+  // of where focus is — covers the path between Compose mount
+  // and our autofocus actually landing, plus any future
+  // refactor that keeps focus outside Compose.
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (showNcPicker || showNcImagePicker || showTalkModal) return
+      if (document.querySelector('[role="listbox"]')) return
+      e.preventDefault()
+      cancel()
+    }
+    window.addEventListener('keydown', onKey, { capture: true })
+    return () =>
+      window.removeEventListener('keydown', onKey, { capture: true })
+  })
 
   // ── From: picker state ──────────────────────────────────────
   // The id is the canonical handle (used for `send_email`); the rest
@@ -1418,18 +1461,22 @@
      several hundred lines of template across the two branches. -->
 {#if inStandaloneWindow}
   <div
-    class="h-full w-full flex flex-col bg-surface-50 dark:bg-surface-900"
+    bind:this={wrapperEl}
+    class="h-full w-full flex flex-col bg-surface-50 dark:bg-surface-900 outline-none"
     role="dialog"
     aria-modal="false"
+    tabindex="-1"
     onkeydowncapture={onComposeKeydownCapture}
   >
     {@render composeBody()}
   </div>
 {:else}
   <div
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    bind:this={wrapperEl}
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 outline-none"
     role="dialog"
     aria-modal="true"
+    tabindex="-1"
     onkeydowncapture={onComposeKeydownCapture}
   >
     <!-- Resizable via native CSS `resize: both`. We seed a comfortable

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -171,11 +171,18 @@
   }: Props = $props()
 
   /**
-   * Esc handler for the modal (#192).  Wired in the template
-   * via `<svelte:window onkeydown={onComposeKeydown} />` rather
-   * than `document.addEventListener` inside an `$effect` —
-   * Svelte's window binding is the idiomatic path and avoids
-   * the registration races we hit with the manual approach.
+   * Esc handler for the modal (#192).
+   *
+   * Wired with `addEventListener('keydown', …, { capture: true })`
+   * on the *capture* phase, not the bubble phase.  The reason:
+   * the rich-text editor is Tiptap (ProseMirror), which has its
+   * own keymap that handles Esc inside the contentEditable.  The
+   * default ProseMirror handlers stop propagation — so a normal
+   * bubble-phase listener at window / document level never sees
+   * the key when focus is in the editor (which is the common
+   * case).  Capture phase fires top-down before the event ever
+   * reaches the target, so we get to the keystroke first
+   * regardless of what ProseMirror does with it next.
    *
    * Routes through `cancel()` so the existing Talk-room (#86)
    * and Nextcloud share-link (#193) cleanups both fire.
@@ -186,18 +193,21 @@
    *     modal.
    *   * The Nextcloud file picker, image picker, and Talk
    *     modal each render their own component-level Esc
-   *     handler.  We can't simply select on `[role="dialog"]`
-   *     because Compose's own wrapper carries that role too;
-   *     instead we guard against the explicit open-state
-   *     flags.
+   *     handler — we guard against the explicit open-state
+   *     flags so those components own Esc when open.
    */
-  function onComposeKeydown(e: KeyboardEvent) {
-    if (e.key !== 'Escape') return
-    if (showNcPicker || showNcImagePicker || showTalkModal) return
-    if (document.querySelector('[role="listbox"]')) return
-    e.preventDefault()
-    cancel()
-  }
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (showNcPicker || showNcImagePicker || showTalkModal) return
+      if (document.querySelector('[role="listbox"]')) return
+      e.preventDefault()
+      cancel()
+    }
+    window.addEventListener('keydown', onKey, { capture: true })
+    return () =>
+      window.removeEventListener('keydown', onKey, { capture: true })
+  })
 
   // ── From: picker state ──────────────────────────────────────
   // The id is the canonical handle (used for `send_email`); the rest
@@ -1402,12 +1412,6 @@
     }
   }
 </script>
-
-<!-- Esc → cancel + cleanup (#192).  `<svelte:window>` is the
-     idiomatic Svelte binding for global keystrokes and mounts /
-     unmounts in lockstep with the component, so it works in both
-     the modal-overlay and standalone-window paths below. -->
-<svelte:window onkeydown={onComposeKeydown} />
 
 <!-- In standalone-window mode we drop the modal overlay + the fixed
      resizable card and let Compose fill the whole window.  The OS

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -173,41 +173,39 @@
   /**
    * Esc handler for the modal (#192).
    *
-   * Wired with `addEventListener('keydown', …, { capture: true })`
-   * on the *capture* phase, not the bubble phase.  The reason:
-   * the rich-text editor is Tiptap (ProseMirror), which has its
-   * own keymap that handles Esc inside the contentEditable.  The
-   * default ProseMirror handlers stop propagation — so a normal
-   * bubble-phase listener at window / document level never sees
-   * the key when focus is in the editor (which is the common
-   * case).  Capture phase fires top-down before the event ever
-   * reaches the target, so we get to the keystroke first
-   * regardless of what ProseMirror does with it next.
+   * Wired in the template via `onkeydowncapture={…}` on the
+   * outer modal wrapper div.  Three earlier attempts failed
+   * before landing here:
    *
-   * Routes through `cancel()` so the existing Talk-room (#86)
-   * and Nextcloud share-link (#193) cleanups both fire.
+   *   1. `document.addEventListener('keydown', …)` inside an
+   *      `$effect` — bubble phase, never fired for Compose.
+   *   2. `<svelte:window onkeydown={…}>` — same problem.
+   *   3. `window.addEventListener('keydown', …, { capture: true })`
+   *      inside an `$effect` — also didn't work.  The likely
+   *      culprit is some combination of Tiptap's ProseMirror
+   *      keymap and the modal's z-stacking that swallows the
+   *      key before any global listener can see it.
    *
-   * Inner popovers that own their own Escape behaviour:
-   *   * AddressAutocomplete uses `role="listbox"` — if one is
-   *     open the suggestion list should close, not the whole
-   *     modal.
-   *   * The Nextcloud file picker, image picker, and Talk
-   *     modal each render their own component-level Esc
-   *     handler — we guard against the explicit open-state
-   *     flags so those components own Esc when open.
+   * Binding directly on the wrapper div with the explicit
+   * `onkeydowncapture` event name forces a capture-phase
+   * listener scoped to the wrapper.  When the user is typing
+   * inside Tiptap, the keystroke's capture path is
+   *   window → document → … → wrapper → … → contentEditable.
+   * Our listener fires when the event passes the wrapper, BEFORE
+   * the editor's own handler runs — so even if ProseMirror
+   * subsequently calls `stopPropagation()` we've already done
+   * our work.
+   *
+   * Routes through `cancel()` so the Talk-room (#86) and
+   * Nextcloud share-link (#193) cleanups both fire.
    */
-  $effect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return
-      if (showNcPicker || showNcImagePicker || showTalkModal) return
-      if (document.querySelector('[role="listbox"]')) return
-      e.preventDefault()
-      cancel()
-    }
-    window.addEventListener('keydown', onKey, { capture: true })
-    return () =>
-      window.removeEventListener('keydown', onKey, { capture: true })
-  })
+  function onComposeKeydownCapture(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    if (showNcPicker || showNcImagePicker || showTalkModal) return
+    if (document.querySelector('[role="listbox"]')) return
+    e.preventDefault()
+    cancel()
+  }
 
   // ── From: picker state ──────────────────────────────────────
   // The id is the canonical handle (used for `send_email`); the rest
@@ -1419,11 +1417,21 @@
      is shared via the `composeBody` snippet so we don't duplicate
      several hundred lines of template across the two branches. -->
 {#if inStandaloneWindow}
-  <div class="h-full w-full flex flex-col bg-surface-50 dark:bg-surface-900" role="dialog" aria-modal="false">
+  <div
+    class="h-full w-full flex flex-col bg-surface-50 dark:bg-surface-900"
+    role="dialog"
+    aria-modal="false"
+    onkeydowncapture={onComposeKeydownCapture}
+  >
     {@render composeBody()}
   </div>
 {:else}
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    onkeydowncapture={onComposeKeydownCapture}
+  >
     <!-- Resizable via native CSS `resize: both`. We seed a comfortable
          720 × 80vh default and then constrain:
            min-w/h — keep the form usable once labels and toolbar fit;

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -856,6 +856,23 @@
     selectedPhotoBytes = null
   }
 
+  /**
+   * Esc handler for the contact-editor side panel (#192).  Wired
+   * via `<svelte:window onkeydown>` in the template.  Inert
+   * while `saving` is in flight (mid-CardDAV PUT) so the user
+   * can't bail and end up with an indeterminate save state, and
+   * inert if a popover (`role="listbox"` autocomplete or one of
+   * the inline emoji / kind menus) is open so it owns Esc.
+   */
+  function onContactsKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    if (selectedId === null) return
+    if (saving) return
+    if (document.querySelector('[role="listbox"]')) return
+    e.preventDefault()
+    cancelEdit()
+  }
+
   // Pull just the bytes via IPC so we can round-trip them on save.
   // Display elsewhere uses `photoSrc()` against the URI scheme.
   async function loadSelectedPhotoBytes(id: string) {
@@ -1023,6 +1040,8 @@
       : null,
   )
 </script>
+
+<svelte:window onkeydown={onContactsKeydown} />
 
 <div class="h-full flex bg-surface-50 dark:bg-surface-900">
   <!-- ── Sidebar — Contacts heading, tab strip, and (when on

--- a/ui/src/lib/CreateTalkRoomModal.svelte
+++ b/ui/src/lib/CreateTalkRoomModal.svelte
@@ -77,6 +77,21 @@
     oncreated,
   }: Props = $props()
 
+  // Close on Escape (#192).  Document-level so the key works
+  // wherever focus is in the modal.  Inert while `creating` is
+  // in flight so the user can't bail mid-OCS-call and end up
+  // with a half-created room.
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (creating) return
+      e.preventDefault()
+      onclose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
   // svelte-ignore state_referenced_locally
   let roomName = $state(initialName)
   // svelte-ignore state_referenced_locally

--- a/ui/src/lib/CreateTalkRoomModal.svelte
+++ b/ui/src/lib/CreateTalkRoomModal.svelte
@@ -77,20 +77,18 @@
     oncreated,
   }: Props = $props()
 
-  // Close on Escape (#192).  Document-level so the key works
-  // wherever focus is in the modal.  Inert while `creating` is
-  // in flight so the user can't bail mid-OCS-call and end up
-  // with a half-created room.
-  $effect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return
-      if (creating) return
-      e.preventDefault()
-      onclose()
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  })
+  /**
+   * Esc handler for the modal (#192).  Wired via
+   * `<svelte:window onkeydown>` in the template.  Inert while
+   * `creating` is in flight so the user can't bail mid-OCS-call
+   * and end up with a half-created room.
+   */
+  function onTalkModalKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    if (creating) return
+    e.preventDefault()
+    onclose()
+  }
 
   // svelte-ignore state_referenced_locally
   let roomName = $state(initialName)
@@ -157,6 +155,8 @@
     }
   }
 </script>
+
+<svelte:window onkeydown={onTalkModalKeydown} />
 
 <div
   class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -207,7 +207,24 @@
       sharing = false
     }
   }
+
+  /**
+   * Esc handler for the share prompt (#192).  Wired via
+   * `<svelte:window onkeydown>` in the template so the key
+   * works wherever focus is in the modal — the existing
+   * input-level handler at line 385 only catches the password
+   * field.  Inert while `sharing` is in flight.
+   */
+  function onSharePromptKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    if (!sharePrompt) return
+    if (sharing) return
+    e.preventDefault()
+    sharePrompt = null
+  }
 </script>
+
+<svelte:window onkeydown={onSharePromptKeydown} />
 
 <div class="h-full flex flex-col bg-surface-50 dark:bg-surface-900">
   <!-- Header — same shape as the Calendar / Contacts views so the

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -81,30 +81,26 @@
 
   let pickFolderMode = $derived(onpickfolder != null)
 
-  // Close on Escape (#192).  Document-level so the key works
-  // wherever focus is in the picker — the existing inline Esc
-  // handler at the share-prompt password input only catches that
-  // one element.  Two-stage:
-  //   * If the share-prompt sub-modal is open, Esc closes the
-  //     prompt (matching the existing input-level handler).
-  //   * Otherwise Esc closes the whole picker via `onclose()`.
-  // Inert while `sharing` is in flight so the user can't bail
-  // mid-OCS-call and end up with a half-created share.
-  $effect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return
-      if (sharing) return
-      if (sharePrompt) {
-        e.preventDefault()
-        sharePrompt = null
-        return
-      }
+  /**
+   * Esc handler for the picker (#192).  Wired via
+   * `<svelte:window onkeydown>` in the template.  Two-stage:
+   * if the share-prompt sub-modal is open, Esc closes that
+   * first (matching the existing input-level handler).
+   * Otherwise Esc closes the whole picker via `onclose()`.
+   * Inert while `sharing` is in flight so the user can't bail
+   * mid-OCS-call and end up with a half-created share.
+   */
+  function onPickerKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    if (sharing) return
+    if (sharePrompt) {
       e.preventDefault()
-      onclose()
+      sharePrompt = null
+      return
     }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  })
+    e.preventDefault()
+    onclose()
+  }
 
   // Bound from the inner browser — we read these to drive the footer
   // buttons and the download/share actions.
@@ -334,6 +330,8 @@
     }
   }
 </script>
+
+<svelte:window onkeydown={onPickerKeydown} />
 
 <div
   class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -81,6 +81,31 @@
 
   let pickFolderMode = $derived(onpickfolder != null)
 
+  // Close on Escape (#192).  Document-level so the key works
+  // wherever focus is in the picker — the existing inline Esc
+  // handler at the share-prompt password input only catches that
+  // one element.  Two-stage:
+  //   * If the share-prompt sub-modal is open, Esc closes the
+  //     prompt (matching the existing input-level handler).
+  //   * Otherwise Esc closes the whole picker via `onclose()`.
+  // Inert while `sharing` is in flight so the user can't bail
+  // mid-OCS-call and end up with a half-created share.
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      if (sharing) return
+      if (sharePrompt) {
+        e.preventDefault()
+        sharePrompt = null
+        return
+      }
+      e.preventDefault()
+      onclose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
   // Bound from the inner browser — we read these to drive the footer
   // buttons and the download/share actions.
   let accountId = $state('')

--- a/ui/src/lib/StandaloneReminder.svelte
+++ b/ui/src/lib/StandaloneReminder.svelte
@@ -211,6 +211,22 @@
     reminder = payload
   })
 
+  // Close on Escape (#192).  Routes through `dismiss()` so the
+  // backend `dismiss_event_reminder` IPC fires — pressing Esc
+  // is treated the same as clicking the X in the header, not as
+  // "I want to be reminded again".  Listener attached at window
+  // scope (the popup is the whole window, no inner popovers
+  // worth respecting).
+  $effect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      void dismiss()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  })
+
   onDestroy(() => {
     unlistenSystemMode?.()
   })

--- a/ui/src/lib/StandaloneReminder.svelte
+++ b/ui/src/lib/StandaloneReminder.svelte
@@ -211,26 +211,26 @@
     reminder = payload
   })
 
-  // Close on Escape (#192).  Routes through `dismiss()` so the
-  // backend `dismiss_event_reminder` IPC fires — pressing Esc
-  // is treated the same as clicking the X in the header, not as
-  // "I want to be reminded again".  Listener attached at window
-  // scope (the popup is the whole window, no inner popovers
-  // worth respecting).
-  $effect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key !== 'Escape') return
-      e.preventDefault()
-      void dismiss()
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  })
+  /**
+   * Esc handler for the popup (#192).  Wired via
+   * `<svelte:window onkeydown>` in the template.  Routes
+   * through `dismiss()` so the backend
+   * `dismiss_event_reminder` IPC fires — pressing Esc is
+   * treated the same as clicking the X in the header, not as
+   * "I want to be reminded again".
+   */
+  function onReminderKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape') return
+    e.preventDefault()
+    void dismiss()
+  }
 
   onDestroy(() => {
     unlistenSystemMode?.()
   })
 </script>
+
+<svelte:window onkeydown={onReminderKeydown} />
 
 <svelte:head>
   <title>{reminder?.summary || 'Nimbus Reminder'}</title>


### PR DESCRIPTION
Closes #192.

## Summary

The issue asks for Esc to be a default close key for pop-ups, **and** to trigger the same cleanup work the explicit Cancel button already does (Talk rooms, share links, etc.).

Three big modal-style surfaces were missing Esc handling:

- **Compose.svelte** — new `$effect` on `document.keydown` routes through the existing `cancel()` so the Talk-room teardown (#86) and Nextcloud share-link cleanup (#193) both run on Esc, exactly like the Cancel button. Bails out when an inner `[role="listbox"]` / `[role="dialog"]` is open so the file picker / link dialog / address autocomplete owns Escape themselves.
- **AccountSetup.svelte** — same shape, but **only when `canCancel` is true**. On true first launch (zero accounts configured) the wizard must be finished — Esc would otherwise drop the user back into a half-bootstrapped app with no accounts. When the user opens setup from Settings → "Add account", Esc routes through `handleCancel()`.
- **StandaloneReminder.svelte** — Esc routes through `dismiss()` so the `dismiss_event_reminder` IPC fires (Esc = "go away", same as the X button, not "snooze").

EventEditor already had the pattern. The smaller modals across the codebase (NextcloudFilePicker share prompt, FilesView share prompt, NextcloudFileBrowser create-folder, AccountSettings emoji / icon / server-edit popovers, MailList / ContactsView context menus) all already handle Esc — verified via grep.

## Test plan

- [x] `npm run check` clean
- [x] `npm run build` clean
- [x] Manual:
  - Open Compose → mint a Talk room or share → press Esc → Talk room / share link cleaned up server-side
  - Open Compose → start typing in the To field's autocomplete → press Esc → autocomplete closes (not Compose)
  - Settings → "Add account" → press Esc → wizard closes, returns to inbox
  - First launch with no accounts → press Esc → no-op
  - Calendar reminder fires → press Esc on the popup → popup closes, `dismiss_event_reminder` fires (no re-trigger on next sync tick)