### PR TITLE
#191: UI-scale setting + auto-scale + Ctrl+wheel

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -125,10 +125,30 @@ pub struct AppSettings {
     /// this setting — only what the user sees while the app runs.
     #[serde(default = "default_logo_style")]
     pub logo_style: String,
+    /// Manual UI-scale multiplier (#191).  Applied via CSS
+    /// `zoom` on the document root, so it scales every visual
+    /// element including icons / SVGs / pixel-pinned widths
+    /// uniformly.  1.0 = "as designed".  Range enforced
+    /// frontend-side: 0.7 .. 1.5 in 0.05 increments.
+    #[serde(default = "default_ui_scale")]
+    pub ui_scale: f32,
+    /// When true, the frontend ignores `ui_scale` and computes
+    /// a scale from the screen width on every launch (#191).
+    /// User interactions that change `ui_scale` directly
+    /// (manual slider in Settings, Ctrl+wheel) flip this to
+    /// false so the auto-scale stops fighting the user's
+    /// explicit choice.
+    #[serde(default = "default_true")]
+    pub ui_scale_auto: bool,
 }
 
 fn default_logo_style() -> String {
     "storm".to_string()
+}
+
+/// Default UI-scale multiplier (#191).  1.0 means "as designed".
+fn default_ui_scale() -> f32 {
+    1.0
 }
 
 /// Serde helper for fields whose post-deserialise default is `true`
@@ -204,6 +224,8 @@ impl Default for AppSettings {
             autostart_enabled: false,
             custom_themes: Vec::new(),
             logo_style: default_logo_style(),
+            ui_scale: default_ui_scale(),
+            ui_scale_auto: true,
         }
     }
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -52,6 +52,12 @@
     type ThemeMode,
     type ThemeOption,
   } from './lib/theme'
+  import {
+    applyUiScale,
+    clampScale,
+    effectiveScale,
+    UI_SCALE_STEP,
+  } from './lib/uiScale'
 
   // ── View state ──────────────────────────────────────────────
   // Which view is currently shown. Starts as 'loading' until we
@@ -218,6 +224,45 @@
     return () => document.removeEventListener('contextmenu', onCtx)
   })
 
+  /** Ctrl+wheel UI scale (#191).
+   *  Captures the wheel event before the webview's native zoom
+   *  kicks in.  Each tick adjusts by `UI_SCALE_STEP` (5 %) up
+   *  or down within `[MIN_UI_SCALE, MAX_UI_SCALE]`.  The change
+   *  is persisted via `set_app_settings` and flips
+   *  `ui_scale_auto` off so the auto-derivation doesn't undo
+   *  the user's choice on the next launch.  Persistence is
+   *  fire-and-forget — a save failure leaves the in-memory
+   *  scale applied and the user can retry by scrolling again. */
+  $effect(() => {
+    function onWheel(e: WheelEvent) {
+      if (!e.ctrlKey) return
+      e.preventDefault()
+      if (!appPrefs) return
+      const current = effectiveScale(appPrefs.ui_scale, appPrefs.ui_scale_auto)
+      // wheel-up (deltaY < 0) zooms in; wheel-down zooms out.
+      const direction = e.deltaY < 0 ? +1 : -1
+      const next = clampScale(current + direction * UI_SCALE_STEP)
+      if (next === current) return
+      // Optimistic local apply so the user sees the change
+      // instantly; the persist roundtrip catches up.
+      applyUiScale(next)
+      const updated: AppPrefs = {
+        ...appPrefs,
+        ui_scale: next,
+        ui_scale_auto: false,
+      }
+      appPrefs = updated
+      void invoke('set_app_settings', { settings: updated }).catch((err) =>
+        console.warn('set_app_settings (ui_scale) failed', err),
+      )
+    }
+    // `passive: false` so `preventDefault` is allowed — without
+    // it the browser would also apply its own zoom on top of
+    // ours, doubling the effect.
+    window.addEventListener('wheel', onWheel, { passive: false })
+    return () => window.removeEventListener('wheel', onWheel)
+  })
+
   function closeAppContextMenu() {
     appContextMenu = null
   }
@@ -335,6 +380,14 @@
     autostart_enabled: boolean
     /** User-imported Skeleton themes (#132 tier 2). */
     custom_themes?: CustomTheme[]
+    /** #191: manual UI-scale multiplier applied via CSS `zoom`
+     *  on the document root.  Range 0.7 .. 1.5. */
+    ui_scale?: number
+    /** #191: when true, `ui_scale` is ignored and the
+     *  effective scale is derived from screen width on
+     *  every launch.  User actions that pick an explicit
+     *  scale (slider, Ctrl+wheel) flip this to false. */
+    ui_scale_auto?: boolean
   }
   type CustomTheme = {
     id: string
@@ -578,6 +631,13 @@
         if (!liveIds.has(id)) unregisterCustomThemePath(id)
       }
       prevCustomThemeIds = Object.fromEntries(list.map((t) => [t.id, true]))
+      // Apply the chosen UI scale (#191).  Resolved every time
+      // `get_app_settings` returns — covers the launch path AND
+      // the post-Settings-save path.  `effectiveScale` honours
+      // the auto/manual toggle.
+      applyUiScale(
+        effectiveScale(appPrefs.ui_scale, appPrefs.ui_scale_auto),
+      )
     } catch (err) {
       console.warn('get_app_settings failed', err)
     }

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1181,7 +1181,7 @@
               step={UI_SCALE_STEP}
               disabled={appSettings.ui_scale_auto ?? true}
               bind:value={appSettings.ui_scale as number}
-              oninput={() => {
+              onchange={() => {
                 appSettings.ui_scale_auto = false
                 applyUiScale(
                   effectiveScale(

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -21,6 +21,13 @@
     type ThemeMode,
     type ThemeOption,
   } from './theme'
+  import {
+    applyUiScale,
+    effectiveScale,
+    MAX_UI_SCALE,
+    MIN_UI_SCALE,
+    UI_SCALE_STEP,
+  } from './uiScale'
 
   // ── Types ───────────────────────────────────────────────────
   // Mirrors the Rust `Account` struct from nimbus-core
@@ -142,6 +149,10 @@
     /** App-icon style slug — drives the tray, window titlebar and
      *  taskbar icon. Picker lives in Settings → Design. */
     logo_style?: string
+    /** #191 manual UI-scale (0.7 .. 1.5). */
+    ui_scale?: number
+    /** #191 when true, scale is auto-derived from screen width. */
+    ui_scale_auto?: boolean
   }
   interface CustomThemeRow {
     id: string
@@ -168,6 +179,8 @@
     autostart_enabled: false,
     custom_themes: [],
     logo_style: 'storm',
+    ui_scale: 1.0,
+    ui_scale_auto: true,
   })
 
   // ── Logo / app-icon picker (Issue #X) ───────────────────────
@@ -1122,6 +1135,67 @@
           <p class="text-xs text-surface-400 mt-1">
             "Follow OS" tracks your system light/dark preference live.
           </p>
+        </div>
+
+        <!-- UI scale (#191).  Auto by default — picks a sensible
+             multiplier from the screen width on every launch.
+             User can override with the slider below; the slider's
+             onchange flips `ui_scale_auto` off so subsequent
+             launches keep the manual choice instead of snapping
+             back to the auto-derived value.  Ctrl+wheel is also
+             wired in App.svelte and updates the same setting. -->
+        <div>
+          <p class="font-medium mb-1">UI scale</p>
+          <p class="text-xs text-surface-400 mb-2">
+            Resize text, icons, and the rest of the UI uniformly.
+            Tip: Ctrl + scroll over the app also adjusts this.
+          </p>
+          <label class="flex items-center gap-3 mb-3">
+            <Toggle
+              bind:checked={appSettings.ui_scale_auto as boolean}
+              label="Auto-scale based on screen size"
+              onchange={() => {
+                applyUiScale(
+                  effectiveScale(
+                    appSettings.ui_scale,
+                    appSettings.ui_scale_auto,
+                  ),
+                )
+                scheduleSave()
+              }}
+            />
+            <span class="text-sm">
+              Auto-scale
+              <span class="block text-xs text-surface-500">
+                Pick a scale automatically based on the current screen.
+              </span>
+            </span>
+          </label>
+          <label class="flex items-center gap-3 text-sm">
+            <span class="shrink-0 w-16">Manual</span>
+            <input
+              type="range"
+              class="flex-1"
+              min={MIN_UI_SCALE}
+              max={MAX_UI_SCALE}
+              step={UI_SCALE_STEP}
+              disabled={appSettings.ui_scale_auto ?? true}
+              bind:value={appSettings.ui_scale as number}
+              oninput={() => {
+                appSettings.ui_scale_auto = false
+                applyUiScale(
+                  effectiveScale(
+                    appSettings.ui_scale,
+                    appSettings.ui_scale_auto,
+                  ),
+                )
+                scheduleSave()
+              }}
+            />
+            <span class="font-mono text-xs w-12 text-right">
+              {Math.round((appSettings.ui_scale ?? 1) * 100)}%
+            </span>
+          </label>
         </div>
 
         <div>

--- a/ui/src/lib/uiScale.ts
+++ b/ui/src/lib/uiScale.ts
@@ -1,0 +1,89 @@
+/**
+ * UI-scale plumbing (#191).
+ *
+ * Applies a global zoom factor to the running webview so the
+ * whole UI scales uniformly — text, icons, SVGs, and pixel-
+ * pinned widths all included.  We use CSS `zoom` rather than
+ * a `transform: scale()` wrapper because zoom keeps the layout
+ * box model honest (hit-testing, scrollbars, intersection
+ * observers all behave correctly), while a transform would
+ * half-bake everything.  `zoom` is a non-standard CSS property
+ * but is universally supported by every webview engine we
+ * ship to (WebView2 on Windows, WKWebView on macOS,
+ * WebKitGTK on Linux).
+ *
+ * Source of truth flow:
+ *   1. AppSettings carries `ui_scale` + `ui_scale_auto`.
+ *   2. Settings come back from the backend on launch + after
+ *      every save.
+ *   3. `effectiveScale(...)` decides what to actually apply:
+ *      - if `ui_scale_auto` is true, derive from screen width;
+ *      - otherwise use `ui_scale` clamped to the safe range.
+ *   4. `applyUiScale(scale)` writes `document.documentElement
+ *      .style.zoom`.
+ *   5. Any user gesture that picks an explicit scale (manual
+ *      slider, Ctrl+wheel) flips `ui_scale_auto` off so the
+ *      auto-derivation stops fighting the user's choice on
+ *      the next launch.
+ */
+
+/** Minimum + maximum scale we'll ever apply.  Below ~0.7 the
+ *  10-px font sizes round down to single-pixel artifacts; above
+ *  ~1.5 the fixed-width modal dialogs start spilling off the
+ *  edge of a 1280×720 screen.  Adjust if a user reports either
+ *  symptom in practice. */
+export const MIN_UI_SCALE = 0.7
+export const MAX_UI_SCALE = 1.5
+/** Step size used by both the settings slider and Ctrl+wheel. */
+export const UI_SCALE_STEP = 0.05
+
+/**
+ * Auto-derive a scale from the current screen.  Bigger
+ * monitors get a bump; small laptops stay at 1.0.  Numbers
+ * tuned against a 1.5 px-density spread (1080p / 1440p / 4K)
+ * so the absolute UI size feels consistent.
+ *
+ * Bands are intentionally coarse: a few discrete steps reads
+ * better than a continuous formula because users get a
+ * predictable "switching monitors changes the size" mental
+ * model rather than fractional drift.
+ */
+export function autoUiScale(): number {
+  if (typeof window === 'undefined') return 1.0
+  const w = window.screen.availWidth
+  if (w >= 2560) return 1.25
+  if (w >= 1920) return 1.10
+  if (w >= 1366) return 1.0
+  if (w >= 1024) return 0.95
+  return 0.90
+}
+
+/** Resolve the scale to apply given the user's settings. */
+export function effectiveScale(
+  uiScale: number | null | undefined,
+  uiScaleAuto: boolean | null | undefined,
+): number {
+  if (uiScaleAuto ?? true) return autoUiScale()
+  return clampScale(uiScale ?? 1.0)
+}
+
+/** Clamp a candidate scale to the supported range, then snap
+ *  to the nearest `UI_SCALE_STEP`.  Snapping keeps the value
+ *  serialised cleanly in the JSON settings file (no `1.0500001`
+ *  drift after a few wheel ticks). */
+export function clampScale(s: number): number {
+  if (!Number.isFinite(s)) return 1.0
+  const stepped = Math.round(s / UI_SCALE_STEP) * UI_SCALE_STEP
+  return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, stepped))
+}
+
+/** Write the scale onto the document root.  Idempotent — calling
+ *  with the same value twice is cheap.  We set `zoom` rather
+ *  than `font-size` because zoom propagates to icons / SVGs /
+ *  arbitrary-pixel widths the way the user expects. */
+export function applyUiScale(scale: number): void {
+  if (typeof document === 'undefined') return
+  // Use `String(scale)` rather than `${scale}rem`-style: zoom
+  // takes a unitless number (1.0 = 100%).
+  document.documentElement.style.zoom = String(scale)
+}


### PR DESCRIPTION
Closes #191.

## Summary

Adds a global UI-scale knob so the app is readable on any monitor. Three asks from the issue, each addressed:

- **System setting** in `Settings → Design` (slotted right under Mode). Toggle for auto + manual slider 70 %–150 %.
- **Auto-scale based on screen size**: coarse buckets keyed off `screen.availWidth` — 1.25× at ≥2560 px, 1.10× at ≥1920 px, 1.0× at ≥1366 px, 0.95× at ≥1024 px, 0.90× otherwise. A few discrete steps reads better than a continuous formula.
- **Ctrl+wheel** anywhere in the app bumps the scale by ±5 %, flips `ui_scale_auto` off so the manual choice persists across launches, and saves via `set_app_settings`.

Implementation uses CSS `zoom` on `<html>` rather than `font-size` because zoom propagates to icons / SVGs / pixel-pinned widths uniformly. `zoom` is non-standard CSS but universally supported by every webview engine we ship to (WebView2 / WKWebView / WebKitGTK).

## Layout

- New `lib/uiScale.ts` — `applyUiScale`, `autoUiScale`, `effectiveScale`, `clampScale`, plus the `MIN_UI_SCALE` / `MAX_UI_SCALE` / `UI_SCALE_STEP` constants.
- `App.svelte` — wires the scale into the post-`get_app_settings` path and adds the Ctrl+wheel `$effect`.
- `AccountSettings.svelte` — adds the toggle + slider.
- `nimbus-core/models.rs` — adds the two settings fields + defaults; existing user configs load unchanged via `#[serde(default)]`.

## Test plan

- [x] `npm run check` clean
- [x] `cargo check -p nimbus-core` clean
- [ ] Visual sweep in `cargo tauri dev`:
  - First launch: UI auto-scales based on monitor (4K monitor → 125 %, 1080p → 100 %, etc.).
  - Drag the slider in Settings → UI changes live, auto toggle flips off.
  - Ctrl+scroll-up over the inbox → text + icons grow ~5 %; auto toggle in Settings is now off.
  - Ctrl+scroll-down past 70 % → no further shrinkage (clamped).
  - Restart Nimbus → manual scale is remembered.
  - Toggle "Auto-scale" back on → scale snaps back to the screen-derived value.