### PR TITLE
#190: language switch shows a 'Restart required' prompt

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8405,6 +8405,21 @@ fn quit_app(app: AppHandle) {
     app.exit(0);
 }
 
+/// Restart Nimbus in place (#190 follow-up).
+///
+/// Used by the language-change confirmation popup: paraglide
+/// resolves the active locale once, at boot, by walking its
+/// strategy chain (`localStorage` → `preferredLanguage` →
+/// `baseLocale`), so a runtime language switch can't take full
+/// effect without a fresh process.  Tauri's `restart()` calls
+/// the platform's "exec same binary" primitive, which is a
+/// lot smoother than asking the user to close and reopen
+/// manually.
+#[tauri::command]
+fn restart_app(app: AppHandle) {
+    app.restart();
+}
+
 // ── App entry point ─────────────────────────────────────────────
 
 fn main() {
@@ -8884,6 +8899,7 @@ fn main() {
             get_unread_counts_by_account,
             show_main_window_cmd,
             quit_app,
+            restart_app,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Nimbus");

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -4,9 +4,13 @@
   "_comment": "German translations.  Mirror the key set of `en.json` exactly — paraglide warns at compile time about missing keys, but a key with no German translation falls back to English at runtime.  Keep the formality at 'Sie' (formal you) for now; switch to 'du' if the team decides on a more casual register later.",
 
   "settings_general_language_label": "Anzeigesprache",
-  "settings_general_language_hint": "Sprache der Nimbus-Mail-Oberfläche ändern. Ein Neustart ist nicht nötig — die Änderung wird sofort übernommen.",
+  "settings_general_language_hint": "Sprache der Nimbus-Mail-Oberfläche ändern. Die neue Sprache wird beim nächsten Start übernommen.",
   "settings_general_language_auto_label": "Systemsprache verwenden",
   "settings_general_language_auto_hint": "Die vom Betriebssystem gemeldete Sprache verwenden. Deaktivieren, um eine bestimmte Sprache fest auszuwählen.",
+  "settings_general_language_restart_title": "Neustart erforderlich",
+  "settings_general_language_restart_body": "Die neue Sprache wird beim nächsten Start von Nimbus Mail übernommen.",
+  "settings_general_language_restart_now": "Jetzt neu starten",
+  "settings_general_language_restart_later": "Später neu starten",
 
   "account_setup_welcome_title": "Willkommen bei Nimbus Mail",
   "account_setup_welcome_subtitle": "Lassen Sie uns Ihr E-Mail-Konto einrichten",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -4,9 +4,13 @@
   "_comment": "Naming convention: <surface>_<element>_<role>. Surface = where the string appears (account_setup, settings, compose, …). Element = which UI thing inside that surface. Role = label / placeholder / hint / error / button / etc. Keep keys snake_case so they look good in autocomplete and don't fight ESLint identifier rules. Add new keys when you touch a string; the codebase is migrated lazily — see CLAUDE.md → i18n.",
 
   "settings_general_language_label": "Display language",
-  "settings_general_language_hint": "Change which language Nimbus Mail uses for its UI. Restart isn't required — the change applies live.",
+  "settings_general_language_hint": "Change which language Nimbus Mail uses for its UI. The new language takes effect after the next restart.",
   "settings_general_language_auto_label": "Match system language",
   "settings_general_language_auto_hint": "Use the language reported by your operating system. Turn off to pin a specific language regardless of system setting.",
+  "settings_general_language_restart_title": "Restart required",
+  "settings_general_language_restart_body": "The new language will be applied the next time Nimbus Mail starts.",
+  "settings_general_language_restart_now": "Restart now",
+  "settings_general_language_restart_later": "Restart later",
 
   "account_setup_welcome_title": "Welcome to Nimbus Mail",
   "account_setup_welcome_subtitle": "Let's set up your email account",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -58,7 +58,7 @@
     effectiveScale,
     UI_SCALE_STEP,
   } from './lib/uiScale'
-  import { setLocale, locales } from './paraglide/runtime'
+  import { locales } from './paraglide/runtime'
 
   // ── View state ──────────────────────────────────────────────
   // Which view is currently shown. Starts as 'loading' until we
@@ -646,27 +646,25 @@
       applyUiScale(
         effectiveScale(appPrefs.ui_scale, appPrefs.ui_scale_auto),
       )
-      // Apply the chosen display locale (#190).  When auto is
-      // on we let paraglide's `preferredLanguage` strategy pick
-      // from `navigator.language`; when manual, we force the
-      // pinned tag.  `setLocale` is a paraglide runtime call —
-      // it persists to localStorage and re-renders any reactive
-      // text via the `m.*()` getters.
-      if (appPrefs.ui_locale_auto !== false) {
-        // Auto: don't override paraglide's resolved locale, but
-        // make sure any previously-pinned localStorage value
-        // gets cleared so navigator.language wins again.
-        try {
+      // Sync the paraglide localStorage pin with the persisted
+      // settings (#190).  Paraglide reads localStorage at boot
+      // and never re-checks; the actual UI language for *this*
+      // process was therefore already decided by the time the
+      // settings come back from disk.  We just make sure the
+      // pin matches what's saved so a future restart picks up
+      // the right value.  The Settings page's language picker
+      // owns the in-process restart prompt — see the comment
+      // there.
+      try {
+        if (appPrefs.ui_locale_auto !== false) {
           window.localStorage.removeItem('PARAGLIDE_LOCALE')
-        } catch {}
-      } else if (
-        appPrefs.ui_locale &&
-        (locales as readonly string[]).includes(appPrefs.ui_locale)
-      ) {
-        setLocale(appPrefs.ui_locale as (typeof locales)[number], {
-          reload: false,
-        })
-      }
+        } else if (
+          appPrefs.ui_locale &&
+          (locales as readonly string[]).includes(appPrefs.ui_locale)
+        ) {
+          window.localStorage.setItem('PARAGLIDE_LOCALE', appPrefs.ui_locale)
+        }
+      } catch {}
     } catch (err) {
       console.warn('get_app_settings failed', err)
     }
@@ -1520,6 +1518,13 @@
      the user authenticates.  Everything else (loading, setup,
      mail / calendar / contacts views) stays unmounted so no IPC
      fires with the cache still locked. -->
+<!-- Locale changes require a full app restart (#190): paraglide
+     resolves the active locale once at boot from its strategy
+     chain (localStorage → preferredLanguage → baseLocale) and
+     never re-reads.  In-place reactivity attempts (page
+     reload, `{#key}` remount, etc.) all had visible
+     side-effects — the language picker in Settings now shows
+     a "restart required" prompt instead. -->
 {#if dbStatus && dbStatus.locked}
   <LockScreen
     methods={dbStatus.methods}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -29,7 +29,7 @@
     UI_SCALE_STEP,
   } from './uiScale'
   import { m } from '../paraglide/messages'
-  import { locales, setLocale } from '../paraglide/runtime'
+  import { getLocale, locales } from '../paraglide/runtime'
 
   // Friendly labels for the locale picker.  Keep the codes in
   // lockstep with `project.inlang/settings.json`.  Native
@@ -40,6 +40,22 @@
     en: 'English',
     de: 'Deutsch',
   }
+
+  /** Drives the "Restart required" prompt that appears after
+   *  the user picks a new locale (#190).  Paraglide reads its
+   *  active locale exactly once at process start (from the
+   *  localStorage pin → navigator.language → baseLocale chain),
+   *  so a runtime switch can't fully take effect without a
+   *  fresh process.  Showing the prompt lets the user decide
+   *  whether to relaunch immediately or wait until next time
+   *  they open the app. */
+  let restartPromptOpen = $state(false)
+  /** Snapshot of the locale that's active *right now* in the
+   *  running process.  We compare against this when deciding
+   *  whether to surface the restart prompt — picking the
+   *  language that's already running is a no-op and shouldn't
+   *  nag the user. */
+  const initialLocale = getLocale()
 
   // ── Types ───────────────────────────────────────────────────
   // Mirrors the Rust `Account` struct from nimbus-core
@@ -950,13 +966,23 @@
             label={m.settings_general_language_auto_label()}
             onchange={() => {
               if (appSettings.ui_locale_auto) {
-                // Returning to auto — drop the pinned value so
-                // paraglide's preferredLanguage strategy can win.
+                // Returning to auto — clear the pinned value so
+                // paraglide's `preferredLanguage` strategy
+                // (`navigator.language`) wins on the next
+                // restart.
                 appSettings.ui_locale = ''
                 try {
                   window.localStorage.removeItem('PARAGLIDE_LOCALE')
                 } catch {}
-                window.location.reload()
+                // Show the restart prompt only when the
+                // resolved auto-locale would actually differ
+                // from what's running now.
+                const wouldBe = (
+                  navigator.language || initialLocale
+                ).split('-')[0]
+                if (wouldBe && wouldBe !== initialLocale) {
+                  restartPromptOpen = true
+                }
               }
               scheduleSave()
             }}
@@ -978,9 +1004,18 @@
                 const v = (e.currentTarget as HTMLSelectElement).value
                 appSettings.ui_locale = v
                 if ((locales as readonly string[]).includes(v)) {
-                  setLocale(v as (typeof locales)[number], { reload: false })
+                  // Pin the localStorage value paraglide reads
+                  // at boot.  `setLocale` is the canonical way
+                  // but it triggers a reload by default and a
+                  // `{#key}` remount otherwise — both had
+                  // visible side-effects in earlier attempts;
+                  // writing the key directly avoids them.
+                  try {
+                    window.localStorage.setItem('PARAGLIDE_LOCALE', v)
+                  } catch {}
                 }
                 scheduleSave()
+                if (v !== initialLocale) restartPromptOpen = true
               }}
             >
               {#each locales as code}
@@ -1831,5 +1866,60 @@
       class="ml-2 underline"
       onclick={() => (trustError = '')}
     >Dismiss</button>
+  </div>
+{/if}
+
+<!-- Restart-required prompt for language changes (#190).
+     Fires from the locale dropdown / auto-toggle when the
+     pick differs from what's currently running.  "Restart
+     later" just dismisses the modal — the new pin is already
+     persisted, so the next manual launch picks it up.
+     "Restart now" calls the Tauri `restart_app` IPC which
+     re-execs the binary; settings have been saved by then via
+     `scheduleSave`. -->
+{#if restartPromptOpen}
+  <div
+    class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="restart-required-title"
+  >
+    <div class="card p-5 max-w-sm w-[90%] bg-surface-100 dark:bg-surface-800 rounded-lg shadow-xl">
+      <h2 id="restart-required-title" class="text-base font-semibold mb-2">
+        {m.settings_general_language_restart_title()}
+      </h2>
+      <p class="text-sm text-surface-600 dark:text-surface-300 mb-4">
+        {m.settings_general_language_restart_body()}
+      </p>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="btn btn-sm preset-outlined-surface-500"
+          onclick={() => (restartPromptOpen = false)}
+        >
+          {m.settings_general_language_restart_later()}
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm preset-filled-primary-500"
+          onclick={() => {
+            // Fire-and-forget — `restart_app` re-execs the
+            // binary; once it completes the current webview is
+            // already gone, so awaiting is moot.  The
+            // `scheduleSave` debounce (~600 ms) might still be
+            // pending, so persist explicitly here so the new
+            // process boots with the right locale even on a
+            // slow disk.
+            void invoke('set_app_settings', {
+              settings: appSettings,
+            }).finally(() => {
+              void invoke('restart_app')
+            })
+          }}
+        >
+          {m.settings_general_language_restart_now()}
+        </button>
+      </div>
+    </div>
   </div>
 {/if}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -983,6 +983,31 @@
                 if (wouldBe && wouldBe !== initialLocale) {
                   restartPromptOpen = true
                 }
+              } else {
+                // Switching FROM auto TO manual — pre-fill
+                // `ui_locale` (and the localStorage pin) with
+                // the locale that's actually running, so the
+                // dropdown that's about to appear reflects
+                // reality.  Without this the dropdown
+                // defaulted to `locales[0]` (English), which
+                // matched what was selected only by accident
+                // — a German user clicking "English" to
+                // confirm wouldn't trigger an `onchange`
+                // (browser elides "selected the already-
+                // selected option") and the restart prompt
+                // never fired.  Pre-filling means picking the
+                // same locale is a no-op (correct) and
+                // picking a different one always fires the
+                // change handler.
+                if (!appSettings.ui_locale) {
+                  appSettings.ui_locale = initialLocale
+                  try {
+                    window.localStorage.setItem(
+                      'PARAGLIDE_LOCALE',
+                      initialLocale,
+                    )
+                  } catch {}
+                }
               }
               scheduleSave()
             }}


### PR DESCRIPTION
Supersedes #241.

## Why

Two earlier attempts at applying a locale change in-place both bugged out:
- **Default `setLocale(...)` reload** bounced the user out of the Settings tab and raced the explicit save.
- **`setLocale(..., { reload: false })` + `{#key}` remount** was reactive enough to update the Settings page itself, but the dropdown jittered as the keyed subtree re-mounted underneath the user's pointer.

Paraglide reads its active locale exactly once at process boot (localStorage → preferredLanguage → baseLocale), so a fresh process is the only reliable way to apply the switch end-to-end anyway. Owning that fact in the UX rather than fighting it.

## What changes

### Backend
- New `restart_app` Tauri IPC. Calls `app.restart()` which re-execs the binary in place.

### Frontend
- **Locale dropdown** writes the `PARAGLIDE_LOCALE` localStorage pin directly + debounces a settings save + opens the modal when the new pick differs from the locale running in the current process.
- **"Match system language" toggle** clears the pin and opens the modal only when the resolved OS-language would differ from what's running.
- **New "Restart required" modal** at the end of `AccountSettings.svelte`:
  - **Restart later** — closes the prompt; the new pin is already saved, next manual launch picks it up.
  - **Restart now** — flushes any pending debounced save via `set_app_settings` then invokes `restart_app`.
- **`App.svelte`** — `loadAppPrefs` just keeps the localStorage pin in sync with persisted settings; no live-switch attempt anywhere.
- Four new translation keys (`settings_general_language_restart_*`) in both `en.json` and `de.json`. Hint under the dropdown reworded from "applies live" to "takes effect after the next restart".

## Test plan

- [x] `npm run check` clean
- [x] `cargo check -p nimbus-core` clean
- [x] Manual:
  - Settings → General → flip "Match system language" off → pick "English" → modal appears.
  - "Restart later" → modal closes, language stays in current locale; relaunching Nimbus shows English.
  - Pick "Deutsch" → modal appears → "Restart now" → Nimbus relaunches in German.
  - Pick the locale that's already running → modal does NOT appear.
  - Flip "Match system language" back on → modal appears only if the OS-language would differ; "Restart now" relaunches in the OS language.