### PR TITLE
#189: hide sidebar icons for features the connected Nextcloud doesn't expose

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -103,6 +103,58 @@
   let accounts = $state<Account[]>([])
   let activeAccountId = $state<string | null>(null)
 
+  // ── Nextcloud capability snapshot (#189) ────────────────────
+  // Drives which integration icons (Contacts / Calendar / Files /
+  // Talk / Notes) the IconRail surfaces at all.  Aggregated from
+  // every connected NC account: a feature is "available" if any
+  // one account exposes it.  Refreshed on the same `loadAppPrefs`
+  // tick that hydrates the rest of the shell so a user adding a
+  // Nextcloud account in Settings sees the rail update on close.
+  interface NextcloudAccountWithCaps {
+    id: string
+    capabilities?: {
+      talk?: boolean
+      files?: boolean
+      caldav?: boolean
+      carddav?: boolean
+      notes?: boolean
+    } | null
+  }
+  let ncCaps = $state({
+    /** True when at least one NC account is connected — gates
+     *  every integration icon at once.  Without this, a user
+     *  who hasn't added a Nextcloud account yet would still see
+     *  the integration nav, click into one, and hit a "no
+     *  accounts" empty state. */
+    hasAny: false,
+    contacts: false,
+    calendar: false,
+    files: false,
+    talk: false,
+    notes: false,
+  })
+
+  async function refreshNextcloudCapabilities() {
+    try {
+      const list = await invoke<NextcloudAccountWithCaps[]>('get_nextcloud_accounts')
+      const any = (pred: (a: NextcloudAccountWithCaps) => boolean) =>
+        list.some(pred)
+      ncCaps = {
+        hasAny: list.length > 0,
+        contacts: any((a) => a.capabilities?.carddav === true),
+        calendar: any((a) => a.capabilities?.caldav === true),
+        files: any((a) => a.capabilities?.files === true),
+        talk: any((a) => a.capabilities?.talk === true),
+        notes: any((a) => a.capabilities?.notes === true),
+      }
+    } catch (e) {
+      console.warn('refreshNextcloudCapabilities failed', e)
+      // Leave the previous snapshot in place on failure — better
+      // to keep a stale "available" answer than to flicker icons
+      // off because of a transient IPC error.
+    }
+  }
+
   // ── Database lock state (#164 Phase 1B) ─────────────────────
   // Cache may be in FIDO-only mode at boot; in that case the
   // lock screen mounts ahead of every other view and the rest
@@ -617,6 +669,14 @@
   }
 
   async function loadAppPrefs() {
+    // Refresh the Nextcloud capability snapshot in parallel with
+    // the settings load (#189).  Doesn't depend on settings — it
+    // queries `get_nextcloud_accounts` which has its own state —
+    // so kicking it off as a side-fire keeps the IconRail's
+    // available-feature flags in sync after Settings closes,
+    // without slowing the main settings round-trip.
+    void refreshNextcloudCapabilities()
+
     try {
       appPrefs = await invoke<AppPrefs>('get_app_settings')
       // Seed the theme module's custom-theme registry so the
@@ -1576,6 +1636,7 @@
       unified={unifiedMode}
       currentView={currentView}
       mailRefreshing={mailRefreshing}
+      ncCaps={ncCaps}
       onselectaccount={selectAccount}
       onselectview={onSelectView}
     />

--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -82,6 +82,22 @@
      *  "Refreshing…" hint lives somewhere persistent rather
      *  than as a buggy strip inside the list (#161). */
     mailRefreshing?: boolean
+    /** Aggregated Nextcloud capability snapshot (#189).  Each
+     *  flag is true when at least one connected NC account
+     *  exposes that feature.  `hasAny` short-circuits the
+     *  whole integration block — without a Nextcloud account
+     *  configured at all, none of the per-feature icons make
+     *  sense.  Defaults to "everything available" so the rail
+     *  doesn't accidentally hide things during the brief
+     *  capability-load window. */
+    ncCaps?: {
+      hasAny: boolean
+      contacts: boolean
+      calendar: boolean
+      files: boolean
+      talk: boolean
+      notes: boolean
+    }
   }
   let {
     accounts,
@@ -91,6 +107,14 @@
     onselectaccount,
     onselectview,
     mailRefreshing = false,
+    ncCaps = {
+      hasAny: true,
+      contacts: true,
+      calendar: true,
+      files: true,
+      talk: true,
+      notes: true,
+    },
   }: Props = $props()
 
   /** First-letter / initial-pair fallback for the avatar bubble.
@@ -211,6 +235,10 @@
   // above the divider already navigate to mail, so a dedicated
   // mail icon would be redundant.  Use `onselectaccount` (with the
   // `'__all__'` sentinel for unified mode) to land in the inbox.
+  // Source-of-truth nav list.  Visibility is gated per-entry
+  // by the matching `ncCaps` flag below; the static list keeps
+  // the order canonical so we don't end up with the icons
+  // shuffling when capabilities flip.
   const MAIN_NAV: NavEntry[] = [
     { match: 'contacts', label: 'Contacts', icon: 'contacts' },
     { match: 'calendar', label: 'Calendar', icon: 'calendar' },
@@ -218,6 +246,28 @@
     { match: 'talk', label: 'Talk', icon: 'meetings' },
     { match: 'notes', label: 'Notes', icon: 'notes' },
   ]
+
+  /** Filtered view of `MAIN_NAV` honouring the Nextcloud
+   *  capability snapshot (#189).  When the user has no NC
+   *  account at all (`hasAny=false`) the whole block is empty,
+   *  matching the issue's "hide features that aren't available
+   *  through Nextcloud" ask.  When they have an account but
+   *  Talk / Notes etc. aren't installed on the server, those
+   *  rows drop out individually. */
+  const visibleNav = $derived(
+    !ncCaps.hasAny
+      ? []
+      : MAIN_NAV.filter((entry) => {
+          switch (entry.match) {
+            case 'contacts': return ncCaps.contacts
+            case 'calendar': return ncCaps.calendar
+            case 'files':    return ncCaps.files
+            case 'talk':     return ncCaps.talk
+            case 'notes':    return ncCaps.notes
+            default:         return true
+          }
+        }),
+  )
 </script>
 
 <aside
@@ -328,14 +378,16 @@
     </button>
   {/each}
 
-  <!-- Divider between account bubbles and the view nav. Only
-       renders when there's at least one account so the very-first-
-       launch empty state doesn't show an orphan line. -->
-  {#if accounts.length > 0}
+  <!-- Divider between account bubbles and the view nav.  Only
+       renders when there's at least one account AND at least
+       one integration icon will follow — when no Nextcloud is
+       connected (#189), the integration block is empty and the
+       divider has nothing to separate. -->
+  {#if accounts.length > 0 && visibleNav.length > 0}
     <div class="w-6 h-px my-1 bg-surface-300 dark:bg-surface-600" aria-hidden="true"></div>
   {/if}
 
-  {#each MAIN_NAV as entry (entry.match)}
+  {#each visibleNav as entry (entry.match)}
     {@const active = currentView === entry.match}
     <button
       class="w-9 h-9 rounded-md flex items-center justify-center text-lg transition-colors relative


### PR DESCRIPTION
Closes #189.

## Summary

The icon rail's integration block (Contacts / Calendar / Files / Talk / Notes) was always rendering all five icons — even when no Nextcloud account was configured at all, or when the connected NC server didn't have Talk / Notes installed. Clicking those icons dropped the user into a useless empty state.

Now the rail honours the live capability snapshot.

## Changes

### `App.svelte`
- New `ncCaps` state: five per-feature booleans + a `hasAny` short-circuit.
- New `refreshNextcloudCapabilities()` reads `get_nextcloud_accounts` (which already returns the cached `NextcloudCapabilities` per account) and aggregates: a feature is "available" when **at least one** connected account exposes it.
- Side-fired from `loadAppPrefs`, so a user who adds a Nextcloud account in Settings sees the rail update on close. Failures leave the previous snapshot in place — a transient IPC error doesn't flicker icons off.

### `IconRail.svelte`
- New `ncCaps` prop, defaulting to "everything available" so the brief capability-load window doesn't accidentally hide icons.
- `visibleNav` is a `$derived` filter over `MAIN_NAV` that drops entries whose feature flag is off. When `hasAny` is false the entire integration list is empty.
- Divider between account bubbles and the integration nav only renders when at least one nav row would follow.

## Test plan

- [x] `npm run check` clean
- [ ] Manual:
  - Fresh install with only an IMAP account, no Nextcloud → rail shows account avatars + Settings only (no integration icons, no divider).
  - Connect a Nextcloud account with Talk + Notes installed → all five integration icons appear after Settings closes.
  - Connect a Nextcloud account without Notes installed → Notes icon hidden, others visible.
  - Connect a Nextcloud account without Talk installed → Talk icon hidden.
  - Disconnect the Nextcloud account → integration block disappears again.