### PR TITLE
#170: fix WebAuthn RP ID and split shared busy state in SecuritySettings

### DIFF
--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -52,7 +52,19 @@
 
   let status = $state<FidoStatus | null>(null)
   let loading = $state(true)
-  let busy = $state(false)
+  // Per-action in-flight flags.  A single shared `busy` flag would
+  // make every button's "Working…" label flip on at the same time,
+  // even when only one action is actually running — so each
+  // mutating handler owns its own flag, and `anyBusy` is the
+  // derived "block other actions while something is in flight"
+  // gate.  Buttons read their own flag for the label, and
+  // `anyBusy` for `disabled` so the user can't kick off two
+  // mutations concurrently.
+  let addingKey = $state(false)
+  let savingPassphrase = $state(false)
+  let removingKey = $state(false)
+  let disablingEncryption = $state(false)
+  const anyBusy = $derived(addingKey || savingPassphrase || removingKey || disablingEncryption)
   let error = $state('')
   // Just a coarse "WebAuthn API exists" check.  Don't gate on
   // PRF capability up front — older engines mis-report it; let
@@ -111,7 +123,7 @@
     }
   }
   async function setKeyEncryption(v: boolean) {
-    if (busy) return
+    if (anyBusy) return
     if (v) {
       keyEncryptionEnabled = true
       persistToggle(true)
@@ -125,7 +137,7 @@
       // is in Settings, which lives behind the unlock screen)
       // for the master key to be in memory.
       if (status && !status.hasPlainKey) {
-        busy = true
+        disablingEncryption = true
         try {
           await invoke('disable_fido_only_mode')
           keyEncryptionEnabled = false
@@ -134,7 +146,7 @@
         } catch (e) {
           error = formatError(e) || 'Failed to disable key encryption'
         } finally {
-          busy = false
+          disablingEncryption = false
         }
         return
       }
@@ -147,7 +159,7 @@
    *  backend still has the plain master key.  Saves the user
    *  from having to find a separate "activate" button. */
   $effect(() => {
-    if (busy) return
+    if (anyBusy) return
     if (!keyEncryptionEnabled) return
     if (!status) return
     if (!status.hasPlainKey) return // already FIDO-only
@@ -234,9 +246,9 @@
   }
 
   async function addKey() {
-    if (busy) return
+    if (anyBusy) return
     const label = newLabel.trim() || 'Untitled hardware key'
-    busy = true
+    addingKey = true
     error = ''
     try {
       // Generate a fresh PRF salt server-side so it shares the
@@ -256,12 +268,12 @@
     } catch (e) {
       error = formatError(e) || 'Failed to enroll hardware key'
     } finally {
-      busy = false
+      addingKey = false
     }
   }
 
   async function addPassphrase() {
-    if (busy) return
+    if (anyBusy) return
     if (passphraseValue.length < 8) {
       error = 'Passphrase must be at least 8 characters.'
       return
@@ -270,7 +282,7 @@
       error = "Passphrase and confirmation don't match."
       return
     }
-    busy = true
+    savingPassphrase = true
     error = ''
     try {
       await invoke('fido_enroll_passphrase', {
@@ -284,12 +296,12 @@
     } catch (e) {
       error = formatError(e) || 'Failed to enroll passphrase'
     } finally {
-      busy = false
+      savingPassphrase = false
     }
   }
 
   async function removeKey(c: FidoCredential) {
-    if (busy) return
+    if (anyBusy) return
     // Pre-flight: removing the last unlock method while
     // FIDO-only mode is active would orphan the encrypted DB
     // forever.  The backend rejects this too, but catching it
@@ -306,7 +318,7 @@
     const promptLabel = c.kind === 'passphrase' ? 'Recovery passphrase' : c.label
     if (!confirm(`Remove "${promptLabel}"? You'll need to re-enroll to use it again.`))
       return
-    busy = true
+    removingKey = true
     error = ''
     try {
       // Require the user to actually still possess the key
@@ -325,7 +337,7 @@
     } catch (e) {
       error = formatError(e) || 'Failed to remove credential'
     } finally {
-      busy = false
+      removingKey = false
     }
   }
 
@@ -462,13 +474,13 @@
               class="input flex-1 text-sm px-3 py-1.5 rounded-md"
               placeholder="Label — e.g. “YubiKey 5C”, “MacBook Touch ID”"
               bind:value={newLabel}
-              disabled={busy}
+              disabled={anyBusy}
             />
             <button
               class="btn preset-filled-primary-500"
-              disabled={busy}
+              disabled={anyBusy}
               onclick={() => void addKey()}
-            >{busy ? 'Working…' : 'Add'}</button>
+            >{addingKey ? 'Working…' : 'Add'}</button>
           </div>
         </div>
       {:else}
@@ -503,7 +515,7 @@
               class="input w-full text-sm px-3 py-1.5 rounded-md"
               placeholder="Passphrase (8+ characters)"
               bind:value={passphraseValue}
-              disabled={busy}
+              disabled={anyBusy}
               autocomplete="new-password"
             />
             <input
@@ -511,14 +523,14 @@
               class="input w-full text-sm px-3 py-1.5 rounded-md"
               placeholder="Confirm passphrase"
               bind:value={passphraseConfirm}
-              disabled={busy}
+              disabled={anyBusy}
               autocomplete="new-password"
             />
             <div class="flex gap-2">
               {#if passphraseEditing}
                 <button
                   class="btn preset-outlined-surface-500 flex-1"
-                  disabled={busy}
+                  disabled={anyBusy}
                   onclick={() => {
                     passphraseEditing = false
                     passphraseValue = ''
@@ -528,9 +540,9 @@
               {/if}
               <button
                 class="btn preset-filled-primary-500 flex-1"
-                disabled={busy || passphraseValue.length < 8}
+                disabled={anyBusy || passphraseValue.length < 8}
                 onclick={() => void addPassphrase()}
-              >{busy ? 'Working…' : hasPassphrase ? 'Update passphrase' : 'Save passphrase'}</button>
+              >{savingPassphrase ? 'Working…' : hasPassphrase ? 'Update passphrase' : 'Save passphrase'}</button>
             </div>
           </div>
         </div>
@@ -567,7 +579,7 @@
                 {#if c.kind === 'passphrase'}
                   <button
                     class="btn btn-sm preset-outlined-surface-500"
-                    disabled={busy}
+                    disabled={anyBusy}
                     title="Change passphrase"
                     aria-label="Change passphrase"
                     onclick={() => {
@@ -579,7 +591,7 @@
                 {/if}
                 <button
                   class="btn btn-sm preset-outlined-error-500"
-                  disabled={busy}
+                  disabled={anyBusy}
                   onclick={() => void removeKey(c)}
                 >Remove</button>
               </li>

--- a/ui/src/lib/webauthnPrf.ts
+++ b/ui/src/lib/webauthnPrf.ts
@@ -16,8 +16,23 @@
 // error if the engine doesn't expose it; the Settings UI surfaces
 // that as a tooltip on the disabled button.
 
-const RP_ID = 'nimbus-mail.local'
 const RP_NAME = 'Nimbus Mail'
+
+// The Relying Party ID must be a registrable suffix of (or equal to)
+// the current page's effective domain, otherwise the browser refuses
+// the call with "The relying party ID is not a registrable domain
+// suffix of, nor equal to the current domain."  Tauri's webview
+// origin differs by platform — `tauri://localhost` on macOS,
+// `https://tauri.localhost` on Windows, `http://localhost:1420` in
+// Linux dev — so we read the actual hostname at call time instead
+// of hardcoding one.  WebAuthn treats `localhost` and `*.localhost`
+// as a special case (no certificate or HTTPS required), which is
+// exactly what we get inside the Tauri webview.  Using the same
+// value at enroll and unlock time is what matters: a credential
+// registered against host X can only be asserted against host X.
+function rpId(): string {
+  return window.location.hostname
+}
 
 function bufToB64(buf: ArrayBuffer | Uint8Array): string {
   const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf)
@@ -88,7 +103,7 @@ export async function enrollFidoCredential(
   const userIdBytes = new TextEncoder().encode(userHandle)
   const cred = (await navigator.credentials.create({
     publicKey: {
-      rp: { id: RP_ID, name: RP_NAME },
+      rp: { id: rpId(), name: RP_NAME },
       user: {
         id: userIdBytes,
         name: userHandle,
@@ -183,7 +198,7 @@ export async function evaluateFidoPrf(
   const assertion = (await navigator.credentials.get({
     publicKey: {
       challenge,
-      rpId: RP_ID,
+      rpId: rpId(),
       allowCredentials: [{ type: 'public-key', id: credentialId }],
       userVerification: 'required',
       timeout: 60_000,


### PR DESCRIPTION
## Summary

Two bugs surfaced via comments on #170:

- **WebAuthn RP ID rejected by the webview.** Registering a FIDO key failed with *"The relying party ID is not a registrable domain suffix of, nor equal to the current domain"* because we hardcoded `nimbus-mail.local` as the RP ID. Tauri's webview origin varies by platform (`tauri://localhost`, `https://tauri.localhost`, `http://localhost:1420`) and WebAuthn requires the RP ID to be a registrable suffix of, or equal to, the current host. Replaced the constant with `window.location.hostname` at call time in both `create()` and `get()`. WebAuthn special-cases `localhost` / `*.localhost` (no cert required), and using the same value at enroll and unlock keeps the credential findable.
- **Shared `busy` flag bled across action buttons.** Adding a FIDO key showed "Working…" on the passphrase save button too, because every handler in `SecuritySettings.svelte` flipped one `busy = $state(false)`. Split into per-action flags (`addingKey`, `savingPassphrase`, `removingKey`, `disablingEncryption`) plus a derived `anyBusy`. Each button's label now reflects only its own in-flight state, while the "don't run two mutations at once" lock is preserved via `anyBusy` on `disabled`.

Closes #170 once the manual smoke test on Windows + macOS confirms a FIDO key actually enrolls.

## Test plan

- [x] Open Settings → Security on Windows. Click **Add** under "Add a hardware key" with a security key plugged in. The OS WebAuthn prompt should appear and enrollment should succeed (no "relying party ID is not a registrable domain suffix" error).
- [ ] Repeat on macOS with Touch ID — registration sheet should appear and the key should land in "Registered methods".
- [x] While the FIDO authenticator sheet is open, confirm the **Save passphrase** button does *not* read "Working…".
- [x] While saving a passphrase, confirm the FIDO **Add** button does *not* read "Working…".
- [x] Remove a registered credential — buttons throughout the panel should still disable while the remove is in flight, but only the Remove button itself should change appearance.