### PR TITLE
#168: portable settings bundle + Nextcloud recovery sync

### DIFF
--- a/crates/nimbus-store/src/lib.rs
+++ b/crates/nimbus-store/src/lib.rs
@@ -9,5 +9,7 @@ pub mod cache;
 pub mod credentials;
 pub mod fido;
 pub mod nextcloud_store;
+pub mod settings_bundle;
+pub mod settings_sync;
 
 pub use cache::Cache;

--- a/crates/nimbus-store/src/settings_bundle.rs
+++ b/crates/nimbus-store/src/settings_bundle.rs
@@ -1,0 +1,233 @@
+//! Portable settings bundle (#168).
+//!
+//! Serialises every user-visible preference into a single
+//! `settings.json` blob the user can save to disk or to a connected
+//! Nextcloud and later restore from. The bundle deliberately
+//! excludes anything that depends on the local machine's secrets:
+//!
+//! - mail / Nextcloud passwords (live in the OS keychain)
+//! - the SQLCipher master key, FIDO PRF wraps, the keychain
+//!   envelope itself
+//! - the encrypted cache database
+//!
+//! After importing on a fresh install the user still has to enter
+//! mail and Nextcloud credentials — but every preference, theme,
+//! folder→emoji mapping, signature, locale, etc. is restored.
+//!
+//! The bundle is schema-versioned so future fields can be added
+//! without breaking older bundles or older clients.  Reading code
+//! treats unknown top-level keys as forward-compatible (`#[serde
+//! (default)]` on the struct), and the explicit `version` integer
+//! lets us hard-fail on a future incompatible migration.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use nimbus_core::NimbusError;
+use nimbus_core::models::{Account, AppSettings};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::Cache;
+
+/// Schema version of the bundle JSON.  Bumped on incompatible
+/// changes; importers refuse anything they can't recognise.
+pub const BUNDLE_SCHEMA_VERSION: u32 = 1;
+
+/// One mail account stripped of the local-only surface (passwords
+/// live in the keychain so they're never in the bundle).  Trusted
+/// TLS certs *are* included — they're a deliberate user choice and
+/// useful to restore on a new machine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BundleAccount {
+    /// The full `Account` record from the user's config.  We let
+    /// serde reuse the existing struct so adding a new account
+    /// field automatically rides along in the bundle without a
+    /// separate touch here.
+    #[serde(flatten)]
+    pub account: Account,
+}
+
+/// Top-level settings bundle.  Schema-versioned so future
+/// migrations can refuse incompatible payloads instead of
+/// silently mis-parsing them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SettingsBundle {
+    /// Schema version.  Always written as
+    /// `BUNDLE_SCHEMA_VERSION`; importers reject higher values.
+    pub version: u32,
+    /// When the bundle was assembled.  Useful for the UI ("backed
+    /// up 2 hours ago") and for the future "is the NC copy newer
+    /// than my local one" prompt.
+    pub exported_at: DateTime<Utc>,
+    /// App-wide preferences (`AppSettings`).
+    pub app_settings: AppSettings,
+    /// Mail accounts (without passwords).
+    pub accounts: Vec<BundleAccount>,
+    /// Frontend-managed prefs that live in `localStorage` rather
+    /// than the Rust config files (FIDO encryption toggle,
+    /// trusted-senders list, locale pin, …).  Opaque map: the
+    /// frontend collects + applies its own keys, the backend
+    /// just round-trips it.
+    pub local_storage: HashMap<String, String>,
+}
+
+impl Default for SettingsBundle {
+    fn default() -> Self {
+        Self {
+            version: BUNDLE_SCHEMA_VERSION,
+            exported_at: Utc::now(),
+            app_settings: AppSettings::default(),
+            accounts: Vec::new(),
+            local_storage: HashMap::new(),
+        }
+    }
+}
+
+/// Build a bundle from the live in-process state.  The frontend
+/// passes its `local_storage` snapshot; everything else is read
+/// from the on-disk app-settings file plus the (already unlocked)
+/// cache so the bundle reflects what's actually persisted.
+pub fn build_bundle(
+    cache: &Cache,
+    local_storage: HashMap<String, String>,
+) -> Result<SettingsBundle, NimbusError> {
+    let app_settings = crate::app_settings::load_settings()?;
+    let accounts = crate::account_store::load_accounts(cache)?
+        .into_iter()
+        .map(|account| BundleAccount { account })
+        .collect();
+    Ok(SettingsBundle {
+        version: BUNDLE_SCHEMA_VERSION,
+        exported_at: Utc::now(),
+        app_settings,
+        accounts,
+        local_storage,
+    })
+}
+
+/// Serialise a bundle to a pretty-printed JSON string suitable for
+/// `settings.json` on disk or on a Nextcloud.
+pub fn serialise(bundle: &SettingsBundle) -> Result<String, NimbusError> {
+    serde_json::to_string_pretty(bundle)
+        .map_err(|e| NimbusError::Storage(format!("serialise settings bundle: {e}")))
+}
+
+/// Parse a JSON string back into a bundle.  Refuses anything
+/// whose `version` is higher than this build understands.
+pub fn parse(json: &str) -> Result<SettingsBundle, NimbusError> {
+    let bundle: SettingsBundle = serde_json::from_str(json)
+        .map_err(|e| NimbusError::Storage(format!("parse settings bundle: {e}")))?;
+    if bundle.version > BUNDLE_SCHEMA_VERSION {
+        return Err(NimbusError::Storage(format!(
+            "settings bundle version {} is newer than this app supports (max {}). \
+             Update Nimbus Mail and try again.",
+            bundle.version, BUNDLE_SCHEMA_VERSION
+        )));
+    }
+    Ok(bundle)
+}
+
+/// Apply a bundle to the local install.  Replaces `app_settings`
+/// outright, upserts each account by id (no destructive delete:
+/// accounts the user added since the bundle was made survive),
+/// and returns the `local_storage` map so the frontend can write
+/// it back.  Passwords aren't carried in the bundle, so accounts
+/// imported from a fresh machine will need re-authentication on
+/// first connect — surfaced as the standard "rejected app
+/// password" path.
+pub fn apply(
+    cache: &Cache,
+    bundle: SettingsBundle,
+) -> Result<HashMap<String, String>, NimbusError> {
+    info!(
+        "Applying settings bundle exported at {} (v{}) — {} account(s)",
+        bundle.exported_at,
+        bundle.version,
+        bundle.accounts.len()
+    );
+
+    crate::app_settings::save_settings(&bundle.app_settings)?;
+
+    let existing_ids: std::collections::HashSet<String> =
+        crate::account_store::load_accounts(cache)?
+            .into_iter()
+            .map(|a| a.id)
+            .collect();
+
+    for entry in bundle.accounts {
+        let imported = entry.account;
+        if existing_ids.contains(&imported.id) {
+            // Update preserves the row id and (importantly) the
+            // OS-keychain password keyed on `imported.id` — that
+            // entry was set when the user first signed in on
+            // *this* machine and we never touch it.
+            crate::account_store::update_account(cache, imported)?;
+        } else {
+            crate::account_store::add_account(cache, imported)?;
+        }
+    }
+
+    debug!("Settings bundle applied");
+    Ok(bundle.local_storage)
+}
+
+/// Soft validation.  Rejects empties + obvious malformed JSON
+/// before we touch state — used by `apply()` callers that want a
+/// pre-flight check.  Never panics.
+pub fn looks_like_bundle(json: &str) -> bool {
+    match serde_json::from_str::<serde_json::Value>(json) {
+        Ok(v) => v.get("version").is_some() && v.get("app_settings").is_some(),
+        Err(_) => {
+            warn!("looks_like_bundle: payload is not valid JSON");
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_default_bundle() {
+        let mut local = HashMap::new();
+        local.insert("nimbus.keyEncryption".into(), "1".into());
+        let bundle = SettingsBundle {
+            local_storage: local.clone(),
+            ..Default::default()
+        };
+        let json = serialise(&bundle).expect("serialise");
+        let parsed = parse(&json).expect("parse");
+        assert_eq!(parsed.version, BUNDLE_SCHEMA_VERSION);
+        assert_eq!(
+            parsed
+                .local_storage
+                .get("nimbus.keyEncryption")
+                .map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn rejects_future_version() {
+        let payload =
+            r#"{ "version": 9999, "app_settings": {}, "accounts": [], "local_storage": {} }"#;
+        let err = parse(payload).expect_err("should reject future version");
+        assert!(err.to_string().contains("newer than this app supports"));
+    }
+
+    #[test]
+    fn looks_like_bundle_accepts_minimal() {
+        let payload =
+            r#"{ "version": 1, "app_settings": {}, "accounts": [], "local_storage": {} }"#;
+        assert!(looks_like_bundle(payload));
+    }
+
+    #[test]
+    fn looks_like_bundle_rejects_garbage() {
+        assert!(!looks_like_bundle("not json"));
+        assert!(!looks_like_bundle(r#"{ "hello": "world" }"#));
+    }
+}

--- a/crates/nimbus-store/src/settings_sync.rs
+++ b/crates/nimbus-store/src/settings_sync.rs
@@ -1,0 +1,76 @@
+//! Persistence for the "Save settings to Nextcloud" feature (#168).
+//!
+//! Tracks two pieces of state:
+//!   - **Sync target** — the id of the connected Nextcloud account
+//!     the user designated as the recovery destination, or `None`
+//!     if the feature is off.  Only one NC at a time can be the
+//!     target — the toggle is mutually exclusive across NC rows.
+//!   - **Pending flag** — set to `true` whenever a settings change
+//!     happened but the most recent push to NC failed (offline,
+//!     401, server down, …).  Cleared when the next push succeeds.
+//!     Persisted so a crash mid-write or a quit-before-reconnect
+//!     still surfaces the retry on next launch.
+//!
+//! Both pieces live in one tiny JSON file alongside
+//! `app_settings.json`.  We deliberately don't put them inside
+//! `AppSettings` itself because the bundle ships `AppSettings` —
+//! and the sync target is a *local* choice that shouldn't ride
+//! along when the user restores their settings on a new device.
+
+use std::path::PathBuf;
+
+use nimbus_core::NimbusError;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Local-only sync state.  Not part of the portable settings
+/// bundle — see the module docstring for why.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SettingsSyncState {
+    /// Connected NC account id chosen as the recovery destination,
+    /// or `None` when the user has the feature turned off.
+    pub target_nc_id: Option<String>,
+    /// `true` when an earlier settings change couldn't be pushed
+    /// and is waiting for the next reachable-server window.
+    pub pending: bool,
+}
+
+fn state_file_path() -> Result<PathBuf, NimbusError> {
+    let data_dir = dirs::config_dir()
+        .ok_or_else(|| NimbusError::Storage("cannot determine config directory".into()))?;
+    Ok(data_dir.join("nimbus-mail").join("settings_sync.json"))
+}
+
+/// Load the saved sync state, or `Default::default()` if the file
+/// doesn't exist yet.  Missing file is the normal first-run path.
+pub fn load_state() -> Result<SettingsSyncState, NimbusError> {
+    let path = state_file_path()?;
+    if !path.exists() {
+        return Ok(SettingsSyncState::default());
+    }
+    let data = std::fs::read_to_string(&path)
+        .map_err(|e| NimbusError::Storage(format!("read settings_sync.json: {e}")))?;
+    serde_json::from_str(&data)
+        .map_err(|e| NimbusError::Storage(format!("parse settings_sync.json: {e}")))
+}
+
+/// Persist the sync state to disk, creating the parent dir if
+/// needed.  Called after every change to `target_nc_id` or
+/// `pending`.
+pub fn save_state(state: &SettingsSyncState) -> Result<(), NimbusError> {
+    let path = state_file_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| NimbusError::Storage(format!("create config dir: {e}")))?;
+    }
+    let json = serde_json::to_string_pretty(state)
+        .map_err(|e| NimbusError::Storage(format!("serialise settings_sync.json: {e}")))?;
+    std::fs::write(&path, json)
+        .map_err(|e| NimbusError::Storage(format!("write settings_sync.json: {e}")))?;
+    debug!(
+        "Saved settings_sync state: target={:?} pending={}",
+        state.target_nc_id, state.pending
+    );
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,7 +35,10 @@ use nimbus_store::cache::{
     CalendarEventRow, CalendarEventServerHandle, CalendarRow, ContactRow, ContactServerHandle,
     SearchFilters, SearchHit, SearchScope, SyncState,
 };
-use nimbus_store::{Cache, account_store, app_settings, credentials, nextcloud_store};
+use nimbus_store::{
+    Cache, account_store, app_settings, credentials, nextcloud_store, settings_bundle,
+    settings_sync,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
@@ -278,9 +281,12 @@ fn add_account(
     account: Account,
     password: String,
     cache: State<'_, Cache>,
+    notify: State<'_, SettingsSyncNotify>,
 ) -> Result<(), NimbusError> {
     credentials::store_imap_password(&account.id, &password)?;
-    account_store::add_account(&cache, account)
+    account_store::add_account(&cache, account)?;
+    notify.0.notify_one();
+    Ok(())
 }
 
 /// Remove an account and its stored password.
@@ -291,20 +297,35 @@ fn add_account(
 /// is deleted last so the rest of the app's "this account exists"
 /// queries stay truthful right up until the cleanup completes.
 #[tauri::command]
-fn remove_account(id: String, cache: State<'_, Cache>) -> Result<(), NimbusError> {
+fn remove_account(
+    id: String,
+    cache: State<'_, Cache>,
+    notify: State<'_, SettingsSyncNotify>,
+) -> Result<(), NimbusError> {
     credentials::delete_imap_password(&id)?;
     // Best-effort: a failure here leaves orphaned cache rows but doesn't
     // block account removal. Log and continue.
     if let Err(e) = cache.wipe_account(&id) {
         tracing::warn!("failed to wipe cache for account '{id}': {e}");
     }
-    account_store::remove_account(&cache, &id)
+    account_store::remove_account(&cache, &id)?;
+    notify.0.notify_one();
+    Ok(())
 }
 
 /// Update an existing account's settings.
 #[tauri::command]
-fn update_account(account: Account, cache: State<'_, Cache>) -> Result<(), NimbusError> {
-    account_store::update_account(&cache, account)
+fn update_account(
+    account: Account,
+    cache: State<'_, Cache>,
+    notify: State<'_, SettingsSyncNotify>,
+) -> Result<(), NimbusError> {
+    account_store::update_account(&cache, account)?;
+    // #168: any account-metadata edit (signature, folder→emoji
+    // overrides, sort order, …) is part of the bundle, so wake
+    // the auto-sync worker.  No-ops cleanly when sync is off.
+    notify.0.notify_one();
+    Ok(())
 }
 
 /// Replace the IMAP/SMTP password stored in the OS keychain for
@@ -337,6 +358,7 @@ fn set_folder_icon(
     folder_name: String,
     icon: Option<String>,
     cache: State<'_, Cache>,
+    notify: State<'_, SettingsSyncNotify>,
 ) -> Result<(), NimbusError> {
     let mut account = load_account(&cache, &account_id)?;
     match icon {
@@ -349,7 +371,9 @@ fn set_folder_icon(
             account.folder_icon_overrides.remove(&folder_name);
         }
     }
-    account_store::update_account(&cache, account)
+    account_store::update_account(&cache, account)?;
+    notify.0.notify_one();
+    Ok(())
 }
 
 /// Probe Mozilla autoconfig and DNS SRV records for the email's
@@ -860,6 +884,17 @@ async fn save_bytes_to_path(path: String, data: Vec<u8>) -> Result<(), NimbusErr
     // don't need to spawn_blocking.
     std::fs::write(&path, &data)
         .map_err(|e| NimbusError::Other(format!("Failed to write {path}: {e}")))
+}
+
+/// Read a small text file (a settings bundle, typically ~kilobytes)
+/// from disk.  Used by the "Import settings" flow (#168): the
+/// frontend opens a file picker via `plugin-dialog`, gets back an
+/// absolute path, and hands it here for the actual read so we
+/// don't need a separate filesystem plugin in `package.json`.
+#[tauri::command]
+async fn read_text_from_path(path: String) -> Result<String, NimbusError> {
+    std::fs::read_to_string(&path)
+        .map_err(|e| NimbusError::Other(format!("Failed to read {path}: {e}")))
 }
 
 /// Upload raw bytes to a file in the user's Nextcloud.
@@ -8157,10 +8192,354 @@ async fn get_app_settings(settings: State<'_, SharedSettings>) -> Result<AppSett
 async fn update_app_settings(
     new_settings: AppSettings,
     settings: State<'_, SharedSettings>,
+    notify: State<'_, SettingsSyncNotify>,
 ) -> Result<(), NimbusError> {
     app_settings::save_settings(&new_settings)?;
     *settings.write().await = new_settings;
+    notify.0.notify_one();
     Ok(())
+}
+
+// ── Settings backup & sync (#168) ──────────────────────────────
+//
+// Lets the user save every preference (app-wide settings, account
+// metadata, folder→emoji mappings, signature, locale, theme, …)
+// to either a local `settings.json` or to a connected Nextcloud
+// under `/Nimbus Mail/settings/settings.json`.  Restoring is the
+// reverse: pick a file, or — on first NC connect — accept the
+// "found a backup, restore?" prompt.
+//
+// Architecture
+//
+//   • Bundle = { version, exported_at, app_settings, accounts,
+//                local_storage }.  Schema-versioned JSON; secrets
+//                (passwords, FIDO wraps, master key) deliberately
+//                excluded.  See `nimbus_store::settings_bundle`.
+//
+//   • NC sync runs in a background task.  Frontend calls
+//     `notify_settings_changed(local_storage)` after any UI
+//     mutation; the worker debounces 2 s, then PUTs the bundle
+//     to NC.  Failure flips `settings_sync::SettingsSyncState
+//     ::pending` to true so the next opportunity (next change OR
+//     the periodic 5-min retry) takes another shot.
+//
+//   • The worker is started once from `main()` after the cache
+//     unlocks (it needs `Cache` access for accounts).  On launch
+//     it consults `pending` from disk; if true, it attempts a
+//     push immediately so a quit-while-offline still recovers.
+//
+//   • Sync target (`target_nc_id`) is stored *outside* the
+//     bundle — it's a per-machine choice.  Restoring on a new
+//     device shouldn't silently start syncing back to the old
+//     server.
+
+/// Path inside a user's Nextcloud where the settings bundle
+/// lives.  Sits under the existing `/Nimbus Mail` root so it
+/// shares a folder with the temp area used by Office viewer.
+const NIMBUS_SETTINGS_DIR: &str = "/Nimbus Mail/settings";
+const NIMBUS_SETTINGS_FILE: &str = "/Nimbus Mail/settings/settings.json";
+
+/// Latest `localStorage` snapshot the frontend has shared with
+/// us.  The auto-sync worker reads from here so it can assemble
+/// a complete bundle without an additional IPC round-trip.
+type SharedLocalStorage = Arc<RwLock<std::collections::HashMap<String, String>>>;
+
+/// Notify channel used to wake the auto-sync worker.  Each
+/// `notify_one()` call coalesces with any already-pending wakeup,
+/// so a burst of settings changes still results in a single push
+/// once the debounce window expires.
+struct SettingsSyncNotify(Arc<tokio::sync::Notify>);
+
+/// Return the live `AppSettings` + accounts + the frontend's
+/// supplied `local_storage` map as one JSON-serialisable bundle.
+/// This is the single entry point the frontend uses for both
+/// "Download settings" (writes the JSON via `dialog.save` on the
+/// frontend) and the manual "Sync now" path.
+#[tauri::command]
+async fn build_settings_bundle(
+    local_storage: std::collections::HashMap<String, String>,
+    cache: State<'_, Cache>,
+) -> Result<String, NimbusError> {
+    let bundle = settings_bundle::build_bundle(&cache, local_storage)?;
+    settings_bundle::serialise(&bundle)
+}
+
+/// Apply a previously-exported bundle.  Replaces `app_settings`,
+/// upserts each account by id, and returns the bundle's
+/// `local_storage` map so the frontend can write each key back
+/// into its own `localStorage`.  The frontend reloads its UI
+/// after this returns — most preferences only re-apply on the
+/// next render pass.
+#[tauri::command]
+async fn apply_settings_bundle(
+    json: String,
+    cache: State<'_, Cache>,
+    settings: State<'_, SharedSettings>,
+) -> Result<std::collections::HashMap<String, String>, NimbusError> {
+    let bundle = settings_bundle::parse(&json)?;
+    let new_app_settings = bundle.app_settings.clone();
+    let local_storage = settings_bundle::apply(&cache, bundle)?;
+    *settings.write().await = new_app_settings;
+    Ok(local_storage)
+}
+
+/// Frontend-facing view of `settings_sync::SettingsSyncState`.
+/// camelCase for the JSON IPC convention used elsewhere in the
+/// file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SettingsSyncStateView {
+    target_nc_id: Option<String>,
+    pending: bool,
+}
+
+#[tauri::command]
+fn get_settings_sync_state() -> Result<SettingsSyncStateView, NimbusError> {
+    let state = settings_sync::load_state()?;
+    Ok(SettingsSyncStateView {
+        target_nc_id: state.target_nc_id,
+        pending: state.pending,
+    })
+}
+
+/// Pick (or clear) the connected Nextcloud account that recovery
+/// pushes go to.  Passing `None` turns the feature off.  Setting
+/// it kicks off a sync immediately so the chosen NC has a fresh
+/// copy without waiting for the next settings change.
+#[tauri::command]
+async fn set_settings_sync_target(
+    target_nc_id: Option<String>,
+    notify: State<'_, SettingsSyncNotify>,
+) -> Result<(), NimbusError> {
+    let mut state = settings_sync::load_state()?;
+    if state.target_nc_id == target_nc_id {
+        return Ok(());
+    }
+    state.target_nc_id = target_nc_id;
+    // Flipping the target counts as a "settings changed" event —
+    // the new NC needs a fresh push so a future restore actually
+    // finds something there.
+    state.pending = state.target_nc_id.is_some();
+    settings_sync::save_state(&state)?;
+    notify.0.notify_one();
+    Ok(())
+}
+
+/// Frontend-side hook: call after any settings mutation that the
+/// user could plausibly want backed up.  Stores the latest
+/// `localStorage` snapshot in shared state and pings the auto-
+/// sync worker, which debounces and pushes to NC if a target is
+/// set.  No-ops cleanly when sync is off.
+#[tauri::command]
+async fn notify_settings_changed(
+    local_storage: std::collections::HashMap<String, String>,
+    storage: State<'_, SharedLocalStorage>,
+    notify: State<'_, SettingsSyncNotify>,
+) -> Result<(), NimbusError> {
+    *storage.write().await = local_storage;
+    notify.0.notify_one();
+    Ok(())
+}
+
+/// Probe a connected NC for a previously-uploaded settings
+/// bundle.  Returns `None` if no bundle exists at the canonical
+/// path, the parsed bundle's `exported_at` if one is found.
+/// Used by the "found a backup, restore?" prompt the frontend
+/// shows on a fresh NC connect.
+#[tauri::command]
+async fn nc_probe_settings_bundle(
+    nc_id: String,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    match nimbus_nextcloud::download_file(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        NIMBUS_SETTINGS_FILE,
+    )
+    .await
+    {
+        Ok(bytes) => {
+            let json = String::from_utf8(bytes).map_err(|e| {
+                NimbusError::Storage(format!("settings bundle on NC is not UTF-8: {e}"))
+            })?;
+            let bundle = settings_bundle::parse(&json)?;
+            Ok(Some(bundle.exported_at))
+        }
+        // 404 = no backup, that's the normal first-time path.
+        // We map it through to None so the UI can stay quiet
+        // instead of surfacing an error toast.
+        Err(NimbusError::Nextcloud(msg)) if msg.contains("not found") => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Download the bundle from NC and apply it.  Used by the
+/// "restore on first NC connect" prompt and by a manual "Restore
+/// from Nextcloud" button on the Backup & Sync settings page.
+#[tauri::command]
+async fn nc_restore_settings_bundle(
+    nc_id: String,
+    cache: State<'_, Cache>,
+    settings: State<'_, SharedSettings>,
+) -> Result<std::collections::HashMap<String, String>, NimbusError> {
+    let account = load_nextcloud_account(&nc_id)?;
+    let app_password = credentials::get_nextcloud_password(&nc_id)?;
+    let bytes = nimbus_nextcloud::download_file(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        NIMBUS_SETTINGS_FILE,
+    )
+    .await?;
+    let json = String::from_utf8(bytes)
+        .map_err(|e| NimbusError::Storage(format!("settings bundle on NC is not UTF-8: {e}")))?;
+    let bundle = settings_bundle::parse(&json)?;
+    let new_app_settings = bundle.app_settings.clone();
+    let local_storage = settings_bundle::apply(&cache, bundle)?;
+    *settings.write().await = new_app_settings;
+    Ok(local_storage)
+}
+
+/// One push attempt.  Best-effort folder creation, then PUT.
+/// Folder creates are intentionally swallowed because
+/// `create_directory` returns `NimbusError::Nextcloud` for the
+/// idempotent "folder already exists" case — it's not actually
+/// an error from our perspective.
+async fn push_settings_to_nc(
+    cache: &Cache,
+    local_storage: std::collections::HashMap<String, String>,
+    nc_id: &str,
+) -> Result<(), NimbusError> {
+    let bundle = settings_bundle::build_bundle(cache, local_storage)?;
+    let json = settings_bundle::serialise(&bundle)?;
+
+    let account = nextcloud_store::load_accounts(cache)?
+        .into_iter()
+        .find(|a| a.id == nc_id)
+        .ok_or_else(|| NimbusError::Other(format!("Nextcloud account '{nc_id}' not found")))?;
+    let app_password = credentials::get_nextcloud_password(nc_id)?;
+
+    // Idempotent folder creates.  The Office viewer code already
+    // ensures `/Nimbus Mail` for the temp area, but a user who
+    // hasn't opened any Office attachments won't have triggered
+    // that path yet — we make sure both rungs of the hierarchy
+    // exist before the PUT.
+    for dir in [NIMBUS_TEMP_ROOT, NIMBUS_SETTINGS_DIR] {
+        if let Err(e) = nimbus_nextcloud::create_directory(
+            &account.server_url,
+            &account.username,
+            &app_password,
+            dir,
+        )
+        .await
+        {
+            // 405 / "already exists" is the happy path; only the
+            // network/auth/quota classes need to bubble up.
+            let msg = e.to_string();
+            if !msg.contains("already") && !msg.contains("405") && !msg.contains("HTTP 405") {
+                return Err(e);
+            }
+        }
+    }
+
+    nimbus_nextcloud::upload_file(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        NIMBUS_SETTINGS_FILE,
+        json.into_bytes(),
+        Some("application/json"),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Auto-sync worker.  Wakes on either a `notify_one()` from a
+/// settings-changed event or a 5-minute periodic tick (the retry
+/// path for "user changed a setting while offline and never
+/// changed another"), and pushes the bundle to the configured NC
+/// account if one is set.  Failures keep `pending=true` so the
+/// next opportunity tries again.
+async fn settings_sync_worker(
+    cache: Cache,
+    local_storage: SharedLocalStorage,
+    notify: Arc<tokio::sync::Notify>,
+) {
+    use tokio::time::{Duration, MissedTickBehavior, interval, sleep};
+
+    let mut retry_tick = interval(Duration::from_secs(300));
+    retry_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // The first `tick()` returns immediately — burn it so the
+    // periodic path doesn't fire on launch.  The launch-time
+    // recovery happens via the explicit `notify_one()` call from
+    // `main()` instead.
+    retry_tick.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = notify.notified() => {
+                // Debounce: a burst of changes (e.g. dragging
+                // the UI scale slider) coalesces into one push.
+                sleep(Duration::from_secs(2)).await;
+            }
+            _ = retry_tick.tick() => {
+                // Periodic retry — only meaningful if we have
+                // something to flush, so peek the disk state.
+                let state = settings_sync::load_state().unwrap_or_default();
+                if !state.pending || state.target_nc_id.is_none() {
+                    continue;
+                }
+            }
+        }
+
+        // Read the disk state fresh; the user may have flipped
+        // the toggle off between the wake and now.
+        let state = match settings_sync::load_state() {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("settings_sync load_state failed: {e}");
+                continue;
+            }
+        };
+        let Some(target) = state.target_nc_id.clone() else {
+            // Sync turned off — clear any stale pending flag so
+            // a re-enable doesn't immediately fire a stale push.
+            if state.pending {
+                let _ = settings_sync::save_state(&settings_sync::SettingsSyncState {
+                    target_nc_id: None,
+                    pending: false,
+                });
+            }
+            continue;
+        };
+
+        let snapshot = local_storage.read().await.clone();
+        match push_settings_to_nc(&cache, snapshot, &target).await {
+            Ok(()) => {
+                tracing::info!("Settings bundle synced to Nextcloud '{target}'");
+                if state.pending {
+                    let _ = settings_sync::save_state(&settings_sync::SettingsSyncState {
+                        target_nc_id: state.target_nc_id,
+                        pending: false,
+                    });
+                }
+            }
+            Err(e) => {
+                // Silent in the UI; warn-level in the log so a
+                // developer chasing "why isn't my NC backup
+                // updating" can see what went wrong.
+                tracing::warn!("Settings sync to '{target}' failed (will retry later): {e}");
+                if !state.pending {
+                    let _ = settings_sync::save_state(&settings_sync::SettingsSyncState {
+                        target_nc_id: state.target_nc_id,
+                        pending: true,
+                    });
+                }
+            }
+        }
+    }
 }
 
 #[tauri::command]
@@ -8481,6 +8860,13 @@ fn main() {
         .manage(cache)
         .manage(shared_settings)
         .manage::<SystemFontsCache>(Arc::new(RwLock::new(Vec::new())))
+        // Settings backup & sync (#168).  Frontend pushes its
+        // localStorage snapshot on every settings change; the
+        // worker reads from this slot when it assembles a bundle
+        // for an NC push.  Starts empty — the first
+        // `notify_settings_changed` IPC fills it in.
+        .manage::<SharedLocalStorage>(Arc::new(RwLock::new(std::collections::HashMap::new())))
+        .manage(SettingsSyncNotify(Arc::new(tokio::sync::Notify::new())))
         .register_uri_scheme_protocol("contact-photo", contact_photo_protocol)
         .register_uri_scheme_protocol("nimbus-logo", logo_protocol)
         .setup(|app| {
@@ -8744,6 +9130,36 @@ fn main() {
                 prerender_inboxes_on_launch(&prerender_handle).await;
             });
 
+            // Settings auto-sync worker (#168).  Listens for
+            // notifications from the frontend via the
+            // `SettingsSyncNotify` state, debounces 2s, then
+            // pushes the bundle to whichever NC the user picked
+            // as their backup target.  Also retries a pending
+            // push every 5 minutes so a "user went offline,
+            // never changed another setting, came back online"
+            // flow eventually catches up without manual action.
+            //
+            // Pumps an immediate notification on startup so a
+            // pending=true flag from a previous session (set
+            // when a quit-while-offline left a push hanging)
+            // gets a fresh attempt as soon as we're up.
+            let sync_cache = app.state::<Cache>().inner().clone();
+            let sync_storage = app.state::<SharedLocalStorage>().inner().clone();
+            let sync_notify = app.state::<SettingsSyncNotify>().inner().0.clone();
+            let initial_kick = sync_notify.clone();
+            tauri::async_runtime::spawn(async move {
+                settings_sync_worker(sync_cache, sync_storage, sync_notify).await;
+            });
+            // Kick the worker once so a pending recovery push
+            // from a previous session retries on launch.  The
+            // worker no-ops cleanly if there's nothing to do.
+            if settings_sync::load_state()
+                .map(|s| s.pending && s.target_nc_id.is_some())
+                .unwrap_or(false)
+            {
+                initial_kick.notify_one();
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -8823,6 +9239,7 @@ fn main() {
             pdf_close_attachment,
             print_attachment,
             save_bytes_to_path,
+            read_text_from_path,
             sync_nextcloud_contacts,
             get_contacts_sync_status,
             get_calendars_sync_status,
@@ -8889,6 +9306,14 @@ fn main() {
             get_wipe_policy,
             set_wipe_policy,
             update_app_settings,
+            // Issue #168: settings backup & sync.
+            build_settings_bundle,
+            apply_settings_bundle,
+            get_settings_sync_state,
+            set_settings_sync_target,
+            notify_settings_changed,
+            nc_probe_settings_bundle,
+            nc_restore_settings_bundle,
             set_logo_style,
             import_custom_theme,
             remove_custom_theme,

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -30,6 +30,16 @@
   } from './uiScale'
   import { m } from '../paraglide/messages'
   import { getLocale, locales } from '../paraglide/runtime'
+  import {
+    downloadBundle,
+    getSyncState,
+    ncProbeBundle,
+    ncRestoreBundle,
+    notifySettingsChanged,
+    setSyncTarget,
+    uploadBundle,
+    type SettingsSyncStateView,
+  } from './settingsBundle'
 
   // Friendly labels for the locale picker.  Keep the codes in
   // lockstep with `project.inlang/settings.json`.  Native
@@ -118,7 +128,14 @@
   // categories users actually look for.  The nav lives in a
   // left column and `activeCategory` gates which section block
   // renders so each panel stays focused.
-  type SettingsCategory = 'general' | 'design' | 'mail' | 'calendar' | 'nextcloud' | 'security'
+  type SettingsCategory =
+    | 'general'
+    | 'design'
+    | 'mail'
+    | 'calendar'
+    | 'nextcloud'
+    | 'security'
+    | 'backup'
   let activeCategory = $state<SettingsCategory>('general')
   interface CategoryEntry {
     id: SettingsCategory
@@ -135,6 +152,12 @@
     { id: 'calendar', label: 'Calendar', icon: 'calendar' },
     { id: 'nextcloud', label: 'Nextcloud', icon: 'cloud' },
     { id: 'security', label: 'Security', icon: 'lock' },
+    // #168 — the page where the user manages local export +
+    // Nextcloud-recovery sync.  The `sync` glyph (two arrows in a
+    // loop) communicates "this is the page where state moves
+    // back and forth between machines" better than a generic
+    // archive icon.
+    { id: 'backup', label: 'Backup & Sync', icon: 'sync' },
   ]
 
   // ── State ───────────────────────────────────────────────────
@@ -293,6 +316,112 @@
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
 
+  // ── Backup & Sync (#168) ─────────────────────────────────────
+  // State for the Backup & Sync category panel.  The dropdown
+  // shows every connected NC account so the user can pick which
+  // one becomes the recovery destination, mirrored by a per-row
+  // toggle on the Nextcloud category.
+  interface NcOption {
+    id: string
+    label: string
+  }
+  let ncOptions = $state<NcOption[]>([])
+  let syncState = $state<SettingsSyncStateView>({ targetNcId: null, pending: false })
+  /** Status string surfaced under the Download / Upload buttons.
+   *  Mirrors the `prefsSaveStatus` pattern but with longer-lived
+   *  messages (we want the user to see "Saved to /tmp/foo.json"
+   *  for a few seconds, not flash through "saved" → ""). */
+  let backupStatus = $state<{ kind: 'idle' | 'busy' | 'done' | 'error'; msg: string }>(
+    { kind: 'idle', msg: '' },
+  )
+  function showBackupStatus(kind: 'busy' | 'done' | 'error', msg: string) {
+    backupStatus = { kind, msg }
+    if (kind !== 'busy') {
+      setTimeout(() => {
+        if (backupStatus.kind === kind && backupStatus.msg === msg) {
+          backupStatus = { kind: 'idle', msg: '' }
+        }
+      }, 4000)
+    }
+  }
+
+  async function loadSyncState() {
+    try {
+      syncState = await getSyncState()
+    } catch (e) {
+      console.warn('get_settings_sync_state failed', e)
+    }
+  }
+  async function loadNcOptions() {
+    try {
+      const accs = await invoke<{ id: string; username: string; server_url: string; display_name?: string | null }[]>('get_nextcloud_accounts')
+      ncOptions = accs.map((a) => ({
+        id: a.id,
+        label: a.display_name || `${a.username} @ ${new URL(a.server_url).hostname}`,
+      }))
+    } catch (e) {
+      console.warn('loadNcOptions failed', e)
+      ncOptions = []
+    }
+  }
+  async function onSyncTargetChange(next: string | null) {
+    try {
+      await setSyncTarget(next)
+      await loadSyncState()
+    } catch (e) {
+      console.warn('setSyncTarget failed', e)
+    }
+  }
+  async function onDownloadClick() {
+    showBackupStatus('busy', 'Saving…')
+    try {
+      const path = await downloadBundle()
+      if (path) showBackupStatus('done', `Saved to ${path}`)
+      else backupStatus = { kind: 'idle', msg: '' }
+    } catch (e: any) {
+      showBackupStatus('error', e?.message ?? String(e))
+    }
+  }
+  async function onUploadClick() {
+    if (
+      !confirm(
+        'Importing a settings backup will overwrite your current preferences and merge in any accounts from the file. Continue?',
+      )
+    )
+      return
+    showBackupStatus('busy', 'Importing…')
+    try {
+      const path = await uploadBundle()
+      if (path) {
+        showBackupStatus('done', 'Imported — reload the window to see every change.')
+        await loadAppSettings()
+        await loadAccounts()
+      } else {
+        backupStatus = { kind: 'idle', msg: '' }
+      }
+    } catch (e: any) {
+      showBackupStatus('error', e?.message ?? String(e))
+    }
+  }
+  async function onRestoreFromNcClick() {
+    if (!syncState.targetNcId) return
+    if (
+      !confirm(
+        'Replace your local preferences with the latest backup from this Nextcloud? Existing accounts on this machine are kept; the bundle just adds back any that were missing and updates metadata.',
+      )
+    )
+      return
+    showBackupStatus('busy', 'Downloading from Nextcloud…')
+    try {
+      await ncRestoreBundle(syncState.targetNcId)
+      showBackupStatus('done', 'Restored — reload the window to see every change.')
+      await loadAppSettings()
+      await loadAccounts()
+    } catch (e: any) {
+      showBackupStatus('error', e?.message ?? String(e))
+    }
+  }
+
   // ── Load accounts on mount ──────────────────────────────────
   // $effect runs when the component is first rendered (like onMount).
   // We call the Rust backend to get all saved accounts.
@@ -300,6 +429,8 @@
     loadAccounts()
     loadAppSettings()
     loadCalendarsForPicker()
+    loadSyncState()
+    loadNcOptions()
   })
 
   async function loadCalendarsForPicker() {
@@ -345,6 +476,11 @@
       try {
         await invoke('update_app_settings', { newSettings: appSettings })
         prefsSaveStatus = 'saved'
+        // Settings changed → kick the auto-sync worker so a
+        // recovery push to the configured Nextcloud (#168)
+        // happens in the background.  Fire-and-forget; the
+        // helper logs and swallows its own errors.
+        void notifySettingsChanged()
         setTimeout(() => {
           if (prefsSaveStatus === 'saved') prefsSaveStatus = ''
         }, 1500)
@@ -1718,6 +1854,116 @@
 
     {#if activeCategory === 'security'}
     <SecuritySettings />
+    {/if}
+
+    {#if activeCategory === 'backup'}
+      <!-- Issue #168: Backup & Sync.
+           Two surfaces in one panel:
+             1. Local — Download / Upload settings.json via the OS
+                file dialog.  Cross-machine portable; users can
+                stash a copy in their own backup pipeline.
+             2. Nextcloud — pick a connected NC, the worker keeps
+                /Nimbus Mail/settings/settings.json fresh.  Used
+                for first-launch recovery on a new install. -->
+      <section class="space-y-6">
+        <header>
+          <h2 class="text-xl font-semibold">Backup &amp; Sync</h2>
+          <p class="text-sm text-surface-500 mt-1 max-w-2xl">
+            Save every preference, account metadata, folder→emoji
+            mapping, signature, theme, and locale to a portable
+            <code>settings.json</code>. Passwords stay in your
+            OS keychain — they're <em>not</em> in the bundle, so
+            restoring on a fresh install will still ask you to
+            re-authenticate each account on first connect.
+          </p>
+        </header>
+
+        <!-- Local backup -->
+        <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4 space-y-3">
+          <div>
+            <h3 class="font-medium leading-tight">Local backup</h3>
+            <p class="text-xs text-surface-500 leading-snug mt-1">
+              Save the bundle to a path of your choice. Re-import
+              it on this or another machine.
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button
+              class="btn preset-filled-primary-500"
+              disabled={backupStatus.kind === 'busy'}
+              onclick={() => void onDownloadClick()}
+            >Download settings.json</button>
+            <button
+              class="btn preset-outlined-surface-500"
+              disabled={backupStatus.kind === 'busy'}
+              onclick={() => void onUploadClick()}
+            >Import from file…</button>
+          </div>
+        </div>
+
+        <!-- Nextcloud recovery sync -->
+        <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4 space-y-3">
+          <div>
+            <h3 class="font-medium leading-tight">Save to Nextcloud</h3>
+            <p class="text-xs text-surface-500 leading-snug mt-1">
+              Keep a copy on a connected Nextcloud at
+              <code>/Nimbus Mail/settings/settings.json</code>.
+              Pushed automatically on every settings change. If
+              the server is unreachable the push is queued and
+              retried — silently — the next time it's online or
+              the next time a setting changes.
+              {#if syncState.pending}
+                <br>
+                <span class="text-warning-600 dark:text-warning-400">
+                  A previous push is still pending — will retry shortly.
+                </span>
+              {/if}
+            </p>
+          </div>
+          {#if ncOptions.length === 0}
+            <p class="text-xs text-surface-500 italic">
+              Connect a Nextcloud first under <strong>Nextcloud</strong> to enable this.
+            </p>
+          {:else}
+            <div class="flex flex-wrap items-center gap-3">
+              <label class="text-sm text-surface-700 dark:text-surface-300" for="sync-target">
+                Sync target
+              </label>
+              <select
+                id="sync-target"
+                class="input w-72 max-w-full text-sm px-3 py-1.5 rounded-md"
+                value={syncState.targetNcId ?? ''}
+                onchange={(e) => {
+                  const v = (e.currentTarget as HTMLSelectElement).value
+                  void onSyncTargetChange(v ? v : null)
+                }}
+              >
+                <option value="">— Off —</option>
+                {#each ncOptions as opt (opt.id)}
+                  <option value={opt.id}>{opt.label}</option>
+                {/each}
+              </select>
+              {#if syncState.targetNcId}
+                <button
+                  class="btn btn-sm preset-outlined-surface-500"
+                  disabled={backupStatus.kind === 'busy'}
+                  onclick={() => void onRestoreFromNcClick()}
+                >Restore from Nextcloud</button>
+              {/if}
+            </div>
+          {/if}
+        </div>
+
+        {#if backupStatus.kind !== 'idle'}
+          <p
+            class="text-sm wrap-break-word {backupStatus.kind === 'error'
+              ? 'text-red-500'
+              : backupStatus.kind === 'done'
+              ? 'text-success-600 dark:text-success-400'
+              : 'text-surface-500'}"
+          >{backupStatus.msg}</p>
+        {/if}
+      </section>
     {/if}
     </div>
   </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1931,7 +1931,7 @@
               </label>
               <select
                 id="sync-target"
-                class="input w-72 max-w-full text-sm px-3 py-1.5 rounded-md"
+                class="select w-72 max-w-full text-sm px-3 py-1.5 rounded-md"
                 value={syncState.targetNcId ?? ''}
                 onchange={(e) => {
                   const v = (e.currentTarget as HTMLSelectElement).value

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -17,6 +17,7 @@
   import { formatError } from './errors'
   import SyncStatusRow from './SyncStatusRow.svelte'
   import Toggle from './Toggle.svelte'
+  import { getSyncState, ncProbeBundle, ncRestoreBundle, setSyncTarget } from './settingsBundle'
 
   // ── Types (mirror the Rust models) ──────────────────────────
   interface NextcloudCapabilities {
@@ -100,6 +101,30 @@
   }
   let calendarsList = $state<Record<string, CalendarSummary[]>>({})
 
+  // ── Settings backup target (#168) ──────────────────────────
+  // Mirrors the dropdown on the Backup & Sync settings page —
+  // exposed here as a per-row toggle because users naturally
+  // look "next to the NC account" when configuring per-account
+  // behaviour.  Mutually exclusive: turning it on for one row
+  // turns off any other row that was previously the target.
+  let settingsSyncTargetId = $state<string | null>(null)
+  async function loadSettingsSyncTarget() {
+    try {
+      const s = await getSyncState()
+      settingsSyncTargetId = s.targetNcId
+    } catch (e) {
+      console.warn('getSyncState failed', e)
+    }
+  }
+  async function onSettingsSyncToggle(ncId: string, on: boolean) {
+    try {
+      await setSyncTarget(on ? ncId : null)
+      settingsSyncTargetId = on ? ncId : null
+    } catch (e) {
+      console.warn('setSyncTarget failed', e)
+    }
+  }
+
   async function loadCalendarsList(ncId: string) {
     try {
       const list = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
@@ -135,6 +160,7 @@
 
   $effect(() => {
     loadAccounts()
+    loadSettingsSyncTarget()
     // Cleanup: cancel any in-flight polling if the component unmounts.
     return () => stopPolling()
   })
@@ -301,6 +327,14 @@
   let pendingLoginUrl = $state('')
 
   function beginPolling(init: LoginFlowInit) {
+    // Snapshot the count of NC accounts that already existed
+    // *before* this login flow so the post-success "found a
+    // backup?" probe (#168) can tell first-ever-connect apart
+    // from "connecting another NC".  Recovery on first connect
+    // is the supported path; subsequent NC connects deliberately
+    // do not prompt — restoring would clobber the user's live
+    // settings on a machine they're already running on.
+    const wasFirstEverConnect = accounts.length === 0
     // 2-second cadence is a compromise between UI responsiveness and
     // not hammering the NC server. Login Flow v2 tokens live for ~20
     // minutes; we stop on success, cancel, or any unexpected error.
@@ -316,6 +350,14 @@
           pendingLoginUrl = ''
           serverInput = ''
           await loadAccounts()
+          // Recovery prompt — only on the very first NC connect
+          // (per the agreed spec: a recovery option, not a sync
+          // option).  Failures during the probe stay silent: a
+          // server with no backup or an unreachable .json
+          // shouldn't surface as an error toast.
+          if (wasFirstEverConnect) {
+            void promptRestoreFromNc(result.id)
+          }
         }
       } catch (e) {
         stopPolling()
@@ -324,6 +366,34 @@
         error = formatError(e) || 'Login failed'
       }
     }, 2000)
+  }
+
+  /** Probe the freshly-connected NC for a settings.json bundle;
+   *  if found, ask the user whether to restore it.  Strictly
+   *  silent on errors — we don't want to scare a user during the
+   *  feel-good "I just connected my server" moment. */
+  async function promptRestoreFromNc(ncId: string) {
+    try {
+      const exportedAt = await ncProbeBundle(ncId)
+      if (!exportedAt) return
+      const formatted = (() => {
+        try {
+          return new Date(exportedAt).toLocaleString()
+        } catch {
+          return exportedAt
+        }
+      })()
+      const ok = confirm(
+        `Found a Nimbus settings backup on this Nextcloud (saved ${formatted}). Restore it now? Existing accounts on this machine are kept; the bundle just adds back any that were missing and updates metadata.`,
+      )
+      if (!ok) return
+      await ncRestoreBundle(ncId)
+      alert(
+        'Settings restored. Reload the window (or restart Nimbus) to see every preference apply.',
+      )
+    } catch (e) {
+      console.warn('post-connect bundle probe / restore failed', e)
+    }
   }
 
   function stopPolling() {
@@ -416,6 +486,23 @@
               >
                 Disconnect
               </button>
+            </div>
+
+            <!-- #168 — designate this NC as the destination for
+                 Nimbus settings backups.  Mutually exclusive
+                 across all NC rows; flipping a different row
+                 silently clears this one's toggle next time the
+                 panel reloads. -->
+            <div class="flex items-center gap-3 pt-1">
+              <Toggle
+                checked={settingsSyncTargetId === acct.id}
+                label="Save Nimbus settings to this Nextcloud"
+                onchange={(v) => void onSettingsSyncToggle(acct.id, v)}
+              />
+              <span class="text-xs text-surface-500">
+                Save Nimbus settings here
+                <span class="text-[10px] text-surface-400">— recovery copy at /Nimbus Mail/settings/</span>
+              </span>
             </div>
 
             <!-- Contacts sync row -->

--- a/ui/src/lib/settingsBundle.ts
+++ b/ui/src/lib/settingsBundle.ts
@@ -1,0 +1,201 @@
+// Settings backup & sync helpers (#168).
+//
+// Three roles:
+//   1. Pack & download — collect every localStorage pref Nimbus
+//      cares about and ask the Rust side to splice it together
+//      with `AppSettings` + accounts into a single JSON blob,
+//      then save it via the OS file dialog.
+//   2. Upload & restore — pick a JSON file from disk, hand it
+//      to the Rust side which writes everything back, then mirror
+//      the bundle's `localStorage` portion into the live storage.
+//   3. Notify — every settings UI mutation calls
+//      `notifySettingsChanged()` to ping the auto-sync worker so
+//      it can debounce + push to the configured Nextcloud.
+//
+// Secrets are deliberately not part of the bundle: passwords stay
+// in the OS keychain, the FIDO wraps stay in the keychain
+// envelope, and the SQLCipher database itself isn't exported.
+// Restoring on a fresh install gives the user back every
+// preference but still requires re-auth on first connect for
+// each account.
+
+import { invoke } from '@tauri-apps/api/core'
+import { open as openFileDialog, save as saveFileDialog } from '@tauri-apps/plugin-dialog'
+
+/**
+ * `localStorage` keys that carry user-visible state we want to
+ * back up.  Adding a new key here means it'll automatically be
+ * included in the next bundle write.  Keep this list curated:
+ * arbitrary keys (like one-shot dismissed-banner flags) probably
+ * don't deserve to ride along between machines.
+ */
+const SYNCED_LOCAL_STORAGE_KEYS = [
+  // FIDO unlock toggle (#164).  The wraps live in the keychain
+  // envelope — only the *user intent* (am I in encrypted mode?)
+  // is on the frontend, and that intent should follow the user
+  // across machines.
+  'nimbus.keyEncryption',
+  // Display-language pin (#190).  Paraglide reads this on every
+  // process start; when present it overrides
+  // `navigator.language`.  Survives bundle import so a user who
+  // pinned `de` on machine A doesn't get English on machine B.
+  'PARAGLIDE_LOCALE',
+  // Trusted-senders allow-list for remote-image autoload.
+  // Stored as a JSON array; we copy it verbatim so the import
+  // path doesn't have to know its inner shape.
+  'nimbus-trusted-senders',
+] as const
+
+/**
+ * Read every synced key from `localStorage` into a plain map.
+ * Missing keys are skipped (not encoded as null/empty) so the
+ * import side can tell "not set" apart from "explicitly empty".
+ */
+export function collectLocalStorage(): Record<string, string> {
+  const out: Record<string, string> = {}
+  try {
+    for (const key of SYNCED_LOCAL_STORAGE_KEYS) {
+      const v = localStorage.getItem(key)
+      if (v !== null) out[key] = v
+    }
+  } catch {
+    // localStorage may be unavailable in some webview modes; the
+    // bundle still works — it'll just carry an empty map.
+  }
+  return out
+}
+
+/**
+ * Write each key from `map` back into `localStorage`.  Keys not
+ * present in `map` but present in `SYNCED_LOCAL_STORAGE_KEYS` are
+ * removed — restoring a bundle should mirror the source machine's
+ * state, not merge with whatever was already there.
+ */
+export function applyLocalStorage(map: Record<string, string>) {
+  try {
+    for (const key of SYNCED_LOCAL_STORAGE_KEYS) {
+      const v = map[key]
+      if (v === undefined) {
+        localStorage.removeItem(key)
+      } else {
+        localStorage.setItem(key, v)
+      }
+    }
+  } catch {
+    /* storage unavailable — silent */
+  }
+}
+
+/**
+ * Ping the auto-sync worker.  Call after any settings UI
+ * mutation so the bundle on Nextcloud (if a target is set) gets
+ * refreshed.  No-op when sync is off or when no NC is reachable
+ * — the worker handles failure / retry on its own.  The
+ * frontend does NOT await the eventual NC PUT; this returns as
+ * soon as the worker's snapshot has been updated.
+ */
+export async function notifySettingsChanged(): Promise<void> {
+  try {
+    await invoke('notify_settings_changed', { localStorage: collectLocalStorage() })
+  } catch (e) {
+    // Failing to update the worker's snapshot is not user-
+    // visible — log and move on so the UI action that triggered
+    // this isn't held up by a backend hiccup.
+    console.warn('notify_settings_changed failed:', e)
+  }
+}
+
+/** Build a bundle JSON string from the live state. */
+export async function packBundle(): Promise<string> {
+  return invoke<string>('build_settings_bundle', {
+    localStorage: collectLocalStorage(),
+  })
+}
+
+/**
+ * Save the live settings bundle to a path the user picks.
+ * Returns the chosen path (so the UI can show "Saved to …") or
+ * `null` if the user cancelled the save dialog.
+ */
+export async function downloadBundle(): Promise<string | null> {
+  const path = await saveFileDialog({
+    title: 'Save Nimbus settings backup',
+    defaultPath: 'nimbus-settings.json',
+    filters: [{ name: 'Nimbus settings', extensions: ['json'] }],
+  })
+  if (!path) return null
+  const json = await packBundle()
+  // Reuse the existing `save_bytes_to_path` command so we don't
+  // have to add the filesystem plugin to `package.json` for one
+  // text write.  TextEncoder gives us a Uint8Array which Tauri
+  // serialises as the `Vec<u8>` the Rust side expects.
+  const bytes = new TextEncoder().encode(json)
+  await invoke('save_bytes_to_path', { path, data: Array.from(bytes) })
+  return path
+}
+
+/**
+ * Open a file picker, read the chosen JSON, hand it to the
+ * Rust side, and apply the bundle's `localStorage` portion
+ * locally.  Returns `null` if the user cancelled, otherwise the
+ * path that was imported.  Throws if the file doesn't parse or
+ * the bundle's schema version is too new.
+ */
+export async function uploadBundle(): Promise<string | null> {
+  const picked = await openFileDialog({
+    title: 'Import Nimbus settings backup',
+    multiple: false,
+    filters: [{ name: 'Nimbus settings', extensions: ['json'] }],
+  })
+  if (!picked || Array.isArray(picked)) return null
+  const path = typeof picked === 'string' ? picked : (picked as { path: string }).path
+  const json = await invoke<string>('read_text_from_path', { path })
+  const localStorageMap = await invoke<Record<string, string>>('apply_settings_bundle', { json })
+  applyLocalStorage(localStorageMap)
+  return path
+}
+
+/** Live view of the auto-sync state for the Settings UI. */
+export interface SettingsSyncStateView {
+  targetNcId: string | null
+  pending: boolean
+}
+
+export async function getSyncState(): Promise<SettingsSyncStateView> {
+  return invoke<SettingsSyncStateView>('get_settings_sync_state')
+}
+
+/**
+ * Set (or clear, with `null`) the NC account that auto-sync
+ * pushes to.  Setting it kicks off an immediate push so the
+ * chosen NC has a fresh copy without waiting for the next
+ * settings change.
+ */
+export async function setSyncTarget(targetNcId: string | null): Promise<void> {
+  await invoke('set_settings_sync_target', { targetNcId })
+}
+
+/**
+ * Check a connected NC for an existing settings bundle.
+ * Returns the bundle's `exported_at` timestamp (RFC 3339) when
+ * one is found, `null` when the path doesn't exist.  Surfaces
+ * server / auth errors as exceptions; callers should catch and
+ * stay quiet — this is only a probe for the "found a backup,
+ * restore?" prompt.
+ */
+export async function ncProbeBundle(ncId: string): Promise<string | null> {
+  return invoke<string | null>('nc_probe_settings_bundle', { ncId })
+}
+
+/**
+ * Download + apply the bundle stored on a connected NC.  Same
+ * post-conditions as `uploadBundle`: every preference is
+ * restored; passwords still need to be re-entered on first
+ * connect.  Returns the bundle's `localStorage` portion (already
+ * applied locally; returned for callers that want to inspect).
+ */
+export async function ncRestoreBundle(ncId: string): Promise<Record<string, string>> {
+  const localStorageMap = await invoke<Record<string, string>>('nc_restore_settings_bundle', { ncId })
+  applyLocalStorage(localStorageMap)
+  return localStorageMap
+}


### PR DESCRIPTION
## Summary

Closes #168.  Ships all four sub-tasks from the issue as one PR per the team's phase-bundling convention.

### What's in the bundle

`SettingsBundle` (schema v1) — `AppSettings`, every mail account record (folder→emoji overrides ride along automatically since they live on `Account`), and a curated set of `localStorage` keys (FIDO toggle, locale pin, trusted senders).  Passwords / FIDO wraps / master key / cache DB are **not** in the bundle — restoring on a fresh install still asks for re-auth on first connect for each account.  Schema-versioned, forward-compatible at the field level, hard-fail on a future incompatible major bump.

### Surfaces

- **Settings → Backup & Sync.**  Download / Import buttons for the local file path.  "Save to Nextcloud" dropdown to pick a connected NC as the recovery destination.  "Restore from Nextcloud" button when a target is set.
- **Settings → Nextcloud → per-row toggle.**  Same backend state as the dropdown; flipping the toggle on a different NC silently clears the previous target.

### Nextcloud sync semantics — recovery, not bidirectional

- Frontend pings the auto-sync worker on every settings mutation; the worker debounces 2 s and PUTs `/Nimbus Mail/settings/settings.json`.
- On any failure (offline, 401, server down, quota), the push is silent and the `pending` flag persists across launches.  Retry happens on (a) the next settings mutation, (b) a 5-min periodic timer, or (c) app launch.
- On first-ever NC connect, the client probes for an existing bundle and prompts the user to restore it.  Subsequent NC connects do not prompt — restoring on a machine that's already in use would clobber live state.

### Implementation

- New: `crates/nimbus-store/src/settings_bundle.rs` (4 unit tests pass), `crates/nimbus-store/src/settings_sync.rs`, `ui/src/lib/settingsBundle.ts`.
- New Tauri commands wired into the invoke handler: `build_settings_bundle`, `apply_settings_bundle`, `get_settings_sync_state`, `set_settings_sync_target`, `notify_settings_changed`, `nc_probe_settings_bundle`, `nc_restore_settings_bundle`, `read_text_from_path`.
- Existing mutation commands (`update_account`, `add_account`, `remove_account`, `set_folder_icon`, `update_app_settings`) now ping the auto-sync worker after a successful save so the bundle on NC stays current without per-call-site touchpoints in the frontend.
- Auto-sync worker spawned in `main()`'s setup block; on launch it kicks once if `pending=true` from a previous session.

## Test plan

- [ ] Settings → Backup & Sync → **Download settings.json**.  Pick a path; reopen the file in a text editor and confirm it contains `version: 1`, `app_settings`, `accounts` (no passwords), `local_storage`.
- [ ] Change a few settings (theme, signature on an account, pin a folder emoji), then **Import from file…** the earlier export.  Confirm the changes are reverted after a window reload.
- [ ] Connect a Nextcloud and pick it from the **Sync target** dropdown.  Confirm `/Nimbus Mail/settings/settings.json` appears on the NC after a settings change.
- [ ] Same path via the per-NC-row toggle on the Nextcloud page.  Verify the dropdown updates to match.
- [ ] Disconnect Wi-Fi, change a setting → no error toast, no UI hang.  Reconnect, change another setting → confirm the bundle on NC reflects both changes.
- [ ] Quit the app while offline (with `pending=true`), come back online, relaunch — verify the bundle is pushed on launch.
- [ ] On a fresh install (or after deleting `app_settings.json`), connect the NC that has a backup → "found a backup, restore?" prompt fires; accepting restores the bundle.
- [ ] Attempt to import a `settings.json` whose `version` is `9999` — confirm the error message names the version mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)