### PR TITLE
#165: URLhaus-backed link safety check

### DIFF
--- a/License.md
+++ b/License.md
@@ -27,6 +27,7 @@ applies to every package listed underneath it.
 | [ISC](#isc-license) | rustls, ring (parts) |
 | [MPL-2.0](#mozilla-public-license-20) | webpki-roots, dompurify |
 | [GPL-3.0](#gnu-general-public-license-v3) | rrule (and Nimbus itself) |
+| [CC0-1.0](#cc0-10-runtime-data-feeds) (data only) | URLhaus malicious-URL feed (#165) |
 | Multi-licence components | [ring](#ring-tls-crypto-provider) (ISC + MIT + OpenSSL) |
 
 ---
@@ -245,6 +246,31 @@ links to GPL-3.0 code requires:
 
 The full GPL-3.0 text is in the repository root [LICENSE](LICENSE)
 file and at <https://www.gnu.org/licenses/gpl-3.0.txt>.
+
+---
+
+## CC0-1.0 (runtime data feeds)
+
+The link-safety check (#165) consumes the **URLhaus** malicious-URL
+feed published by [abuse.ch](https://urlhaus.abuse.ch/). The data
+itself is dedicated to the public domain under
+[CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) — no
+attribution clause forces redistribution semantics, and no
+copyleft pressure spreads to the rest of Nimbus. We still credit
+abuse.ch in the Settings UI as a goodwill gesture: the project
+runs on community contributions and a visible "powered by" link
+helps them keep funding the work.
+
+The CC0-1.0 dedication does not impose any reproduction or notice
+obligation. Reproduced here for completeness:
+
+> CC0 1.0 Universal — The person who associated a work with this
+> deed has dedicated the work to the public domain by waiving all
+> of his or her rights to the work worldwide under copyright law,
+> including all related and neighboring rights, to the extent
+> allowed by law.
+
+Full text: <https://creativecommons.org/publicdomain/zero/1.0/legalcode>
 
 ---
 

--- a/SBOM.md
+++ b/SBOM.md
@@ -113,7 +113,7 @@ strong-copyleft licence stronger than what we already have (e.g.
 AGPL-3.0) is a project-level decision, not a routine PR. See
 [CLAUDE.md](CLAUDE.md) for the AI-assistant version of this rule.
 
-Last manual reconciliation: 2026-05-03 (i18n via `@inlang/paraglide-js` — Apache-2.0, runtime ships a small message-selector function in the bundle; no licence change for the app overall).
+Last manual reconciliation: 2026-05-03 (URLhaus malicious-URL feed via abuse.ch — CC0-1.0, no Rust/JS dependency added; the data itself is fetched at runtime from `urlhaus.abuse.ch/downloads/csv_online/` and stored locally in the encrypted SQLCipher cache).
 
 ---
 
@@ -222,6 +222,18 @@ don't affect distribution. Still worth knowing what's in the toolchain:
 | `tailwindcss` | MIT | CSS framework. |
 | `typescript` | Apache-2.0 | TS compiler. |
 | `vite` | MIT | Build tool / dev server. |
+
+---
+
+## Runtime data feeds
+
+Not a code dependency — **data** consumed at runtime. Each feed
+needs the same kind of attention as a code dep when its licence
+or terms change.
+
+| Source | Licence | Notes |
+|---|---|---|
+| URLhaus by abuse.ch (`urlhaus.abuse.ch/downloads/csv_online/`) | CC0-1.0 | Malicious-URL feed for the link-safety check (#165). Fetched once an hour over HTTPS, stored in the encrypted SQLCipher cache. Public domain — no attribution clause forces redistribution semantics, but we still credit abuse.ch in the Settings UI as a goodwill gesture. |
 
 ---
 

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -155,6 +155,20 @@ pub struct AppSettings {
     /// picking an explicit language) sets this to false.
     #[serde(default = "default_true")]
     pub ui_locale_auto: bool,
+    /// Master toggle for the URLhaus link-safety check (#165).
+    /// When on (default), every link in a rendered email is
+    /// looked up against the local URLhaus snapshot and rendered
+    /// with a green "Safe" or red "Unsafe" pill; clicks on
+    /// unsafe links go through a confirm modal.  When off, the
+    /// pills are suppressed, links open without interception,
+    /// and the background refresh worker sleeps.  Default-on
+    /// matches the project's privacy-first defaults — the
+    /// URLhaus list is fetched once an hour over plain HTTPS
+    /// with no per-user identifiers, so the privacy cost is
+    /// negligible compared to the value of catching malware
+    /// links before the user clicks them.
+    #[serde(default = "default_true")]
+    pub link_check_enabled: bool,
 }
 
 fn default_logo_style() -> String {
@@ -243,6 +257,7 @@ impl Default for AppSettings {
             ui_scale_auto: true,
             ui_locale: String::new(),
             ui_locale_auto: true,
+            link_check_enabled: true,
         }
     }
 }

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -788,6 +788,41 @@ const MIGRATIONS: &[&str] = &[
     r#"
     ALTER TABLE messages ADD COLUMN pending_action TEXT;
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // vN → vN+1: URLhaus link-safety table (#165)
+    //
+    // Local snapshot of abuse.ch's URLhaus "online malicious URLs"
+    // dump.  Refreshed every ~hour by a background task; the
+    // mail-render path looks up each <a href> against this table
+    // and renders a Safe / Unsafe pill next to the link.
+    //
+    // We store both the full URL and a derived `host` so we can
+    // ask either question (exact match → "this link is on
+    // URLhaus", or just-host match → "this domain has hosted
+    // malware before").  v1 only renders the binary safe/unsafe
+    // pill, but we keep the host index in case a future tier of
+    // "caution" is wanted without another migration.
+    //
+    // `meta` is the small key/value table for sync state — last
+    // refresh timestamp, source ETag, etc.  One row per key.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    CREATE TABLE urlhaus_urls (
+        url            TEXT PRIMARY KEY,
+        host           TEXT NOT NULL,
+        threat         TEXT NOT NULL DEFAULT '',
+        tags           TEXT NOT NULL DEFAULT '',  -- comma-separated tag list
+        date_added     INTEGER NOT NULL,           -- unix epoch seconds
+        last_refreshed INTEGER NOT NULL            -- unix epoch seconds
+    );
+
+    CREATE INDEX urlhaus_by_host ON urlhaus_urls (host);
+
+    CREATE TABLE urlhaus_meta (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    );
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/crates/nimbus-store/src/lib.rs
+++ b/crates/nimbus-store/src/lib.rs
@@ -8,6 +8,7 @@ pub mod app_settings;
 pub mod cache;
 pub mod credentials;
 pub mod fido;
+pub mod link_check;
 pub mod nextcloud_store;
 pub mod settings_bundle;
 pub mod settings_sync;

--- a/crates/nimbus-store/src/link_check.rs
+++ b/crates/nimbus-store/src/link_check.rs
@@ -1,0 +1,367 @@
+//! URLhaus-backed link-safety check (#165).
+//!
+//! Stores a periodically-refreshed snapshot of abuse.ch's URLhaus
+//! "online malicious URLs" feed inside the encrypted SQLCipher
+//! cache and exposes a small lookup API.  Two questions matter:
+//!
+//!   - **Is this exact URL on URLhaus?** — strongest signal; the
+//!     URL has been observed serving malware or phishing.
+//!   - **Has this host been on URLhaus?** — weaker signal; the
+//!     domain has hosted malicious content in the past.  v1 of
+//!     the UI collapses both into a single "unsafe" verdict;
+//!     keeping the distinction in the API leaves room for a
+//!     future "caution" tier without a schema change.
+//!
+//! Lookups are case-insensitive on host and trim a single
+//! trailing slash on the path so cosmetic differences between
+//! `https://evil.example.com/foo` and
+//! `https://evil.example.com/foo/` don't desynchronise.  The
+//! match isn't a security boundary — a determined attacker can
+//! always permute the path to evade an exact-string list — but
+//! it's the contract of the upstream feed and it's the right
+//! tier of paranoia for a "warn the user before they click"
+//! affordance.
+
+use chrono::Utc;
+use rusqlite::{OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::Cache;
+use crate::cache::CacheError;
+
+/// One URLhaus row matched against a candidate URL.  Returned
+/// from `lookup` so callers know *which* dimension matched and
+/// can render a different pill colour / hover hint per tier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UrlhausMatch {
+    /// `true` if the full URL was on the list; `false` if only
+    /// the host matched (i.e. the same domain has hosted other
+    /// malicious URLs but this exact URL isn't currently flagged).
+    pub exact: bool,
+    /// URLhaus' `threat` column — typically `"malware_download"`
+    /// or `"phishing"`.  Plain-text passthrough.
+    pub threat: String,
+    /// URLhaus' `tags` column — comma-separated list of tags
+    /// like `"emotet,exe"`.  Plain-text passthrough; the UI
+    /// renders this verbatim in a tooltip.
+    pub tags: String,
+}
+
+/// Snapshot summary for the Settings UI — how many URLs we
+/// currently know about and when the local copy was last
+/// refreshed.  `None` for `last_refreshed_at` means "we've
+/// never successfully refreshed", which the UI surfaces as
+/// "Never" rather than the unix epoch zero.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UrlhausStatus {
+    pub total_urls: u32,
+    pub last_refreshed_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Look up a URL in the local URLhaus snapshot.  Returns `None`
+/// for "no known threat indicators" (i.e. the safe path).
+///
+/// Two lookups in sequence:
+///   1. Exact-URL match against the primary key.
+///   2. Host-only match against the `host` index.
+///
+/// Both are O(1) / O(log n) and the index is small enough
+/// (typically a few thousand URLs) that the full-table size
+/// stays well within SQLite's page cache.
+pub fn lookup(cache: &Cache, url: &str) -> Result<Option<UrlhausMatch>, CacheError> {
+    let trimmed = trim_url(url);
+    let host = match extract_host(&trimmed) {
+        Some(h) => h,
+        // Couldn't parse a host — nothing to match against, so
+        // we report "safe" and let the UI render the green pill.
+        // A weird URL is much more likely to be a `mailto:` /
+        // `tel:` / `javascript:` than something URLhaus would
+        // flag anyway.
+        None => return Ok(None),
+    };
+
+    let conn = cache.conn()?;
+
+    // Exact URL match first — it's the stronger signal and
+    // costs nothing to check.
+    if let Some((threat, tags)) = conn
+        .query_row(
+            "SELECT threat, tags FROM urlhaus_urls WHERE url = ?1",
+            params![&trimmed],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?
+    {
+        return Ok(Some(UrlhausMatch {
+            exact: true,
+            threat,
+            tags,
+        }));
+    }
+
+    // Fall back to host-only match.  We pick the most recent
+    // entry by `date_added` so the surfaced threat label
+    // reflects current activity rather than ancient history.
+    let host_match = conn
+        .query_row(
+            "SELECT threat, tags
+             FROM urlhaus_urls
+             WHERE host = ?1
+             ORDER BY date_added DESC
+             LIMIT 1",
+            params![&host],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+
+    Ok(host_match.map(|(threat, tags)| UrlhausMatch {
+        exact: false,
+        threat,
+        tags,
+    }))
+}
+
+/// Replace the entire URLhaus snapshot in one transaction.
+/// Called by the background refresh worker after a successful
+/// CSV download — the safest atomic-update story for "wholesale
+/// list replacement" data.
+///
+/// `entries` is the parsed CSV; rows with an unparseable URL or
+/// missing host are silently skipped (the upstream CSV
+/// occasionally carries malformed lines).
+pub fn replace_all(cache: &Cache, entries: &[UrlhausCsvRow]) -> Result<u32, CacheError> {
+    let now = Utc::now().timestamp();
+    let mut conn = cache.conn()?;
+    let tx = conn.transaction()?;
+
+    tx.execute("DELETE FROM urlhaus_urls", [])?;
+
+    let mut inserted: u32 = 0;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT OR IGNORE INTO urlhaus_urls
+                    (url, host, threat, tags, date_added, last_refreshed)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?;
+
+        for entry in entries {
+            let trimmed = trim_url(&entry.url);
+            let Some(host) = extract_host(&trimmed) else {
+                continue;
+            };
+            stmt.execute(params![
+                &trimmed,
+                &host,
+                &entry.threat,
+                &entry.tags,
+                entry.date_added,
+                now,
+            ])?;
+            inserted += 1;
+        }
+    }
+
+    tx.execute(
+        "INSERT INTO urlhaus_meta (key, value) VALUES ('last_refreshed_at', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![now.to_string()],
+    )?;
+
+    tx.commit()?;
+
+    debug!("URLhaus snapshot replaced: {} URL(s)", inserted);
+    Ok(inserted)
+}
+
+/// Read the snapshot status — used by the Settings UI to render
+/// "{n} URLs, last refreshed N hours ago".
+pub fn status(cache: &Cache) -> Result<UrlhausStatus, CacheError> {
+    let conn = cache.conn()?;
+    let total: u32 = conn.query_row("SELECT COUNT(*) FROM urlhaus_urls", [], |r| {
+        r.get::<_, i64>(0).map(|n| n as u32)
+    })?;
+
+    let last_refreshed_epoch: Option<i64> = conn
+        .query_row(
+            "SELECT value FROM urlhaus_meta WHERE key = 'last_refreshed_at'",
+            [],
+            |r| {
+                let s: String = r.get(0)?;
+                Ok(s.parse::<i64>().ok())
+            },
+        )
+        .optional()?
+        .flatten();
+
+    Ok(UrlhausStatus {
+        total_urls: total,
+        last_refreshed_at: last_refreshed_epoch
+            .and_then(|epoch| chrono::DateTime::<chrono::Utc>::from_timestamp(epoch, 0)),
+    })
+}
+
+/// One row parsed from the URLhaus CSV.  Public so the
+/// http-fetcher (in `nimbus-app`, where the http client lives)
+/// can build these and hand them to `replace_all`.
+#[derive(Debug, Clone)]
+pub struct UrlhausCsvRow {
+    pub url: String,
+    pub threat: String,
+    pub tags: String,
+    /// `dateadded` column from URLhaus, parsed to unix epoch
+    /// seconds.  Used as the tiebreaker in host-only matches.
+    pub date_added: i64,
+}
+
+fn trim_url(url: &str) -> String {
+    let trimmed = url.trim();
+    // Drop a single trailing `/` so two URLs that differ only in
+    // that position land on the same row.  Not aggressive about
+    // case-folding the path — URLhaus entries are typically
+    // case-sensitive (an attacker may serve different content
+    // from `/Pay` vs `/pay`).
+    if trimmed.ends_with('/') && trimmed.len() > 1 {
+        trimmed[..trimmed.len() - 1].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn extract_host(url: &str) -> Option<String> {
+    // We don't need a full URL parser here — a hand-rolled
+    // scheme-strip + host-up-to-(`:` or `/` or `?` or `#`) is
+    // enough for the URLhaus format and saves us a `url` crate
+    // dependency for one function.
+    let after_scheme = if let Some(idx) = url.find("://") {
+        &url[idx + 3..]
+    } else {
+        url
+    };
+    if after_scheme.is_empty() {
+        return None;
+    }
+    let end = after_scheme
+        .find(|c: char| c == '/' || c == '?' || c == '#' || c == ':')
+        .unwrap_or(after_scheme.len());
+    let host = &after_scheme[..end];
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_host_strips_scheme_and_trailing_path() {
+        assert_eq!(
+            extract_host("https://evil.example.com/foo/bar?q=1"),
+            Some("evil.example.com".into())
+        );
+        assert_eq!(
+            extract_host("http://Evil.Example.COM:8080/x"),
+            Some("evil.example.com".into())
+        );
+        assert_eq!(extract_host("//no-scheme.example.com/x"), None);
+        assert_eq!(extract_host(""), None);
+    }
+
+    #[test]
+    fn trim_url_drops_single_trailing_slash() {
+        assert_eq!(
+            trim_url("https://x.example.com/foo/"),
+            "https://x.example.com/foo"
+        );
+        assert_eq!(
+            trim_url("https://x.example.com/foo"),
+            "https://x.example.com/foo"
+        );
+        // Don't strip the lone `/` that's the path itself —
+        // that would conflate two distinct URLs.
+        assert_eq!(trim_url("/"), "/");
+    }
+
+    fn open_test_cache() -> Cache {
+        Cache::open_in_memory().expect("in-memory cache")
+    }
+
+    #[test]
+    fn lookup_finds_exact_url() {
+        let cache = open_test_cache();
+        replace_all(
+            &cache,
+            &[UrlhausCsvRow {
+                url: "https://evil.example.com/payload.exe".into(),
+                threat: "malware_download".into(),
+                tags: "emotet,exe".into(),
+                date_added: 1_700_000_000,
+            }],
+        )
+        .expect("replace");
+        let m = lookup(&cache, "https://evil.example.com/payload.exe")
+            .expect("lookup")
+            .expect("hit");
+        assert!(m.exact);
+        assert_eq!(m.threat, "malware_download");
+    }
+
+    #[test]
+    fn lookup_falls_back_to_host_match() {
+        let cache = open_test_cache();
+        replace_all(
+            &cache,
+            &[UrlhausCsvRow {
+                url: "https://evil.example.com/payload.exe".into(),
+                threat: "malware_download".into(),
+                tags: "emotet".into(),
+                date_added: 1_700_000_000,
+            }],
+        )
+        .expect("replace");
+        let m = lookup(&cache, "https://evil.example.com/different-path")
+            .expect("lookup")
+            .expect("host hit");
+        assert!(!m.exact);
+        assert_eq!(m.threat, "malware_download");
+    }
+
+    #[test]
+    fn lookup_returns_none_for_safe_url() {
+        let cache = open_test_cache();
+        replace_all(&cache, &[]).expect("replace");
+        let m = lookup(&cache, "https://example.com/").expect("lookup");
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn status_reflects_replace_all() {
+        let cache = open_test_cache();
+        replace_all(
+            &cache,
+            &[
+                UrlhausCsvRow {
+                    url: "https://a.example.com/x".into(),
+                    threat: "malware_download".into(),
+                    tags: String::new(),
+                    date_added: 1_700_000_000,
+                },
+                UrlhausCsvRow {
+                    url: "https://b.example.com/y".into(),
+                    threat: "phishing".into(),
+                    tags: String::new(),
+                    date_added: 1_700_000_001,
+                },
+            ],
+        )
+        .expect("replace");
+        let s = status(&cache).expect("status");
+        assert_eq!(s.total_urls, 2);
+        assert!(s.last_refreshed_at.is_some());
+    }
+}

--- a/crates/nimbus-store/src/link_check.rs
+++ b/crates/nimbus-store/src/link_check.rs
@@ -176,6 +176,24 @@ pub fn replace_all(cache: &Cache, entries: &[UrlhausCsvRow]) -> Result<u32, Cach
     Ok(inserted)
 }
 
+/// Count rows in the snapshot whose `host` column matches a
+/// candidate URL's host.  Used by the diagnostic IPC (#165) to
+/// tell "URL not in URLhaus" apart from "host known but exact +
+/// fallback both missed".  Returns 0 when the URL has no
+/// extractable host.
+pub fn host_count_for_url(cache: &Cache, url: &str) -> Result<u32, CacheError> {
+    let Some(host) = extract_host(&trim_url(url)) else {
+        return Ok(0);
+    };
+    let conn = cache.conn()?;
+    let n: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM urlhaus_urls WHERE host = ?1",
+        params![&host],
+        |r| r.get(0),
+    )?;
+    Ok(n as u32)
+}
+
 /// Read the snapshot status — used by the Settings UI to render
 /// "{n} URLs, last refreshed N hours ago".
 pub fn status(cache: &Cache) -> Result<UrlhausStatus, CacheError> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -36,7 +36,7 @@ use nimbus_store::cache::{
     SearchFilters, SearchHit, SearchScope, SyncState,
 };
 use nimbus_store::{
-    Cache, account_store, app_settings, credentials, nextcloud_store, settings_bundle,
+    Cache, account_store, app_settings, credentials, link_check, nextcloud_store, settings_bundle,
     settings_sync,
 };
 use serde::{Deserialize, Serialize};
@@ -8547,6 +8547,303 @@ async fn check_mail_now(app: AppHandle) -> Result<(), NimbusError> {
     check_mail_now_inner(&app).await
 }
 
+// ── URLhaus link safety (#165) ─────────────────────────────────
+//
+// Local snapshot of abuse.ch's URLhaus "online malicious URLs"
+// CSV.  Refreshed every hour by a background task; lookups go
+// against the encrypted SQLite cache (so the URL list inherits
+// the same at-rest protection as the user's mail).
+//
+// Frontend behaviour:
+//   - On message open, MailView walks every <a href> in the
+//     rendered body, batches the URLs into one `check_urls`
+//     IPC, and renders a green "Safe" / red "Unsafe" pill next
+//     to each link.
+//   - Click on an Unsafe link is intercepted: a confirm modal
+//     offers "Delete mail" (move to Trash) or "Open link
+//     anyway".  Safe links open normally.
+//
+// Refresh behaviour:
+//   - Background worker spawned in main()'s setup block.
+//   - On launch: refresh immediately if the local snapshot is
+//     empty or older than 24 h; otherwise wait for the next
+//     hourly tick.
+//   - Errors are logged at warn level; the worker keeps the
+//     previous snapshot so a transient outage at abuse.ch
+//     doesn't wipe the list.
+
+const URLHAUS_CSV_URL: &str = "https://urlhaus.abuse.ch/downloads/csv_online/";
+
+/// Verdict surfaced to the frontend per URL.  `safe` means the
+/// URL didn't match anything in URLhaus; `unsafe` means there
+/// was either an exact-URL match or a host match (the v1 UI
+/// collapses both into the red pill).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LinkVerdict {
+    /// The URL the verdict was computed for, echoed back so the
+    /// frontend can correlate without keeping its own index.
+    url: String,
+    /// `"safe"` | `"unsafe"`.  String tag rather than a bool so
+    /// future tiers ("caution", "unknown") slot in without an
+    /// IPC schema break.
+    verdict: String,
+    /// Optional context for the unsafe path: URLhaus' threat
+    /// classification (e.g. `"malware_download"`) and tag list.
+    /// `None` for safe URLs.
+    threat: Option<String>,
+    tags: Option<String>,
+    /// `true` when the URL itself was on the list (vs only the
+    /// host).  Used by the modal to render a slightly different
+    /// hint ("This URL is on URLhaus" vs "This domain has
+    /// hosted malicious content before").
+    exact: bool,
+}
+
+#[tauri::command]
+fn check_urls(
+    urls: Vec<String>,
+    cache: State<'_, Cache>,
+    settings: State<'_, SharedSettings>,
+) -> Result<Vec<LinkVerdict>, NimbusError> {
+    // Master toggle short-circuit: when the user has the link
+    // checker turned off, return "unknown" verdicts that the
+    // frontend renders without a pill at all.  We use the
+    // existing `verdict` string ("off") rather than carrying a
+    // separate enabled flag so the UI's per-URL render code
+    // stays a single match.
+    let enabled = futures::executor::block_on(settings.read()).link_check_enabled;
+    if !enabled {
+        return Ok(urls
+            .into_iter()
+            .map(|url| LinkVerdict {
+                url,
+                verdict: "off".into(),
+                threat: None,
+                tags: None,
+                exact: false,
+            })
+            .collect());
+    }
+
+    let mut out = Vec::with_capacity(urls.len());
+    for url in urls {
+        match link_check::lookup(&cache, &url) {
+            Ok(Some(m)) => out.push(LinkVerdict {
+                url,
+                verdict: "unsafe".into(),
+                threat: Some(m.threat),
+                tags: Some(m.tags),
+                exact: m.exact,
+            }),
+            Ok(None) => out.push(LinkVerdict {
+                url,
+                verdict: "safe".into(),
+                threat: None,
+                tags: None,
+                exact: false,
+            }),
+            Err(e) => {
+                // Surface as "unknown" rather than failing the
+                // whole batch; an SQLite error mid-walk is rare
+                // and a single bad lookup shouldn't wipe pills
+                // off every other link in the email.
+                tracing::warn!("link_check lookup failed for {url}: {e}");
+                out.push(LinkVerdict {
+                    url,
+                    verdict: "off".into(),
+                    threat: None,
+                    tags: None,
+                    exact: false,
+                });
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[tauri::command]
+fn get_link_check_status(
+    cache: State<'_, Cache>,
+) -> Result<link_check::UrlhausStatus, NimbusError> {
+    link_check::status(&cache).map_err(NimbusError::from)
+}
+
+/// Manually trigger a URLhaus refresh.  Used by the "Refresh
+/// now" button on the Settings page; also called by the
+/// background worker on its hourly tick.
+#[tauri::command]
+async fn refresh_urlhaus_now(cache: State<'_, Cache>) -> Result<u32, NimbusError> {
+    refresh_urlhaus_inner(&cache).await
+}
+
+async fn refresh_urlhaus_inner(cache: &Cache) -> Result<u32, NimbusError> {
+    let http = reqwest::Client::builder()
+        .user_agent(concat!("nimbus-mail/", env!("CARGO_PKG_VERSION")))
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .map_err(|e| NimbusError::Network(format!("urlhaus client build: {e}")))?;
+    let resp = http
+        .get(URLHAUS_CSV_URL)
+        .send()
+        .await
+        .map_err(|e| NimbusError::Network(format!("urlhaus fetch: {e}")))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(NimbusError::Network(format!(
+            "urlhaus fetch returned HTTP {status}"
+        )));
+    }
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| NimbusError::Network(format!("urlhaus body read: {e}")))?;
+    let rows = parse_urlhaus_csv(&body);
+    let cache_clone = cache.clone();
+    let count = tokio::task::spawn_blocking(move || link_check::replace_all(&cache_clone, &rows))
+        .await
+        .map_err(|e| NimbusError::Other(format!("urlhaus replace_all join: {e}")))?
+        .map_err(NimbusError::from)?;
+    tracing::info!("URLhaus refresh complete — {count} URL(s)");
+    Ok(count)
+}
+
+/// Hand-rolled minimal CSV parser for the URLhaus
+/// `csv_online` dump.  The format is well-defined and stable:
+///
+/// ```text
+/// # comment line
+/// "id","dateadded","url","url_status","last_online","threat","tags","urlhaus_link","reporter"
+/// ```
+///
+/// All fields are quoted; embedded commas and quotes are not
+/// part of any URL we'll see in practice (URLhaus only catalogs
+/// HTTP / HTTPS URLs, which can't legally contain unescaped
+/// double quotes anyway).  Going hand-rolled here saves us a
+/// `csv` crate workspace dependency for one feature.
+fn parse_urlhaus_csv(body: &str) -> Vec<link_check::UrlhausCsvRow> {
+    let mut out = Vec::with_capacity(8192);
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let fields = split_csv_line(line);
+        // Expect the canonical 9 fields; rows with the wrong
+        // arity are upstream malformations we silently skip.
+        if fields.len() < 7 {
+            continue;
+        }
+        let date_added = parse_urlhaus_date(&fields[1]).unwrap_or(0);
+        out.push(link_check::UrlhausCsvRow {
+            url: fields[2].clone(),
+            threat: fields[5].clone(),
+            tags: fields[6].clone(),
+            date_added,
+        });
+    }
+    out
+}
+
+/// Split one CSV line into its quoted fields.  We tolerate
+/// unquoted fields too (the URLhaus header / the occasional
+/// malformed row), so a record with mixed quoting still
+/// recovers cleanly.  Doubled `""` inside a quoted field
+/// decodes to a single literal quote per RFC 4180.
+fn split_csv_line(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        match (c, in_quotes) {
+            ('"', true) => {
+                if matches!(chars.peek(), Some('"')) {
+                    chars.next();
+                    current.push('"');
+                } else {
+                    in_quotes = false;
+                }
+            }
+            ('"', false) => in_quotes = true,
+            (',', false) => {
+                fields.push(std::mem::take(&mut current));
+            }
+            (other, _) => current.push(other),
+        }
+    }
+    fields.push(current);
+    fields
+}
+
+/// Parse URLhaus' `dateadded` field (`YYYY-MM-DD HH:MM:SS` UTC)
+/// into unix epoch seconds.  Falls back to `None` on a malformed
+/// row so the caller can substitute zero rather than skipping.
+fn parse_urlhaus_date(s: &str) -> Option<i64> {
+    use chrono::NaiveDateTime;
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        .map(|dt| dt.and_utc().timestamp())
+}
+
+/// Background refresh worker.  Driven by an hourly tick plus a
+/// startup-time decision: if the local snapshot is empty or
+/// older than 24 h, refresh immediately; otherwise wait.  The
+/// worker respects the `link_check_enabled` master toggle —
+/// when off, it sleeps for the full tick window and re-checks
+/// before doing any network work.
+async fn urlhaus_refresh_worker(cache: Cache, settings: SharedSettings) {
+    use tokio::time::{Duration, MissedTickBehavior, interval};
+
+    // Initial decision based on the on-disk snapshot.  We
+    // intentionally do *not* gate this on `link_check_enabled`:
+    // a user who turned the feature off probably wants the
+    // pre-existing list scrubbed too, but we also don't want
+    // to re-download on every restart for a feature they
+    // disabled.  Compromise: only the "stale" path triggers an
+    // initial refresh, and we still respect the toggle inside
+    // the refresh function below.
+    let stale = match link_check::status(&cache) {
+        Ok(s) => match s.last_refreshed_at {
+            None => true, // never refreshed
+            Some(ts) => {
+                let age = chrono::Utc::now().signed_duration_since(ts).num_hours();
+                age >= 24 || s.total_urls == 0
+            }
+        },
+        Err(_) => true,
+    };
+    if stale {
+        let enabled = settings.read().await.link_check_enabled;
+        if enabled {
+            if let Err(e) = refresh_urlhaus_inner(&cache).await {
+                tracing::warn!("URLhaus initial refresh failed: {e}");
+            }
+        }
+    }
+
+    let mut tick = interval(Duration::from_secs(60 * 60));
+    tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    // Burn the immediate first tick so we don't stack on top
+    // of the startup refresh above.
+    tick.tick().await;
+
+    loop {
+        tick.tick().await;
+        let enabled = settings.read().await.link_check_enabled;
+        if !enabled {
+            continue;
+        }
+        if let Err(e) = refresh_urlhaus_inner(&cache).await {
+            tracing::warn!("URLhaus refresh failed (will retry next tick): {e}");
+        }
+    }
+}
+
 /// Switch the running app's icon (tray, window titlebar, taskbar)
 /// to the user's picked logo style and persist the choice in
 /// `AppSettings.logo_style`.  The next boot reapplies it.
@@ -9160,6 +9457,17 @@ fn main() {
                 initial_kick.notify_one();
             }
 
+            // URLhaus link-safety refresh worker (#165).  Pulls
+            // the abuse.ch CSV every hour, decides on launch
+            // whether the local copy is stale enough to refresh
+            // immediately, and respects the link_check_enabled
+            // master toggle in AppSettings.
+            let urlhaus_cache = app.state::<Cache>().inner().clone();
+            let urlhaus_settings = app.state::<SharedSettings>().inner().clone();
+            tauri::async_runtime::spawn(async move {
+                urlhaus_refresh_worker(urlhaus_cache, urlhaus_settings).await;
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -9314,6 +9622,10 @@ fn main() {
             notify_settings_changed,
             nc_probe_settings_bundle,
             nc_restore_settings_bundle,
+            // Issue #165: URLhaus link safety.
+            check_urls,
+            get_link_check_status,
+            refresh_urlhaus_now,
             set_logo_style,
             import_custom_theme,
             remove_custom_theme,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8601,6 +8601,32 @@ struct LinkVerdict {
 }
 
 #[tauri::command]
+fn debug_link_check(
+    url: String,
+    cache: State<'_, Cache>,
+) -> Result<serde_json::Value, NimbusError> {
+    let status = link_check::status(&cache).map_err(NimbusError::from)?;
+    let lookup = link_check::lookup(&cache, &url).map_err(NimbusError::from)?;
+    let host_count = link_check::host_count_for_url(&cache, &url).map_err(NimbusError::from)?;
+    let host = url
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(&url)
+        .split(['/', '?', '#', ':'])
+        .next()
+        .unwrap_or("")
+        .to_lowercase();
+    Ok(serde_json::json!({
+        "url": url,
+        "extractedHost": host,
+        "snapshotTotal": status.total_urls,
+        "lastRefreshedAt": status.last_refreshed_at,
+        "hostUrlCount": host_count,
+        "lookupResult": lookup,
+    }))
+}
+
+#[tauri::command]
 fn check_urls(
     urls: Vec<String>,
     cache: State<'_, Cache>,
@@ -9624,6 +9650,7 @@ fn main() {
             nc_restore_settings_bundle,
             // Issue #165: URLhaus link safety.
             check_urls,
+            debug_link_check,
             get_link_check_status,
             refresh_urlhaus_now,
             set_logo_style,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8572,7 +8572,22 @@ async fn check_mail_now(app: AppHandle) -> Result<(), NimbusError> {
 //     previous snapshot so a transient outage at abuse.ch
 //     doesn't wipe the list.
 
-const URLHAUS_CSV_URL: &str = "https://urlhaus.abuse.ch/downloads/csv_online/";
+// URLhaus exposes three feed sizes:
+//   - `csv_online`  — currently-active malicious URLs only (~10-20k)
+//   - `csv_recent`  — last 30 days, online + offline (~30k)
+//   - `csv`         — full historical dump (~5M, ~500MB)
+//
+// `csv_online` is too narrow for email use: malware infrastructure
+// usually goes offline within hours of being identified, so a URL
+// the user copied from the URLhaus website is more often than not
+// already missing from `csv_online` even though URLhaus publicly
+// shows it as a known-bad URL.  `csv_recent` covers the practical
+// "this URL has been flagged in the last month" case at a quarter
+// the storage size of going to the full dump.  Anything older than
+// 30 days that's not also currently online drops off the local
+// snapshot — acceptable trade-off for a 30k-row hourly refresh
+// vs. a 5M-row monthly download.
+const URLHAUS_CSV_URL: &str = "https://urlhaus.abuse.ch/downloads/csv_recent/";
 
 /// Verdict surfaced to the frontend per URL.  `safe` means the
 /// URL didn't match anything in URLhaus; `unsafe` means there

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -448,6 +448,11 @@
     /** #190: when true, `ui_locale` is ignored and paraglide
      *  picks from `navigator.language` on launch. */
     ui_locale_auto?: boolean
+    /** #165 master toggle for the URLhaus link checker.  When
+     *  true, every link in a rendered email gets a green / red
+     *  safety pill and unsafe clicks confirm.  When false,
+     *  links open without interception. */
+    link_check_enabled?: boolean
   }
   type CustomTheme = {
     id: string
@@ -1738,6 +1743,7 @@
         uid={selectedUid}
         forceWhiteBackground={appPrefs?.mail_html_white_background ?? true}
         autoLoadRemoteImages={appPrefs?.auto_load_remote_images ?? false}
+        linkCheckEnabled={appPrefs?.link_check_enabled ?? true}
         onread={onMessageRead}
         onreply={onReply}
         onreplyall={onReplyAll}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1321,7 +1321,7 @@
                 · {linkCheckStatus.totalUrls.toLocaleString()} URLs in local snapshot
                 <button
                   type="button"
-                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5 ml-2 text-white!"
+                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5 ml-2"
                   disabled={linkCheckRefreshing}
                   onclick={() => void onRefreshUrlhausNow()}
                 >

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1321,10 +1321,13 @@
                 · {linkCheckStatus.totalUrls.toLocaleString()} URLs in local snapshot
                 <button
                   type="button"
-                  class="btn btn-sm preset-outlined-surface-500 ml-2"
+                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5 ml-2"
                   disabled={linkCheckRefreshing}
                   onclick={() => void onRefreshUrlhausNow()}
-                >{linkCheckRefreshing ? 'Refreshing…' : 'Refresh now'}</button>
+                >
+                  <Icon name={linkCheckRefreshing ? 'loading' : 'sync'} size={14} />
+                  {linkCheckRefreshing ? 'Refreshing…' : 'Refresh now'}
+                </button>
               </p>
             {/if}
           </div>

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -180,6 +180,14 @@
     mail_html_white_background: boolean
     auto_load_remote_images: boolean
     auto_advance_after_remove: boolean
+    /** #165 master toggle for the URLhaus link checker.
+     *  Off → no pills, no click interception, refresh worker
+     *  sleeps.  On (default) → links in rendered email show
+     *  green / red safety pills and unsafe clicks confirm.
+     *  Always present once `loadAppSettings` returns (the Rust
+     *  side serialises it with a default), so the type is
+     *  required even though older bundle files may lack it. */
+    link_check_enabled: boolean
     default_calendar_id: string | null
     /** Reminders for events that carry a meeting URL (Talk /
      *  Zoom / Meet / Teams / Jitsi / …).  #203 renamed from
@@ -227,6 +235,7 @@
     mail_html_white_background: true,
     auto_load_remote_images: false,
     auto_advance_after_remove: true,
+    link_check_enabled: true,
     default_calendar_id: null,
     meeting_reminders_enabled: true,
     calendar_reminders_enabled: true,
@@ -315,6 +324,47 @@
   let calendarsForPicker = $state<CalendarRow[]>([])
   let prefsSaveStatus = $state<'' | 'saving' | 'saved' | 'error'>('')
   let checkNowBusy = $state(false)
+
+  // ── Link-check status (#165) ─────────────────────────────────
+  // Surfaced under Settings → E-Mail next to the toggle.  Two
+  // pieces of state: the snapshot status (count + last refresh
+  // timestamp) and a busy flag for the manual "Refresh now"
+  // button so it can show a spinner-ish disabled state.
+  interface LinkCheckStatus {
+    totalUrls: number
+    lastRefreshedAt: string | null
+  }
+  let linkCheckStatus = $state<LinkCheckStatus>({ totalUrls: 0, lastRefreshedAt: null })
+  let linkCheckRefreshing = $state(false)
+  async function loadLinkCheckStatus() {
+    try {
+      linkCheckStatus = await invoke<LinkCheckStatus>('get_link_check_status')
+    } catch (e) {
+      console.warn('get_link_check_status failed', e)
+    }
+  }
+  async function onRefreshUrlhausNow() {
+    if (linkCheckRefreshing) return
+    linkCheckRefreshing = true
+    try {
+      await invoke('refresh_urlhaus_now')
+      await loadLinkCheckStatus()
+    } catch (e) {
+      console.warn('refresh_urlhaus_now failed', e)
+    } finally {
+      linkCheckRefreshing = false
+    }
+  }
+  function formatRefreshAge(ts: string | null): string {
+    if (!ts) return 'Never'
+    const then = new Date(ts).getTime()
+    if (!Number.isFinite(then)) return 'Unknown'
+    const ageSec = Math.max(0, (Date.now() - then) / 1000)
+    if (ageSec < 60) return 'Just now'
+    if (ageSec < 3600) return `${Math.floor(ageSec / 60)} min ago`
+    if (ageSec < 86_400) return `${Math.floor(ageSec / 3600)} h ago`
+    return `${Math.floor(ageSec / 86_400)} d ago`
+  }
 
   // ── Backup & Sync (#168) ─────────────────────────────────────
   // State for the Backup & Sync category panel.  The dropdown
@@ -431,6 +481,7 @@
     loadCalendarsForPicker()
     loadSyncState()
     loadNcOptions()
+    loadLinkCheckStatus()
   })
 
   async function loadCalendarsForPicker() {
@@ -1236,6 +1287,46 @@
               Off (default) blocks remote images and shows a "Show images" banner per message — protects against tracking pixels.
               On loads every image automatically and hides the banner.
             </p>
+          </div>
+        </div>
+
+        <!-- #165 — URLhaus link checker.  When on, every link in
+             a rendered email gets a green "Safe" / red "Unsafe"
+             pill, and a click on an Unsafe link goes through a
+             confirm modal in MailView.  When off, links open
+             without interception and the pills are suppressed. -->
+        <div class="flex items-start gap-3">
+          <Toggle
+            bind:checked={appSettings.link_check_enabled}
+            label="Check links against URLhaus"
+            onchange={() => scheduleSave()}
+          />
+          <div class="flex-1">
+            <span>Check links against URLhaus</span>
+            <p class="text-xs text-surface-400 mt-0.5">
+              Looks up every link in a received mail against
+              <a
+                href="https://urlhaus.abuse.ch/"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-primary-500 underline"
+              >abuse.ch's URLhaus</a> malicious-URL list. Marks safe links
+              with a green pill and unsafe ones with a red pill; clicking an
+              unsafe link asks before opening. The list is downloaded over
+              HTTPS once an hour with no per-user identifiers.
+            </p>
+            {#if appSettings.link_check_enabled}
+              <p class="text-xs text-surface-500 mt-2">
+                Last refreshed: <strong>{formatRefreshAge(linkCheckStatus.lastRefreshedAt)}</strong>
+                · {linkCheckStatus.totalUrls.toLocaleString()} URLs in local snapshot
+                <button
+                  type="button"
+                  class="btn btn-sm preset-outlined-surface-500 ml-2"
+                  disabled={linkCheckRefreshing}
+                  onclick={() => void onRefreshUrlhausNow()}
+                >{linkCheckRefreshing ? 'Refreshing…' : 'Refresh now'}</button>
+              </p>
+            {/if}
           </div>
         </div>
 

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1321,7 +1321,7 @@
                 · {linkCheckStatus.totalUrls.toLocaleString()} URLs in local snapshot
                 <button
                   type="button"
-                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5 ml-2"
+                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5 ml-2 text-white!"
                   disabled={linkCheckRefreshing}
                   onclick={() => void onRefreshUrlhausNow()}
                 >

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1316,19 +1316,29 @@
               HTTPS once an hour with no per-user identifiers.
             </p>
             {#if appSettings.link_check_enabled}
-              <p class="text-xs text-surface-500 mt-2">
-                Last refreshed: <strong>{formatRefreshAge(linkCheckStatus.lastRefreshedAt)}</strong>
-                · {linkCheckStatus.totalUrls.toLocaleString()} URLs in local snapshot
+              <!-- Wrapping <div> instead of <p> so the
+                   `text-surface-500` on the status line stays
+                   on the status line and doesn't cascade into
+                   the button via `currentColor` — Skeleton's
+                   outlined preset paints the label in
+                   `currentColor`, so a parent `text-*` class
+                   would otherwise override the theme's
+                   primary-on colour and give us grey text. -->
+              <div class="flex flex-wrap items-center gap-2 mt-2">
+                <span class="text-xs text-surface-500">
+                  Last refreshed: <strong>{formatRefreshAge(linkCheckStatus.lastRefreshedAt)}</strong>
+                  · {linkCheckStatus.totalUrls.toLocaleString()} URLs in local snapshot
+                </span>
                 <button
                   type="button"
-                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5 ml-2"
+                  class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5"
                   disabled={linkCheckRefreshing}
                   onclick={() => void onRefreshUrlhausNow()}
                 >
                   <Icon name={linkCheckRefreshing ? 'loading' : 'sync'} size={14} />
                   {linkCheckRefreshing ? 'Refreshing…' : 'Refresh now'}
                 </button>
-              </p>
+              </div>
             {/if}
           </div>
         </div>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -691,17 +691,27 @@
    *  round-trip anyway). */
   $effect(() => {
     if (!email || !processedHtml.html) {
+      console.debug('[link-check] skip: no body', {
+        hasEmail: !!email,
+        hasHtml: !!processedHtml.html,
+      })
       linkVerdicts = {}
       lastCheckedEmailId = null
       return
     }
     if (!linkCheckEnabled) {
+      console.debug('[link-check] skip: master toggle off')
       linkVerdicts = {}
       return
     }
-    if (lastCheckedEmailId === email.id) return
+    if (lastCheckedEmailId === email.id) {
+      console.debug('[link-check] skip: already checked this message', email.id)
+      return
+    }
     const urls = extractCheckableUrls(processedHtml.html)
+    console.debug('[link-check] extracted URLs:', urls)
     if (urls.length === 0) {
+      console.debug('[link-check] no http(s) anchors in body — done')
       linkVerdicts = {}
       lastCheckedEmailId = email.id
       return
@@ -713,13 +723,14 @@
         // message before it landed — annotating a stale email
         // would paint pills on the wrong body.
         if (email?.id !== expectedId) return
+        console.debug('[link-check] verdicts:', rows)
         const map: Record<string, LinkVerdict> = {}
         for (const r of rows) map[r.url] = r
         linkVerdicts = map
         lastCheckedEmailId = expectedId
       })
       .catch((e) => {
-        console.warn('check_urls failed', e)
+        console.warn('[link-check] check_urls failed', e)
       })
   })
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -103,6 +103,12 @@
         the "Remote images are blocked" banner doesn't appear.
         Trades the privacy default for convenience. */
     autoLoadRemoteImages?: boolean
+    /** App-wide master toggle (#165) for the URLhaus link
+     *  checker.  When true, every link in the rendered body
+     *  gets a green "Safe" / red "Unsafe" pill, and clicks on
+     *  unsafe links go through a confirm modal.  When false,
+     *  links open without interception. */
+    linkCheckEnabled?: boolean
     /** True when this `MailView` is the root of a popped-out
         standalone window (#104).  Hides the "Open in window"
         button (no point inside the window it would open) and
@@ -136,6 +142,7 @@
     inStandaloneWindow = false,
     forceWhiteBackground = true,
     autoLoadRemoteImages = false,
+    linkCheckEnabled = true,
     onmailto,
     refreshing = $bindable(false),
   }: Props = $props()
@@ -542,6 +549,175 @@
     )
   })
 
+  // ── URLhaus link safety (#165) ───────────────────────────────────────
+  //
+  // Two-pass render.  Pass 1 (`processedHtml` above) is synchronous and
+  // gives us the sanitised HTML immediately.  Pass 2 walks that HTML for
+  // <a href> nodes, batches them into one `check_urls` IPC, and produces
+  // an annotated HTML string with green / red pills inserted next to
+  // each link.  Until pass 2 completes the user sees the sanitised body
+  // *without* pills — never with a flash of the wrong colour.
+  //
+  // Verdicts are cached per message-id so re-opening the same message
+  // doesn't re-run the lookup; the cache is cleared whenever `email`
+  // changes to a different id.
+
+  interface LinkVerdict {
+    url: string
+    /** `'safe'` | `'unsafe'` | `'off'` (the master toggle is off). */
+    verdict: 'safe' | 'unsafe' | 'off'
+    threat: string | null
+    tags: string | null
+    exact: boolean
+  }
+  let linkVerdicts = $state<Record<string, LinkVerdict>>({})
+  let lastCheckedEmailId = $state<string | null>(null)
+
+  /** Walk the processed HTML, harvest every distinct http(s) URL,
+   *  and ask the backend for a verdict per URL.  Skips when the
+   *  master toggle is off (the IPC short-circuits but we save a
+   *  round-trip anyway). */
+  $effect(() => {
+    if (!email || !processedHtml.html) {
+      linkVerdicts = {}
+      lastCheckedEmailId = null
+      return
+    }
+    if (!linkCheckEnabled) {
+      linkVerdicts = {}
+      return
+    }
+    if (lastCheckedEmailId === email.id) return
+    const urls = extractCheckableUrls(processedHtml.html)
+    if (urls.length === 0) {
+      linkVerdicts = {}
+      lastCheckedEmailId = email.id
+      return
+    }
+    const expectedId = email.id
+    void invoke<LinkVerdict[]>('check_urls', { urls })
+      .then((rows) => {
+        // Drop the response if the user moved on to a different
+        // message before it landed — annotating a stale email
+        // would paint pills on the wrong body.
+        if (email?.id !== expectedId) return
+        const map: Record<string, LinkVerdict> = {}
+        for (const r of rows) map[r.url] = r
+        linkVerdicts = map
+        lastCheckedEmailId = expectedId
+      })
+      .catch((e) => {
+        console.warn('check_urls failed', e)
+      })
+  })
+
+  function extractCheckableUrls(html: string): string[] {
+    const seen = new Set<string>()
+    const out: string[] = []
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+    doc.querySelectorAll('a[href]').forEach((a) => {
+      const href = (a.getAttribute('href') ?? '').trim()
+      const lower = href.toLowerCase()
+      if (!lower.startsWith('http://') && !lower.startsWith('https://')) return
+      if (seen.has(href)) return
+      seen.add(href)
+      out.push(href)
+    })
+    return out
+  }
+
+  /** Inject pill spans next to each <a href> based on the verdict
+   *  map.  When the master toggle is off (or no verdicts have
+   *  arrived yet) returns the input verbatim — no pills. */
+  function annotateLinkPills(
+    html: string,
+    verdicts: Record<string, LinkVerdict>,
+  ): string {
+    if (Object.keys(verdicts).length === 0) return html
+    try {
+      const doc = new DOMParser().parseFromString(html, 'text/html')
+      doc.querySelectorAll('a[href]').forEach((a) => {
+        const href = (a.getAttribute('href') ?? '').trim()
+        const v = verdicts[href]
+        if (!v || v.verdict === 'off') return
+        // Style is intentionally inline so it survives a future
+        // Tailwind purge of class names that don't appear in any
+        // .svelte file directly.  Pills sit immediately before
+        // the link, separated by a thin no-break space so they
+        // visually attach to the URL they describe.
+        const pill = doc.createElement('span')
+        pill.setAttribute('data-nimbus-link-pill', v.verdict)
+        if (v.verdict === 'unsafe') {
+          pill.style.cssText =
+            'display:inline-block;font-size:0.7rem;font-weight:600;' +
+            'padding:0.1rem 0.4rem;margin-right:0.25rem;border-radius:9999px;' +
+            'background:#dc2626;color:#fff;vertical-align:middle;'
+          pill.textContent = 'Unsafe'
+          if (v.threat) {
+            pill.title = v.exact
+              ? `URLhaus flagged this URL — threat: ${v.threat}`
+              : `URLhaus has flagged other URLs on this domain — threat: ${v.threat}`
+          }
+          // Mark the anchor so the click handler knows to
+          // intercept and show the confirm modal.
+          a.setAttribute('data-nimbus-unsafe-link', '1')
+          if (v.threat) a.setAttribute('data-nimbus-threat', v.threat)
+          if (v.exact) a.setAttribute('data-nimbus-link-exact', '1')
+        } else {
+          // Safe pill stays understated — a green dot pill so it
+          // doesn't draw the eye away from the actual content.
+          pill.style.cssText =
+            'display:inline-block;font-size:0.7rem;font-weight:600;' +
+            'padding:0.1rem 0.4rem;margin-right:0.25rem;border-radius:9999px;' +
+            'background:#16a34a;color:#fff;vertical-align:middle;'
+          pill.textContent = 'Safe'
+          pill.title = 'No known threat indicators on URLhaus'
+        }
+        a.parentNode?.insertBefore(pill, a)
+      })
+      return doc.body.innerHTML
+    } catch (e) {
+      console.warn('annotateLinkPills failed', e)
+      return html
+    }
+  }
+
+  let annotatedHtml = $derived(
+    !linkCheckEnabled || Object.keys(linkVerdicts).length === 0
+      ? processedHtml.html
+      : annotateLinkPills(processedHtml.html, linkVerdicts),
+  )
+
+  /** State for the "Unsafe link clicked" confirm modal.  When
+   *  non-null, MailView paints the modal over the reading pane
+   *  with two actions: Delete mail (move to Trash) and Open link
+   *  anyway.  Esc / outside-click cancel. */
+  let unsafeLinkPrompt = $state<
+    { url: string; threat: string | null; exact: boolean } | null
+  >(null)
+
+  async function onUnsafeLinkOpenAnyway() {
+    if (!unsafeLinkPrompt) return
+    const url = unsafeLinkPrompt.url
+    unsafeLinkPrompt = null
+    try {
+      await invoke('open_url', { url })
+    } catch (e) {
+      console.warn('open_url failed', e)
+    }
+  }
+  async function onUnsafeLinkDeleteMail() {
+    unsafeLinkPrompt = null
+    if (!email) return
+    // Soft delete via the existing toolbar path — moves the
+    // message to Trash so a misclick is recoverable.
+    try {
+      await deleteMessage()
+    } catch (e) {
+      console.warn('delete after unsafe-link prompt failed', e)
+    }
+  }
+
   // ── Click handling for the inline HTML body div ───────────────────────
   //
   // cid: links open the matching attachment (same as before).
@@ -633,6 +809,23 @@
       e.stopPropagation()
       const init = parseMailtoUrl(href)
       onmailto?.(init)
+      return
+    }
+    // #165 — URLhaus-flagged links go through a confirm modal
+    // instead of opening straight to the system browser.  The
+    // anchor is tagged with `data-nimbus-unsafe-link` by
+    // `annotateLinkPills` only when the verdict came back
+    // 'unsafe' (and the master toggle is on), so a missing
+    // attribute is the safe / off path that keeps the original
+    // open-in-browser behaviour.
+    if (anchor.hasAttribute('data-nimbus-unsafe-link')) {
+      e.preventDefault()
+      e.stopPropagation()
+      unsafeLinkPrompt = {
+        url: href,
+        threat: anchor.getAttribute('data-nimbus-threat'),
+        exact: anchor.hasAttribute('data-nimbus-link-exact'),
+      }
       return
     }
     e.preventDefault()
@@ -1530,7 +1723,7 @@
           aria-label="Email body"
           onclick={onBodyClick}
         >
-          {@html processedHtml.html}
+          {@html annotatedHtml}
         </div>
       {:else if email.body_text}
         <!-- Plain-text fallback for messages without an HTML part. -->
@@ -1562,5 +1755,63 @@
       onpicked={(name) => void moveToFolder(name)}
       onclose={() => (moveMenuOpen = false)}
     />
+  {/if}
+
+  <!-- #165 — confirm modal shown when the user clicks an
+       URLhaus-flagged link.  Two primary actions, plus an
+       implicit Cancel via Escape / outside-click.  Soft delete
+       (move to Trash) so a misclick is recoverable. -->
+  {#if unsafeLinkPrompt}
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      onmousedown={(e) => {
+        if (e.target === e.currentTarget) unsafeLinkPrompt = null
+      }}
+      onkeydown={(e) => {
+        if (e.key === 'Escape') unsafeLinkPrompt = null
+      }}
+    >
+      <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-md max-w-full mx-4 p-6 space-y-4">
+        <div class="flex items-start gap-3">
+          <span class="text-2xl" aria-hidden="true">⚠️</span>
+          <div class="flex-1 min-w-0">
+            <h3 class="text-base font-semibold">This link is on URLhaus</h3>
+            <p class="text-sm text-surface-600 dark:text-surface-300 mt-1">
+              {#if unsafeLinkPrompt.exact}
+                The exact URL has been flagged as malicious.
+              {:else}
+                Other URLs on this domain have been flagged as malicious — this specific URL isn't on the list, but the domain has hosted malware before.
+              {/if}
+              {#if unsafeLinkPrompt.threat}
+                <br>Threat: <code>{unsafeLinkPrompt.threat}</code>
+              {/if}
+            </p>
+            <p class="text-xs text-surface-500 mt-2 break-all">
+              <strong>URL:</strong> {unsafeLinkPrompt.url}
+            </p>
+          </div>
+        </div>
+        <div class="flex flex-wrap gap-2 justify-end">
+          <button
+            type="button"
+            class="btn preset-outlined-surface-500"
+            onclick={() => (unsafeLinkPrompt = null)}
+          >Cancel</button>
+          <button
+            type="button"
+            class="btn preset-outlined-error-500"
+            onclick={() => void onUnsafeLinkDeleteMail()}
+          >Delete mail</button>
+          <button
+            type="button"
+            class="btn preset-filled-warning-500"
+            onclick={() => void onUnsafeLinkOpenAnyway()}
+          >Open link anyway</button>
+        </div>
+      </div>
+    </div>
   {/if}
 </main>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -467,6 +467,75 @@
   const BLOCKED_IMG_PLACEHOLDER =
     'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 
+  /** Walk the body's text nodes and replace any naked http(s)
+   *  URL with an `<a href>` so the link-check pass picks it up
+   *  and so the user gets a clickable target (matches the
+   *  behaviour of every modern mail client).  Skips text inside
+   *  existing `<a>`, `<script>`, or `<style>` so we never
+   *  nest anchors or rewrite code samples.  Trailing common
+   *  punctuation (`.`, `,`, `)`, etc.) is stripped from the
+   *  match so "see https://example.com." doesn't promote the
+   *  sentence-final period into part of the URL. */
+  function autolinkPlainTextUrls(doc: Document) {
+    const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        let p: Node | null = node.parentNode
+        while (p) {
+          if (p.nodeType === Node.ELEMENT_NODE) {
+            const tag = (p as Element).tagName.toLowerCase()
+            if (tag === 'a' || tag === 'script' || tag === 'style') {
+              return NodeFilter.FILTER_REJECT
+            }
+          }
+          p = p.parentNode
+        }
+        // `RegExp.test` mutates `lastIndex` on /g regexes, so
+        // build a non-global probe just for the filter.
+        return /https?:\/\/[^\s<>"]/i.test(node.textContent ?? '')
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_REJECT
+      },
+    })
+    const targets: Text[] = []
+    let n: Node | null
+    while ((n = walker.nextNode())) targets.push(n as Text)
+    if (targets.length === 0) return
+
+    const urlRe = /(https?:\/\/[^\s<>"]+)/g
+    for (const text of targets) {
+      const content = text.textContent ?? ''
+      urlRe.lastIndex = 0
+      const fragment = doc.createDocumentFragment()
+      let lastIndex = 0
+      let match: RegExpExecArray | null
+      while ((match = urlRe.exec(content)) !== null) {
+        let url = match[0]
+        let trailing = ''
+        while (url.length > 0 && /[.,;:!?)\]]/.test(url[url.length - 1])) {
+          trailing = url[url.length - 1] + trailing
+          url = url.slice(0, -1)
+        }
+        if (url.length === 0) continue
+        const start = match.index
+        if (start > lastIndex) {
+          fragment.appendChild(doc.createTextNode(content.slice(lastIndex, start)))
+        }
+        const a = doc.createElement('a')
+        a.setAttribute('href', url)
+        a.setAttribute('target', '_blank')
+        a.setAttribute('rel', 'noopener noreferrer')
+        a.textContent = url
+        fragment.appendChild(a)
+        if (trailing) fragment.appendChild(doc.createTextNode(trailing))
+        lastIndex = start + url.length + trailing.length
+      }
+      if (lastIndex < content.length) {
+        fragment.appendChild(doc.createTextNode(content.slice(lastIndex)))
+      }
+      text.parentNode?.replaceChild(fragment, text)
+    }
+  }
+
   function processEmailHtml(
     html: string,
     showImages: boolean,
@@ -497,6 +566,18 @@
       })
 
       const doc = new DOMParser().parseFromString(clean, 'text/html')
+
+      // Auto-link plain-text URLs (#165 follow-up).  Many
+      // senders put a URL straight into their message body as
+      // plain text — Tiptap before its `autolink` config, most
+      // CLI mailers, and any hand-written HTML that just embeds
+      // the URL without wrapping it in <a>.  Without this pass
+      // those URLs render as text and bypass the URLhaus link
+      // check entirely (the extractor only walks `<a[href]>`).
+      // We also annotate cid: / mailto: text-URLs?  No — only
+      // http(s), since those are what URLhaus catalogues and
+      // what the open-in-browser path handles.
+      autolinkPlainTextUrls(doc)
 
       // Annotate links with tooltip + handle cid: anchors
       doc.querySelectorAll('a[href]').forEach((a) => {

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -623,12 +623,43 @@
 
   // Recompute whenever the email body, per-message toggle, or trust state changes.
   let processedHtml = $derived.by(() => {
-    if (!email?.body_html) return { html: '', hadBlocked: false }
-    return processEmailHtml(
-      email.body_html,
-      showImagesForMessage || trustedSender || autoLoadRemoteImages,
-    )
+    if (email?.body_html) {
+      return processEmailHtml(
+        email.body_html,
+        showImagesForMessage || trustedSender || autoLoadRemoteImages,
+      )
+    }
+    // Plain-text-only message — synthesize a minimal HTML
+    // wrapper so the same DOMPurify → auto-link → URLhaus
+    // check → click-handler pipeline applies.  Without this
+    // path, plain-text URLs would render unchecked and clicks
+    // would bypass the unsafe-link confirm modal entirely
+    // (#165 follow-up).  We HTML-escape first so any literal
+    // `<` / `&` in the user's body stays as text rather than
+    // being interpreted as markup.
+    if (email?.body_text) {
+      const wrapped = `<pre style="white-space: pre-wrap; font-family: inherit; margin: 0;">${escapeHtmlForPre(email.body_text)}</pre>`
+      return processEmailHtml(
+        wrapped,
+        showImagesForMessage || trustedSender || autoLoadRemoteImages,
+      )
+    }
+    return { html: '', hadBlocked: false }
   })
+
+  /** Minimal HTML escape for the plain-text → HTML wrapper.
+   *  We don't run user-supplied HTML through this — the body
+   *  goes straight to DOMPurify after wrapping — but we still
+   *  need to escape `<`, `>`, `&`, `"` so a plain-text body
+   *  containing the literal sequence "<script>" doesn't get
+   *  interpreted as markup before DOMPurify can sanitise it. */
+  function escapeHtmlForPre(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+  }
 
   // ── URLhaus link safety (#165) ───────────────────────────────────────
   //
@@ -1769,7 +1800,7 @@
          brand styles). DOMPurify + remote-image blocking make this
          safe; we fall back to plain text only when no HTML part exists. -->
     <div class="flex-1 overflow-y-auto">
-      {#if email.body_html}
+      {#if processedHtml.html}
         <!-- Image-blocking banner — only visible when at least one remote
              image was replaced with a placeholder and the user hasn't opted
              in for this message or trusted this sender. -->
@@ -1807,7 +1838,13 @@
           {@html annotatedHtml}
         </div>
       {:else if email.body_text}
-        <!-- Plain-text fallback for messages without an HTML part. -->
+        <!-- This branch is now reachable only when the
+             plain-text body fed through processEmailHtml above
+             produced an empty result for some reason (e.g.
+             DOMPurify nuked a particularly weird wrapper).
+             Falls back to the raw text so the message still
+             reads — at the cost of skipping the URLhaus check
+             for that specific malformed case. -->
         <pre class="whitespace-pre-wrap font-sans text-sm p-6">{email.body_text}</pre>
       {:else}
         <p class="text-sm text-surface-500 p-6">(This message has no visible body.)</p>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -691,59 +691,35 @@
    *  round-trip anyway). */
   $effect(() => {
     if (!email || !processedHtml.html) {
-      console.log('[link-check] skip: no body', {
-        hasEmail: !!email,
-        hasHtml: !!processedHtml.html,
-      })
       linkVerdicts = {}
       lastCheckedEmailId = null
       return
     }
     if (!linkCheckEnabled) {
-      console.log('[link-check] skip: master toggle off')
       linkVerdicts = {}
       return
     }
-    if (lastCheckedEmailId === email.id) {
-      console.log('[link-check] skip: already checked this message', email.id)
-      return
-    }
+    if (lastCheckedEmailId === email.id) return
     const urls = extractCheckableUrls(processedHtml.html)
-    console.log('[link-check] extracted URLs:', urls)
     if (urls.length === 0) {
-      console.log('[link-check] no http(s) anchors in body — done')
       linkVerdicts = {}
       lastCheckedEmailId = email.id
       return
     }
     const expectedId = email.id
     void invoke<LinkVerdict[]>('check_urls', { urls })
-      .then(async (rows) => {
+      .then((rows) => {
         // Drop the response if the user moved on to a different
         // message before it landed — annotating a stale email
         // would paint pills on the wrong body.
         if (email?.id !== expectedId) return
-        console.log('[link-check] verdicts:', rows)
         const map: Record<string, LinkVerdict> = {}
         for (const r of rows) map[r.url] = r
         linkVerdicts = map
         lastCheckedEmailId = expectedId
-        // Diagnostic: when the verdict is 'safe' but the user
-        // has reason to suspect otherwise, dump the snapshot
-        // total + per-host count so we can tell "URLhaus has
-        // no entry for this URL" apart from "the snapshot is
-        // empty / our matching is broken".
-        for (const r of rows.filter((x) => x.verdict === 'safe')) {
-          try {
-            const detail = await invoke('debug_link_check', { url: r.url })
-            console.log('[link-check] debug for', r.url, detail)
-          } catch (e) {
-            console.warn('[link-check] debug_link_check failed', e)
-          }
-        }
       })
       .catch((e) => {
-        console.warn('[link-check] check_urls failed', e)
+        console.warn('check_urls failed', e)
       })
   })
 
@@ -1949,7 +1925,7 @@
           >Delete mail</button>
           <button
             type="button"
-            class="btn preset-filled-warning-500"
+            class="btn preset-filled-error-500"
             onclick={() => void onUnsafeLinkOpenAnyway()}
           >Open link anyway</button>
         </div>

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -691,7 +691,7 @@
    *  round-trip anyway). */
   $effect(() => {
     if (!email || !processedHtml.html) {
-      console.debug('[link-check] skip: no body', {
+      console.log('[link-check] skip: no body', {
         hasEmail: !!email,
         hasHtml: !!processedHtml.html,
       })
@@ -700,18 +700,18 @@
       return
     }
     if (!linkCheckEnabled) {
-      console.debug('[link-check] skip: master toggle off')
+      console.log('[link-check] skip: master toggle off')
       linkVerdicts = {}
       return
     }
     if (lastCheckedEmailId === email.id) {
-      console.debug('[link-check] skip: already checked this message', email.id)
+      console.log('[link-check] skip: already checked this message', email.id)
       return
     }
     const urls = extractCheckableUrls(processedHtml.html)
-    console.debug('[link-check] extracted URLs:', urls)
+    console.log('[link-check] extracted URLs:', urls)
     if (urls.length === 0) {
-      console.debug('[link-check] no http(s) anchors in body — done')
+      console.log('[link-check] no http(s) anchors in body — done')
       linkVerdicts = {}
       lastCheckedEmailId = email.id
       return
@@ -723,7 +723,7 @@
         // message before it landed — annotating a stale email
         // would paint pills on the wrong body.
         if (email?.id !== expectedId) return
-        console.debug('[link-check] verdicts:', rows)
+        console.log('[link-check] verdicts:', rows)
         const map: Record<string, LinkVerdict> = {}
         for (const r of rows) map[r.url] = r
         linkVerdicts = map

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -718,7 +718,7 @@
     }
     const expectedId = email.id
     void invoke<LinkVerdict[]>('check_urls', { urls })
-      .then((rows) => {
+      .then(async (rows) => {
         // Drop the response if the user moved on to a different
         // message before it landed — annotating a stale email
         // would paint pills on the wrong body.
@@ -728,6 +728,19 @@
         for (const r of rows) map[r.url] = r
         linkVerdicts = map
         lastCheckedEmailId = expectedId
+        // Diagnostic: when the verdict is 'safe' but the user
+        // has reason to suspect otherwise, dump the snapshot
+        // total + per-host count so we can tell "URLhaus has
+        // no entry for this URL" apart from "the snapshot is
+        // empty / our matching is broken".
+        for (const r of rows.filter((x) => x.verdict === 'safe')) {
+          try {
+            const detail = await invoke('debug_link_check', { url: r.url })
+            console.log('[link-check] debug for', r.url, detail)
+          } catch (e) {
+            console.warn('[link-check] debug_link_check failed', e)
+          }
+        }
       })
       .catch((e) => {
         console.warn('[link-check] check_urls failed', e)

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -417,6 +417,12 @@
         },
       }).configure({
         openOnClick: false,
+        // Auto-promote pasted / typed URLs into real anchors so
+        // the receiving side's URLhaus check (#165) sees them
+        // as `<a href>` rather than plain text — and so the
+        // sender benefits from the same hover-tooltip behaviour
+        // we add for explicitly-inserted links.
+        autolink: true,
         HTMLAttributes: { target: '_blank', rel: 'noopener noreferrer' },
       }),
       // Image extended with drag-to-resize. A plain `<img>` doesn't

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -394,6 +394,13 @@
         // one undo unit — Ctrl-Z then undoes a word (not a single
         // character), which is what every modern editor does.
         undoRedo: { newGroupDelay: 500 },
+        // StarterKit ships its own Link + Underline; disable
+        // them so the explicit `Link.extend(...)` and the
+        // standalone `Underline` import below don't register a
+        // second copy ("Duplicate extension names found:
+        // ['link', 'underline']" in the console).
+        link: false,
+        underline: false,
       }),
       Underline,
       // Extend the Link mark so every rendered <a> carries a `title`


### PR DESCRIPTION
## Summary

Closes #165.  Adds a privacy-preserving "is this link malicious?" check on every link in received HTML mail, backed by [abuse.ch's URLhaus](https://urlhaus.abuse.ch/) feed.

### How it works

- **Local snapshot.**  Background worker refreshes `https://urlhaus.abuse.ch/downloads/csv_online/` every hour over HTTPS, parses the CSV, and replaces a `urlhaus_urls` table inside the encrypted SQLCipher cache in one transaction.  No per-user identifiers leave the machine — every link lookup is offline.  Initial refresh fires on launch if the snapshot is empty or older than 24 h; a "Refresh now" button in Settings → E-Mail covers the manual case.
- **Render-time scan.**  After MailView's existing DOMPurify pass, the rendered HTML's `<a href>` URLs are batched into one `check_urls` IPC.  Verdicts come back asynchronously and trigger a re-render with green **"Safe"** / red **"Unsafe"** pills inserted inline before each link.  Verdicts are cached per message-id so re-opens don't re-scan.  Hybrid: scan when opening, results cached.
- **Click-time confirm modal.**  Clicking an Unsafe link is intercepted: a modal with **Cancel**, **Delete mail** (soft delete → Trash), and **Open link anyway** replaces the direct `open_url`.  Safe links open without interception.  Esc / outside-click cancel.

### Settings

New row under Settings → E-Mail: master toggle "Check links against URLhaus" (default on), live "Last refreshed N ago" + URL count line, plus a "Refresh now" button.  Off suppresses pills, click interception, and the background refresh.

### Schema + licensing

- Migration adds `urlhaus_urls` (PK `url`, indexed `host`) and `urlhaus_meta` tables.
- 6 new unit tests in `nimbus_store::link_check` (host parsing, URL trim, exact + host fallback lookup, status snapshot).  All pass.
- URLhaus is CC0-1.0 — no copyleft cascade.  `SBOM.md` gets a "Runtime data feeds" section; `License.md` gets a CC0-1.0 section reproducing the dedication notice.

## Test plan

- [x] Open Settings → E-Mail.  Toggle "Check links against URLhaus" off and back on.  Click "Refresh now" and verify the URL count + timestamp update.
- [x] Open any HTML email containing links.  Confirm a green "Safe" pill appears before each link after a brief moment (the async verdict pass).
- [ ] Send yourself an email containing a known-malicious URL from URLhaus' current online list (or temporarily insert a known-bad URL into the test database for verification).  Open it; confirm the link is preceded by a red "Unsafe" pill.
- [ ] Click the unsafe link → the confirm modal opens.  Verify all three actions:
   - Cancel → modal closes, no other side-effects.
   - Open link anyway → opens in the system browser.
   - Delete mail → moves the message to Trash via the existing delete flow.
- [ ] Toggle the master switch off; reopen the mail.  Confirm pills disappear and unsafe links open without the modal.
- [ ] Disable network, restart the app.  The cached snapshot still serves verdicts; the background refresh logs a warning but doesn't surface a UI error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)