### PR TITLE
#250: warn when body mentions an attachment but none is attached

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -67,5 +67,9 @@
   "account_setup_cert_probe_failed": "Server-Zertifikat konnte nicht abgerufen werden: {reason}",
   "account_setup_cert_trusting_one": "1 selbst signiertes Zertifikat wird für dieses Konto akzeptiert.",
   "account_setup_cert_trusting_many": "{n} selbst signierte Zertifikate werden für dieses Konto akzeptiert.",
-  "account_setup_save_failed": "Konto konnte nicht gespeichert werden"
+  "account_setup_save_failed": "Konto konnte nicht gespeichert werden",
+
+  "compose_attachment_warning_title": "Sie haben einen Anhang erwähnt, aber keine Datei angehängt.",
+  "compose_attachment_warning_body": "Fügen Sie vor dem Senden eine Datei hinzu oder schließen Sie diese Warnung, falls es ein Fehlalarm ist.",
+  "compose_attachment_warning_dismiss": "Schließen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -67,5 +67,9 @@
   "account_setup_cert_probe_failed": "Could not retrieve the server certificate to display: {reason}",
   "account_setup_cert_trusting_one": "Trusting 1 self-signed certificate for this account.",
   "account_setup_cert_trusting_many": "Trusting {n} self-signed certificates for this account.",
-  "account_setup_save_failed": "Failed to save account"
+  "account_setup_save_failed": "Failed to save account",
+
+  "compose_attachment_warning_title": "You mentioned an attachment but didn't attach a file.",
+  "compose_attachment_warning_body": "Add a file before sending, or dismiss this warning if it's a false alarm.",
+  "compose_attachment_warning_dismiss": "Dismiss"
 }

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -36,6 +36,8 @@
   import FileTypeIcon from './FileTypeIcon.svelte'
   import AttachmentThumb, { prewarm as prewarmAttachmentThumb } from './AttachmentThumb.svelte'
   import { openAttachment } from './attachmentOpen'
+  import { mentionsAttachment } from './attachmentMentions'
+  import { m } from '../paraglide/messages'
   import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
   import { openComposeInStandaloneWindow } from './standaloneComposeWindow'
 
@@ -430,6 +432,37 @@
   // plain text, so we convert newlines to <br> for the WYSIWYG view.
   // svelte-ignore state_referenced_locally
   let bodyHtml = $state(initialBodyHtml())
+
+  // ── Attachment-mention warning (#250) ────────────────────────
+  // When the user writes "attachment" / "Anhang" / "anbei" /
+  // similar in the body but hasn't actually attached a file, we
+  // surface a small warning banner above the editor.  Goes away
+  // automatically once a file is attached, or when the user
+  // dismisses it explicitly.  Per-Compose-instance state — a
+  // fresh draft starts with the dismissal cleared so a previous
+  // draft's "I don't care" doesn't leak across.
+  let attachmentMentionDismissed = $state(false)
+  /** Cheap plain-text projection of `bodyHtml`.  Doesn't go
+   *  through the heavier `htmlToText` we use at submit time —
+   *  this runs on every keystroke, so we just strip tags
+   *  (regex) and rely on the mention detector's own quoted-
+   *  reply strip downstream. */
+  function bodyToPlainTextForMentionCheck(html: string): string {
+    return html
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|li|tr)>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&amp;/gi, '&')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+  }
+  const showAttachmentMentionWarning = $derived(
+    !attachmentMentionDismissed
+      && attachments.length === 0
+      && mentionsAttachment(bodyToPlainTextForMentionCheck(bodyHtml)),
+  )
 
   // Cards (Talk + meeting + quoted-history) all live IN the
   // editor's HTML body (#195 follow-up²). The RichTextEditor's
@@ -1620,6 +1653,29 @@
           extraTabs={composeExtraTabs}
         />
       </div>
+
+      <!-- #250 — gentle "you mentioned an attachment but didn't
+           attach a file" warning.  Hides itself the moment any
+           file is attached; user can also dismiss it explicitly
+           if their mention is intentional (e.g. "as we discussed
+           in the attached PDF I sent earlier"). -->
+      {#if showAttachmentMentionWarning}
+        <div
+          class="flex items-start gap-3 px-3 py-2 rounded-md border border-warning-500/40 bg-warning-500/10 text-sm text-warning-700 dark:text-warning-300"
+          role="alert"
+        >
+          <span aria-hidden="true">⚠️</span>
+          <div class="flex-1 min-w-0">
+            <p class="font-medium">{m.compose_attachment_warning_title()}</p>
+            <p class="text-xs mt-0.5">{m.compose_attachment_warning_body()}</p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-sm preset-outlined-warning-500 shrink-0"
+            onclick={() => (attachmentMentionDismissed = true)}
+          >{m.compose_attachment_warning_dismiss()}</button>
+        </div>
+      {/if}
 
       {#if attachments.length > 0}
         <div class="flex flex-wrap gap-2">

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -442,21 +442,53 @@
   // fresh draft starts with the dismissal cleared so a previous
   // draft's "I don't care" doesn't leak across.
   let attachmentMentionDismissed = $state(false)
-  /** Cheap plain-text projection of `bodyHtml`.  Doesn't go
-   *  through the heavier `htmlToText` we use at submit time —
-   *  this runs on every keystroke, so we just strip tags
-   *  (regex) and rely on the mention detector's own quoted-
-   *  reply strip downstream. */
+  /** Plain-text projection of `bodyHtml` for the mention
+   *  detector.  Two reply-quote shapes have to be removed
+   *  *structurally* before scanning, since neither is "the
+   *  user's own new text" — finding "attached" inside a
+   *  quoted thread we're replying to should never fire the
+   *  warning:
+   *
+   *    1. `<div data-nimbus-block="quoted-history">…</div>` —
+   *       the wrapper Compose stamps around the quoted
+   *       original message on reply / forward.  Wraps a
+   *       multi-paragraph block, so the closing `</div>` is
+   *       far away from the opener and a regex can't match
+   *       it reliably.
+   *    2. `<blockquote>…</blockquote>` — the standard HTML
+   *       reply-quote, used when the user pastes / quotes
+   *       text manually via the editor's blockquote button.
+   *
+   *  We use DOMParser (browser-native, no dep) to walk the
+   *  tree and remove the matching elements, then take the
+   *  remaining text content.  Newlines are inserted at
+   *  natural block boundaries so the mention detector's
+   *  word-boundary regex doesn't accidentally bridge two
+   *  paragraphs into one match.  */
   function bodyToPlainTextForMentionCheck(html: string): string {
-    return html
-      .replace(/<br\s*\/?>/gi, '\n')
-      .replace(/<\/(p|div|li|tr)>/gi, '\n')
-      .replace(/<[^>]+>/g, '')
-      .replace(/&nbsp;/gi, ' ')
-      .replace(/&amp;/gi, '&')
-      .replace(/&lt;/gi, '<')
-      .replace(/&gt;/gi, '>')
-      .replace(/&quot;/gi, '"')
+    if (!html) return ''
+    try {
+      const doc = new DOMParser().parseFromString(html, 'text/html')
+      doc
+        .querySelectorAll('div[data-nimbus-block="quoted-history"], blockquote')
+        .forEach((el) => el.remove())
+      // Inject `\n` at block-element boundaries before grabbing
+      // textContent, so a paragraph break in the source HTML
+      // becomes a newline in the plain-text output.
+      doc.querySelectorAll('br').forEach((el) => el.replaceWith(doc.createTextNode('\n')))
+      doc
+        .querySelectorAll('p, div, li, tr, h1, h2, h3, h4, h5, h6')
+        .forEach((el) => el.append(doc.createTextNode('\n')))
+      return (doc.body.textContent ?? '').trim()
+    } catch {
+      // DOMParser is part of the standard Web platform but
+      // some test / non-browser harnesses don't ship it.  Fall
+      // back to the raw HTML so the detector still gets to
+      // run; the worst case is a stale-quoted-text false
+      // positive in that environment, which is strictly
+      // better than crashing the editor.
+      return html
+    }
   }
   const showAttachmentMentionWarning = $derived(
     !attachmentMentionDismissed

--- a/ui/src/lib/attachmentMentions.ts
+++ b/ui/src/lib/attachmentMentions.ts
@@ -1,0 +1,120 @@
+// Attachment-mention detector (#250).
+//
+// Compose runs the user's body text through `mentionsAttachment`
+// to decide whether to show the "you mentioned an attachment but
+// didn't attach a file" banner.  Multi-language by design: we
+// match against keywords from every supported locale at once
+// rather than only the active UI locale, because users routinely
+// write a German email while the UI runs in English (or vice
+// versa).
+//
+// Detection rules:
+//
+//   - Word-boundary matches only.  "detached" / "anhängig" /
+//     "attaché" must NOT trigger.  We use Unicode-aware regex
+//     `\b` semantics (the standard `/\b/u` flag).
+//   - Quoted-reply text is excluded.  Lines starting with `>`
+//     (the standard plain-text reply quote) and HTML
+//     `<blockquote>` blocks (Tiptap-formatted replies) are
+//     stripped before scanning, so a forwarded thread with
+//     "see attached" in the original message doesn't fire the
+//     warning when the user just wrote "Hi, FYI."
+//   - Threshold: any single match.  If the user really wants to
+//     write the word "attachment" without attaching anything,
+//     the banner has a Dismiss button.
+//
+// Future-proofing: when a new locale is added to
+// `messages/<code>.json`, append its keywords here in the same
+// shape.  The file pattern keeps adding new locales a localised
+// change rather than a sweep across detection logic.
+
+/**
+ * Word-stems we recognise as "the user is mentioning an
+ * attachment", grouped per locale.  Stems use the regex
+ * source-string convention; the consumer wraps each stem in
+ * `\b…\b` at match time.
+ *
+ * Conservative on purpose: we'd rather miss an oblique
+ * reference than fire the warning on a false positive (e.g.
+ * "detached" or "anhängig").  The keys here are the obvious
+ * core verbs / nouns that mean "I'm referring to the file I
+ * attached":
+ *
+ *   - English: attached, attachment(s), enclosed, "see/find
+ *     attached" (caught via the bare "attached" stem).
+ *   - German: Anhang/Anhänge, anbei, beigefügt.  Pure
+ *     `anhäng-` is too greedy ("anhängig" = pending) so we
+ *     anchor the noun forms specifically.
+ */
+const MENTION_STEMS_BY_LOCALE: Record<string, string[]> = {
+  en: [
+    'attached',
+    'attachment',
+    'attachments',
+    'enclosed',
+  ],
+  de: [
+    // Noun forms — both the singular "Anhang" and the
+    // plural / dative "Anhänge"/"Anhängen".  Word boundaries
+    // around the regex stop the match from picking up
+    // unrelated -hang words ("Vorhang", "anhängig").
+    'Anhang',
+    'Anhänge',
+    'Anhängen',
+    'anbei',
+    'beigefügt',
+    'beigefügte',
+    'beigefügten',
+  ],
+}
+
+/**
+ * Strip quoted-reply blocks from `text` so a forwarded thread
+ * with "see attached" in the original doesn't trigger the
+ * warning.  Recognises:
+ *   - lines starting with `>` (RFC-2822 plain-text quote)
+ *   - HTML <blockquote>...</blockquote> wrappers (Tiptap
+ *     reply formatting)
+ *
+ * The plain-text strip happens line-by-line, so a `>` later in
+ * a line (e.g. inside running text) is preserved.
+ */
+function stripQuotedReplies(text: string): string {
+  // Drop blockquote element contents.  We pass the body
+ // through `htmlToText`-style normalisation upstream, but a
+  // belt-and-braces pass against `<blockquote>...</blockquote>`
+  // catches cases where the Tiptap output wasn't fully
+  // serialised before this function runs.
+  let cleaned = text.replace(/<blockquote[\s\S]*?<\/blockquote>/gi, '\n')
+  cleaned = cleaned
+    .split('\n')
+    .filter((line) => !/^\s*>/.test(line))
+    .join('\n')
+  return cleaned
+}
+
+/**
+ * Return `true` when `text` (a plain-text version of the
+ * Compose body) contains an attachment mention in any
+ * supported locale.  Intended to be called on the full
+ * post-quoted-strip body — the function does that strip
+ * itself so callers don't have to remember.
+ */
+export function mentionsAttachment(text: string): boolean {
+  const cleaned = stripQuotedReplies(text)
+  if (!cleaned.trim()) return false
+  for (const stems of Object.values(MENTION_STEMS_BY_LOCALE)) {
+    for (const stem of stems) {
+      // `i` is fine: keyword lists are ASCII-or-Latin-1, and
+      // German nouns (capitalised) should still trigger when
+      // the user writes them lowercase mid-sentence.
+      const re = new RegExp(`\\b${escapeRegex(stem)}\\b`, 'iu')
+      if (re.test(cleaned)) return true
+    }
+  }
+  return false
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}


### PR DESCRIPTION
## Summary

Closes #250.  Adds a gentle warning banner above Compose's attachment area that fires when the body text mentions an attachment but the attachment list is empty.  Hides itself the moment the user adds a file (the most common "right, attaching now" path is invisible extra friction); a Dismiss button covers the legitimate case where the user is referring to a previously-sent attachment in running prose.

### Detection

Lives in a new `ui/src/lib/attachmentMentions.ts`:

- **Multi-language**: scans against keywords from every supported locale at once (English + German today), not just the active UI locale.  A user writing a German email with their UI in English still gets the warning.
- **Word-boundary matches only**: "detached", "anhängig", "attaché" do *not* fire.
- **Quoted-reply stripping**: lines starting with `>` (plain-text quote) and HTML `<blockquote>` blocks (Tiptap reply formatting) are removed before scanning, so a forwarded thread with "see attached" in the original doesn't trigger the warning when the user just wrote "Hi, FYI".

Adding a third locale is a localised change: append a new entry to `MENTION_STEMS_BY_LOCALE` in the same shape, alongside the corresponding `messages/<code>.json`.

### UI

Banner uses Skeleton's `preset-outlined-warning-500` styling matching the existing remote-images-blocked pattern in MailView.  Renders only when `mentionsAttachment(body) && attachments.length === 0 && !dismissed`.  Per-Compose-instance dismissal — fresh drafts start clear.

Banner copy is localised via paraglide (`compose_attachment_warning_*` keys, en + de).

## Test plan

- [x] Compose a new message; type "Please find attached the report" — banner appears.
- [x] Attach any file — banner disappears.
- [x] Remove the file — banner reappears.
- [x] Click "Dismiss" — banner disappears, doesn't return as you keep typing.
- [ ] Reply to a message that contains "see attached" in the quoted body — banner does *not* fire when your own reply text doesn't mention an attachment.
- [x] Switch UI to German; compose a German email containing "anbei sende ich Ihnen das Dokument" — banner appears.
- [x] Type "detached" / "anhängig" — banner does NOT fire (word-boundary check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)