### PR TITLE
Contacts header + search bar parity with Notes (#264)

### DIFF
--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1982,10 +1982,10 @@
              Notes search row.  `pickerOpen` swaps the bound query
              so the same input alternates between filtering members
              and filtering the contact-picker pool.  The compact
-             "+ Add contact" / "Done" toggle sits to the right of
-             the search input — same row, smaller weight. -->
-        <div class="border-b border-surface-200 dark:border-surface-700 p-2 flex items-center gap-2">
-          <div class="relative flex-1 min-w-0">
+             "+ Add contact" / "Done" toggle sits below the search
+             on its own row, anchored right via `self-end`. -->
+        <div class="border-b border-surface-200 dark:border-surface-700 p-2 flex flex-col">
+          <div class="relative w-full">
             <span
               class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none flex items-center"
               aria-hidden="true"
@@ -2032,10 +2032,9 @@
             <!-- Compact "+ Add contact" / "Done" toggle — same
                  shape as NC Files' "+ New folder" affordance:
                  primary-text, no border, subtle primary halo on
-                 hover.  Anchored right of the search input so the
-                 row reads "search [a thing] / add a thing". -->
+                 hover.  Sits below the search bar, anchored right. -->
             <button
-              class="shrink-0 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
+              class="self-end mt-2 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
               onclick={() => {
                 pickerOpen = !pickerOpen
                 pickerQuery = ''

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1984,41 +1984,73 @@
             {ml.members.filter((m) => m.email).length} / {ml.members.length}
           </span>
         </div>
-        <!-- Search + Add Contact row.  Search filters the
-             member list inline.  + Add Contact flips the
-             column into a contact-picker that lists every
-             contact NOT already in the list. -->
-        <!-- Search field + Add Contact button stack — same
-             vertical layout the Contacts tab middle column
-             uses (search on top, primary action below) for
-             visual consistency. -->
-        <div class="p-3 flex flex-col gap-2 border-b border-surface-200 dark:border-surface-700">
-          {#if pickerOpen}
-            <input
-              type="search"
-              class="input"
-              placeholder="Search contacts to add"
-              bind:value={pickerQuery}
-            />
-          {:else}
-            <input
-              type="search"
-              class="input"
-              placeholder="Search members"
-              bind:value={memberQuery}
-            />
-          {/if}
+        <!-- Search bar — same shape as the Contacts tab + Notes
+             search row (pill `.input` with magnifier + `×` clear).
+             `pickerOpen` swaps the bound query so the same input
+             alternates between filtering members and filtering the
+             contact-picker pool. -->
+        <div class="border-b border-surface-200 dark:border-surface-700 p-2">
+          <div class="relative w-full">
+            <span
+              class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none flex items-center"
+              aria-hidden="true"
+            >
+              <Icon name="search" size={14} />
+            </span>
+            {#if pickerOpen}
+              <input
+                type="text"
+                class="input w-full pl-7 pr-8 py-1.5 text-sm rounded-md"
+                placeholder="Search contacts to add"
+                bind:value={pickerQuery}
+                aria-label="Search contacts to add"
+              />
+              {#if pickerQuery}
+                <button
+                  type="button"
+                  class="absolute right-2 top-1/2 -translate-y-1/2 text-surface-500 hover:text-surface-700 dark:hover:text-surface-200 text-xs"
+                  onclick={() => (pickerQuery = '')}
+                  title="Clear search"
+                  aria-label="Clear search"
+                >&#x2715;</button>
+              {/if}
+            {:else}
+              <input
+                type="text"
+                class="input w-full pl-7 pr-8 py-1.5 text-sm rounded-md"
+                placeholder="Search members"
+                bind:value={memberQuery}
+                aria-label="Search members"
+              />
+              {#if memberQuery}
+                <button
+                  type="button"
+                  class="absolute right-2 top-1/2 -translate-y-1/2 text-surface-500 hover:text-surface-700 dark:hover:text-surface-200 text-xs"
+                  onclick={() => (memberQuery = '')}
+                  title="Clear search"
+                  aria-label="Clear search"
+                >&#x2715;</button>
+              {/if}
+            {/if}
+          </div>
           {#if editable}
             <button
-              class="btn preset-filled-primary-500"
+              class="btn preset-filled-primary-500 w-full mt-2 inline-flex items-center justify-center gap-1.5"
               onclick={() => {
                 pickerOpen = !pickerOpen
                 pickerQuery = ''
               }}
-            >{pickerOpen ? 'Done' : '+ Add contact'}</button>
+            >
+              {#if pickerOpen}
+                Done
+              {:else}
+                <span class="text-lg font-semibold leading-none">+</span>
+                Add contact
+              {/if}
+            </button>
           {/if}
         </div>
-        <div class="flex-1 overflow-y-auto p-3 space-y-1">
+        <div class="flex-1 overflow-y-auto pb-3">
           {#if pickerOpen}
             {#if pickableContacts.length === 0}
               <p class="px-3 py-2 text-xs text-surface-500 italic">
@@ -2029,7 +2061,7 @@
             {/if}
             {#each pickableContacts as c (c.id)}
               <button
-                class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm text-left hover:bg-surface-200 dark:hover:bg-surface-700"
+                class="w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors border-b border-surface-100 dark:border-surface-800 hover:bg-surface-100 dark:hover:bg-surface-800"
                 onclick={() => void addContactToSelectedList(c.id)}
               >
                 <span class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-600 text-xs font-semibold flex items-center justify-center shrink-0">
@@ -2055,7 +2087,7 @@
             {#each filteredMembers as m, i (`${m.email}::${i}`)}
               {@const linkedContact = m.email ? contactByEmail.get(m.email.toLowerCase()) : undefined}
               {@const memberPhoto = linkedContact ? photoSrc(linkedContact) : null}
-              <div class="group flex items-center gap-2 px-3 py-2 rounded-md bg-surface-200/40 dark:bg-surface-700/40">
+              <div class="group flex items-center gap-2 px-3 py-2 text-sm transition-colors border-b border-surface-100 dark:border-surface-800 hover:bg-surface-100 dark:hover:bg-surface-800">
                 {#if memberPhoto}
                   <img
                     src={memberPhoto}

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1893,7 +1893,7 @@
       </div>
     </div>
 
-    <div class="flex-1 overflow-y-auto px-2 pb-3">
+    <div class="flex-1 overflow-y-auto pb-3">
       {#if loading}
         <p class="px-3 py-2 text-xs text-surface-500">Loading contacts…</p>
       {:else if error}
@@ -1907,10 +1907,10 @@
       {:else}
         {#each filteredContacts as c (c.id)}
           <button
-            class="w-full flex items-center gap-2 px-3 py-2 rounded-md text-sm transition-colors
+            class="w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors border-b border-surface-100 dark:border-surface-800
               {selectedId === c.id
                 ? 'bg-primary-500/10 text-primary-500 font-medium'
-                : 'hover:bg-surface-200 dark:hover:bg-surface-700'}"
+                : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
             draggable="true"
             ondragstart={(e) => {
               draggedContactId = c.id

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1468,25 +1468,19 @@
     <!-- Primary action — same shape + filled-primary preset as
          the mail Compose CTA / Notes' "New note" button.  Back
          navigation lives in the app-wide IconRail; the per-tab
-         title was redundant with the active tab strip below. -->
+         title was redundant with the active tab strip below.
+         "+ New contact" stays on both tabs — creating contacts is
+         the universal action across this view, and the Lists tab
+         already has its own "+ Mailing lists" affordance inline
+         with the section header further down the sidebar. -->
     <div class="p-3">
-      {#if activeTab === 'contacts'}
-        <button
-          class="btn preset-filled-primary-500 w-full inline-flex items-center justify-center gap-1.5"
-          onclick={startNew}
-        >
-          <span class="text-lg font-semibold leading-none">+</span>
-          New contact
-        </button>
-      {:else}
-        <button
-          class="btn preset-filled-primary-500 w-full inline-flex items-center justify-center gap-1.5"
-          onclick={openNewMailingListForm}
-        >
-          <span class="text-lg font-semibold leading-none">+</span>
-          New list
-        </button>
-      {/if}
+      <button
+        class="btn preset-filled-primary-500 w-full inline-flex items-center justify-center gap-1.5"
+        onclick={startNew}
+      >
+        <span class="text-lg font-semibold leading-none">+</span>
+        New contact
+      </button>
     </div>
     <!-- Tab strip.  Buttons explicitly stop propagation +
          set activeTab on a separate handler so any pending
@@ -1989,7 +1983,7 @@
              `pickerOpen` swaps the bound query so the same input
              alternates between filtering members and filtering the
              contact-picker pool. -->
-        <div class="border-b border-surface-200 dark:border-surface-700 p-2">
+        <div class="border-b border-surface-200 dark:border-surface-700 p-2 flex flex-col">
           <div class="relative w-full">
             <span
               class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none flex items-center"
@@ -2034,8 +2028,13 @@
             {/if}
           </div>
           {#if editable}
+            <!-- Compact "+ Add contact" / "Done" toggle — same
+                 shape as NC Files' "+ New folder" affordance:
+                 primary-text, no border, subtle primary halo on
+                 hover.  Sits below the search bar so it doesn't
+                 fight the search input for visual weight. -->
             <button
-              class="btn preset-filled-primary-500 w-full mt-2 inline-flex items-center justify-center gap-1.5"
+              class="self-start mt-2 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
               onclick={() => {
                 pickerOpen = !pickerOpen
                 pickerQuery = ''
@@ -2044,7 +2043,7 @@
               {#if pickerOpen}
                 Done
               {:else}
-                <span class="text-lg font-semibold leading-none">+</span>
+                <span class="font-semibold">+</span>
                 Add contact
               {/if}
             </button>

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1465,17 +1465,27 @@
        tab strip + heading don't move; only the navigation
        sections collapse. ───────────────────────────────────── -->
   <aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100/60 dark:bg-surface-800/40 flex flex-col">
-    <div class="p-3 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2">
-      <button
-        class="btn-icon btn-icon-sm preset-tonal"
-        aria-label="Back"
-        onclick={onclose}
-      >&larr;</button>
-      <h2 class="text-base font-semibold flex-1 truncate">
-        {activeTab === 'contacts' ? 'Contacts' : 'Mailing lists'}
-      </h2>
-      {#if syncing}
-        <span class="text-[10px] text-surface-500">Syncing…</span>
+    <!-- Primary action — same shape + filled-primary preset as
+         the mail Compose CTA / Notes' "New note" button.  Back
+         navigation lives in the app-wide IconRail; the per-tab
+         title was redundant with the active tab strip below. -->
+    <div class="p-3">
+      {#if activeTab === 'contacts'}
+        <button
+          class="btn preset-filled-primary-500 w-full inline-flex items-center justify-center gap-1.5"
+          onclick={startNew}
+        >
+          <span class="text-lg font-semibold leading-none">+</span>
+          New contact
+        </button>
+      {:else}
+        <button
+          class="btn preset-filled-primary-500 w-full inline-flex items-center justify-center gap-1.5"
+          onclick={openNewMailingListForm}
+        >
+          <span class="text-lg font-semibold leading-none">+</span>
+          New list
+        </button>
       {/if}
     </div>
     <!-- Tab strip.  Buttons explicitly stop propagation +
@@ -1849,21 +1859,38 @@
        above, so this column's job is just the list itself. ─ -->
   <aside class="w-80 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col">
     {#if activeTab === 'contacts'}
-    <div class="p-3 flex flex-col gap-2">
-      <div class="relative">
-        <span class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none flex items-center" aria-hidden="true">
+    <!-- Search bar — same shape as `SearchBar.svelte` in the mail
+         view + the Notes UI: pill `.input` field with a magnifier
+         left adornment and an `×` clear button on the right when
+         there's a query.  "+ New contact" moved to the sidebar's
+         CTA slot so this row is search-only. -->
+    <div class="border-b border-surface-200 dark:border-surface-700 p-2">
+      <div class="relative w-full">
+        <span
+          class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none flex items-center"
+          aria-hidden="true"
+        >
           <Icon name="search" size={14} />
         </span>
         <input
-          type="search"
-          class="input pl-7"
-          placeholder="Search"
+          type="text"
+          class="input w-full pl-7 pr-8 py-1.5 text-sm rounded-md"
+          placeholder="Search contacts"
           bind:value={query}
+          aria-label="Search contacts"
         />
+        {#if query}
+          <button
+            type="button"
+            class="absolute right-2 top-1/2 -translate-y-1/2 text-surface-500 hover:text-surface-700 dark:hover:text-surface-200 text-xs"
+            onclick={() => (query = '')}
+            title="Clear search"
+            aria-label="Clear search"
+          >
+            &#x2715;
+          </button>
+        {/if}
       </div>
-      <button class="btn preset-filled-primary-500" onclick={startNew}>
-        + New contact
-      </button>
     </div>
 
     <div class="flex-1 overflow-y-auto px-2 pb-3">

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -2032,9 +2032,9 @@
             <!-- Compact "+ Add contact" / "Done" toggle — same
                  shape as NC Files' "+ New folder" affordance:
                  primary-text, no border, subtle primary halo on
-                 hover.  Sits below the search bar, anchored right. -->
+                 hover.  Sits below the search bar, anchored left. -->
             <button
-              class="self-end mt-2 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
+              class="self-start mt-2 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
               onclick={() => {
                 pickerOpen = !pickerOpen
                 pickerQuery = ''

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1978,13 +1978,14 @@
             {ml.members.filter((m) => m.email).length} / {ml.members.length}
           </span>
         </div>
-        <!-- Search bar — same shape as the Contacts tab + Notes
-             search row (pill `.input` with magnifier + `×` clear).
-             `pickerOpen` swaps the bound query so the same input
-             alternates between filtering members and filtering the
-             contact-picker pool. -->
-        <div class="border-b border-surface-200 dark:border-surface-700 p-2 flex flex-col">
-          <div class="relative w-full">
+        <!-- Search bar — same pill shape as the Contacts tab +
+             Notes search row.  `pickerOpen` swaps the bound query
+             so the same input alternates between filtering members
+             and filtering the contact-picker pool.  The compact
+             "+ Add contact" / "Done" toggle sits to the right of
+             the search input — same row, smaller weight. -->
+        <div class="border-b border-surface-200 dark:border-surface-700 p-2 flex items-center gap-2">
+          <div class="relative flex-1 min-w-0">
             <span
               class="absolute left-2 top-1/2 -translate-y-1/2 text-surface-400 pointer-events-none flex items-center"
               aria-hidden="true"
@@ -2031,10 +2032,10 @@
             <!-- Compact "+ Add contact" / "Done" toggle — same
                  shape as NC Files' "+ New folder" affordance:
                  primary-text, no border, subtle primary halo on
-                 hover.  Sits below the search bar so it doesn't
-                 fight the search input for visual weight. -->
+                 hover.  Anchored right of the search input so the
+                 row reads "search [a thing] / add a thing". -->
             <button
-              class="self-start mt-2 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
+              class="shrink-0 inline-flex items-center gap-1 text-sm text-primary-500 hover:bg-primary-500/10 rounded-md px-2 py-1"
               onclick={() => {
                 pickerOpen = !pickerOpen
                 pickerQuery = ''
@@ -2086,7 +2087,35 @@
             {#each filteredMembers as m, i (`${m.email}::${i}`)}
               {@const linkedContact = m.email ? contactByEmail.get(m.email.toLowerCase()) : undefined}
               {@const memberPhoto = linkedContact ? photoSrc(linkedContact) : null}
-              <div class="group flex items-center gap-2 px-3 py-2 text-sm transition-colors border-b border-surface-100 dark:border-surface-800 hover:bg-surface-100 dark:hover:bg-surface-800">
+              {@const isOpenable = !!linkedContact}
+              <!-- Members that resolve to an in-cache contact open
+                   the right pane on click — same affordance as
+                   selecting from the Contacts tab.  Members that
+                   are just an email (no contact card) stay
+                   non-clickable so the cursor doesn't lie about
+                   what's interactive.  Wrapper stays a `<div>`
+                   because it nests the Remove `<button>` and we
+                   can't put `<button>` inside `<button>`. -->
+              <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+              <div
+                class="group flex items-center gap-2 px-3 py-2 text-sm transition-colors border-b border-surface-100 dark:border-surface-800 {isOpenable
+                  ? 'cursor-pointer hover:bg-surface-100 dark:hover:bg-surface-800'
+                  : ''} {linkedContact && selectedId === linkedContact.id
+                  ? 'bg-primary-500/10 text-primary-500 font-medium'
+                  : ''}"
+                role={isOpenable ? 'button' : undefined}
+                tabindex={isOpenable ? 0 : undefined}
+                onclick={() => {
+                  if (linkedContact) selectContact(linkedContact.id)
+                }}
+                onkeydown={(e) => {
+                  if (!linkedContact) return
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    selectContact(linkedContact.id)
+                  }
+                }}
+              >
                 {#if memberPhoto}
                   <img
                     src={memberPhoto}
@@ -2110,7 +2139,10 @@
                     class="opacity-0 group-hover:opacity-100 transition-opacity w-7 h-7 rounded-md text-surface-500 hover:bg-error-500/15 hover:text-error-500 leading-none shrink-0"
                     title="Remove from list"
                     aria-label="Remove from list"
-                    onclick={() => void removeContactFromSelectedList(m.email)}
+                    onclick={(e) => {
+                      e.stopPropagation()
+                      void removeContactFromSelectedList(m.email)
+                    }}
                   >×</button>
                 {/if}
               </div>

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -1464,7 +1464,7 @@
        sidebar stays mounted on the Mailing lists tab so the
        tab strip + heading don't move; only the navigation
        sections collapse. ───────────────────────────────────── -->
-  <aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100/60 dark:bg-surface-800/40 flex flex-col">
+  <aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col">
     <!-- Primary action — same shape + filled-primary preset as
          the mail Compose CTA / Notes' "New note" button.  Back
          navigation lives in the app-wide IconRail; the per-tab
@@ -1857,7 +1857,7 @@
   <!-- ── Middle column: contact list / mailing-list catalogue.
        The shell heading + tab strip moved into the sidebar
        above, so this column's job is just the list itself. ─ -->
-  <aside class="w-80 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col">
+  <aside class="w-80 shrink-0 border-r border-surface-200 dark:border-surface-700 flex flex-col">
     {#if activeTab === 'contacts'}
     <!-- Search bar — same shape as `SearchBar.svelte` in the mail
          view + the Notes UI: pill `.input` field with a magnifier


### PR DESCRIPTION
## Summary

Closes #264.  Brings the Contacts view's chrome into parity with the freshly-shipped Notes UI (#138) and tidies up the Lists tab so both tabs feel like siblings of Mail / Notes.

### Sidebar (left column)

- Back button + per-tab "Contacts / Mailing lists" headline removed.  Back navigation lives in the app-wide IconRail like every other integration view; the per-tab title was redundant with the active-state tab strip below it.
- Header slot now holds a primary-filled **"+ New contact"** CTA — same shape as Mail's Compose button and Notes' "+ New note".  CTA is universal across both tabs (creating a contact is the action a user reaches for from either tab; the Lists tab keeps its own per-section "+" affordance further down for spinning up a new list).
- Background tightened from `bg-surface-100/60 dark:bg-surface-800/40` → opaque `bg-surface-100 dark:bg-surface-800` to match the Notes sidebar exactly.

### Contacts list (middle pane, Contacts tab)

- Pane background dropped (was `bg-surface-100 dark:bg-surface-800`); now inherits `surface-50` so the Skeleton `.input` resolves to the same hues used by Notes.
- Search bar restyled to mirror `SearchBar.svelte` from the mail view + the Notes UI: pill `.input` with magnifier on the left and `×` clear on the right.  "+ New contact" removed from this row since the sidebar slot above owns it now.
- Each contact row gets the Notes treatment: `border-b border-surface-100 dark:border-surface-800` separators, no more `rounded-md`, lighter `surface-100/800` hover, full edge-to-edge highlight band.

### Lists tab middle pane

- Same search-bar shape (pill input + magnifier + `×` clear).  `pickerOpen` swaps which query the input drives (members vs. add-contact pool); each branch carries its own clear button.
- The "+ Add contact" / "Done" toggle now sits below the search input as a compact text-button — primary-text + subtle primary halo on hover, matching NC Files' "+ New folder" affordance.  Anchored left via `self-start` so it lines up with the search input's leading edge.
- Pickable contact rows + member rows updated to the same `border-b` / lighter-hover / no-rounded treatment as the Contacts list.  Wrapper switched from `p-3 space-y-1` to `pb-3` so the borders run edge-to-edge.
- Member rows are now click-to-open when the member resolves to an in-cache contact (`contactByEmail` lookup) — clicking opens the contact in the right pane, exactly like clicking from the Contacts tab.  Members that are just an email with no matching contact card stay non-clickable so the cursor doesn't lie.  Selected linked row gets the same primary-tinted highlight.  Remove `×` handler `stopPropagation`s so clicking it doesn't also fire the row click.

## Test plan

- [ ] Open Contacts → sidebar top shows the "+ New contact" CTA, no back button, no headline.  Click → opens the create-contact form.
- [ ] Switch to the Lists tab → CTA stays "+ New contact" (universal).  Spinning up a new list still works via the small `+` next to the "Manual lists" / "Mailing lists" subheaders.
- [ ] Switch back to Contacts → middle-pane search bar matches Notes / Mail style.  `×` clears the query.  Rows have hairline separators, full-width highlight on hover and selection.
- [ ] On the Lists tab, pick a list → middle pane shows the same search-bar style; "+ Add contact" toggle is a small primary-text button below the search, anchored left.  Toggle flips to "Done" while the picker is open.
- [ ] In the picker view, contact rows have the same separator + hover treatment as the Contacts list.
- [ ] Click a member row that resolves to an existing contact → right pane opens the contact's read-only view.  Selected row highlights.
- [ ] Click the Remove `×` on a member row → only the remove fires; the row click doesn't pull the contact open.
- [ ] German locale: every label still translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)