### PR TITLE
Compose: float toolbar dropdowns above the editor (#267)

### DIFF
--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1316,6 +1316,29 @@
 
   let showEmojiPicker = $state(false)
 
+  /** Toolbar dropdown anchor coordinates (#267).  The toolbar panel
+   *  uses `overflow-x: auto` for narrow-width horizontal scrolling,
+   *  which per CSS spec also forces `overflow-y` to `auto` and clips
+   *  vertically.  An `position: absolute` popover inside that
+   *  container therefore disappears below the editor area + the
+   *  horizontal scrollbar.  We dodge the clip by `position: fixed`-ing
+   *  the popovers and stashing the trigger's `getBoundingClientRect()`
+   *  on open so the menu still lands directly under its button.
+   *  Same shape Notes uses for its folder action menu. */
+  let fontPickerPos = $state<{ x: number; y: number }>({ x: 0, y: 0 })
+  let tablePickerPos = $state<{ x: number; y: number }>({ x: 0, y: 0 })
+  let emojiPickerPos = $state<{ x: number; y: number }>({ x: 0, y: 0 })
+
+  /** Stash the trigger's screen-space rect so the matching popover
+   *  can render at `position: fixed` above any clipping ancestor.
+   *  Distinct from the `anchorBelow(rect)` helper above — that one
+   *  takes a Tiptap-suggestion DOMRect; this one reads from a
+   *  click event's currentTarget. */
+  function anchorPopover(e: MouseEvent): { x: number; y: number } {
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
+    return { x: r.left, y: r.bottom + 4 }
+  }
+
   function insertEmoji(e: string | null) {
     if (!e) return
     cmd().insertContent(e).run()
@@ -1700,19 +1723,23 @@
     <div class="rt-tab-panel flex flex-nowrap items-center gap-0.5 px-2 py-1.5 min-h-12 overflow-x-auto">
       {#if activeTab === 'format'}
         <!-- Font family — wider trigger, dropdown menu. -->
-        <div class="relative inline-block">
+        <div class="inline-block">
           <button
             type="button"
             class="rt-btn rt-btn-wide"
             title="Font family"
-            onclick={() => (showFontPicker = !showFontPicker)}
+            onclick={(e) => {
+              if (!showFontPicker) fontPickerPos = anchorPopover(e)
+              showFontPicker = !showFontPicker
+            }}
           >
             <span class="rt-btn-icon" aria-hidden="true">𝐀</span>
             <span class="rt-btn-label">{currentFontLabel()} ▾</span>
           </button>
           {#if showFontPicker}
             <div
-              class="absolute z-20 mt-1 w-64 rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-md py-1 flex flex-col"
+              class="fixed z-60 mt-0 w-64 rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-md py-1 flex flex-col"
+              style="left: {Math.min(fontPickerPos.x, window.innerWidth - 272)}px; top: {fontPickerPos.y}px;"
               role="menu"
               tabindex="-1"
               onclick={(e) => e.stopPropagation()}
@@ -1828,15 +1855,23 @@
         <span class="rt-divider"></span>
 
         <!-- Table picker -->
-        <div class="relative inline-block" bind:this={tablePickerAnchor}>
-          <button class="rt-btn" title="Insert table at cursor" onclick={openTablePicker}>
+        <div class="inline-block" bind:this={tablePickerAnchor}>
+          <button
+            class="rt-btn"
+            title="Insert table at cursor"
+            onclick={(e) => {
+              if (!showTablePicker) tablePickerPos = anchorPopover(e)
+              openTablePicker()
+            }}
+          >
             <span class="rt-btn-icon"><Icon name="table" size={20} /></span>
             <span class="rt-btn-label">Table</span>
           </button>
           {#if showTablePicker}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
-              class="absolute left-0 top-full mt-1 z-50 p-2 bg-white dark:bg-surface-800 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg"
+              class="fixed z-60 p-2 bg-white dark:bg-surface-800 border border-surface-300 dark:border-surface-600 rounded-md shadow-lg"
+              style="left: {Math.min(tablePickerPos.x, window.innerWidth - 200)}px; top: {tablePickerPos.y}px;"
               onmouseleave={() => { tableHoverRows = 0; tableHoverCols = 0 }}
               onkeydown={(e) => e.key === 'Escape' && (showTablePicker = false)}
             >
@@ -1873,14 +1908,22 @@
 
         <!-- Emoji picker — popup grid of curated emojis (#103
              follow-up).  Click outside or pick an emoji to dismiss. -->
-        <div class="relative inline-block">
-          <button class="rt-btn" title="Insert emoji" onclick={() => (showEmojiPicker = !showEmojiPicker)}>
+        <div class="inline-block">
+          <button
+            class="rt-btn"
+            title="Insert emoji"
+            onclick={(e) => {
+              if (!showEmojiPicker) emojiPickerPos = anchorPopover(e)
+              showEmojiPicker = !showEmojiPicker
+            }}
+          >
             <span class="rt-btn-icon"><Icon name="emoji" size={20} /></span>
             <span class="rt-btn-label">Emoji</span>
           </button>
           {#if showEmojiPicker}
             <div
-              class="absolute left-0 top-full mt-1 z-50"
+              class="fixed z-60"
+              style="left: {Math.min(emojiPickerPos.x, window.innerWidth - 360)}px; top: {emojiPickerPos.y}px;"
               role="menu"
               tabindex="-1"
               onclick={(e) => e.stopPropagation()}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1339,6 +1339,29 @@
     return { x: r.left, y: r.bottom + 4 }
   }
 
+  /** Document-level Escape dismissal for the three toolbar
+   *  popovers.  The popovers' inline `onkeydown={...Escape...}`
+   *  handlers only fire when focus is inside the popover; with
+   *  `position: fixed` (and most pickers having no auto-focused
+   *  input) focus tends to stay on the trigger button, so the
+   *  inline handler never sees the keystroke.  Subscribing at
+   *  the document level catches Escape from anywhere in the
+   *  Compose window. */
+  $effect(() => {
+    if (!showFontPicker && !showTablePicker && !showEmojiPicker) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      if (showFontPicker) {
+        showFontPicker = false
+        fontPickerQuery = ''
+      }
+      if (showTablePicker) showTablePicker = false
+      if (showEmojiPicker) showEmojiPicker = false
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  })
+
   function insertEmoji(e: string | null) {
     if (!e) return
     cmd().insertContent(e).run()


### PR DESCRIPTION
## Summary

Closes #267.  Fixes the font / table / emoji popovers in the Compose toolbar being clipped behind the editor area + the horizontal scroll bar.

### Root cause

The toolbar's panel uses `overflow-x: auto` for narrow-width horizontal scrolling (introduced in #152).  Per CSS spec, when *one* overflow axis is set to `auto / scroll / hidden`, the *other* axis is forced to `auto` as well — so the panel clips vertically, not just horizontally.  Any popover rendered with `position: absolute` inside the panel disappears below the editor + scroll bar, regardless of its `z-index` (the clip happens before stacking).

### Fix

Switch the three affected popovers from `position: absolute` (constrained by the clipping ancestor) to `position: fixed` with screen-space coordinates computed from the trigger button's `getBoundingClientRect()` on open — same shape the Notes folder action menu and move-to-folder modal already use.

- Font picker (line 1713)
- Table picker (line 1836)
- Emoji picker (line 1881)

`z-60` keeps them above the Compose modal's `z-50` backdrop.  Coordinates are clamped against `window.innerWidth - <popover width>` so the menu doesn't fall off the right edge on narrow Compose layouts.  Trigger wrappers drop their now-redundant `relative` class.

The native `<input type="color">` picker (Color / Highlight buttons) is browser-native chrome and was never affected — those always paint above everything regardless of CSS.

## Test plan

- [x] Open Compose, scroll the toolbar horizontally if needed, click **Font family** → list paints fully visible above the editor area, doesn't clip behind the horizontal scroll bar.
- [x] Click **Insert → Table** → 8×8 grid floats above the editor; hover-highlights respond correctly.
- [x] Click **Insert → Emoji** → emoji grid renders above the editor; clicking an emoji inserts it and dismisses.
- [x] Open each popover near the right edge of a narrow Compose window → popover doesn't fall off-screen.
- [x] Color / Highlight buttons still open the native OS colour picker as before (untouched path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)