### PR TITLE
Rich-text signature builder (#248)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -280,9 +280,19 @@ pub struct Account {
     /// during account setup if the server supports `.well-known/jmap`.
     #[serde(default)]
     pub jmap_url: Option<String>,
-    /// Optional plain-text signature appended below new messages
-    /// composed from this account. Empty/None = no signature. The
-    /// frontend renders the standard `-- ` separator before it.
+    /// Signature appended below new messages composed from this
+    /// account.  Empty/None = no signature.  The frontend renders
+    /// the standard RFC 3676 `-- ` separator before it.
+    ///
+    /// As of #248 this is rich HTML produced by the Tiptap editor in
+    /// AccountSettings — bold / italic / lists / links / inline
+    /// images all round-trip end-to-end.  Legacy plain-text
+    /// signatures saved before #248 still work: Compose's
+    /// `signatureBlock` detects whether the value contains HTML tags
+    /// and either passes it through verbatim or runs the historical
+    /// escape-and-`<br>` path.  No migration is needed; users who
+    /// open the settings panel after the upgrade and save will end
+    /// up with an HTML signature for free.
     #[serde(default)]
     pub signature: Option<String>,
     /// User-defined "folder name contains X → use icon Y" rules.

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -14,6 +14,7 @@
   import SecuritySettings from './SecuritySettings.svelte'
   import EmojiPicker from './EmojiPicker.svelte'
   import Icon, { type IconName } from './Icon.svelte'
+  import RichTextEditor from './RichTextEditor.svelte'
   import Toggle from './Toggle.svelte'
   import {
     STOCK_THEMES,
@@ -1842,14 +1843,22 @@
                   <span class="text-xs text-error-500">Save failed</span>
                 {/if}
               </div>
-              <textarea
-                id="sig-{account.id}"
-                rows="4"
-                value={account.signature ?? ''}
-                oninput={(e) => onSignatureChange(account, (e.currentTarget as HTMLTextAreaElement).value)}
-                placeholder="Appended to new messages sent from this account."
-                class="input w-full px-3 py-2 rounded-md font-mono text-sm"
-              ></textarea>
+              <!-- #248 — rich-text signature.  Same Tiptap editor
+                   the Compose flow uses, just instantiated in a
+                   fixed-height container so it sits cleanly inside
+                   the settings panel.  The user can author with
+                   bold / italic / lists / images / colours; the
+                   HTML output rides through `update_account` →
+                   `Account.signature` and Compose's `signatureBlock`
+                   passes it through verbatim with the RFC 3676
+                   `-- ` separator above. -->
+              <div class="signature-editor-shell">
+                <RichTextEditor
+                  content={account.signature ?? ''}
+                  placeholder="Appended to new messages sent from this account."
+                  onchange={(html) => onSignatureChange(account, html)}
+                />
+              </div>
             </div>
 
             <!-- Folder icon rules (Issue #63). Match a folder name
@@ -2298,3 +2307,22 @@
     </div>
   </div>
 {/if}
+
+<style>
+  /* #248 — fixed-height shell for the signature `RichTextEditor`.
+     Tiptap's editor expects a parent with bounded height (its
+     scroller is `flex-1 min-h-0`); without one the toolbar would
+     stack on top of an unbounded body. */
+  :global(.signature-editor-shell) {
+    height: 18rem;
+    min-height: 18rem;
+    border: 1px solid var(--color-surface-300);
+    border-radius: 0.375rem;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  :global([data-mode='dark'] .signature-editor-shell) {
+    border-color: var(--color-surface-700);
+  }
+</style>

--- a/ui/src/lib/AccountSetup.svelte
+++ b/ui/src/lib/AccountSetup.svelte
@@ -26,6 +26,7 @@
   import { formatError } from './errors'
   import Toggle from './Toggle.svelte'
   import Icon, { type IconName } from './Icon.svelte'
+  import RichTextEditor from './RichTextEditor.svelte'
   import { m } from '../paraglide/messages'
 
   // ── Props ───────────────────────────────────────────────────
@@ -586,12 +587,18 @@
 
           <label class="block mb-4">
             <span class="text-sm font-medium text-surface-700 dark:text-surface-300">{m.account_setup_signature_label()}</span>
-            <textarea
-              bind:value={signature}
-              rows="4"
-              placeholder={`Jane Doe\nProduct Manager · Example Corp\n+1 555 0100`}
-              class="input w-full mt-1 px-3 py-2 rounded-md font-mono text-sm"
-            ></textarea>
+            <!-- #248 — rich-text signature editor.  HTML output rides
+                 through unchanged via `Account.signature`; Compose's
+                 `signatureBlock` detects the HTML shape and passes it
+                 through verbatim (legacy plain-text signatures still
+                 work via the same code path). -->
+            <div class="signature-editor-shell mt-1">
+              <RichTextEditor
+                content={signature}
+                placeholder={`Jane Doe\nProduct Manager · Example Corp\n+1 555 0100`}
+                onchange={(html) => (signature = html)}
+              />
+            </div>
             <span class="block text-xs text-surface-500 mt-1">
               {m.account_setup_signature_hint()}
             </span>
@@ -702,3 +709,21 @@
     </div>
   </div>
 </div>
+
+<style>
+  /* #248 — fixed-height shell so the embedded `RichTextEditor`
+     has bounded vertical room (its scroller is `flex-1 min-h-0`).
+     Same shape as the signature shell in AccountSettings. */
+  :global(.signature-editor-shell) {
+    height: 16rem;
+    min-height: 16rem;
+    border: 1px solid var(--color-surface-300);
+    border-radius: 0.375rem;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  :global([data-mode='dark'] .signature-editor-shell) {
+    border-color: var(--color-surface-700);
+  }
+</style>

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -643,16 +643,31 @@
   })
 
   /** Render a per-account signature as the standard `-- ` separator
-      followed by the user's lines. Returns `''` when there's no
-      signature configured so callers can append unconditionally. */
+      followed by the user's body. Returns `''` when there's no
+      signature configured so callers can append unconditionally.
+
+      Two storage shapes are supported (#248):
+      - **HTML** — produced by the rich-text signature editor in
+        AccountSettings.  Passes through verbatim with the
+        separator on its own line so the recipient's mail client
+        can collapse the trailing block as a quoted reply.
+      - **Plain text** — the legacy shape from before #248.  We
+        HTML-escape, convert newlines to `<br>`, and prepend the
+        separator.  Detection is a generic `<[a-z]…>` check;
+        any tag-shaped substring picks the HTML branch. */
   function signatureBlock(sig: string | null | undefined): string {
     const text = (sig ?? '').trim()
     if (!text) return ''
+    const looksLikeHtml = /<[a-z][\s\S]*>/i.test(text)
+    if (looksLikeHtml) {
+      // RFC 3676 separator on its own paragraph above the rich
+      // body so it still survives the standard reply-quote
+      // collapse rules.
+      return `<p>-- </p>${text}`
+    }
     const esc = (s: string) =>
       s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     const lines = text.split('\n').map(esc).join('<br>')
-    // The "-- " (with trailing space) prefix is the RFC 3676 signature
-    // delimiter — well-behaved mail clients hide it from quoted replies.
     return `<p>-- <br>${lines}</p>`
   }
   // svelte-ignore state_referenced_locally

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -539,7 +539,18 @@
             }
           }
         },
-      }).configure({ inline: true }),
+      }).configure({
+        inline: true,
+        // #248 — without this, Tiptap's `parseHTML` strips
+        // `<img src="data:…">` on re-mount, so any inline-encoded
+        // image (signature builder, NC files attached as data URLs,
+        // pasted screenshots) vanishes the second time the editor
+        // opens against the same body.  In-memory Compose hides
+        // this because the editor never re-parses its own
+        // `getHTML()`; the signature panel exposes it because the
+        // settings tab unmounts + remounts on every visit.
+        allowBase64: true,
+      }),
       TextAlign.configure({ types: ['heading', 'paragraph'] }),
       // svelte-ignore state_referenced_locally
       Placeholder.configure({ placeholder }),


### PR DESCRIPTION
## Summary

Closes #248.  The plain-text signature textarea becomes the same Tiptap `RichTextEditor` Compose uses, so users can author HTML signatures with bold / italic / lists / links / colours and inline images.  Legacy plain-text signatures keep working through the upgrade — Compose detects which shape is on disk and routes accordingly.

### What changed

**UI**
- `AccountSettings.svelte`: signature `<textarea>` → `<RichTextEditor>` inside an 18 rem fixed-height shell.  Same toolbar (Format / Insert / Layout / Attach) the user already knows from Compose.  Output flows through the existing debounced `onSignatureChange` → `update_account` Tauri call.
- `AccountSetup.svelte`: matching swap on the wizard's signature step, 16 rem shell.
- New `<style>` blocks in both files give the editor a bounded height so its `flex-1 min-h-0` scroller has somewhere to live.

**Storage shape**
- `Account.signature: Option<String>` unchanged — same JSON round-trip, same SQL column.  The string now carries HTML for newly-saved signatures.  Doc comment updated to spell out the new shape and the back-compat path.

**Compose**
- `signatureBlock` runs a `/<[a-z][\s\S]*>/i` shape check on the saved value:
  - Tag-shaped → pass through verbatim with the RFC 3676 `-- ` separator on its own `<p>` above so recipients' clients still collapse on reply.
  - No tags → the historical escape + `<br>` + leading separator path, unchanged.

### Deliberately not in this PR

- **HTML sanitisation** — signatures are author-controlled (the user types their own) and never rendered in any context where another user's HTML executes against ours, so the XSS surface is zero.  If signatures ever surface from untrusted senders, wrap with `dompurify`-style scrubbing at the rendering boundary.
- **Image hosting changes** — pictures inserted via the toolbar embed as `data:` URLs, same as Compose's existing image paths.  If large embedded images become common we'll move to a separate signature-images table with `cid:` references in a follow-up issue.
- **No backend changes** — `Option<String>` accepts HTML transparently and the SQL column is untyped beyond `TEXT`.

## Test plan

- [x] Open Settings → Mail accounts → expand an account → signature row shows the rich-text editor with the existing signature pre-filled.
- [x] Type bold + italic + an inline image (toolbar → Insert → Image, paste a data URL or pick from disk) → "Saved" pill appears after the debounce.
- [x] Reload the app → the signature is still there with the formatting + image intact.
- [x] Open Compose against that account → signature appears in the body with the formatting and image rendered.
- [x] Switch the From: account to one that still has a plain-text signature (saved before this PR) → the legacy escape path still produces the `-- \n<plain text>` block; no double-escape, no ghost tags.
- [x] Setup wizard: connect a brand-new account, fill the signature step with formatted text, save → new account opens with the rich signature.
- [ ] German locale: every label / placeholder still translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)