### PR TITLE
#254: register Nimbus for .ics and .eml files

### DIFF
--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -16,6 +16,134 @@ use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 
 use crate::mutf7;
 
+/// Parse a raw RFC 5322 message into our `Email` shape.  Same MIME
+/// walk + transfer-decoding + charset logic `fetch_message` runs
+/// against IMAP-fetched bytes, factored out so the Tauri layer can
+/// reuse it for offline `.eml` opens (#254) without an account
+/// context.  Defaults `is_read = true` and `is_starred = false`
+/// because there are no IMAP flags on a file from disk.
+pub fn parse_eml_bytes(
+    raw: &[u8],
+    id: &str,
+    account_id: &str,
+    folder: &str,
+) -> Result<Email, NimbusError> {
+    let parsed = MessageParser::default()
+        .parse(raw)
+        .ok_or_else(|| NimbusError::Protocol("Failed to parse message".into()))?;
+
+    let subject = parsed.subject().unwrap_or("").to_string();
+    let from = parsed
+        .from()
+        .and_then(|list| list.first())
+        .map(|addr| {
+            let name = addr.name().unwrap_or("");
+            let email = addr.address().unwrap_or("");
+            if name.is_empty() {
+                email.to_string()
+            } else {
+                format!("{name} <{email}>")
+            }
+        })
+        .unwrap_or_default();
+
+    let to = parsed
+        .to()
+        .map(|list| {
+            list.iter()
+                .filter_map(|a| a.address().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let cc = parsed
+        .cc()
+        .map(|list| {
+            list.iter()
+                .filter_map(|a| a.address().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let body_text = (0..parsed.text_body_count())
+        .filter_map(|i| parsed.body_text(i).map(|s| s.to_string()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body_text = if body_text.is_empty() {
+        None
+    } else {
+        Some(body_text.replace("\r\n", "\n").replace('\r', "\n"))
+    };
+
+    let body_html = (0..parsed.html_body_count())
+        .filter_map(|i| parsed.body_html(i).map(|s| s.to_string()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body_html = if body_html.is_empty() {
+        None
+    } else {
+        Some(body_html)
+    };
+
+    let has_attachments = parsed.attachment_count() > 0;
+    let attachments: Vec<EmailAttachment> = parsed
+        .attachments()
+        .enumerate()
+        .map(|(idx, part)| {
+            let part_id = idx as u32;
+            let filename = part
+                .attachment_name()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "attachment".to_string());
+            let content_type = part
+                .content_type()
+                .map(|ct| {
+                    let ctype = ct.ctype();
+                    match ct.subtype() {
+                        Some(sub) => format!("{ctype}/{sub}"),
+                        None => ctype.to_string(),
+                    }
+                })
+                .unwrap_or_else(|| "application/octet-stream".to_string());
+            let size = Some(part.contents().len() as u64);
+            let content_id = part.content_id().map(|s| s.to_string());
+            EmailAttachment {
+                filename,
+                content_type,
+                size,
+                part_id,
+                content_id,
+            }
+        })
+        .collect();
+
+    let date = parsed
+        .date()
+        .and_then(|d| {
+            DateTime::parse_from_rfc3339(&d.to_rfc3339())
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        })
+        .unwrap_or_else(Utc::now);
+
+    Ok(Email {
+        id: id.to_string(),
+        account_id: account_id.to_string(),
+        folder: folder.to_string(),
+        from,
+        to,
+        cc,
+        subject,
+        body_text,
+        body_html,
+        date,
+        is_read: true,
+        is_starred: false,
+        has_attachments,
+        attachments,
+    })
+}
+
 /// `async-imap`'s `Session` is generic over its underlying I/O. We
 /// pin the alias to the concrete `Compat<TlsStream<TcpStream>>` so
 /// downstream callers don't have to think about the four layers of

--- a/crates/nimbus-imap/src/lib.rs
+++ b/crates/nimbus-imap/src/lib.rs
@@ -6,4 +6,4 @@
 mod client;
 mod mutf7;
 
-pub use client::{EnvelopeBatch, ImapClient, probe_server_certificate};
+pub use client::{EnvelopeBatch, ImapClient, parse_eml_bytes, probe_server_certificate};

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9588,10 +9588,138 @@ fn restart_app(app: AppHandle) {
     app.restart();
 }
 
+// ── File-association handlers (#254) ────────────────────────────
+//
+// `bundle.fileAssociations` in `tauri.conf.json` registers Nimbus
+// with the OS as an "Open with…" candidate for `.ics` and `.eml`.
+// When the user double-clicks (or `start file.eml`s) one of those
+// the OS launches us with the path as `argv[1]`.  We capture the
+// argument once at startup and stash it in `PENDING_FILE_OPEN`;
+// the frontend polls `take_pending_file_to_open` after mount and
+// routes the path to the right view.
+
+/// One-shot slot for the file the OS handed us at launch time.
+/// Frontend takes ownership on its first read so a refresh of the
+/// main window doesn't loop into the same import flow.
+static PENDING_FILE_OPEN: std::sync::OnceLock<Mutex<Option<String>>> = std::sync::OnceLock::new();
+
+fn pending_file_slot() -> &'static Mutex<Option<String>> {
+    PENDING_FILE_OPEN.get_or_init(|| Mutex::new(None))
+}
+
+/// Capture argv[1] at startup if it points at an `.ics` or `.eml`
+/// file we know how to open.  Anything else is ignored — Tauri
+/// passes any `--flag` style argv too and we don't want to
+/// accidentally treat those as paths.
+fn capture_launch_file_arg() {
+    let Some(arg) = std::env::args().nth(1) else {
+        return;
+    };
+    if arg.starts_with('-') {
+        return;
+    }
+    let lower = arg.to_lowercase();
+    if !(lower.ends_with(".ics") || lower.ends_with(".eml")) {
+        return;
+    }
+    if !std::path::Path::new(&arg).is_file() {
+        return;
+    }
+    if let Ok(mut slot) = pending_file_slot().lock() {
+        *slot = Some(arg);
+    }
+}
+
+/// Frontend hook: returns the launch-time file path (if any) and
+/// clears the slot so a window refresh doesn't re-open it.
+#[tauri::command]
+fn take_pending_file_to_open() -> Option<String> {
+    pending_file_slot()
+        .lock()
+        .ok()
+        .and_then(|mut slot| slot.take())
+}
+
+/// Read an `.eml` file from disk and parse it into the same
+/// `Email` shape `get_mail` returns from the cache.  Used by the
+/// view-only popout when the OS hands us a `.eml` to open.  No
+/// account context — the popout disables reply / forward / archive
+/// because there's no IMAP session to act against.
+#[tauri::command]
+fn parse_eml_file(path: String) -> Result<nimbus_core::models::Email, NimbusError> {
+    let bytes =
+        std::fs::read(&path).map_err(|e| NimbusError::Other(format!("read {path}: {e}")))?;
+    let stem = std::path::Path::new(&path)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("file");
+    nimbus_imap::parse_eml_bytes(&bytes, &format!("file:{stem}"), "", "")
+}
+
+/// Read an `.ics` file from disk and parse it into one or more
+/// `CalendarEvent`s.  Caller (the import-from-disk flow) opens the
+/// first event in the EventEditor so the user can pick a target
+/// calendar and save it via the existing create path.
+#[tauri::command]
+fn parse_ics_file(path: String) -> Result<Vec<nimbus_core::models::CalendarEvent>, NimbusError> {
+    let body = std::fs::read_to_string(&path)
+        .map_err(|e| NimbusError::Other(format!("read {path}: {e}")))?;
+    nimbus_caldav::ical::parse_ics(&body)
+}
+
+/// Cross-platform "open the OS Default Apps panel" — used by the
+/// settings page button so users can mark Nimbus as the default
+/// handler for `.ics` / `.eml` (which OS APIs don't let us do
+/// programmatically without a COM dance on Windows).
+///
+/// - Windows: `start ms-settings:defaultapps` opens the modern
+///   Settings panel directly on the Default-Apps page.
+/// - macOS: no settings deep-link for default apps; we open the
+///   user's home directory in Finder so they can right-click an
+///   `.ics` / `.eml` → Get Info → "Open with" → "Change All".
+/// - Linux: `xdg-mime default` is the canonical CLI; opening a
+///   GUI panel varies wildly across desktops, so we fall back to
+///   doing nothing and let the user run the CLI themselves.
+#[tauri::command]
+fn open_default_apps_settings() -> Result<(), NimbusError> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", "ms-settings:defaultapps"])
+            .spawn()
+            .map_err(|e| NimbusError::Other(format!("open defaults panel: {e}")))?;
+        return Ok(());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(std::env::var("HOME").unwrap_or_else(|_| "/".into()))
+            .spawn()
+            .map_err(|e| NimbusError::Other(format!("open defaults panel: {e}")))?;
+        return Ok(());
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    {
+        Err(NimbusError::Other(
+            "Default-app registration on Linux is per-desktop; \
+             use `xdg-mime default nimbus-mail.desktop text/calendar message/rfc822` \
+             from a terminal to mark Nimbus as the default handler."
+                .into(),
+        ))
+    }
+}
+
 // ── App entry point ─────────────────────────────────────────────
 
 fn main() {
     tracing_subscriber::fmt::init();
+
+    // Pick up the path the OS handed us if Nimbus was invoked as
+    // an `.ics` / `.eml` file handler (#254).  Capturing here —
+    // before the Tauri builder runs — means the slot is populated
+    // by the time the frontend's `take_pending_file_to_open`
+    // ping arrives on first paint.
+    capture_launch_file_arg();
 
     // Open (and migrate) the local mail cache once at startup, then
     // hand it to Tauri as managed state so every command can borrow it.
@@ -10161,6 +10289,11 @@ fn main() {
             show_main_window_cmd,
             quit_app,
             restart_app,
+            // #254 — file-association entry points
+            take_pending_file_to_open,
+            parse_eml_file,
+            parse_ics_file,
+            open_default_apps_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Nimbus");

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,5 +25,23 @@
     "security": {
       "csp": null
     }
+  },
+  "bundle": {
+    "fileAssociations": [
+      {
+        "ext": ["ics"],
+        "name": "iCalendar Event",
+        "description": "iCalendar event invitation",
+        "mimeType": "text/calendar",
+        "role": "Editor"
+      },
+      {
+        "ext": ["eml"],
+        "name": "Email Message",
+        "description": "RFC 822 email message",
+        "mimeType": "message/rfc822",
+        "role": "Viewer"
+      }
+    ]
   }
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -12,6 +12,10 @@
   "settings_general_language_restart_now": "Jetzt neu starten",
   "settings_general_language_restart_later": "Später neu starten",
 
+  "settings_general_file_assoc_label": ".ics- und .eml-Dateien in Nimbus öffnen",
+  "settings_general_file_assoc_hint": "Nimbus ist beim Betriebssystem als möglicher Handler registriert. Setzen Sie Nimbus in den OS-Einstellungen als Standardprogramm, damit doppelt angeklickte Kalender­einladungen und E-Mail-Dateien hier geöffnet werden.",
+  "settings_general_file_assoc_button": "OS-Einstellungen öffnen",
+
   "account_setup_welcome_title": "Willkommen bei Nimbus Mail",
   "account_setup_welcome_subtitle": "Lassen Sie uns Ihr E-Mail-Konto einrichten",
   "account_setup_close_label": "Einrichtungsassistenten schließen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -12,6 +12,10 @@
   "settings_general_language_restart_now": "Restart now",
   "settings_general_language_restart_later": "Restart later",
 
+  "settings_general_file_assoc_label": "Open .ics and .eml files in Nimbus",
+  "settings_general_file_assoc_hint": "Nimbus is registered with your operating system as a possible handler. Mark it as the default in your OS settings to have double-clicked calendar invites and email files open here.",
+  "settings_general_file_assoc_button": "Open OS settings",
+
   "account_setup_welcome_title": "Welcome to Nimbus Mail",
   "account_setup_welcome_subtitle": "Let's set up your email account",
   "account_setup_close_label": "Close setup wizard",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -33,6 +33,7 @@
   import ContactsView from './lib/ContactsView.svelte'
   import CalendarView from './lib/CalendarView.svelte'
   import { openReminderInStandaloneWindow } from './lib/reminderPopupWindow'
+  import { openMailFileInStandaloneWindow } from './lib/standaloneMailFileWindow'
   import FilesView from './lib/FilesView.svelte'
   import TalkView from './lib/TalkView.svelte'
   import NotesView from './lib/NotesView.svelte'
@@ -823,6 +824,16 @@
       unlistenMailtoFromMail = await listen<{
         init: { to?: string; cc?: string; bcc?: string; subject?: string; body?: string }
       }>('mailto-from-mail', (e) => openCompose(e.payload.init))
+
+      // #254 — when Nimbus is launched as the OS handler for an
+      // .ics or .eml file (Windows registry / macOS UTI / Linux
+      // .desktop), the backend stashes the path in a one-shot
+      // slot during process startup.  Pull it now, after the
+      // event listeners are wired so an iCal "Show event" path
+      // can still race past us if it ever overlaps.  Best-effort:
+      // any failure is logged and dropped so a malformed handoff
+      // doesn't keep the user staring at an empty app shell.
+      void processPendingLaunchFile()
     })()
     return () => {
       unlistenNewMail?.()
@@ -1348,15 +1359,21 @@
       start: Date
       end: Date
       summary: string
+      description?: string
+      location?: string
+      url?: string
       requiredAttendees: string[]
       optionalAttendees: string[]
+      chairAttendees?: string[]
       createTalkRoom: boolean
     }
     /** Original thread the user clicked "Respond with meeting"
      *  on — held here so `onMeetingEditorSaved` can reopen
      *  Compose pre-filled as a reply once the event lands
-     *  (#195). */
-    replyTo: OpenMail
+     *  (#195).  Absent when the editor was opened from a
+     *  source other than an email thread (e.g. an .ics file
+     *  the OS handed us via "Open with…", #254). */
+    replyTo?: OpenMail
   } | null>(null)
 
   /** Strip an `"Name" <addr>` wrapper down to the bare email. */
@@ -1496,6 +1513,12 @@
       talkUrl: isUrl ? loc : null,
     }
 
+    // No source thread (e.g. the editor was opened from an .ics
+    // file we got handed via the OS, #254) — just save the event
+    // and bow out.  No reply Compose makes sense without an
+    // email to reply to.
+    if (!ctx.replyTo) return
+
     // Open Compose as a reply to the original thread, with the
     // styled meeting card pre-filled into the body.  Existing
     // reply ergonomics (To from From, Re: subject prefix, quoted
@@ -1514,6 +1537,183 @@
       body: quoteBody(original.from, original.date, original.body_text),
       meetingInvite,
     })
+  }
+
+  // ── OS file-association handoff (#254) ─────────────────────────
+  // When the user launches Nimbus by double-clicking an .ics /
+  // .eml file (or via "Open with… → Nimbus"), the OS hands the
+  // path to the process as `argv[1]`.  The Rust side stashes it
+  // in a one-shot slot during process startup; we drain it here
+  // and dispatch by extension:
+  //
+  //   .eml → spawn a view-only popout window (read-only by
+  //          design — no account context, no folder, so reply /
+  //          archive don't make sense)
+  //   .ics → load the user's calendars, parse the file into
+  //          our CalendarEvent shape, prefill EventEditor in
+  //          create-mode so the user can adjust the title /
+  //          time / attendees and save into a calendar of their
+  //          choice (per the user's directive — NOT read-only)
+
+  /** Lift a `CalendarEvent.attendees` list into the
+   *  required / optional / chair buckets EventEditor's draft
+   *  prop expects.  Each attendee is rendered as `"Name" <addr>`
+   *  when CN is present, or just the bare address otherwise —
+   *  matches `parseAddress` everywhere else. */
+  function bucketAttendeesByRole(
+    attendees: { email: string; common_name?: string | null; role?: string | null }[],
+    self: string,
+  ): {
+    required: string[]
+    optional: string[]
+    chair: string[]
+  } {
+    const required: string[] = []
+    const optional: string[] = []
+    const chair: string[] = []
+    const selfAddr = self.toLowerCase()
+    for (const a of attendees) {
+      const email = (a.email || '').replace(/^mailto:/i, '').trim()
+      if (!email) continue
+      if (email.toLowerCase() === selfAddr) continue
+      const piece = a.common_name ? `"${a.common_name}" <${email}>` : email
+      const role = (a.role || 'REQ-PARTICIPANT').toUpperCase()
+      if (role === 'OPT-PARTICIPANT') optional.push(piece)
+      else if (role === 'CHAIR') chair.push(piece)
+      else required.push(piece)
+    }
+    return { required, optional, chair }
+  }
+
+  /** Drain the one-shot launch-file slot in the Rust backend
+   *  and dispatch the path by extension.  Called once during
+   *  the main app's startup `$effect`. */
+  async function processPendingLaunchFile() {
+    let path: string | null = null
+    try {
+      path = await invoke<string | null>('take_pending_file_to_open')
+    } catch (e) {
+      console.warn('take_pending_file_to_open failed', e)
+      return
+    }
+    if (!path) return
+
+    const lower = path.toLowerCase()
+    if (lower.endsWith('.eml')) {
+      try {
+        await openMailFileInStandaloneWindow(path)
+      } catch (e) {
+        console.warn('openMailFileInStandaloneWindow failed', e)
+      }
+      return
+    }
+    if (lower.endsWith('.ics')) {
+      await openIcsFileInEditor(path)
+      return
+    }
+    console.warn('pending file has unsupported extension:', path)
+  }
+
+  /** Subset of the Rust `CalendarEvent` shape we read off of
+   *  `parse_ics_file`.  EventEditor and CalendarView each
+   *  define their own internal interface for the same data;
+   *  rather than reach in and import a non-exported type, we
+   *  stamp out the fields we actually need here. */
+  interface ImportedIcsEvent {
+    summary: string
+    description?: string | null
+    start: string
+    end: string
+    location?: string | null
+    url?: string | null
+    attendees?: { email: string; common_name?: string | null; role?: string | null }[]
+  }
+
+  /** Parse an .ics on disk and open EventEditor in create-mode
+   *  pre-filled with the parsed event's data.  Multiple VEVENTs
+   *  in one file are uncommon for hand-shared invites — we use
+   *  the first one and let the user save it; the others are
+   *  ignored.  The user picks the calendar in the editor. */
+  async function openIcsFileInEditor(path: string) {
+    let events: ImportedIcsEvent[] = []
+    try {
+      events = await invoke<ImportedIcsEvent[]>('parse_ics_file', { path })
+    } catch (e) {
+      alert(`Could not parse the calendar file: ${e}`)
+      return
+    }
+    if (events.length === 0) {
+      alert('The calendar file did not contain any events.')
+      return
+    }
+    const ev = events[0]
+
+    // Calendars come from the user's first connected Nextcloud
+    // account (same source the "Respond with meeting" flow
+    // uses).  Without an NC account there's nowhere to save
+    // the event, so we surface that and bail.
+    let ncId = ''
+    try {
+      const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+      if (list.length === 0) {
+        alert(
+          'Connect a Nextcloud account first (Settings → Nextcloud) so this event has a calendar to land in.',
+        )
+        return
+      }
+      ncId = list[0].id
+    } catch (e) {
+      alert(`Failed to load Nextcloud accounts: ${e}`)
+      return
+    }
+
+    let calendars: CalendarSummary[] = []
+    try {
+      calendars = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
+    } catch (e) {
+      alert(`Failed to load calendars: ${e}`)
+      return
+    }
+    const visible = calendars.filter((c) => !c.hidden)
+    if (visible.length === 0) {
+      alert('No writable calendars found on your Nextcloud account.')
+      return
+    }
+    let initialCalendarId = visible[0].id
+    try {
+      const s = await invoke<{ default_calendar_id: string | null }>(
+        'get_app_settings',
+      )
+      if (s.default_calendar_id && visible.some((c) => c.id === s.default_calendar_id)) {
+        initialCalendarId = s.default_calendar_id!
+      }
+    } catch {}
+
+    const buckets = bucketAttendeesByRole(ev.attendees ?? [], activeAccountEmail)
+
+    meetingDraft = {
+      calendars: visible,
+      draft: {
+        calendarId: initialCalendarId,
+        start: new Date(ev.start),
+        end: new Date(ev.end),
+        summary: ev.summary || '',
+        description: ev.description ?? undefined,
+        location: ev.location ?? undefined,
+        url: ev.url ?? undefined,
+        requiredAttendees: buckets.required,
+        optionalAttendees: buckets.optional,
+        chairAttendees: buckets.chair,
+        // Don't auto-mint a Talk room for a third-party invite
+        // we just imported — the original file may already have
+        // a join URL in LOCATION or URL, and creating a fresh
+        // room would muddy the invite.
+        createTalkRoom: false,
+      },
+      // No source thread — this is a file the user opened, not
+      // a reply path.  `onMeetingEditorSaved` skips its Compose
+      // step when this is absent.
+    }
   }
 
   /** "Save as note" handler — issue #67's email→note bridge. Builds

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -565,6 +565,24 @@
     }
   }
 
+  /** Open the OS's default-apps settings page so the user can
+   *  pick Nimbus as the default handler for .ics / .eml (#254).
+   *  Nimbus is *eligible* once installed thanks to the
+   *  `bundle.fileAssociations` declarations, but on Windows
+   *  marking it as the *default* requires user consent in the
+   *  Settings panel — programmatic association without the
+   *  user clicking through is locked down by Windows for
+   *  anti-hijacking reasons.  The Rust command shell-execs the
+   *  appropriate OS surface (`ms-settings:defaultapps` /
+   *  `~/Library/Preferences` / xdg-mime hint). */
+  async function openDefaultAppsSettings() {
+    try {
+      await invoke('open_default_apps_settings')
+    } catch (e) {
+      alert(`Could not open the default-apps settings page: ${e}`)
+    }
+  }
+
   /** Reconcile the stored bit against the OS on mount — picks
    *  up the case where the user removed the autostart entry
    *  manually (e.g. via system settings) since the last
@@ -1240,6 +1258,33 @@
             {m.settings_general_language_hint()}
           </p>
         {/if}
+
+        <!-- File associations (#254).  Nimbus is registered as an
+             eligible handler for .ics / .eml during install via
+             the bundle.fileAssociations entries in
+             tauri.conf.json — but on Windows, "eligible" doesn't
+             mean "default".  The user has to flip the toggle in
+             the OS settings panel themselves; we provide a
+             shortcut button instead of asking them to dig
+             through Settings → Apps → Default apps by hand. -->
+        <div class="pt-2 border-t border-surface-300/40 dark:border-surface-700/40">
+          <div class="flex items-start justify-between gap-3">
+            <div class="text-sm">
+              <div>{m.settings_general_file_assoc_label()}</div>
+              <div class="text-xs text-surface-500 mt-0.5">
+                {m.settings_general_file_assoc_hint()}
+              </div>
+            </div>
+            <button
+              type="button"
+              class="btn btn-sm preset-outlined-surface-500 shrink-0 inline-flex items-center gap-1.5"
+              onclick={openDefaultAppsSettings}
+            >
+              <Icon name="open-link" size={14} />
+              {m.settings_general_file_assoc_button()}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
     {/if}

--- a/ui/src/lib/StandaloneMailFile.svelte
+++ b/ui/src/lib/StandaloneMailFile.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  /**
+   * StandaloneMailFile — view-only popout for an .eml file (#254).
+   *
+   * Mounted by main.ts when the URL carries
+   * `?view=mailfile&path=...`.  The path points at a local .eml on
+   * disk (typically supplied by the OS via "Open with… → Nimbus").
+   * We hand the path to the `parse_eml_file` Tauri command, which
+   * runs the same MIME walker `fetch_message` uses internally and
+   * returns the same Email shape.  No IMAP, no cache — just bytes
+   * from disk turned into a renderable message.
+   *
+   * Read-only by design: the file isn't tied to any account or
+   * folder, so reply / forward / archive don't have a well-defined
+   * destination.  Subject + headers + body, sanitised HTML, that's
+   * the entire UI.  Closing the window is the only outbound action.
+   */
+
+  import { invoke } from '@tauri-apps/api/core'
+  import { getCurrentWindow } from '@tauri-apps/api/window'
+  import DOMPurify from 'dompurify'
+  import { onMount, onDestroy } from 'svelte'
+  import Icon from './Icon.svelte'
+  import { applyTheme, installSystemModeListener, type ThemeMode } from './theme'
+  import { formatError } from './errors'
+
+  interface EmailAttachment {
+    filename: string
+    content_type: string
+    size: number | null
+    part_id: number
+    content_id?: string | null
+  }
+
+  interface ParsedEmail {
+    id: string
+    account_id: string
+    folder: string
+    from: string
+    to: string[]
+    cc: string[]
+    subject: string
+    body_text: string | null
+    body_html: string | null
+    date: string
+    is_read: boolean
+    is_starred: boolean
+    has_attachments: boolean
+    attachments: EmailAttachment[]
+  }
+
+  let { path }: { path: string } = $props()
+
+  let email = $state<ParsedEmail | null>(null)
+  let loading = $state(true)
+  let loadError = $state('')
+  let unlistenSystemMode: (() => void) | null = null
+
+  onMount(() => {
+    void (async () => {
+      try {
+        const prefs = await invoke<{
+          theme_name: string
+          theme_mode: ThemeMode
+        }>('get_app_settings')
+        applyTheme(prefs.theme_name, prefs.theme_mode)
+        unlistenSystemMode = installSystemModeListener(
+          prefs.theme_mode,
+          prefs.theme_name,
+        )
+      } catch (e) {
+        console.warn('get_app_settings failed in standalone mailfile', e)
+      }
+
+      try {
+        email = await invoke<ParsedEmail>('parse_eml_file', { path })
+      } catch (e) {
+        loadError = formatError(e) || 'Could not parse the email file.'
+      } finally {
+        loading = false
+      }
+    })()
+  })
+
+  onDestroy(() => {
+    unlistenSystemMode?.()
+  })
+
+  // Same allow-list as MailView's sanitiser, minus the per-message
+  // image-blocking flow — a file the user explicitly opened from
+  // disk is already trusted enough to load remote images, and
+  // there's no per-sender trust state to read here anyway.  Scripts,
+  // iframes, forms, and embedded stylesheet blocks are still
+  // stripped so a hostile message can't mount a UI redress attack
+  // against the popout chrome.
+  function sanitiseHtml(html: string): string {
+    const clean = DOMPurify.sanitize(html, {
+      FORBID_TAGS: [
+        'script',
+        'noscript',
+        'object',
+        'embed',
+        'applet',
+        'iframe',
+        'frame',
+        'frameset',
+        'form',
+        'input',
+        'textarea',
+        'select',
+        'button',
+        'base',
+        'meta',
+        'link',
+        'style',
+      ],
+      ADD_ATTR: ['target', 'title'],
+      FORCE_BODY: true,
+    })
+    const doc = new DOMParser().parseFromString(clean, 'text/html')
+    for (const a of Array.from(doc.querySelectorAll('a[href]'))) {
+      a.setAttribute('target', '_blank')
+      a.setAttribute('rel', 'noopener noreferrer')
+    }
+    return doc.body.innerHTML
+  }
+
+  let renderedHtml = $derived(
+    email && email.body_html ? sanitiseHtml(email.body_html) : '',
+  )
+
+  function formatFullDate(iso: string): string {
+    if (!iso) return ''
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return iso
+    return d.toLocaleString()
+  }
+
+  function closeWindow() {
+    void getCurrentWindow().close()
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      closeWindow()
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<svelte:head>
+  <title>{email?.subject || 'Nimbus Mail'}</title>
+</svelte:head>
+
+<div class="h-screen flex flex-col bg-surface-50 dark:bg-surface-900 text-surface-900 dark:text-surface-100">
+  {#if loading}
+    <div class="flex-1 flex items-center justify-center text-sm text-surface-500">
+      Loading…
+    </div>
+  {:else if loadError}
+    <div class="flex-1 flex items-center justify-center px-6">
+      <div class="max-w-md text-center space-y-2">
+        <div class="text-error-500"><Icon name="warning" size={32} /></div>
+        <div class="text-base font-semibold">Could not open this email file</div>
+        <div class="text-sm text-surface-500 wrap-break-word">{loadError}</div>
+        <button type="button" class="btn btn-sm preset-outlined-surface-500 mt-3" onclick={closeWindow}>
+          Close
+        </button>
+      </div>
+    </div>
+  {:else if email}
+    <header class="px-6 pt-5 pb-4 border-b border-surface-300/60 dark:border-surface-700/60">
+      <h1 class="text-lg font-semibold leading-snug wrap-break-word">
+        {email.subject || '(no subject)'}
+      </h1>
+      <dl class="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+        <dt class="text-surface-500">From</dt>
+        <dd class="wrap-break-word">{email.from || '(unknown sender)'}</dd>
+        {#if email.to.length > 0}
+          <dt class="text-surface-500">To</dt>
+          <dd class="wrap-break-word">{email.to.join(', ')}</dd>
+        {/if}
+        {#if email.cc.length > 0}
+          <dt class="text-surface-500">Cc</dt>
+          <dd class="wrap-break-word">{email.cc.join(', ')}</dd>
+        {/if}
+        {#if email.date}
+          <dt class="text-surface-500">Date</dt>
+          <dd>{formatFullDate(email.date)}</dd>
+        {/if}
+      </dl>
+      {#if email.attachments.length > 0}
+        <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-surface-500">
+          <span class="flex items-center gap-1">
+            <Icon name="attachment" size={12} />
+            {email.attachments.length} attachment{email.attachments.length === 1 ? '' : 's'}
+          </span>
+          {#each email.attachments as a}
+            <span class="px-2 py-0.5 rounded-full bg-surface-200 dark:bg-surface-800 wrap-break-word">
+              {a.filename || a.content_type}
+            </span>
+          {/each}
+        </div>
+      {/if}
+    </header>
+
+    <section class="flex-1 overflow-auto">
+      {#if renderedHtml}
+        <div class="px-6 py-4 mail-body" style="background:white;color:#111">
+          {@html renderedHtml}
+        </div>
+      {:else if email.body_text}
+        <pre class="px-6 py-4 text-sm whitespace-pre-wrap wrap-break-word font-mono">{email.body_text}</pre>
+      {:else}
+        <div class="px-6 py-4 text-sm text-surface-500 italic">
+          (This message has no displayable body.)
+        </div>
+      {/if}
+    </section>
+  {/if}
+</div>
+
+<style>
+  .mail-body :global(img) {
+    max-width: 100%;
+    height: auto;
+  }
+  .mail-body :global(table) {
+    max-width: 100%;
+  }
+</style>

--- a/ui/src/lib/standaloneMailFileWindow.ts
+++ b/ui/src/lib/standaloneMailFileWindow.ts
@@ -1,0 +1,28 @@
+/**
+ * Spawn a standalone Tauri webview window that displays an .eml
+ * file from disk (#254 — "Open with… → Nimbus" flow).
+ *
+ * Same bundle as the main app; `main.ts` routes `view=mailfile`
+ * to `StandaloneMailFile.svelte`.  The path is passed straight
+ * through the URL query — Tauri's webview does the percent-
+ * encoding for us as long as we hand it the raw value via
+ * `URLSearchParams`.
+ */
+export async function openMailFileInStandaloneWindow(
+  path: string,
+): Promise<void> {
+  const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow')
+  const label = `mailfile-${crypto.randomUUID().replaceAll('-', '')}`
+  const params = new URLSearchParams({
+    view: 'mailfile',
+    path,
+  })
+  new WebviewWindow(label, {
+    url: `index.html?${params.toString()}`,
+    title: 'Nimbus Mail',
+    width: 900,
+    height: 700,
+    minWidth: 500,
+    minHeight: 400,
+  })
+}

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -2,15 +2,17 @@ import { mount } from 'svelte'
 import './app.css'
 import App from './App.svelte'
 import StandaloneMail from './lib/StandaloneMail.svelte'
+import StandaloneMailFile from './lib/StandaloneMailFile.svelte'
 import StandaloneCompose from './lib/StandaloneCompose.svelte'
 import StandaloneReminder from './lib/StandaloneReminder.svelte'
 
-// Same Vite bundle, four entry routes selected via the URL query:
+// Same Vite bundle, five entry routes selected via the URL query:
 //
 //   ?view=mail&account=…&folder=…&uid=…  → standalone mail reader (#104)
-//   ?view=compose&key=…                 → standalone compose window (#110)
-//   ?view=reminder&key=…                → calendar reminder popup (#203)
-//   anything else                       → the full 3-pane app
+//   ?view=mailfile&path=…                → view-only .eml from disk (#254)
+//   ?view=compose&key=…                  → standalone compose window (#110)
+//   ?view=reminder&key=…                 → calendar reminder popup (#203)
+//   anything else                        → the full 3-pane app
 //
 // Reusing one bundle keeps the build simple and gives every route
 // access to the full component library (MailView, Compose) without
@@ -27,6 +29,11 @@ if (view === 'mail') {
   app = mount(StandaloneMail, {
     target,
     props: { accountId, folder, uid },
+  })
+} else if (view === 'mailfile') {
+  app = mount(StandaloneMailFile, {
+    target,
+    props: { path: params.get('path') ?? '' },
   })
 } else if (view === 'compose') {
   app = mount(StandaloneCompose, {


### PR DESCRIPTION
## Summary

Closes #254.

Nimbus now declares itself as a handler for `.ics` and `.eml` in
`bundle.fileAssociations` so the OS lists it under "Open with…" once
installed.  When the OS hands a file to Nimbus on launch (`argv[1]`),
the backend parses the path on disk and the frontend dispatches by
extension:

- **`.eml` → view-only popout window.**  A new `StandaloneMailFile.svelte`
  view (route `?view=mailfile&path=…`) renders subject / headers /
  body via the same MIME walker `fetch_message` uses internally —
  no IMAP, no cache, just the file.  Read-only by design: the file
  isn't tied to an account or folder, so reply / forward / archive
  don't have a well-defined destination.
- **`.ics` → EventEditor in create-mode.**  We load the user's
  Nextcloud calendars, parse the file via `parse_ics_file`, prefill
  the existing EventEditor with summary / start / end / location /
  description / attendees (split by `ROLE`), and let the user pick
  the destination calendar and adjust before saving.  Deliberately
  editable — the user explicitly asked for "not read-only, with the
  option to save it to a calendar."
- **AccountSettings → General → "Open OS settings"** button.
  Programmatic default-handler association is locked down on
  Windows for anti-hijacking reasons, so we shell-exec
  `ms-settings:defaultapps` and let the user mark Nimbus as the
  default themselves.  macOS opens `~`; Linux returns an
  `xdg-mime default` hint.

Three new paraglide keys (en + de) for the settings row.

## Test plan

- [ ] Install a fresh dev build on Windows; double-click an `.ics`
      → EventEditor opens prefilled with summary / time /
      attendees, calendar picker shows visible calendars, Save
      writes the event to the chosen calendar.
- [ ] Double-click an `.eml` → popout opens with subject /
      headers / sanitised body; remote images load (file is
      "trusted"); links open externally with `noopener`.
- [x] Settings → General → "Open OS settings" → Windows Settings
      app opens to the default-apps page; pick Nimbus as the
      `.ics` / `.eml` default; double-click an associated file
      → Nimbus is what runs.
- [x] Frontend `npm run check` clean; `cargo check --workspace`
      clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)