### PR TITLE
#255: show reply / reply-all / meeting-reply icon on answered mails

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -407,6 +407,25 @@ pub struct EmailEnvelope {
     pub date: DateTime<Utc>,
     pub is_read: bool,
     pub is_starred: bool,
+    /// Mirrors the IMAP `\Answered` system flag (#255).  Refreshed
+    /// on every envelope re-fetch.  Drives the generic reply icon
+    /// in the mail list for messages the user answered before this
+    /// feature shipped or answered from a different client; the
+    /// per-kind `replied_kind` below takes precedence when set.
+    /// `#[serde(default)]` so older cached payloads deserialise
+    /// cleanly.
+    #[serde(default)]
+    pub is_answered: bool,
+    /// Nimbus-only metadata recording *how* the user replied
+    /// (#255): `"reply"`, `"reply-all"`, or `"meeting"`.  IMAP
+    /// carries one boolean answered bit, but the user's intent
+    /// (which icon to show) is something only we know — we
+    /// stamp this on the original message after Compose's send
+    /// path succeeds.  `None` means we didn't track a reply via
+    /// Nimbus; the UI then falls back to `is_answered` for the
+    /// icon decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replied_kind: Option<String>,
     /// Owning account id. Populated when envelopes are read out of the
     /// cache (where `account_id` is a column on every row) so the UI
     /// can render an account label in unified-inbox mode and route the

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -1062,11 +1062,7 @@ impl ImapClient {
     /// other mail clients the user might have open, and gives
     /// Nimbus's mail-list a stable signal across cache rebuilds.
     /// Uses `UID STORE <uid> +FLAGS (\Answered)`; idempotent.
-    pub async fn mark_as_answered(
-        &mut self,
-        folder: &str,
-        uid: u32,
-    ) -> Result<(), NimbusError> {
+    pub async fn mark_as_answered(&mut self, folder: &str, uid: u32) -> Result<(), NimbusError> {
         let session = self
             .session
             .as_mut()

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -303,6 +303,22 @@ pub struct EnvelopeBatch {
     pub envelopes: Vec<EmailEnvelope>,
 }
 
+/// IMAP system-flag snapshot for a single message UID.
+///
+/// Returned by `fetch_flags`, which exists to refresh the
+/// `\Seen` / `\Flagged` / `\Answered` bits on already-cached
+/// envelopes — the standard envelope-fetch path is incremental and
+/// doesn't re-read flags on UIDs the cache already knows about, so
+/// flag changes another mail client makes (mark-read on a phone,
+/// answer from webmail, etc.) need this catch-up to round-trip.
+#[derive(Debug, Clone, Copy)]
+pub struct FlagSnapshot {
+    pub uid: u32,
+    pub is_read: bool,
+    pub is_starred: bool,
+    pub is_answered: bool,
+}
+
 impl ImapClient {
     /// Connect to an IMAP server over TLS and log in.
     ///
@@ -1083,6 +1099,91 @@ impl ImapClient {
 
         info!("Marked UID {uid} as \\Answered in '{folder}'");
         Ok(())
+    }
+
+    /// Re-read the IMAP system flags on a set of UIDs, returning a
+    /// snapshot of `\Seen` / `\Flagged` / `\Answered` per UID.
+    ///
+    /// The standard envelope-fetch path (`fetch_envelopes`) only
+    /// pulls UIDs strictly newer than the cache bookmark — so flag
+    /// changes another client makes (marked-read on a phone,
+    /// answered from webmail) never round-trip to Nimbus on their
+    /// own.  This is the catch-up: cheap (`UID FETCH x,y,z (UID
+    /// FLAGS)`), no envelope payload, just the flag bits.
+    ///
+    /// Returns an entry per UID the server actually reports back
+    /// (a UID that was expunged between calls just drops out).
+    pub async fn fetch_flags(
+        &mut self,
+        folder: &str,
+        uids: &[u32],
+    ) -> Result<Vec<FlagSnapshot>, NimbusError> {
+        if uids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        // EXAMINE (read-only) is enough — we're not flipping flags
+        // here, just observing them, and read-only avoids
+        // accidentally clearing the server's `\Recent` flag
+        // bookkeeping for the folder.
+        session.examine(to_wire(folder)).await.map_err(|e| {
+            NimbusError::Protocol(format!("Failed to examine folder '{folder}': {e}"))
+        })?;
+
+        // Comma-separated UID set is the canonical IMAP way to
+        // address a discrete list — no "1:50" range wastefulness if
+        // the cached UIDs aren't contiguous, and the server folds
+        // adjacent ones into ranges in its parser anyway.
+        let uid_set = uids
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let fetches: Vec<_> = session
+            .uid_fetch(&uid_set, "(UID FLAGS)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID FETCH (FLAGS) failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID FETCH (FLAGS): {e}")))?;
+
+        let snapshots: Vec<FlagSnapshot> = fetches
+            .iter()
+            .filter_map(|fetch| {
+                let uid = fetch.uid?;
+                let mut is_read = false;
+                let mut is_starred = false;
+                let mut is_answered = false;
+                for flag in fetch.flags() {
+                    match flag {
+                        async_imap::types::Flag::Seen => is_read = true,
+                        async_imap::types::Flag::Flagged => is_starred = true,
+                        async_imap::types::Flag::Answered => is_answered = true,
+                        _ => {}
+                    }
+                }
+                Some(FlagSnapshot {
+                    uid,
+                    is_read,
+                    is_starred,
+                    is_answered,
+                })
+            })
+            .collect();
+
+        debug!(
+            "Refreshed flags for {} UID(s) in '{folder}' (asked: {}, got: {})",
+            snapshots.len(),
+            uids.len(),
+            snapshots.len()
+        );
+        Ok(snapshots)
     }
 
     /// Append a raw RFC 822 message to a folder via IMAP `APPEND`.

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -601,13 +601,17 @@ impl ImapClient {
                     })
                     .unwrap_or_else(Utc::now);
 
-                // Flags: \Seen means read, \Flagged means starred
+                // Flags: \Seen → read, \Flagged → starred,
+                // \Answered → user-or-other-client replied to this
+                // message (#255).
                 let mut is_read = false;
                 let mut is_starred = false;
+                let mut is_answered = false;
                 for flag in fetch.flags() {
                     match flag {
                         async_imap::types::Flag::Seen => is_read = true,
                         async_imap::types::Flag::Flagged => is_starred = true,
+                        async_imap::types::Flag::Answered => is_answered = true,
                         _ => {}
                     }
                 }
@@ -620,6 +624,13 @@ impl ImapClient {
                     date,
                     is_read,
                     is_starred,
+                    is_answered,
+                    // The IMAP client doesn't track *how* the user
+                    // replied — that's Nimbus-only metadata stamped
+                    // by the send path (#255), so leave it None
+                    // here; the cache merge preserves whatever's
+                    // already on disk.
+                    replied_kind: None,
                     // The IMAP client doesn't carry the account id; the
                     // caller stamps it into the cache via
                     // `upsert_envelopes_for_account`, and cache reads
@@ -1040,6 +1051,41 @@ impl ImapClient {
             .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
 
         info!("Marked UID {uid} as \\Seen in '{folder}'");
+        Ok(())
+    }
+
+    /// Set the IMAP `\Answered` system flag on a message (#255).
+    ///
+    /// Called after Compose's send path delivers a successful reply
+    /// (or reply-all, or "respond with meeting") so the original
+    /// message is marked answered on the server — round-trips to
+    /// other mail clients the user might have open, and gives
+    /// Nimbus's mail-list a stable signal across cache rebuilds.
+    /// Uses `UID STORE <uid> +FLAGS (\Answered)`; idempotent.
+    pub async fn mark_as_answered(
+        &mut self,
+        folder: &str,
+        uid: u32,
+    ) -> Result<(), NimbusError> {
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        // Read-write SELECT so the server accepts the STORE.
+        session.select(to_wire(folder)).await.map_err(|e| {
+            NimbusError::Protocol(format!("Failed to select folder '{folder}': {e}"))
+        })?;
+
+        let _updates: Vec<_> = session
+            .uid_store(uid.to_string(), "+FLAGS (\\Answered)")
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("UID STORE failed: {e}")))?
+            .try_collect()
+            .await
+            .map_err(|e| NimbusError::Protocol(format!("Failed to read UID STORE: {e}")))?;
+
+        info!("Marked UID {uid} as \\Answered in '{folder}'");
         Ok(())
     }
 
@@ -1473,10 +1519,12 @@ impl ImapClient {
 
                 let mut is_read = false;
                 let mut is_starred = false;
+                let mut is_answered = false;
                 for flag in fetch.flags() {
                     match flag {
                         async_imap::types::Flag::Seen => is_read = true,
                         async_imap::types::Flag::Flagged => is_starred = true,
+                        async_imap::types::Flag::Answered => is_answered = true,
                         _ => {}
                     }
                 }
@@ -1489,6 +1537,8 @@ impl ImapClient {
                     date,
                     is_read,
                     is_starred,
+                    is_answered,
+                    replied_kind: None,
                     account_id: String::new(),
                 })
             })
@@ -1584,10 +1634,12 @@ impl ImapClient {
                     .unwrap_or_else(Utc::now);
                 let mut is_read = false;
                 let mut is_starred = false;
+                let mut is_answered = false;
                 for flag in fetch.flags() {
                     match flag {
                         async_imap::types::Flag::Seen => is_read = true,
                         async_imap::types::Flag::Flagged => is_starred = true,
+                        async_imap::types::Flag::Answered => is_answered = true,
                         _ => {}
                     }
                 }
@@ -1599,6 +1651,8 @@ impl ImapClient {
                     date,
                     is_read,
                     is_starred,
+                    is_answered,
+                    replied_kind: None,
                     account_id: String::new(),
                 })
             })
@@ -1710,10 +1764,12 @@ impl ImapClient {
 
                 let mut is_read = false;
                 let mut is_starred = false;
+                let mut is_answered = false;
                 for flag in fetch.flags() {
                     match flag {
                         async_imap::types::Flag::Seen => is_read = true,
                         async_imap::types::Flag::Flagged => is_starred = true,
+                        async_imap::types::Flag::Answered => is_answered = true,
                         _ => {}
                     }
                 }
@@ -1726,6 +1782,8 @@ impl ImapClient {
                     date,
                     is_read,
                     is_starred,
+                    is_answered,
+                    replied_kind: None,
                     account_id: String::new(),
                 })
             })

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -1827,6 +1827,15 @@ fn decode_header(bytes: &[u8]) -> String {
 }
 
 /// Format an IMAP envelope address as "Name <user@host>" (or just the address).
+///
+/// When the envelope's display-name slot equals the bare email
+/// (case-insensitive), we drop the name and emit just the address.
+/// Some senders / mail servers populate the personal-name component
+/// with the email itself, which would produce malformed RFC 5322
+/// like `alex@example.com <alex@example.com>` — the unquoted `@` in
+/// the phrase makes the result unparseable, and a plain reply would
+/// fail with "Invalid 'to' address".  Collapsing the redundant name
+/// also cleans up the mail-list display.
 fn format_address(addr: &async_imap::imap_proto::types::Address<'_>) -> String {
     let name = addr
         .name
@@ -1850,10 +1859,22 @@ fn format_address(addr: &async_imap::imap_proto::types::Address<'_>) -> String {
         format!("{mailbox}@{host}")
     };
 
-    match (name.is_empty(), email.is_empty()) {
+    let decoded_name = if name.is_empty() {
+        String::new()
+    } else {
+        decode_header(name.as_bytes())
+    };
+
+    // Treat a name that's identical to the email as no name at all.
+    let name_is_redundant = !email.is_empty() && decoded_name.trim().eq_ignore_ascii_case(&email);
+
+    match (
+        decoded_name.is_empty() || name_is_redundant,
+        email.is_empty(),
+    ) {
         (true, _) => email,
-        (false, true) => decode_header(name.as_bytes()),
-        (false, false) => format!("{} <{email}>", decode_header(name.as_bytes())),
+        (false, true) => decoded_name,
+        (false, false) => format!("{decoded_name} <{email}>"),
     }
 }
 

--- a/crates/nimbus-imap/src/lib.rs
+++ b/crates/nimbus-imap/src/lib.rs
@@ -6,4 +6,6 @@
 mod client;
 mod mutf7;
 
-pub use client::{EnvelopeBatch, ImapClient, parse_eml_bytes, probe_server_certificate};
+pub use client::{
+    EnvelopeBatch, FlagSnapshot, ImapClient, parse_eml_bytes, probe_server_certificate,
+};

--- a/crates/nimbus-jmap/src/client.rs
+++ b/crates/nimbus-jmap/src/client.rs
@@ -330,9 +330,11 @@ impl JmapClient {
                     .unwrap_or_else(Utc::now);
 
                 // JMAP uses keywords instead of flags:
-                //   $seen → read, $flagged → starred
+                //   $seen → read, $flagged → starred,
+                //   $answered → user has replied to this message (#255)
                 let is_read = email.keywords.contains_key("$seen");
                 let is_starred = email.keywords.contains_key("$flagged");
+                let is_answered = email.keywords.contains_key("$answered");
 
                 EmailEnvelope {
                     // JMAP IDs are strings, but our model uses u32 UIDs.
@@ -345,6 +347,8 @@ impl JmapClient {
                     date,
                     is_read,
                     is_starred,
+                    is_answered,
+                    replied_kind: None,
                     // Stamped into the cache by the caller; left empty
                     // here for the same reason as the IMAP path.
                     account_id: String::new(),
@@ -557,6 +561,46 @@ impl JmapClient {
         }
 
         info!("JMAP: marked '{jmap_id}' as $seen");
+        Ok(())
+    }
+
+    /// Set the `$answered` keyword on a message (#255) — equivalent
+    /// of IMAP's `UID STORE +FLAGS (\Answered)`.  Called from the
+    /// send path after a successful reply / reply-all / meeting
+    /// reply so the original message reflects the answered state
+    /// across clients.
+    pub async fn mark_as_answered(
+        &self,
+        folder: &str,
+        uid: u32,
+    ) -> Result<(), NimbusError> {
+        let jmap_id = self.resolve_jmap_id(folder, uid).await?;
+
+        let resp = self
+            .call(vec![MethodCall {
+                name: "Email/set".into(),
+                args: json!({
+                    "accountId": self.account_id,
+                    "update": {
+                        jmap_id.clone(): {
+                            "keywords/$answered": true,
+                        },
+                    },
+                }),
+                call_id: "answered0".into(),
+            }])
+            .await?;
+
+        let args = Self::find_response(&resp.method_responses, "answered0")?;
+        if let Some(errors) = args.get("notUpdated")
+            && let Some(err) = errors.get(&jmap_id)
+        {
+            return Err(NimbusError::Protocol(format!(
+                "Failed to mark as answered: {err}"
+            )));
+        }
+
+        info!("JMAP: marked '{jmap_id}' as $answered");
         Ok(())
     }
 

--- a/crates/nimbus-jmap/src/client.rs
+++ b/crates/nimbus-jmap/src/client.rs
@@ -569,11 +569,7 @@ impl JmapClient {
     /// send path after a successful reply / reply-all / meeting
     /// reply so the original message reflects the answered state
     /// across clients.
-    pub async fn mark_as_answered(
-        &self,
-        folder: &str,
-        uid: u32,
-    ) -> Result<(), NimbusError> {
+    pub async fn mark_as_answered(&self, folder: &str, uid: u32) -> Result<(), NimbusError> {
         let jmap_id = self.resolve_jmap_id(folder, uid).await?;
 
         let resp = self

--- a/crates/nimbus-smtp/src/client.rs
+++ b/crates/nimbus-smtp/src/client.rs
@@ -178,6 +178,44 @@ pub async fn probe_server_certificate(host: &str, port: u16) -> Result<Vec<u8>, 
     Ok(leaf)
 }
 
+/// Strip a redundant display name when it equals the email address.
+///
+/// Some senders / IMAP envelopes populate the personal-name slot with
+/// the bare email address.  Our IMAP `format_address` already collapses
+/// those upstream, but envelopes cached *before* that fix still carry
+/// the malformed `addr <addr>` form — which lettre's `Mailbox::parse`
+/// rejects because the unquoted `@` violates RFC 5322's phrase syntax.
+///
+/// This sanitiser is a defensive last-mile pass: if a candidate
+/// recipient looks like `Name <user@host>` and the name (stripped of
+/// surrounding quotes / whitespace) equals the email itself, we
+/// return just the bare `user@host` so lettre accepts it.  Any other
+/// shape is returned unchanged.
+fn sanitise_recipient(addr: &str) -> String {
+    let trimmed = addr.trim();
+    let Some(open) = trimmed.rfind('<') else {
+        return addr.to_string();
+    };
+    let Some(close) = trimmed.rfind('>') else {
+        return addr.to_string();
+    };
+    if close <= open {
+        return addr.to_string();
+    }
+    let email = trimmed[open + 1..close].trim();
+    let name = trimmed[..open].trim();
+    let name_unquoted = name
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(name)
+        .trim();
+    if name_unquoted.eq_ignore_ascii_case(email) {
+        email.to_string()
+    } else {
+        addr.to_string()
+    }
+}
+
 /// Build the lettre `Message` for an outgoing email *without* sending it.
 ///
 /// Exposed so callers (e.g. `main.rs`) can build the message once, send
@@ -185,8 +223,9 @@ pub async fn probe_server_certificate(host: &str, port: u16) -> Result<Vec<u8>, 
 /// `message.formatted()` to `APPEND` a copy into the IMAP Sent folder
 /// — without re-running the (potentially expensive) MIME serialization.
 pub fn build_outgoing_message(email: &OutgoingEmail) -> Result<Message, NimbusError> {
-    let from_mailbox: Mailbox = email.from.parse().map_err(|e| {
-        NimbusError::Protocol(format!("Invalid 'from' address '{}': {e}", email.from))
+    let from_clean = sanitise_recipient(&email.from);
+    let from_mailbox: Mailbox = from_clean.parse().map_err(|e| {
+        NimbusError::Protocol(format!("Invalid 'from' address '{from_clean}': {e}"))
     })?;
 
     let mut builder: MessageBuilder = Message::builder()
@@ -194,27 +233,31 @@ pub fn build_outgoing_message(email: &OutgoingEmail) -> Result<Message, NimbusEr
         .subject(&email.subject);
 
     for addr in &email.to {
-        let mailbox: Mailbox = addr
+        let clean = sanitise_recipient(addr);
+        let mailbox: Mailbox = clean
             .parse()
-            .map_err(|e| NimbusError::Protocol(format!("Invalid 'to' address '{addr}': {e}")))?;
+            .map_err(|e| NimbusError::Protocol(format!("Invalid 'to' address '{clean}': {e}")))?;
         builder = builder.to(mailbox);
     }
     for addr in &email.cc {
-        let mailbox: Mailbox = addr
+        let clean = sanitise_recipient(addr);
+        let mailbox: Mailbox = clean
             .parse()
-            .map_err(|e| NimbusError::Protocol(format!("Invalid 'cc' address '{addr}': {e}")))?;
+            .map_err(|e| NimbusError::Protocol(format!("Invalid 'cc' address '{clean}': {e}")))?;
         builder = builder.cc(mailbox);
     }
     for addr in &email.bcc {
-        let mailbox: Mailbox = addr
+        let clean = sanitise_recipient(addr);
+        let mailbox: Mailbox = clean
             .parse()
-            .map_err(|e| NimbusError::Protocol(format!("Invalid 'bcc' address '{addr}': {e}")))?;
+            .map_err(|e| NimbusError::Protocol(format!("Invalid 'bcc' address '{clean}': {e}")))?;
         builder = builder.bcc(mailbox);
     }
 
     if let Some(reply_to) = &email.reply_to {
-        let mailbox: Mailbox = reply_to.parse().map_err(|e| {
-            NimbusError::Protocol(format!("Invalid 'reply-to' address '{reply_to}': {e}"))
+        let clean = sanitise_recipient(reply_to);
+        let mailbox: Mailbox = clean.parse().map_err(|e| {
+            NimbusError::Protocol(format!("Invalid 'reply-to' address '{clean}': {e}"))
         })?;
         builder = builder.reply_to(mailbox);
     }
@@ -496,4 +539,49 @@ fn build_with_calendar(
     builder
         .multipart(mixed)
         .map_err(|e| NimbusError::Protocol(format!("Failed to build invite email: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitise_recipient;
+
+    #[test]
+    fn drops_redundant_display_name_equal_to_email() {
+        // Some IMAP envelopes carry the email itself in the
+        // personal-name slot; lettre rejects the resulting
+        // `addr <addr>` because the unquoted `@` breaks RFC 5322.
+        assert_eq!(
+            sanitise_recipient("alex@example.com <alex@example.com>"),
+            "alex@example.com"
+        );
+    }
+
+    #[test]
+    fn drops_redundant_quoted_display_name_equal_to_email() {
+        assert_eq!(
+            sanitise_recipient("\"alex@example.com\" <alex@example.com>"),
+            "alex@example.com"
+        );
+    }
+
+    #[test]
+    fn case_insensitive_redundancy_check() {
+        assert_eq!(
+            sanitise_recipient("ALEX@example.com <alex@example.com>"),
+            "alex@example.com"
+        );
+    }
+
+    #[test]
+    fn keeps_real_display_name() {
+        assert_eq!(
+            sanitise_recipient("Alex Morgan <alex@example.com>"),
+            "Alex Morgan <alex@example.com>"
+        );
+    }
+
+    #[test]
+    fn passes_through_bare_address() {
+        assert_eq!(sanitise_recipient("alex@example.com"), "alex@example.com");
+    }
 }

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -768,6 +768,35 @@ impl Cache {
         Ok(uids)
     }
 
+    /// Newest `limit` cached envelope UIDs for a folder, sorted by
+    /// `internal_date DESC` — the same ordering the mail list
+    /// renders.  Used by the flag-refresh path (#255 follow-up) to
+    /// catch up on cross-client `\Seen` / `\Flagged` / `\Answered`
+    /// changes on the visible window without re-pulling the whole
+    /// folder's flag set.
+    pub fn list_recent_envelope_uids(
+        &self,
+        account_id: &str,
+        folder: &str,
+        limit: u32,
+    ) -> Result<Vec<u32>, CacheError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT uid FROM messages
+             WHERE account_id = ?1 AND folder = ?2
+             ORDER BY internal_date DESC
+             LIMIT ?3",
+        )?;
+        let rows = stmt.query_map(params![account_id, folder, limit as i64], |r| {
+            r.get::<_, i64>(0)
+        })?;
+        let mut uids = Vec::new();
+        for row in rows {
+            uids.push(row? as u32);
+        }
+        Ok(uids)
+    }
+
     /// Mark a cached envelope as having an in-flight optimistic
     /// action so envelope-list queries hide it instantly (#174).
     /// `action` is a free-form string — `"delete"` for delete /
@@ -915,6 +944,106 @@ impl Cache {
 
         tx.commit()?;
         Ok(())
+    }
+
+    /// Reconcile the cached `is_read` / `is_starred` / `is_answered`
+    /// flags for a batch of envelope rows against fresh server-side
+    /// values (#255 follow-up).
+    ///
+    /// The standard envelope-fetch path is incremental — it never
+    /// re-reads flags on UIDs older than the bookmark.  Without
+    /// this catch-up, marks made from another mail client (read on
+    /// a phone, answered from webmail, starred elsewhere) never
+    /// round-trip into the local cache, and Nimbus's mail list
+    /// drifts out of sync with reality.
+    ///
+    /// `replied_kind` is intentionally not touched — it's
+    /// Nimbus-only metadata about *how* the user replied via
+    /// Compose, and the IMAP `\Answered` bit doesn't carry the
+    /// kind, so leave whatever the send path stamped earlier.
+    /// The `unread_count` on the folder is kept in sync by
+    /// crediting / debiting per-row read-state flips inside the
+    /// same transaction.
+    ///
+    /// Each tuple is `(uid, is_read, is_starred, is_answered)`.
+    /// UIDs that don't exist in the cache are silently skipped —
+    /// they got expunged between fetch and reconcile, and the
+    /// envelope-fetch path will sweep them out on its own
+    /// reconcile pass.
+    pub fn reconcile_envelope_flags(
+        &self,
+        account_id: &str,
+        folder: &str,
+        snapshots: &[(u32, bool, bool, bool)],
+    ) -> Result<u32, CacheError> {
+        if snapshots.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.conn()?;
+        let tx = conn.transaction()?;
+
+        let mut unread_delta: i64 = 0;
+        let mut changed: u32 = 0;
+        for (uid, is_read, is_starred, is_answered) in snapshots {
+            // Fetch current flags so we know whether to bump the
+            // folder's unread badge.  `query_row` returns
+            // `QueryReturnedNoRows` when the UID isn't cached —
+            // skip those.
+            let prior: Option<(bool, bool, bool)> = tx
+                .query_row(
+                    "SELECT is_read, is_starred, is_answered FROM messages
+                     WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+                    params![account_id, folder, *uid as i64],
+                    |r| {
+                        Ok((
+                            r.get::<_, i64>(0)? != 0,
+                            r.get::<_, i64>(1)? != 0,
+                            r.get::<_, i64>(2)? != 0,
+                        ))
+                    },
+                )
+                .ok();
+            let Some((was_read, was_starred, was_answered)) = prior else {
+                continue;
+            };
+            if was_read == *is_read && was_starred == *is_starred && was_answered == *is_answered {
+                continue;
+            }
+
+            tx.execute(
+                "UPDATE messages
+                 SET is_read = ?4, is_starred = ?5, is_answered = ?6
+                 WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+                params![
+                    account_id,
+                    folder,
+                    *uid as i64,
+                    *is_read as i64,
+                    *is_starred as i64,
+                    *is_answered as i64,
+                ],
+            )?;
+            changed += 1;
+
+            // Bump the unread accumulator: if the flag flipped
+            // unread → read, the folder count drops by one; if it
+            // flipped read → unread, it goes up by one.
+            if was_read != *is_read {
+                unread_delta += if *is_read { -1 } else { 1 };
+            }
+        }
+
+        if unread_delta != 0 {
+            tx.execute(
+                "UPDATE folders
+                 SET unread_count = MAX(COALESCE(unread_count, 0) + ?3, 0)
+                 WHERE account_id = ?1 AND name = ?2",
+                params![account_id, folder, unread_delta],
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(changed)
     }
 
     /// Stamp a cached envelope as answered (#255).  Sets both

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -527,17 +527,25 @@ impl Cache {
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
         {
+            // Note (#255): `replied_kind` is intentionally NOT in
+            // the UPDATE clause — IMAP envelope re-fetches don't
+            // know which kind of reply happened, so leave whatever
+            // we stamped from the send path in place.  `is_answered`
+            // *is* refreshed because the IMAP `\Answered` flag is
+            // authoritative for "did anyone (incl. another client)
+            // answer this".
             let mut stmt = tx.prepare(
                 "INSERT INTO messages
                    (account_id, folder, uid, from_addr, subject, internal_date,
-                    is_read, is_starred, cached_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                    is_read, is_starred, is_answered, cached_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
                  ON CONFLICT (account_id, folder, uid) DO UPDATE SET
                    from_addr     = excluded.from_addr,
                    subject       = excluded.subject,
                    internal_date = excluded.internal_date,
                    is_read       = excluded.is_read,
                    is_starred    = excluded.is_starred,
+                   is_answered   = excluded.is_answered,
                    cached_at     = excluded.cached_at",
             )?;
             for env in envelopes {
@@ -550,6 +558,7 @@ impl Cache {
                     env.date.timestamp(),
                     env.is_read as i64,
                     env.is_starred as i64,
+                    env.is_answered as i64,
                     now,
                 ])?;
             }
@@ -574,7 +583,8 @@ impl Cache {
     ) -> Result<Vec<EmailEnvelope>, CacheError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT uid, folder, from_addr, subject, internal_date, is_read, is_starred
+            "SELECT uid, folder, from_addr, subject, internal_date,
+                    is_read, is_starred, is_answered, replied_kind
              FROM messages
              WHERE account_id = ?1 AND folder = ?2 AND pending_action IS NULL
              ORDER BY internal_date DESC
@@ -591,6 +601,8 @@ impl Cache {
                 date,
                 is_read: r.get::<_, i64>(5)? != 0,
                 is_starred: r.get::<_, i64>(6)? != 0,
+                is_answered: r.get::<_, i64>(7)? != 0,
+                replied_kind: r.get(8)?,
                 account_id: account_id.to_string(),
             })
         })?;
@@ -647,7 +659,8 @@ impl Cache {
     ) -> Result<Vec<EmailEnvelope>, CacheError> {
         let conn = self.conn()?;
         let mut stmt = conn.prepare(
-            "SELECT account_id, uid, folder, from_addr, subject, internal_date, is_read, is_starred
+            "SELECT account_id, uid, folder, from_addr, subject, internal_date,
+                    is_read, is_starred, is_answered, replied_kind
              FROM messages
              WHERE folder = ?1 AND pending_action IS NULL
              ORDER BY internal_date DESC
@@ -665,6 +678,8 @@ impl Cache {
                 date,
                 is_read: r.get::<_, i64>(6)? != 0,
                 is_starred: r.get::<_, i64>(7)? != 0,
+                is_answered: r.get::<_, i64>(8)? != 0,
+                replied_kind: r.get(9)?,
             })
         })?;
 
@@ -899,6 +914,36 @@ impl Cache {
         }
 
         tx.commit()?;
+        Ok(())
+    }
+
+    /// Stamp a cached envelope as answered (#255).  Sets both
+    /// `is_answered = 1` (so the row keeps the generic-reply
+    /// fallback even after the IMAP `\Answered` flag round-trips
+    /// from the server) and `replied_kind` to one of `"reply"`,
+    /// `"reply-all"`, or `"meeting"`.
+    ///
+    /// Called from the Compose send path after a successful
+    /// reply / reply-all / meeting reply.  Idempotent: re-running
+    /// with the same kind is a no-op; re-running with a different
+    /// kind overwrites — useful only in unusual flows where the
+    /// user replies, then later "responds with meeting" on the
+    /// same source thread.
+    pub fn mark_envelope_replied(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+        kind: &str,
+    ) -> Result<(), CacheError> {
+        let conn = self.conn()?;
+        conn.execute(
+            "UPDATE messages
+             SET is_answered = 1,
+                 replied_kind = ?4
+             WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+            params![account_id, folder, uid as i64, kind],
+        )?;
         Ok(())
     }
 
@@ -1363,6 +1408,8 @@ mod tests {
             date: Utc::now() - Duration::minutes(offset_min),
             is_read: false,
             is_starred: false,
+            is_answered: false,
+            replied_kind: None,
             account_id: String::new(),
         }
     }

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -874,6 +874,30 @@ const MIGRATIONS: &[&str] = &[
     ALTER TABLE nextcloud_accounts
         ADD COLUMN trusted_certs_json TEXT NOT NULL DEFAULT '[]';
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v25 → v26: track which messages the user has answered so the
+    // mail list can show a small reply / reply-all / meeting-reply
+    // icon in front of the subject (#255).
+    //
+    // Two columns:
+    //   * `is_answered` — mirrors the IMAP `\Answered` system flag.
+    //     Refreshed on every envelope re-fetch.  `1` is enough to
+    //     show a generic reply icon for messages the user
+    //     answered before this feature shipped (or answered from
+    //     a different client) — IMAP-canonical fallback.
+    //   * `replied_kind` — Nimbus-only metadata recording *how*
+    //     the user replied: `'reply'`, `'reply-all'`, or
+    //     `'meeting'`.  IMAP carries one boolean answered bit;
+    //     the kind is something only we know, so we store it
+    //     locally and never overwrite it on envelope re-fetches.
+    //     `NULL` means "we didn't reply via Nimbus" — fall back
+    //     to `is_answered` for the icon decision.
+    r#"
+    ALTER TABLE messages
+        ADD COLUMN is_answered INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE messages
+        ADD COLUMN replied_kind TEXT;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6555,11 +6555,7 @@ async fn send_email(
 /// flag on the original message that a Compose reply just answered
 /// (#255).  Logs on failure rather than propagating — the user's
 /// mail already left the building.
-async fn mark_original_answered_imap(
-    account: &Account,
-    cache: &Cache,
-    rt: &RepliedToRef,
-) {
+async fn mark_original_answered_imap(account: &Account, cache: &Cache, rt: &RepliedToRef) {
     if let Err(e) = cache.mark_envelope_replied(&account.id, &rt.folder, rt.uid, &rt.kind) {
         tracing::warn!(
             "answered-cache update failed for account '{}', folder '{}', uid {}: {e}",
@@ -6572,9 +6568,7 @@ async fn mark_original_answered_imap(
     let password = match credentials::get_imap_password(&account.id) {
         Ok(p) => p,
         Err(e) => {
-            tracing::warn!(
-                "answered-flag IMAP STORE skipped — keychain lookup failed: {e}"
-            );
+            tracing::warn!("answered-flag IMAP STORE skipped — keychain lookup failed: {e}");
             return;
         }
     };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6448,6 +6448,24 @@ fn pick_archive_folder(account_id: &str, cache: &Cache) -> Option<String> {
 
 // ── SMTP commands ───────────────────────────────────────────────
 
+/// Reference to the original message a Compose send is responding to
+/// (#255).  Set by Compose's reply / reply-all / "respond with
+/// meeting" flows so the backend can flip the IMAP `\Answered` flag
+/// (or JMAP `$answered` keyword) on the original and stamp the
+/// per-kind `replied_kind` into the local cache, which drives the
+/// reply-icon prefix on the mail-list row.  `None` for fresh
+/// composes / forwards / drafts — none of which are "answers".
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RepliedToRef {
+    folder: String,
+    uid: u32,
+    /// `"reply"` / `"reply-all"` / `"meeting"`.  Anything else falls
+    /// through to a generic answered icon — the validation here is
+    /// loose because the backend treats this as opaque metadata.
+    kind: String,
+}
+
 /// Send an email via the account's configured SMTP server.
 ///
 /// The frontend builds an `OutgoingEmail` (recipients, subject, body,
@@ -6459,10 +6477,16 @@ fn pick_archive_folder(account_id: &str, cache: &Cache) -> Option<String> {
 ///
 /// After SMTP delivery, the message is appended to the IMAP Sent folder
 /// so the user has a visible record. JMAP handles this server-side.
+///
+/// `replied_to` (#255) optionally points at the original message —
+/// when present, after a successful send we set the `\Answered` /
+/// `$answered` flag on the original and stamp `replied_kind` into
+/// the cache so the mail-list row gains its reply icon.
 #[tauri::command]
 async fn send_email(
     account_id: String,
     email: OutgoingEmail,
+    replied_to: Option<RepliedToRef>,
     cache: State<'_, Cache>,
 ) -> Result<(), NimbusError> {
     let account = load_account(&cache, &account_id)?;
@@ -6471,7 +6495,11 @@ async fn send_email(
     // a copy to Sent itself — no separate SMTP/APPEND needed.
     if uses_jmap(&account) {
         let client = connect_jmap(&account).await?;
-        return client.send_email(&email).await;
+        client.send_email(&email).await?;
+        if let Some(rt) = replied_to.as_ref() {
+            mark_original_answered_jmap(&account, &cache, &client, rt).await;
+        }
+        return Ok(());
     }
 
     // Build the lettre message once so the same bytes go to both the
@@ -6511,7 +6539,94 @@ async fn send_email(
             account.id
         );
     }
+
+    // Same best-effort treatment for the answered-flag flip: SMTP
+    // already succeeded so the user's reply is out the door, and a
+    // missing flag here just means the icon won't appear until the
+    // next IMAP envelope fetch (which sees `\Answered` independently
+    // because the user's other clients also carry it).
+    if let Some(rt) = replied_to.as_ref() {
+        mark_original_answered_imap(&account, &cache, rt).await;
+    }
     Ok(())
+}
+
+/// Best-effort: stamp the local cache row + the IMAP `\Answered`
+/// flag on the original message that a Compose reply just answered
+/// (#255).  Logs on failure rather than propagating — the user's
+/// mail already left the building.
+async fn mark_original_answered_imap(
+    account: &Account,
+    cache: &Cache,
+    rt: &RepliedToRef,
+) {
+    if let Err(e) = cache.mark_envelope_replied(&account.id, &rt.folder, rt.uid, &rt.kind) {
+        tracing::warn!(
+            "answered-cache update failed for account '{}', folder '{}', uid {}: {e}",
+            account.id,
+            rt.folder,
+            rt.uid
+        );
+    }
+
+    let password = match credentials::get_imap_password(&account.id) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                "answered-flag IMAP STORE skipped — keychain lookup failed: {e}"
+            );
+            return;
+        }
+    };
+    let mut client = match ImapClient::connect(
+        &account.imap_host,
+        account.imap_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("answered-flag IMAP STORE skipped — connect failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = client.mark_as_answered(&rt.folder, rt.uid).await {
+        tracing::warn!(
+            "answered-flag IMAP STORE failed for '{}' uid {}: {e}",
+            rt.folder,
+            rt.uid
+        );
+    }
+    let _ = client.logout().await;
+}
+
+/// JMAP analogue of `mark_original_answered_imap` — uses the
+/// already-connected JMAP client (no second connect needed since
+/// JMAP is HTTPS-pooled, not a long-lived session).
+async fn mark_original_answered_jmap(
+    account: &Account,
+    cache: &Cache,
+    client: &JmapClient,
+    rt: &RepliedToRef,
+) {
+    if let Err(e) = cache.mark_envelope_replied(&account.id, &rt.folder, rt.uid, &rt.kind) {
+        tracing::warn!(
+            "answered-cache update failed for account '{}', folder '{}', uid {}: {e}",
+            account.id,
+            rt.folder,
+            rt.uid
+        );
+    }
+    if let Err(e) = client.mark_as_answered(&rt.folder, rt.uid).await {
+        tracing::warn!(
+            "answered-keyword JMAP set failed for '{}' uid {}: {e}",
+            rt.folder,
+            rt.uid
+        );
+    }
 }
 
 /// Locate the account's Sent folder (via the IMAP `\Sent` attribute,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5552,6 +5552,13 @@ async fn fetch_unified_envelopes(
 /// message.
 struct FolderPollOutcome {
     new_envelopes: Vec<EmailEnvelope>,
+    /// Count of cached envelope rows whose `\Seen` / `\Flagged` /
+    /// `\Answered` flags drifted between polls — typically because
+    /// another mail client (phone, webmail) flipped a flag and we
+    /// just caught up.  Callers use this to fire the
+    /// `mail-flags-updated` Tauri event so the frontend can re-read
+    /// the cache without a manual refresh (#255 follow-up).
+    flag_changes: u32,
 }
 
 /// Fetch+cache+reconcile for one (account, folder) pair.
@@ -5619,7 +5626,14 @@ async fn poll_folder(
             tracing::warn!("cache.set_sync_state (JMAP) failed: {e}");
         }
 
-        return Ok(FolderPollOutcome { new_envelopes });
+        // JMAP cross-client flag refresh isn't wired here yet —
+        // `Email/changes` would be the proper way, but the user's
+        // primary path is IMAP and JMAP cross-client `$answered` is
+        // a follow-up.  Report zero flag changes for now.
+        return Ok(FolderPollOutcome {
+            new_envelopes,
+            flag_changes: 0,
+        });
     }
 
     // ── IMAP path ──────────────────────────────────────────────
@@ -5663,6 +5677,36 @@ async fn poll_folder(
                 "list_all_uids for '{account_id}'/'{folder}' failed (skipping reconcile): {e}"
             );
             Vec::new()
+        }
+    };
+
+    // Flag refresh on the visible window (#255 follow-up).
+    // `fetch_envelopes` above only fetches UIDs strictly newer than
+    // the cache bookmark, so flag flips another client made
+    // (mark-read on a phone, answer from webmail, star elsewhere)
+    // never round-trip into Nimbus.  Cheap catch-up: one
+    // `UID FETCH x,y,z (UID FLAGS)` on the same window the user
+    // sees in the mail list.  Read the recent UIDs from the cache
+    // *before* the upsert below — the freshly-fetched batch will
+    // get its flags through the upsert path, this snapshot covers
+    // everything older than the bookmark.
+    let recent_cached_uids = cache
+        .list_recent_envelope_uids(account_id, folder, limit)
+        .unwrap_or_else(|e| {
+            tracing::warn!("list_recent_envelope_uids failed (skipping flag refresh): {e}");
+            Vec::new()
+        });
+    let flag_snapshots = if recent_cached_uids.is_empty() || uidvalidity_rotated {
+        Vec::new()
+    } else {
+        match client.fetch_flags(folder, &recent_cached_uids).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    "fetch_flags for '{account_id}'/'{folder}' failed (skipping flag refresh): {e}"
+                );
+                Vec::new()
+            }
         }
     };
 
@@ -5735,7 +5779,35 @@ async fn poll_folder(
         tracing::warn!("cache.set_sync_state failed: {e}");
     }
 
-    Ok(FolderPollOutcome { new_envelopes })
+    // Apply the flag snapshot we collected before logout.  Done
+    // here (after the envelope upsert) so a UID that was both new
+    // *and* re-flagged won't be flickered between the two writes —
+    // the upsert lands its envelope-derived flags first, the
+    // reconcile then runs against everything else.  `replied_kind`
+    // is preserved by `reconcile_envelope_flags` (Nimbus-only
+    // metadata that IMAP can't carry).
+    let flag_changes = if flag_snapshots.is_empty() {
+        0
+    } else {
+        let tuples: Vec<(u32, bool, bool, bool)> = flag_snapshots
+            .iter()
+            .map(|s| (s.uid, s.is_read, s.is_starred, s.is_answered))
+            .collect();
+        cache
+            .reconcile_envelope_flags(account_id, folder, &tuples)
+            .unwrap_or_else(|e| {
+                tracing::warn!("reconcile_envelope_flags failed: {e}");
+                0
+            })
+    };
+    if flag_changes > 0 {
+        tracing::info!("Reconciled {flag_changes} flag change(s) for '{account_id}'/'{folder}'");
+    }
+
+    Ok(FolderPollOutcome {
+        new_envelopes,
+        flag_changes,
+    })
 }
 
 /// Fetch a full message (headers + body) by folder + UID.
@@ -6488,6 +6560,7 @@ async fn send_email(
     email: OutgoingEmail,
     replied_to: Option<RepliedToRef>,
     cache: State<'_, Cache>,
+    app: AppHandle,
 ) -> Result<(), NimbusError> {
     let account = load_account(&cache, &account_id)?;
 
@@ -6498,6 +6571,7 @@ async fn send_email(
         client.send_email(&email).await?;
         if let Some(rt) = replied_to.as_ref() {
             mark_original_answered_jmap(&account, &cache, &client, rt).await;
+            emit_mail_flags_updated(&app, &account.id, &rt.folder);
         }
         return Ok(());
     }
@@ -6547,8 +6621,24 @@ async fn send_email(
     // because the user's other clients also carry it).
     if let Some(rt) = replied_to.as_ref() {
         mark_original_answered_imap(&account, &cache, rt).await;
+        emit_mail_flags_updated(&app, &account.id, &rt.folder);
     }
     Ok(())
+}
+
+/// Fire the `mail-flags-updated` Tauri event so the frontend
+/// re-reads the cache and the mail list reflects a flag change
+/// without a manual refresh.  Best-effort — a dropped event just
+/// means the user has to click refresh, which they would have
+/// before this plumbing existed anyway.
+fn emit_mail_flags_updated(app: &AppHandle, account_id: &str, folder: &str) {
+    let payload = MailFlagsUpdatedPayload {
+        account_id: account_id.to_string(),
+        folder: folder.to_string(),
+    };
+    if let Err(e) = app.emit("mail-flags-updated", &payload) {
+        tracing::warn!("failed to emit mail-flags-updated event: {e}");
+    }
 }
 
 /// Best-effort: stamp the local cache row + the IMAP `\Answered`
@@ -7348,6 +7438,24 @@ struct NewMailPayload {
     subject: String,
 }
 
+/// `mail-flags-updated` event payload (#255 follow-up).  Tells the
+/// frontend "the cached envelopes for this (account, folder) had a
+/// flag-only change — please re-read the cache".  Two emit sites:
+///
+///   * Compose's send path, right after stamping `replied_kind` /
+///     flipping `\Answered` on the message we just answered, so the
+///     reply icon appears in the mail list immediately rather than
+///     waiting for the next user-initiated refresh.
+///   * The poll path's catch-up flag refresh, when it detects a
+///     `\Seen` / `\Flagged` / `\Answered` change made on another
+///     mail client.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MailFlagsUpdatedPayload {
+    account_id: String,
+    folder: String,
+}
+
 /// Bring the main window to the front. Called from the tray's
 /// left-click handler, the tray menu's "Open Nimbus" item, and the
 /// `show_main_window` command.
@@ -7394,6 +7502,21 @@ async fn check_mail_now_inner(app: &AppHandle) -> Result<(), NimbusError> {
                         account.id,
                         outcome.new_envelopes.len()
                     );
+                }
+                // #255: when the catch-up flag refresh found a
+                // cross-client `\Seen` / `\Flagged` / `\Answered`
+                // change, signal the frontend to re-read the cache
+                // so the mail list picks it up without a manual
+                // refresh.  Skip when nothing changed — silence is
+                // the point.
+                if outcome.flag_changes > 0 {
+                    let payload = MailFlagsUpdatedPayload {
+                        account_id: account.id.clone(),
+                        folder: "INBOX".to_string(),
+                    };
+                    if let Err(e) = app.emit("mail-flags-updated", &payload) {
+                        tracing::warn!("failed to emit mail-flags-updated event: {e}");
+                    }
                 }
             }
             Err(e) => {

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -411,6 +411,18 @@
     subject: string
   }
 
+  /** `mail-flags-updated` event payload (#255 follow-up).  Backend
+   *  fires this whenever the cached `\Seen` / `\Flagged` /
+   *  `\Answered` flags change — either Compose's post-send
+   *  marking or the poll path's cross-client catch-up.  We don't
+   *  inspect the fields today (the listener just bumps
+   *  `refreshToken` to re-read the cache), but they're kept on
+   *  the type so per-folder filtering stays an easy follow-up. */
+  type MailFlagsUpdatedPayload = {
+    accountId: string
+    folder: string
+  }
+
   type AppPrefs = {
     minimize_to_tray: boolean
     background_sync_enabled: boolean
@@ -770,9 +782,22 @@
     let unlistenComposeFromMail: UnlistenFn | null = null
     let unlistenEditDraftFromMail: UnlistenFn | null = null
     let unlistenMailtoFromMail: UnlistenFn | null = null
+    let unlistenMailFlagsUpdated: UnlistenFn | null = null
     ;(async () => {
       unlistenNewMail = await listen<NewMail>('new-mail', (e) =>
         handleNewMail(e.payload),
+      )
+      // #255: backend fires this whenever the answered / read /
+      // starred flag on a cached envelope changes (Compose's
+      // post-send marking, plus the cross-client catch-up the
+      // poll path runs).  Bump the refresh token so MailList
+      // re-reads the cache and the row picks up the new flags
+      // without a manual refresh.
+      unlistenMailFlagsUpdated = await listen<MailFlagsUpdatedPayload>(
+        'mail-flags-updated',
+        () => {
+          refreshToken++
+        },
       )
       unlistenEventReminder = await listen<EventReminder>(
         'event-reminder',
@@ -844,6 +869,7 @@
       unlistenComposeFromMail?.()
       unlistenEditDraftFromMail?.()
       unlistenMailtoFromMail?.()
+      unlistenMailFlagsUpdated?.()
       if (pendingSummaryTimer) clearTimeout(pendingSummaryTimer)
     }
   })

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1460,41 +1460,21 @@
   }
 
   async function onRespondWithMeeting(mail: ReplyableMail) {
-    console.log('[respond-with-meeting] click', {
-      uid: mail.uid,
-      account_id: mail.account_id,
-      folder: mail.folder,
-      meetingDraftAlreadySet: meetingDraft !== null,
-      composeInitialAlreadySet: composeInitial !== null,
-    })
+    // Defensive: if a previous flow left state behind (e.g. a
+    // Compose modal whose overlay would z-index over the new
+    // editor), clear it so the EventEditor lands on top of an
+    // empty surface.
+    meetingDraft = null
+    composeInitial = null
 
-    // Defensive: if a previous flow left state behind (e.g. an
-    // unclosed Compose modal whose overlay would hide the editor),
-    // clear it so the new EventEditor lands on top of an empty
-    // surface.  Should be rare with the recent fixes — log so we
-    // can spot the leak if it does happen.
-    if (meetingDraft !== null) {
-      console.warn(
-        '[respond-with-meeting] meetingDraft was already set; clearing before re-open',
-      )
-      meetingDraft = null
-    }
-    if (composeInitial !== null) {
-      console.warn(
-        '[respond-with-meeting] composeInitial was set; clearing before opening editor',
-      )
-      composeInitial = null
-    }
-
-    // Top-level try/catch so any unhandled rejection surfaces as a
-    // visible alert instead of leaving the user staring at a
-    // button that did nothing.  Inner blocks still run their own
-    // try/catch where they can give a more specific message.
+    // Top-level try/catch so any unhandled rejection surfaces as
+    // a visible alert instead of leaving the user staring at a
+    // button that did nothing.  The inner blocks still run their
+    // own try/catch where they can give a more specific message.
     try {
       let ncId = ''
       try {
         const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
-        console.log('[respond-with-meeting] nc accounts:', list.length)
         if (list.length === 0) {
           alert('Connect a Nextcloud account first (Settings → Nextcloud).')
           return
@@ -1508,12 +1488,6 @@
       let calendars: CalendarSummary[] = []
       try {
         calendars = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
-        console.log(
-          '[respond-with-meeting] calendars total:',
-          calendars.length,
-          'hidden:',
-          calendars.filter((c) => c.hidden).length,
-        )
       } catch (e) {
         alert(`Failed to load calendars: ${e}`)
         return
@@ -1560,14 +1534,6 @@
       const start = nextHalfHour(new Date())
       const end = new Date(start.getTime() + 30 * 60 * 1000)
 
-      console.log(
-        '[respond-with-meeting] setting meetingDraft, required:',
-        required.length,
-        'optional:',
-        optional.length,
-        'calendarId:',
-        initialCalendarId,
-      )
       meetingDraft = {
         calendars: visible,
         draft: {
@@ -1581,11 +1547,7 @@
         },
         replyTo: mail,
       }
-      console.log(
-        '[respond-with-meeting] meetingDraft set; EventEditor should now mount',
-      )
     } catch (e) {
-      console.error('[respond-with-meeting] unhandled error', e)
       alert(`Failed to open meeting editor: ${e}`)
     }
   }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1460,80 +1460,133 @@
   }
 
   async function onRespondWithMeeting(mail: ReplyableMail) {
-    let ncId = ''
+    console.log('[respond-with-meeting] click', {
+      uid: mail.uid,
+      account_id: mail.account_id,
+      folder: mail.folder,
+      meetingDraftAlreadySet: meetingDraft !== null,
+      composeInitialAlreadySet: composeInitial !== null,
+    })
+
+    // Defensive: if a previous flow left state behind (e.g. an
+    // unclosed Compose modal whose overlay would hide the editor),
+    // clear it so the new EventEditor lands on top of an empty
+    // surface.  Should be rare with the recent fixes — log so we
+    // can spot the leak if it does happen.
+    if (meetingDraft !== null) {
+      console.warn(
+        '[respond-with-meeting] meetingDraft was already set; clearing before re-open',
+      )
+      meetingDraft = null
+    }
+    if (composeInitial !== null) {
+      console.warn(
+        '[respond-with-meeting] composeInitial was set; clearing before opening editor',
+      )
+      composeInitial = null
+    }
+
+    // Top-level try/catch so any unhandled rejection surfaces as a
+    // visible alert instead of leaving the user staring at a
+    // button that did nothing.  Inner blocks still run their own
+    // try/catch where they can give a more specific message.
     try {
-      const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
-      if (list.length === 0) {
-        alert('Connect a Nextcloud account first (Settings → Nextcloud).')
+      let ncId = ''
+      try {
+        const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
+        console.log('[respond-with-meeting] nc accounts:', list.length)
+        if (list.length === 0) {
+          alert('Connect a Nextcloud account first (Settings → Nextcloud).')
+          return
+        }
+        ncId = list[0].id
+      } catch (e) {
+        alert(`Failed to load Nextcloud accounts: ${e}`)
         return
       }
-      ncId = list[0].id
-    } catch (e) {
-      alert(`Failed to load Nextcloud accounts: ${e}`)
-      return
-    }
 
-    let calendars: CalendarSummary[] = []
-    try {
-      calendars = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
-    } catch (e) {
-      alert(`Failed to load calendars: ${e}`)
-      return
-    }
-    const visible = calendars.filter((c) => !c.hidden)
-    if (visible.length === 0) {
-      alert('No writable calendars found on your Nextcloud account.')
-      return
-    }
-    let initialCalendarId = visible[0].id
-    try {
-      const s = await invoke<{ default_calendar_id: string | null }>('get_app_settings')
-      if (s.default_calendar_id && visible.some((c) => c.id === s.default_calendar_id)) {
-        initialCalendarId = s.default_calendar_id!
+      let calendars: CalendarSummary[] = []
+      try {
+        calendars = await invoke<CalendarSummary[]>('get_cached_calendars', { ncId })
+        console.log(
+          '[respond-with-meeting] calendars total:',
+          calendars.length,
+          'hidden:',
+          calendars.filter((c) => c.hidden).length,
+        )
+      } catch (e) {
+        alert(`Failed to load calendars: ${e}`)
+        return
       }
-    } catch {}
+      const visible = calendars.filter((c) => !c.hidden)
+      if (visible.length === 0) {
+        alert('No writable calendars found on your Nextcloud account.')
+        return
+      }
+      let initialCalendarId = visible[0].id
+      try {
+        const s = await invoke<{ default_calendar_id: string | null }>('get_app_settings')
+        if (s.default_calendar_id && visible.some((c) => c.id === s.default_calendar_id)) {
+          initialCalendarId = s.default_calendar_id!
+        }
+      } catch {}
 
-    // Split the thread's participants — From + To go required,
-    // Cc goes optional.  Skip the active account (the user is the
-    // organizer; the editor adds them as CHAIR).  De-dupe across
-    // buckets so an address that appears in both To and Cc only
-    // shows up once in the higher-priority bucket.
-    const self = activeAccountEmail.toLowerCase()
-    const seen = new Set<string>()
-    const required: string[] = []
-    for (const piece of [mail.from, ...mail.to]) {
-      const addr = bareEmail(piece)
-      if (!addr) continue
-      const key = addr.toLowerCase()
-      if (key === self || seen.has(key)) continue
-      seen.add(key)
-      required.push(piece)
-    }
-    const optional: string[] = []
-    for (const piece of mail.cc) {
-      const addr = bareEmail(piece)
-      if (!addr) continue
-      const key = addr.toLowerCase()
-      if (key === self || seen.has(key)) continue
-      seen.add(key)
-      optional.push(piece)
-    }
+      // Split the thread's participants — From + To go required,
+      // Cc goes optional.  Skip the active account (the user is the
+      // organizer; the editor adds them as CHAIR).  De-dupe across
+      // buckets so an address that appears in both To and Cc only
+      // shows up once in the higher-priority bucket.
+      const self = activeAccountEmail.toLowerCase()
+      const seen = new Set<string>()
+      const required: string[] = []
+      for (const piece of [mail.from, ...mail.to]) {
+        const addr = bareEmail(piece)
+        if (!addr) continue
+        const key = addr.toLowerCase()
+        if (key === self || seen.has(key)) continue
+        seen.add(key)
+        required.push(piece)
+      }
+      const optional: string[] = []
+      for (const piece of mail.cc) {
+        const addr = bareEmail(piece)
+        if (!addr) continue
+        const key = addr.toLowerCase()
+        if (key === self || seen.has(key)) continue
+        seen.add(key)
+        optional.push(piece)
+      }
 
-    const start = nextHalfHour(new Date())
-    const end = new Date(start.getTime() + 30 * 60 * 1000)
+      const start = nextHalfHour(new Date())
+      const end = new Date(start.getTime() + 30 * 60 * 1000)
 
-    meetingDraft = {
-      calendars: visible,
-      draft: {
-        calendarId: initialCalendarId,
-        start,
-        end,
-        summary: meetingSubject(mail.subject),
-        requiredAttendees: required,
-        optionalAttendees: optional,
-        createTalkRoom: true,
-      },
-      replyTo: mail,
+      console.log(
+        '[respond-with-meeting] setting meetingDraft, required:',
+        required.length,
+        'optional:',
+        optional.length,
+        'calendarId:',
+        initialCalendarId,
+      )
+      meetingDraft = {
+        calendars: visible,
+        draft: {
+          calendarId: initialCalendarId,
+          start,
+          end,
+          summary: meetingSubject(mail.subject),
+          requiredAttendees: required,
+          optionalAttendees: optional,
+          createTalkRoom: true,
+        },
+        replyTo: mail,
+      }
+      console.log(
+        '[respond-with-meeting] meetingDraft set; EventEditor should now mount',
+      )
+    } catch (e) {
+      console.error('[respond-with-meeting] unhandled error', e)
+      alert(`Failed to open meeting editor: ${e}`)
     }
   }
 

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -810,7 +810,7 @@
       // and signature state already wired up.
       unlistenComposeFromMail = await listen<{
         kind: 'reply' | 'reply-all' | 'forward'
-        mail: OpenMail
+        mail: ReplyableMail
       }>('compose-from-mail', (e) => {
         const { kind, mail } = e.payload
         if (kind === 'reply') onReply(mail)
@@ -1209,15 +1209,33 @@
     date: string
   }
 
-  function onReply(mail: OpenMail) {
+  /** Reply / reply-all / "respond with meeting" need to know
+   *  (account_id, folder, uid) so the answered-tracking flow
+   *  (#255) can flip `\Answered` on the original message after
+   *  a successful send.  MailView passes them through via
+   *  `{...email, uid}`; the standalone-window emit threads the
+   *  same shape across windows. */
+  type ReplyableMail = OpenMail & {
+    account_id: string
+    folder: string
+    uid: number
+  }
+
+  function onReply(mail: ReplyableMail) {
     openCompose({
       to: mail.from,
       subject: replySubject(mail.subject),
       body: quoteBody(mail.from, mail.date, mail.body_text),
+      repliedTo: {
+        accountId: mail.account_id,
+        folder: mail.folder,
+        uid: mail.uid,
+        kind: 'reply',
+      },
     })
   }
 
-  function onReplyAll(mail: OpenMail) {
+  function onReplyAll(mail: ReplyableMail) {
     const others = [...mail.to, ...mail.cc].filter(
       (a) => a && a.toLowerCase() !== activeAccountEmail.toLowerCase(),
     )
@@ -1226,6 +1244,12 @@
       cc: others.join(', '),
       subject: replySubject(mail.subject),
       body: quoteBody(mail.from, mail.date, mail.body_text),
+      repliedTo: {
+        accountId: mail.account_id,
+        folder: mail.folder,
+        uid: mail.uid,
+        kind: 'reply-all',
+      },
     })
   }
 
@@ -1372,8 +1396,11 @@
      *  Compose pre-filled as a reply once the event lands
      *  (#195).  Absent when the editor was opened from a
      *  source other than an email thread (e.g. an .ics file
-     *  the OS handed us via "Open with…", #254). */
-    replyTo?: OpenMail
+     *  the OS handed us via "Open with…", #254).  Carries the
+     *  `ReplyableMail` shape so the post-save Compose knows the
+     *  (account_id, folder, uid) needed to flip `\Answered`
+     *  (#255). */
+    replyTo?: ReplyableMail
   } | null>(null)
 
   /** Strip an `"Name" <addr>` wrapper down to the bare email. */
@@ -1406,7 +1433,7 @@
     return out
   }
 
-  async function onRespondWithMeeting(mail: OpenMail) {
+  async function onRespondWithMeeting(mail: ReplyableMail) {
     let ncId = ''
     try {
       const list = await invoke<{ id: string }[]>('get_nextcloud_accounts')
@@ -1536,6 +1563,15 @@
       // which prepends `meetingInvite`-rendered HTML.
       body: quoteBody(original.from, original.date, original.body_text),
       meetingInvite,
+      // #255 — flag the original as `\Answered` once the meeting
+      // reply lands.  The icon distinguishes "respond with
+      // meeting" from a plain reply or reply-all.
+      repliedTo: {
+        accountId: original.account_id,
+        folder: original.folder,
+        uid: original.uid,
+        kind: 'meeting',
+      },
     })
   }
 

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -124,6 +124,20 @@
         the note content with the user's signature *below* it,
         not stranded above an empty body.  Default `false`. */
     bodyAboveSignature?: boolean
+    /** Original-message reference for reply / reply-all / "respond
+        with meeting" flows (#255).  Threads the answer-kind
+        through Compose's send invoke so the backend can flip
+        `\Answered` on the original message and stamp the local
+        cache row's `replied_kind` — that's what drives the small
+        reply icon in front of the subject in the mail list.
+        Unset for fresh composes, forwards, draft-edits, and the
+        calendar-machinery sends. */
+    repliedTo?: {
+      accountId: string
+      folder: string
+      uid: number
+      kind: 'reply' | 'reply-all' | 'meeting'
+    }
     /** When Compose is opened by clicking "Edit" on an existing draft
         in the Drafts folder, this points at the server-side copy we
         opened from. Once the user sends or re-saves, that copy needs
@@ -1547,6 +1561,11 @@
           body_html: snap.bodyHtml || null,
           attachments: snap.attachments,
         },
+        // #255: lets the backend stamp `\Answered` on the
+        // original + persist `replied_kind` for the mail-list
+        // reply icon.  Only present when this Compose was opened
+        // by a reply / reply-all / "respond with meeting" flow.
+        repliedTo: snap.initialAtSend?.repliedTo ?? null,
       })
     } catch (e: any) {
       const msg = formatError(e) || 'Failed to send'
@@ -1561,6 +1580,10 @@
           body: snap.body,
           attachments: snap.attachments,
           in_reply_to: snap.initialAtSend?.in_reply_to ?? null,
+          // Carry the answered-tracking ref into the recovery
+          // draft so a successful retry still flips `\Answered`
+          // on the original (#255).
+          repliedTo: snap.initialAtSend?.repliedTo,
           nextcloudLinks: snap.initialAtSend?.nextcloudLinks,
           talkLink: snap.initialAtSend?.talkLink,
           draftSource: snap.draftSource ?? undefined,

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -574,6 +574,22 @@
       html = ''
     }
 
+    // Integration blocks first — meeting invite, Talk link, NC
+    // file links.  These read as "what I'm sending you" content,
+    // so the signature belongs *after* them: it signs off the
+    // whole message including the cards, not just the empty
+    // typing space.  Reply / "Respond with meeting" flows
+    // depend on the meeting card landing above the signature
+    // (the signature is the bottom of the user's content).
+    if (initial?.meetingInvite) lead += meetingInviteHtml(initial.meetingInvite)
+    if (initial?.talkLink) lead += talkInviteHtml(initial.talkLink)
+    if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
+      const items = initial.nextcloudLinks
+        .map((l) => `<p>🔗 <a href="${l.url}">${esc(l.filename)}</a></p>`)
+        .join('')
+      lead += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
+    }
+
     // Signature: best-effort grab of the active account at init
     // time so replies open with the user's name already attached.
     // If the account list hasn't loaded yet, we skip and let the
@@ -584,15 +600,6 @@
     if (initSig) {
       lead += initSig
       insertedSignatureHtml = initSig
-    }
-
-    if (initial?.meetingInvite) lead += meetingInviteHtml(initial.meetingInvite)
-    if (initial?.talkLink) lead += talkInviteHtml(initial.talkLink)
-    if (initial?.nextcloudLinks && initial.nextcloudLinks.length > 0) {
-      const items = initial.nextcloudLinks
-        .map((l) => `<p>🔗 <a href="${l.url}">${esc(l.filename)}</a></p>`)
-        .join('')
-      lead += `<p><strong>Shared via Nextcloud:</strong></p>${items}`
     }
 
     return lead + html
@@ -621,13 +628,29 @@
 
     if (insertedSignatureHtml === null) {
       if (!nextSig) return
-      // Splice the signature right after the leading two empty
-      // paragraphs that initialBodyHtml stamps in.  Falls back to
-      // appendHtml when the body shape is unfamiliar (drafts).
+      // Splice the signature into the lead.  Layout target:
+      //   <p></p><p></p>            ← empty typing area
+      //   [meeting / talk / NC integration blocks]
+      //   [signature]                ← here
+      //   [quoted reply / body]
+      //
+      // Prefer the position right BEFORE the quoted-history
+      // wrapper — that pins the signature after any integration
+      // cards the user is sending.  Fall back to the position
+      // right after the empty paragraphs (correct for fresh
+      // composes with no quote and no integrations).  Last
+      // resort: appendHtml when the body shape is unfamiliar
+      // (e.g. an opened draft we can't reason about).
       const leadIdx = bodyHtml.indexOf('<p></p><p></p>')
       if (leadIdx !== -1) {
-        const after = leadIdx + '<p></p><p></p>'.length
-        const replaced = bodyHtml.slice(0, after) + nextSig + bodyHtml.slice(after)
+        const afterLead = leadIdx + '<p></p><p></p>'.length
+        const quoteIdx = bodyHtml.indexOf(
+          '<div data-nimbus-block="quoted-history"',
+          afterLead,
+        )
+        const insertAt = quoteIdx !== -1 ? quoteIdx : afterLead
+        const replaced =
+          bodyHtml.slice(0, insertAt) + nextSig + bodyHtml.slice(insertAt)
         editorApi.setHtml(replaced)
         bodyHtml = replaced
       } else {

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -746,9 +746,34 @@
     // contacts so a user who types just the display name and
     // then commits (Enter / comma / blur) without using the
     // dropdown still picks up the matching email automatically.
-    for (const c of contactsByEmail.values()) {
-      if ((c.display_name ?? '').toLowerCase() === trimmed.toLowerCase()) {
-        return { email: primaryEmail(c), common_name: c.display_name, role }
+    //
+    // Guard against the temporal dead zone: this function is
+    // *also* invoked from the initial `$state` seeders for
+    // `requiredAttendees` / `optionalAttendees` / `chairAttendees`
+    // up at the top of the script, which run BEFORE
+    // `contactsByEmail` is declared further down.  Reaching the
+    // for-loop with a bare-email piece (the recipient of an
+    // already-answered thread, for example, where the From header
+    // came back as a plain `user@host`) used to throw
+    // `Cannot access 'contactsByEmail' before initialization` and
+    // crash EventEditor's mount silently.  Skipping the lookup at
+    // init time is harmless: the draft we're seeding from already
+    // carries email addresses, not display names, so the
+    // display-name-to-email match wouldn't help anyway.  User-
+    // typed bare-email pieces (the original use case for this
+    // lookup) reach this function long after init, so the
+    // try/catch falls through to the real Map.
+    let contactsLookup: Map<string, Contact> | null = null
+    try {
+      contactsLookup = contactsByEmail
+    } catch {
+      contactsLookup = null
+    }
+    if (contactsLookup) {
+      for (const c of contactsLookup.values()) {
+        if ((c.display_name ?? '').toLowerCase() === trimmed.toLowerCase()) {
+          return { email: primaryEmail(c), common_name: c.display_name, role }
+        }
       }
     }
     return { email: trimmed, common_name: null, role }

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -1286,17 +1286,32 @@
         onsaved()
       }
 
-      // Sync Talk participants + room visibility once the
-      // CalDAV save has stuck.  Only fires when the user
-      // created a Talk room from this editor session and
-      // there's at least one attendee — pure "Talk-but-no-
-      // attendees" rooms behave like personal scratch rooms
-      // and don't need any of this.
-      if (pendingTalkRoom && input.attendees.length > 0) {
-        await syncTalkParticipants(input.attendees)
-      }
-
+      // Dismiss IMMEDIATELY now that the calendar event is
+      // persisted (#255 follow-up).  Awaiting Talk-participant
+      // sync inside the same try-block kept the editor — and the
+      // closure holding `onclose` — alive for the 1-3 s of
+      // sequential NC round-trips, and any late `onclose()` would
+      // race against the parent's next "open editor" gesture
+      // (e.g. a second "Respond with meeting" reply on the same
+      // thread).  The parent's `onsaved` already fired above, so
+      // the editor has done everything it owes the caller; the
+      // Talk-participant sync is post-success housekeeping that
+      // the user shouldn't have to wait on.
       onclose()
+
+      // Fire-and-forget Talk participant sync.  Only fires when
+      // the user created a Talk room from this editor session
+      // and there's at least one attendee — pure "Talk-but-no-
+      // attendees" rooms behave like personal scratch rooms and
+      // don't need any of this.  Errors land in the console; the
+      // calendar event is already saved and the user has moved
+      // on.  Misses get caught the next time the user opens the
+      // event in the editor (the room sync re-runs from there).
+      if (pendingTalkRoom && input.attendees.length > 0) {
+        void syncTalkParticipants(input.attendees).catch((e) =>
+          console.warn('syncTalkParticipants failed (event already saved)', e),
+        )
+      }
     } catch (e) {
       error = formatError(e) || 'Failed to save event'
     } finally {

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -26,6 +26,14 @@
     date: string      // RFC 3339 string (serde serialises DateTime<Utc> this way)
     is_read: boolean
     is_starred: boolean
+    /** IMAP `\Answered` flag (#255).  Drives the generic-reply
+     *  fallback icon — true when *anyone* (Nimbus, another
+     *  client, the user's phone) has answered the message. */
+    is_answered?: boolean
+    /** Nimbus-only reply kind (#255): `'reply'`, `'reply-all'`,
+     *  `'meeting'`.  Stamped by the send path; takes precedence
+     *  over `is_answered` for the icon decision. */
+    replied_kind?: string | null
     /** Owning account id. Always populated for envelopes read out of
         the cache; left empty for envelopes coming straight from the
         IMAP/JMAP clients (those paths don't surface to the UI). */
@@ -734,6 +742,45 @@
     void loadOlder()
   })
 
+  // ── Answered-indicator (#255) ───────────────────────────────
+  // Small icon prefixed to the subject when this message has
+  // been answered.  Three sources of truth, in priority order:
+  //
+  //   1. `replied_kind` — Nimbus stamped this when the user
+  //      replied via Compose.  Carries the *kind* of reply
+  //      (reply / reply-all / meeting), so we can pick the
+  //      matching icon.
+  //   2. `is_answered` — the IMAP `\Answered` system flag.
+  //      True when *anyone* (Nimbus, another mail client, the
+  //      user's phone) has answered the message.  We don't
+  //      know how, so fall back to the generic reply icon.
+  //   3. neither — return null, the subject renders without an
+  //      icon prefix.
+  function answeredIconName(
+    env: EmailEnvelope,
+  ): 'reply' | 'reply-all' | 'respond-with-meeting' | null {
+    switch (env.replied_kind) {
+      case 'reply':
+        return 'reply'
+      case 'reply-all':
+        return 'reply-all'
+      case 'meeting':
+        return 'respond-with-meeting'
+    }
+    return env.is_answered ? 'reply' : null
+  }
+  function answeredIconTitle(env: EmailEnvelope): string {
+    switch (env.replied_kind) {
+      case 'reply':
+        return 'You replied'
+      case 'reply-all':
+        return 'You replied to all'
+      case 'meeting':
+        return 'You responded with a meeting'
+    }
+    return 'Answered'
+  }
+
   // Render dates compactly: today → time, otherwise short date.
   function formatDate(iso: string): string {
     const d = new Date(iso)
@@ -932,8 +979,19 @@
               </span>
               <span class="text-xs {!env.is_read ? 'text-primary-500 font-medium' : 'text-surface-500'} shrink-0">{formatDate(env.date)}</span>
             </div>
-            <p class="text-sm {!env.is_read ? 'font-medium' : ''} truncate">
-              {env.subject || '(no subject)'}
+            <p class="text-sm {!env.is_read ? 'font-medium' : ''} truncate flex items-center gap-1.5">
+              {#if answeredIconName(env)}
+                <span
+                  class="shrink-0 inline-flex items-center text-primary-500"
+                  title={answeredIconTitle(env)}
+                  aria-label={answeredIconTitle(env)}
+                >
+                  <Icon name={answeredIconName(env)!} size={14} />
+                </span>
+              {/if}
+              <span class="truncate min-w-0">
+                {env.subject || '(no subject)'}
+              </span>
             </p>
             {#if unified && env.account_id}
               <p class="text-[11px] text-surface-500 mt-1 truncate">

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -65,13 +65,13 @@
     folder?: string
     uid: number | null
     onread?: (uid: number) => void
-    onreply?: (mail: Email) => void
-    onreplyall?: (mail: Email) => void
-    onforward?: (mail: Email) => void
+    onreply?: (mail: Email & { uid: number }) => void
+    onreplyall?: (mail: Email & { uid: number }) => void
+    onforward?: (mail: Email & { uid: number }) => void
     /** Open the "Create Talk room" flow seeded from this email's
         subject + thread participants. Wired from `App.svelte` so the
         resulting Compose window stacks on top of the inbox view. */
-    onrespondwithmeeting?: (mail: Email) => void
+    onrespondwithmeeting?: (mail: Email & { uid: number }) => void
     /** Save the email as a Nextcloud note. The handler in
         `App.svelte` picks the NC account and POSTs to the Notes
         API — we just hand over the email so the title/body are
@@ -1359,26 +1359,26 @@
       {:else}
         <button
           class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
-          onclick={() => email && onreply?.(email)}
+          onclick={() => email && uid != null && onreply?.({ ...email, uid })}
           title="Reply"
           aria-label="Reply"
         ><Icon name="reply" size={16} /></button>
         <button
           class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
-          onclick={() => email && onreplyall?.(email)}
+          onclick={() => email && uid != null && onreplyall?.({ ...email, uid })}
           title="Reply to everyone"
           aria-label="Reply to everyone"
         ><Icon name="reply-all" size={16} /></button>
         <button
           class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
-          onclick={() => email && onforward?.(email)}
+          onclick={() => email && uid != null && onforward?.({ ...email, uid })}
           title="Forward"
           aria-label="Forward"
         ><Icon name="forward" size={16} /></button>
         {#if onrespondwithmeeting}
           <button
             class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-primary-500/15 hover:text-primary-500 hover:border-primary-500/40"
-            onclick={() => email && onrespondwithmeeting?.(email)}
+            onclick={() => email && uid != null && onrespondwithmeeting?.({ ...email, uid })}
             title="Create a calendar event with a Talk link and the thread's participants as attendees"
             aria-label="Respond with meeting"
           ><Icon name="respond-with-meeting" size={16} /></button>


### PR DESCRIPTION
## Summary

Closes #255.

Mail-list rows now carry a small icon in front of the subject when the
user (or any other client) has answered the message.  Three kinds, with
distinct icons where Nimbus knows the answer:

- **`reply`** — plain reply
- **`reply-all`** — reply to everyone
- **`respond-with-meeting`** — calendar-reply flow (#195)

Falls back to the generic reply icon for messages already marked
`\Answered` on the IMAP server before this feature shipped (or
answered from a different client) — Nimbus doesn't know *how* those
were answered, but the visual cue still lands.

The inline-before-subject placement fits inside the existing 320px
mail-list column — no width bump needed.

## Implementation notes

- **Schema v25 → v26.**  `messages.is_answered` mirrors the IMAP
  `\Answered` system flag; `messages.replied_kind` is Nimbus-only
  per-kind metadata (`reply` / `reply-all` / `meeting`) and is
  *never* overwritten on envelope re-fetch — so the kind survives
  cache rebuilds.
- **IMAP + JMAP fetch:** parse `\Answered` / `$answered` alongside
  `\Seen` / `\Flagged` at every envelope-fetch site.
- **`mark_as_answered`** added on both `ImapClient` (`UID STORE +FLAGS
  (\Answered)`) and `JmapClient` (`keywords/$answered: true`); cache
  helper `mark_envelope_replied(folder, uid, kind)` persists locally.
- **`send_email` Tauri command** grows an optional `repliedTo`
  param (folder + uid + kind).  After SMTP/JMAP success and the
  Sent append, best-effort: flip the answered flag and stamp the
  cache row.  Failures are logged — the user's reply already left.
- **Compose** threads `repliedTo` through `ComposeInitial` and into
  the send invoke; failure-recovery drafts preserve it.  App.svelte's
  `onReply` / `onReplyAll` / `onMeetingEditorSaved` populate it from
  the original thread's (account_id, folder, uid).
- **MailView** callback signature widened from `(mail: Email)` to
  `(mail: Email & { uid: number })` so the UID hops over to App.svelte
  alongside the rest of the mail body.  StandaloneMail forwards the
  same shape via the `compose-from-mail` event.

## Test plan

- [x] Reply to a fresh mail → original gets `reply` icon, IMAP
      `\Answered` flag set on the server (verify via another client).
- [x] Reply-all → `reply-all` icon.
- [x] "Respond with meeting" → `respond-with-meeting` icon.
- [x] Answer a mail in a different client (or pre-existing
      `\Answered` mail) → generic `reply` icon shows on next sync.
- [ ] Forward → no icon (forwards don't set `\Answered` per RFC).
- [x] `cargo test --workspace` clean; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)