### PR TITLE
Kill the "If-Match failed, refresh and try again" toast

### DIFF
--- a/crates/nimbus-caldav/src/write.rs
+++ b/crates/nimbus-caldav/src/write.rs
@@ -206,10 +206,14 @@ async fn delete_event_inner(
     };
     let status = resp.status();
     if status == StatusCode::PRECONDITION_FAILED {
-        return Err(NimbusError::Nextcloud(
-            "event was modified on the server since last sync â€” refresh and try again"
-                .to_string(),
-        ));
+        // Programmatically-detectable variant — same shape as
+        // `update_event` so the Tauri layer can transparently
+        // sync + retry instead of surfacing a "refresh and try
+        // again" toast to the user.  See
+        // `delete_event_with_etag_retry` in `src-tauri`.
+        return Err(NimbusError::EtagMismatch(format!(
+            "If-Match failed for DELETE {href} (server etag != cached)"
+        )));
     }
     // 404 is fine â€” already gone is the state we wanted.
     if status == StatusCode::NOT_FOUND {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3777,6 +3777,28 @@ async fn sync_nextcloud_calendars(
     Ok(report)
 }
 
+/// Single-calendar sync by app-side `calendar_id`.  Used by the
+/// EventEditor to freshen one calendar's events the moment the
+/// user opens an event for editing — narrows the window where a
+/// stale-etag PUT (the "If-Match failed" race) can happen.  Soft-
+/// fails on any error and just propagates it; the caller logs
+/// without surfacing a toast because this is best-effort
+/// freshening, not a user-initiated sync.
+#[tauri::command]
+async fn sync_calendar_by_id(
+    calendar_id: String,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let (nc_id, path) = cache
+        .get_calendar_server_path(&calendar_id)?
+        .ok_or_else(|| {
+            NimbusError::Other(format!(
+                "calendar '{calendar_id}' is not in the local cache"
+            ))
+        })?;
+    refresh_calendar_cache(&cache, &nc_id, &path).await
+}
+
 /// Cache-only list of calendars for a Nextcloud account. Used by the
 /// sidebar widget on startup so it can paint before the first sync
 /// finishes (or if the user is offline).
@@ -4385,19 +4407,10 @@ async fn delete_calendar_event(
     app: AppHandle,
 ) -> Result<(), NimbusError> {
     let handle = load_event_handle(&cache, &event_id)?;
-    let nc_account = load_nextcloud_account(&handle.nextcloud_account_id)?;
-    let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
-
     let calendar_id = handle.calendar_id.clone();
-    caldav_delete_event(
-        &handle.href,
-        &nc_account.username,
-        &app_password,
-        &handle.etag,
-        &nc_account.trusted_certs,
-    )
-    .await
-    .inspect_err(|e| flag_calendar_read_only_on_forbidden(&app, &cache, &calendar_id, e))?;
+    delete_event_with_etag_retry(&cache, &event_id, &handle)
+        .await
+        .inspect_err(|e| flag_calendar_read_only_on_forbidden(&app, &cache, &calendar_id, e))?;
     cache.delete_event_by_id(&event_id)?;
     Ok(())
 }
@@ -5459,6 +5472,72 @@ async fn update_event_with_etag_retry(
             )
             .await?;
             Ok((outcome, fresh))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// `caldav_delete_event` with the same transparent etag-mismatch
+/// recovery the update path uses.  When the cached etag is stale
+/// (another client edited the event since our last sync) the
+/// PUT comes back as `EtagMismatch` instead of a wordy
+/// "refresh and try again" error; we sync the parent calendar,
+/// reload the handle with the fresh etag, and retry once.  If
+/// the retry comes back 404 (`caldav_delete_event` reports that
+/// as `Ok(())` per RFC 4918 §9.6 — the resource is already
+/// gone, which is the state we wanted), we surface success too.
+///
+/// Caller passes the already-loaded `handle` so we don't repeat
+/// the cache lookup; in the rare two-step retry case we re-load
+/// internally to pick up the fresh href / etag.
+async fn delete_event_with_etag_retry(
+    cache: &Cache,
+    event_id: &str,
+    handle: &CalendarEventServerHandle,
+) -> Result<(), NimbusError> {
+    let nc_account = load_nextcloud_account(&handle.nextcloud_account_id)?;
+    let app_password = credentials::get_nextcloud_password(&handle.nextcloud_account_id)?;
+
+    match caldav_delete_event(
+        &handle.href,
+        &nc_account.username,
+        &app_password,
+        &handle.etag,
+        &nc_account.trusted_certs,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(NimbusError::EtagMismatch(_)) => {
+            tracing::info!("stale etag for delete of {event_id}; refreshing calendar and retrying");
+            let cal_path = cache
+                .get_calendar_server_path(&handle.calendar_id)?
+                .map(|(_, p)| p)
+                .ok_or_else(|| {
+                    NimbusError::Other(format!(
+                        "calendar '{}' is not in the local cache",
+                        handle.calendar_id
+                    ))
+                })?;
+            refresh_calendar_cache(cache, &handle.nextcloud_account_id, &cal_path).await?;
+            // Refresh may have removed the row entirely (someone
+            // else already deleted the event).  Treat that as
+            // success — our intent was "make this event go
+            // away", which is now true.
+            let Some(fresh) = cache
+                .get_event_server_handle(event_id)
+                .map_err(NimbusError::from)?
+            else {
+                return Ok(());
+            };
+            caldav_delete_event(
+                &fresh.href,
+                &nc_account.username,
+                &app_password,
+                &fresh.etag,
+                &nc_account.trusted_certs,
+            )
+            .await
         }
         Err(e) => Err(e),
     }
@@ -11371,6 +11450,7 @@ fn main() {
             list_nextcloud_addressbooks,
             list_nextcloud_calendars,
             sync_nextcloud_calendars,
+            sync_calendar_by_id,
             get_cached_calendars,
             create_nextcloud_calendar,
             update_nextcloud_calendar,

--- a/ui/src/lib/EventEditor.svelte
+++ b/ui/src/lib/EventEditor.svelte
@@ -1542,6 +1542,22 @@
       read_only_count: calendars.filter((cc) => cc.read_only).length,
     })
   })
+
+  // Best-effort autosync of this event's calendar the moment the
+  // editor opens in edit mode.  Narrows the window where another
+  // client's edit since our last sync would cause our PUT/DELETE
+  // to come back as 412 / "If-Match failed".  The save path's
+  // own etag-retry logic still backs us up if the user clicks
+  // Save before this sync completes; this one just makes that
+  // safety net rarely fire.  Errors are intentionally swallowed
+  // — the editor opens and works regardless.
+  $effect(() => {
+    if (mode !== 'edit') return
+    if (!calendarId) return
+    void invoke('sync_calendar_by_id', { calendarId }).catch((e) => {
+      console.warn('event-editor: autosync_calendar failed', e)
+    })
+  })
 </script>
 
 <!-- Backdrop click closes the editor — same UX pattern as the


### PR DESCRIPTION
## Summary

The wordy "Nextcloud: event was modified on the server since last sync — refresh and try again" toast fires when another CalDAV client has touched the event between our last sync and the user's PUT / DELETE.  The update path already handled this silently (`update_event_with_etag_retry` syncs the calendar, reloads the handle, retries once).  The delete path didn't.  Two stacked fixes:

### 1. Reactive — delete now self-heals (mirrors update)

- `delete_event_inner` returns `NimbusError::EtagMismatch` instead of an opaque `Nextcloud(_)` string for 412.
- New `delete_event_with_etag_retry` Tauri helper: catches `EtagMismatch`, calls `refresh_calendar_cache`, reloads the handle, retries once.
- Two short-circuit success paths during recovery:
  - The post-sync handle lookup comes back empty → someone else already deleted the event → `Ok(())` (our intent was "make this go away").
  - The retry returns 404 → already gone → `Ok(())` (the underlying caldav helper does this mapping per RFC 4918 §9.6).

### 2. Proactive — sync the affected calendar when the editor opens

- New `sync_calendar_by_id(calendarId)` Tauri command: thin wrapper around the existing `refresh_calendar_cache` helper, keyed by app-side calendar id (so the frontend doesn't need to know about path mapping).
- EventEditor fires it fire-and-forget the moment it mounts in edit mode.  Errors are logged at `warn` and swallowed — this is best-effort freshening, not a user-initiated sync.

The proactive sync narrows the window where the reactive retry needs to fire; the reactive retry catches anything that slips through (e.g. a user who clicks Save before the sync completes, or another client editing during the user's session).

## Test plan

- [x] Open an event in Nimbus that's been edited from another client since the last sync → editor freshens silently, no toast.
- [x] Save / delete a stale-etag event → no error toast, the change goes through after one transparent retry.
- [x] Delete an event that's already been deleted on another client → no error, local cache row removed.
- [x] `cargo test --workspace` (caldav 45, store 64).
- [x] `cargo fmt --check` clean.
- [x] `npm run check` clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)