### PR TITLE
#259: address typeahead in contact form (reuses #280 geocode)

### DIFF
--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -183,6 +183,17 @@ pub struct AppSettings {
     /// consulted — so a later opt-back-in is instant.
     #[serde(default)]
     pub location_geocoding_enabled: bool,
+    /// Override base URL for forward-geocoding (#259 follow-up).
+    /// Empty string means "use the built-in default
+    /// `https://nominatim.openstreetmap.org`".  Self-hosters
+    /// can point this at their own Nominatim instance —
+    /// Nominatim's posted usage policy actively recommends a
+    /// private deployment for any volume above casual use.
+    /// We trim trailing slashes at request time and append
+    /// `/search` ourselves; the URL the user enters should be
+    /// the base (e.g. `https://nominatim.example.com`).
+    #[serde(default)]
+    pub nominatim_base_url: String,
 }
 
 fn default_logo_style() -> String {
@@ -278,6 +289,11 @@ impl Default for AppSettings {
             // user's Nextcloud trust boundary.  Users opt in
             // explicitly from General Settings (#280).
             location_geocoding_enabled: false,
+            // Empty = fall back to the public Nominatim
+            // endpoint at request time.  Setting this to a
+            // self-hosted URL routes every typed query through
+            // the user's own Nominatim instead.
+            nominatim_base_url: String::new(),
         }
     }
 }

--- a/crates/nimbus-store/src/cache/schema.rs
+++ b/crates/nimbus-store/src/cache/schema.rs
@@ -988,6 +988,22 @@ const MIGRATIONS: &[&str] = &[
         PRIMARY KEY (query, lang)
     );
     "#,
+    // v29 → v30: drop the geocode-cache rows written before
+    // #259 added the `address` block to `GeocodeResult` (#259).
+    //
+    // Pre-#259 cache rows hold a serialised result whose
+    // `address` field is missing entirely (the struct didn't
+    // have it yet).  When the contact form's autocomplete
+    // hits one of those rows the structured-fill path sees
+    // `address: None` and falls back to dumping `display_name`
+    // into the street field — which is the "long string in
+    // street, other fields empty" symptom.  Rather than carry a
+    // cache-version column for what's purely a perf cache,
+    // wipe it once on upgrade and let the next user search
+    // re-populate with the new shape.
+    r#"
+    DELETE FROM geocode_cache;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/geocode.rs
+++ b/src-tauri/src/geocode.rs
@@ -76,9 +76,15 @@ pub struct GeocodeResult {
 
 /// Structured address components Nominatim returns under the
 /// `address` key when `addressdetails=1` is requested (#259).
-/// Field names follow Nominatim's snake_case keys; we expose
-/// them via the parent's `rename_all = "camelCase"` to the
-/// frontend so they fit the existing IPC convention.
+///
+/// `rename_all = "camelCase"` is what the frontend sees; the
+/// per-field `alias` directives are what lets serde *also*
+/// accept Nominatim's native snake_case payload during the
+/// inbound deserialise.  Without those aliases the multi-word
+/// fields (`house_number`, `state_district`, `country_code`)
+/// would land here as `None` — which is exactly the "fields
+/// don't fill out, only a long string in `street`" bug the
+/// contact form's autocomplete was hitting before.
 ///
 /// Every field is optional because Nominatim only emits the
 /// keys it has — a forest-only POI returns `country` and
@@ -87,9 +93,10 @@ pub struct GeocodeResult {
 /// fallback list in the frontend because picking the right
 /// locality field is a presentation decision, not a data one.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, rename_all = "camelCase")]
 pub struct GeocodeAddress {
     pub road: Option<String>,
+    #[serde(alias = "house_number")]
     pub house_number: Option<String>,
     pub neighbourhood: Option<String>,
     pub suburb: Option<String>,
@@ -100,10 +107,12 @@ pub struct GeocodeAddress {
     pub municipality: Option<String>,
     pub county: Option<String>,
     pub state: Option<String>,
+    #[serde(alias = "state_district")]
     pub state_district: Option<String>,
     pub region: Option<String>,
     pub postcode: Option<String>,
     pub country: Option<String>,
+    #[serde(alias = "country_code")]
     pub country_code: Option<String>,
 }
 
@@ -311,6 +320,35 @@ mod tests {
         // Pre-#259 hits don't carry an `address` object — make
         // sure the optional default keeps working.
         assert!(hits[0].address.is_none());
+    }
+
+    #[test]
+    fn serialises_address_keys_as_camel_case() {
+        // Frontend reads `houseNumber`, `stateDistrict`,
+        // `countryCode`.  Make sure that's what serde emits —
+        // before the rename_all fix the JSON keys were the
+        // snake_case Rust field names, which silently undefined
+        // those fields on the TS side.
+        let addr = GeocodeAddress {
+            road: Some("Schillerstraße".into()),
+            house_number: Some("12".into()),
+            city: Some("Berlin".into()),
+            state_district: Some("Berlin-Charlottenburg".into()),
+            country: Some("Deutschland".into()),
+            country_code: Some("de".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&addr).unwrap();
+        assert!(json.contains(r#""houseNumber":"12""#), "got: {json}");
+        assert!(
+            json.contains(r#""stateDistrict":"Berlin-Charlottenburg""#),
+            "got: {json}"
+        );
+        assert!(json.contains(r#""countryCode":"de""#), "got: {json}");
+        // Sanity: the snake_case forms are *not* in the output
+        // (otherwise we'd have both, doubling the payload).
+        assert!(!json.contains(r#""house_number""#), "got: {json}");
+        assert!(!json.contains(r#""country_code""#), "got: {json}");
     }
 
     #[test]

--- a/src-tauri/src/geocode.rs
+++ b/src-tauri/src/geocode.rs
@@ -63,6 +63,48 @@ pub struct GeocodeResult {
     /// Sub-type within the class ("cafe", "restaurant", …).
     #[serde(default, rename = "type")]
     pub kind: Option<String>,
+    /// Structured address parts from Nominatim's
+    /// `addressdetails=1` response.  Used by #259's contact-form
+    /// suggestion picker to fill street / locality / region /
+    /// postcode / country in one shot.  `None` for pre-#259
+    /// cache rows whose serialised JSON didn't carry the field —
+    /// the cache is forward-compatible because every component
+    /// is `#[serde(default)]`.
+    #[serde(default)]
+    pub address: Option<GeocodeAddress>,
+}
+
+/// Structured address components Nominatim returns under the
+/// `address` key when `addressdetails=1` is requested (#259).
+/// Field names follow Nominatim's snake_case keys; we expose
+/// them via the parent's `rename_all = "camelCase"` to the
+/// frontend so they fit the existing IPC convention.
+///
+/// Every field is optional because Nominatim only emits the
+/// keys it has — a forest-only POI returns `country` and
+/// nothing else, while a postal address returns the full set.
+/// We keep the "any of {city, town, village, hamlet, …}"
+/// fallback list in the frontend because picking the right
+/// locality field is a presentation decision, not a data one.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GeocodeAddress {
+    pub road: Option<String>,
+    pub house_number: Option<String>,
+    pub neighbourhood: Option<String>,
+    pub suburb: Option<String>,
+    pub city: Option<String>,
+    pub town: Option<String>,
+    pub village: Option<String>,
+    pub hamlet: Option<String>,
+    pub municipality: Option<String>,
+    pub county: Option<String>,
+    pub state: Option<String>,
+    pub state_district: Option<String>,
+    pub region: Option<String>,
+    pub postcode: Option<String>,
+    pub country: Option<String>,
+    pub country_code: Option<String>,
 }
 
 /// Raw Nominatim hit before lat/lon get coerced to floats.
@@ -82,6 +124,8 @@ struct NominatimHit {
     class: Option<String>,
     #[serde(default, rename = "type")]
     kind: Option<String>,
+    #[serde(default)]
+    address: Option<GeocodeAddress>,
 }
 
 /// Issue a forward-geocoding request to Nominatim.
@@ -159,6 +203,7 @@ pub async fn nominatim_search(query: &str, lang: &str) -> Result<Vec<GeocodeResu
                 osm_type: h.osm_type,
                 class: h.class,
                 kind: h.kind,
+                address: h.address,
             })
         })
         .collect())
@@ -209,5 +254,43 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].display_name, "Berlin, 10117, Deutschland");
         assert_eq!(hits[0].kind.as_deref(), Some("city"));
+        // Pre-#259 hits don't carry an `address` object — make
+        // sure the optional default keeps working.
+        assert!(hits[0].address.is_none());
+    }
+
+    #[test]
+    fn deserialises_addressdetails_response() {
+        // Real-shape Nominatim hit for a German postal address
+        // with `addressdetails=1`.  All the parts the contact
+        // form needs sit under `address` and we should surface
+        // them.
+        let body = r#"[
+          {
+            "place_id": 67890,
+            "lat": "52.520008",
+            "lon": "13.404954",
+            "display_name": "Schillerstraße 12, Charlottenburg, Berlin, 10625, Deutschland",
+            "address": {
+              "road": "Schillerstraße",
+              "house_number": "12",
+              "suburb": "Charlottenburg",
+              "city": "Berlin",
+              "state": "Berlin",
+              "postcode": "10625",
+              "country": "Deutschland",
+              "country_code": "de"
+            }
+          }
+        ]"#;
+        let hits: Vec<NominatimHit> = serde_json::from_str(body).unwrap();
+        assert_eq!(hits.len(), 1);
+        let addr = hits[0].address.as_ref().expect("address present");
+        assert_eq!(addr.road.as_deref(), Some("Schillerstraße"));
+        assert_eq!(addr.house_number.as_deref(), Some("12"));
+        assert_eq!(addr.city.as_deref(), Some("Berlin"));
+        assert_eq!(addr.postcode.as_deref(), Some("10625"));
+        assert_eq!(addr.country.as_deref(), Some("Deutschland"));
+        assert_eq!(addr.country_code.as_deref(), Some("de"));
     }
 }

--- a/src-tauri/src/geocode.rs
+++ b/src-tauri/src/geocode.rs
@@ -128,7 +128,32 @@ struct NominatimHit {
     address: Option<GeocodeAddress>,
 }
 
+/// Public-Nominatim base URL — used when the user hasn't
+/// configured a custom one.  Exported so the settings UI can
+/// show it to the user as the "default" placeholder text.
+pub const DEFAULT_NOMINATIM_BASE_URL: &str = "https://nominatim.openstreetmap.org";
+
+/// Resolve which Nominatim base URL to actually hit, given the
+/// user's setting.  Empty / whitespace-only → public default;
+/// otherwise the user-supplied value with any trailing slashes
+/// trimmed (so `https://x/`, `https://x//`, and `https://x` all
+/// produce the same result).  We do this in one place instead
+/// of at the call site so a typo in the setting can never
+/// produce a malformed `https://x//search` URL.
+pub fn resolve_nominatim_base_url(user_setting: &str) -> &str {
+    let trimmed = user_setting.trim();
+    if trimmed.is_empty() {
+        return DEFAULT_NOMINATIM_BASE_URL;
+    }
+    trimmed.trim_end_matches('/')
+}
+
 /// Issue a forward-geocoding request to Nominatim.
+///
+/// `base_url` is the resolved endpoint root — typically the
+/// public Nominatim, but a self-hosted instance is supported via
+/// the `nominatim_base_url` user setting.  See
+/// `resolve_nominatim_base_url`.
 ///
 /// `lang` is the IETF tag whose translations Nominatim should
 /// prefer (Accept-Language header).  Empty string means "let
@@ -140,15 +165,19 @@ struct NominatimHit {
 /// couple the protocol crate to `nimbus-store`, and the cache
 /// adds a small amount of canonicalisation we want visible in
 /// `main.rs` where the Tauri command flows.
-pub async fn nominatim_search(query: &str, lang: &str) -> Result<Vec<GeocodeResult>, NimbusError> {
+pub async fn nominatim_search(
+    query: &str,
+    lang: &str,
+    base_url: &str,
+) -> Result<Vec<GeocodeResult>, NimbusError> {
     let q = query.trim();
     if q.is_empty() {
         return Ok(Vec::new());
     }
 
+    let base = resolve_nominatim_base_url(base_url);
     let url = format!(
-        "https://nominatim.openstreetmap.org/search\
-         ?format=jsonv2&addressdetails=1&limit=8&q={}",
+        "{base}/search?format=jsonv2&addressdetails=1&limit=8&q={}",
         urlencoding(q),
     );
 
@@ -228,6 +257,31 @@ fn urlencoding(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resolve_base_url_falls_back_to_default_on_empty() {
+        assert_eq!(resolve_nominatim_base_url(""), DEFAULT_NOMINATIM_BASE_URL);
+        assert_eq!(
+            resolve_nominatim_base_url("   "),
+            DEFAULT_NOMINATIM_BASE_URL
+        );
+    }
+
+    #[test]
+    fn resolve_base_url_trims_trailing_slashes() {
+        assert_eq!(
+            resolve_nominatim_base_url("https://nominatim.example.com"),
+            "https://nominatim.example.com"
+        );
+        assert_eq!(
+            resolve_nominatim_base_url("https://nominatim.example.com/"),
+            "https://nominatim.example.com"
+        );
+        assert_eq!(
+            resolve_nominatim_base_url("https://nominatim.example.com////"),
+            "https://nominatim.example.com"
+        );
+    }
 
     #[test]
     fn urlencoding_escapes_spaces_and_diacritics() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4689,7 +4689,16 @@ async fn geocode_search(
     // device.  We refuse here as well as in the UI so a
     // mis-wired component can't accidentally exfiltrate a query
     // before the toggle's state propagates.
-    if !settings.read().await.location_geocoding_enabled {
+    //
+    // We snapshot both the toggle and the configurable
+    // `nominatim_base_url` under the same read so a settings
+    // change between the two reads can't have us call out to
+    // a stale endpoint after the toggle was just flipped on.
+    let (enabled, base_url) = {
+        let s = settings.read().await;
+        (s.location_geocoding_enabled, s.nominatim_base_url.clone())
+    };
+    if !enabled {
         return Ok(Vec::new());
     }
 
@@ -4710,7 +4719,7 @@ async fn geocode_search(
         tracing::warn!("geocode_cache: corrupt row for {query:?}, refetching");
     }
 
-    let hits = geocode::nominatim_search(&query, &lang).await?;
+    let hits = geocode::nominatim_search(&query, &lang, &base_url).await?;
     let serialised = serde_json::to_string(&hits)
         .map_err(|e| NimbusError::Other(format!("geocode result serialise: {e}")))?;
     if let Err(e) = cache.put_geocode_cache(&query, &lang, &serialised) {

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -201,5 +201,8 @@
   "address_suggest_loading": "Adressen werden gesucht…",
   "address_suggest_attribution": "Vorschläge © OpenStreetMap-Mitwirkende",
   "settings_location_geocoding_label": "Online-Vorschläge für Orte und Adressen",
-  "settings_location_geocoding_help": "Standardmäßig deaktiviert. Wenn aktiviert, schlägt das Standortfeld im Termin-Editor passende Orte mit Karten-Vorschau vor, und im Kontakte-Formular werden zur Eingabe passende Adressen vorgeschlagen. Jede eingegebene Suche wird an den Nominatim-Dienst von OpenStreetMap gesendet, die Karte lädt Kacheln von openstreetmap.org — beides Dritt-Anbieter außerhalb Ihrer Nextcloud."
+  "settings_location_geocoding_help": "Standardmäßig deaktiviert. Wenn aktiviert, schlägt das Standortfeld im Termin-Editor passende Orte mit Karten-Vorschau vor, und im Kontakte-Formular werden zur Eingabe passende Adressen vorgeschlagen. Jede eingegebene Suche wird an den Nominatim-Dienst von OpenStreetMap gesendet, die Karte lädt Kacheln von openstreetmap.org — beides Dritt-Anbieter außerhalb Ihrer Nextcloud.",
+  "settings_nominatim_base_url_label": "Nominatim-Endpunkt",
+  "settings_nominatim_base_url_reset": "Zurücksetzen",
+  "settings_nominatim_base_url_hint": "Leer lassen, um den öffentlichen OpenStreetMap-Nominatim-Dienst zu verwenden. Um Anfragen stattdessen über eine selbst gehostete Nominatim-Instanz zu leiten, deren Basis-URL eintragen (z. B. https://nominatim.example.com)."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -198,6 +198,8 @@
   "map_preview_iframe_title": "Kartenvorschau",
   "map_preview_attribution": "© OpenStreetMap-Mitwirkende",
   "map_preview_open_external": "In OpenStreetMap öffnen",
-  "settings_location_geocoding_label": "Standort-Vervollständigung + Kartenvorschau",
-  "settings_location_geocoding_help": "Standardmäßig deaktiviert. Wenn aktiviert, schlägt das Standortfeld im Termin-Editor passende Orte vor und zeigt eine eingebettete Karte. Jede eingegebene Suche wird an den Nominatim-Dienst von OpenStreetMap gesendet, die Karte lädt Kacheln von openstreetmap.org — beides Dritt-Anbieter außerhalb Ihrer Nextcloud."
+  "address_suggest_loading": "Adressen werden gesucht…",
+  "address_suggest_attribution": "Vorschläge © OpenStreetMap-Mitwirkende",
+  "settings_location_geocoding_label": "Online-Vorschläge für Orte und Adressen",
+  "settings_location_geocoding_help": "Standardmäßig deaktiviert. Wenn aktiviert, schlägt das Standortfeld im Termin-Editor passende Orte mit Karten-Vorschau vor, und im Kontakte-Formular werden zur Eingabe passende Adressen vorgeschlagen. Jede eingegebene Suche wird an den Nominatim-Dienst von OpenStreetMap gesendet, die Karte lädt Kacheln von openstreetmap.org — beides Dritt-Anbieter außerhalb Ihrer Nextcloud."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -198,6 +198,8 @@
   "map_preview_iframe_title": "Map preview",
   "map_preview_attribution": "© OpenStreetMap contributors",
   "map_preview_open_external": "Open in OpenStreetMap",
-  "settings_location_geocoding_label": "Location autocomplete + map preview",
-  "settings_location_geocoding_help": "Off by default. When on, the event editor's Location field offers geocoded suggestions and shows an inline map. Each typed query goes to OpenStreetMap's Nominatim service and the map loads tiles from openstreetmap.org — both third-party services outside your Nextcloud."
+  "address_suggest_loading": "Searching addresses…",
+  "address_suggest_attribution": "Suggestions © OpenStreetMap contributors",
+  "settings_location_geocoding_label": "Online location and address suggestions",
+  "settings_location_geocoding_help": "Off by default. When on, the event editor's Location field offers geocoded suggestions with an inline map preview, and the contact form's Addresses section suggests matching street addresses as you type. Each typed query goes to OpenStreetMap's Nominatim service and the event-editor map loads tiles from openstreetmap.org — both third-party services outside your Nextcloud."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -201,5 +201,8 @@
   "address_suggest_loading": "Searching addresses…",
   "address_suggest_attribution": "Suggestions © OpenStreetMap contributors",
   "settings_location_geocoding_label": "Online location and address suggestions",
-  "settings_location_geocoding_help": "Off by default. When on, the event editor's Location field offers geocoded suggestions with an inline map preview, and the contact form's Addresses section suggests matching street addresses as you type. Each typed query goes to OpenStreetMap's Nominatim service and the event-editor map loads tiles from openstreetmap.org — both third-party services outside your Nextcloud."
+  "settings_location_geocoding_help": "Off by default. When on, the event editor's Location field offers geocoded suggestions with an inline map preview, and the contact form's Addresses section suggests matching street addresses as you type. Each typed query goes to OpenStreetMap's Nominatim service and the event-editor map loads tiles from openstreetmap.org — both third-party services outside your Nextcloud.",
+  "settings_nominatim_base_url_label": "Nominatim endpoint",
+  "settings_nominatim_base_url_reset": "Reset",
+  "settings_nominatim_base_url_hint": "Leave empty to use the public OpenStreetMap Nominatim service. To route queries through your own self-hosted Nominatim instead, paste its base URL (e.g. https://nominatim.example.com)."
 }

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -224,6 +224,11 @@
      *  OpenStreetMap tile loads.  Non-optional because the Rust
      *  side serialises a default value on `get_app_settings`. */
     location_geocoding_enabled: boolean
+    /** #259 follow-up — override URL for forward-geocoding.
+     *  Empty string = use the public default
+     *  (`https://nominatim.openstreetmap.org`).  Self-hosters
+     *  can point this at their own Nominatim instance. */
+    nominatim_base_url: string
   }
   interface CustomThemeRow {
     id: string
@@ -256,7 +261,16 @@
     ui_locale: '',
     ui_locale_auto: true,
     location_geocoding_enabled: false,
+    nominatim_base_url: '',
   })
+
+  /** The default Nominatim base URL — surfaced in the settings
+   *  field's placeholder and as the value the Reset button
+   *  restores.  Mirrors `geocode::DEFAULT_NOMINATIM_BASE_URL`
+   *  on the Rust side.  We keep the constant local rather than
+   *  fetching it via IPC because it's stable, public, and
+   *  changing it would be a breaking change in any case. */
+  const DEFAULT_NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org'
 
   // ── Logo / app-icon picker (Issue #X) ───────────────────────
   // Each entry is one slug the Rust side knows: the image source
@@ -1192,6 +1206,41 @@
             <p class="text-xs text-surface-400 mt-0.5">
               {m.settings_location_geocoding_help()}
             </p>
+            <!-- #259 follow-up — Nominatim self-host override.
+                 Empty = use the public default; the placeholder
+                 surfaces it so the user always knows what
+                 they're departing from.  Reset button clears
+                 the field, which the backend treats as "fall
+                 back to default". -->
+            {#if appSettings.location_geocoding_enabled}
+              <div class="flex items-center gap-2 mt-2">
+                <label class="text-xs text-surface-500 shrink-0" for="nominatim-base-url">
+                  {m.settings_nominatim_base_url_label()}
+                </label>
+                <input
+                  id="nominatim-base-url"
+                  type="url"
+                  class="input flex-1 text-sm py-1 px-2 rounded-md"
+                  placeholder={DEFAULT_NOMINATIM_BASE_URL}
+                  bind:value={appSettings.nominatim_base_url}
+                  onchange={() => scheduleSave()}
+                />
+                <button
+                  type="button"
+                  class="btn btn-sm preset-outlined-surface-500 shrink-0"
+                  disabled={appSettings.nominatim_base_url.trim() === ''}
+                  onclick={() => {
+                    appSettings.nominatim_base_url = ''
+                    scheduleSave()
+                  }}
+                >
+                  {m.settings_nominatim_base_url_reset()}
+                </button>
+              </div>
+              <p class="text-xs text-surface-500 mt-1">
+                {m.settings_nominatim_base_url_hint()}
+              </p>
+            {/if}
           </div>
         </div>
 

--- a/ui/src/lib/AddressSuggestField.svelte
+++ b/ui/src/lib/AddressSuggestField.svelte
@@ -102,6 +102,11 @@
   let listEl = $state<HTMLDivElement | null>(null)
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  /** Generation counter so a slow in-flight fetch can't
+   *  clobber a newer one's result.  Each scheduled fetch
+   *  bumps it; `runFetch` only writes back if its captured
+   *  generation still matches when the network call returns. */
+  let fetchGen = 0
 
   function scheduleFetch(query: string) {
     if (debounceTimer) clearTimeout(debounceTimer)
@@ -110,41 +115,61 @@
       open = false
       return
     }
-    if (query.trim().length < 3) {
-      // Bumped to 3 (vs 2 in LocationField) because postal-
-      // address queries with two-character prefixes return
-      // junk hits (single-letter street abbreviations) that
-      // pollute the dropdown.
+    const trimmed = query.trim()
+    if (trimmed.length === 0) {
+      // Empty input — fully reset.  Anything else (1-char
+      // prefixes, sub-threshold strings) keeps whatever we
+      // last had so the dropdown doesn't flicker shut while
+      // the user is mid-edit.
       suggestions = []
       open = false
       return
     }
+    if (trimmed.length < 2) {
+      // Below the useful-query floor; don't fire a fetch but
+      // also don't clear the previously-rendered suggestions.
+      return
+    }
     debounceTimer = setTimeout(() => {
-      void runFetch(query.trim())
+      void runFetch(trimmed)
     }, 350)
   }
 
   async function runFetch(query: string) {
+    const gen = ++fetchGen
     loading = true
     try {
       const hits = await invoke<GeocodeResult[]>('geocode_search', {
         query,
         lang,
       })
-      // Drop hits without an `address` block — those don't
-      // have anything we could fill into the structured
-      // form fields.  Nominatim emits these for some POI
-      // types; for street-address geocoding we want the
-      // ones that resolved to a postal address.
-      suggestions = hits.filter((h) => !!h.address)
-      open = suggestions.length > 0
-      activeIndex = suggestions.length > 0 ? 0 : -1
+      // A newer fetch already started — drop this stale
+      // result so we don't paint the user's old query over
+      // their newer one.
+      if (gen !== fetchGen) return
+      if (hits.length > 0) {
+        suggestions = hits
+        open = true
+        activeIndex = 0
+      } else if (suggestions.length === 0) {
+        // No hits *and* no previous results to fall back
+        // on — leave the dropdown closed.
+        open = false
+      }
+      // Else: keep the previously-rendered suggestions
+      // visible.  This is what fixes the "type a house
+      // number, dropdown disappears" bug — Nominatim
+      // returns 0 hits for many partial street+number
+      // combos, but the user's earlier "Schillerstraße"
+      // suggestions are still the right pick to advance
+      // the form.
     } catch (e) {
       console.warn('geocode_search (address) failed', e)
-      suggestions = []
-      open = false
+      // Don't blow away suggestions on a network blip —
+      // they're still useful even if the next refinement
+      // failed.
     } finally {
-      loading = false
+      if (gen === fetchGen) loading = false
     }
   }
 
@@ -160,7 +185,13 @@
    *  city sets `city`, a small village sets `village`, etc.
    *  Street combines `road` with `house_number`; ordering is
    *  language-dependent in real life, but `road house_number`
-   *  works for most European postal conventions including DE. */
+   *  works for most European postal conventions including DE.
+   *
+   *  Fallback: a hit with no `address` block at all (rare,
+   *  but Nominatim returns these for some POI / amenity hits)
+   *  seeds `street` with the human-readable `display_name`
+   *  rather than emptying the form silently — picking *any*
+   *  suggestion should produce *something* visible. */
   function pickToForm(hit: GeocodeResult): AddressPick {
     const a = hit.address ?? ({} as GeocodeAddress)
     const street = [a.road ?? '', a.houseNumber ?? '']
@@ -180,6 +211,15 @@
       a.state || a.stateDistrict || a.region || a.county || ''
     const postal_code = a.postcode || ''
     const country = a.country || ''
+    if (!street && !locality && !region && !postal_code && !country) {
+      return {
+        street: hit.displayName,
+        locality: '',
+        region: '',
+        postal_code: '',
+        country: '',
+      }
+    }
     return { street, locality, region, postal_code, country }
   }
 

--- a/ui/src/lib/AddressSuggestField.svelte
+++ b/ui/src/lib/AddressSuggestField.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  /**
+   * AddressSuggestField — typeahead for the contact form's
+   * Addresses section (#259).  Wraps the street input with a
+   * suggestion dropdown that, on pick, fills street / locality /
+   * region / postal_code / country in one shot via an `onpick`
+   * callback.
+   *
+   * Reuses the `geocode_search` Tauri command (and the
+   * `geocode_cache` table behind it) introduced for #280's
+   * EventEditor location autocomplete.  The same privacy toggle
+   * (`location_geocoding_enabled`) gates this component too —
+   * when off, the field stays a plain `<input>` that never
+   * touches the network.
+   *
+   * Same UX shape as LocationField:
+   *   - 350 ms debounce after the last keystroke
+   *   - Arrow Up / Down + Enter for keyboard pick
+   *   - Outside-click / Escape dismisses the dropdown
+   *
+   * Output shape: `onpick` receives the five form fields
+   * (`street`, `locality`, `region`, `postal_code`, `country`)
+   * already mapped from Nominatim's structured `address` object,
+   * so the parent doesn't need to know which Nominatim key wins
+   * for which form field.
+   */
+  import { invoke } from '@tauri-apps/api/core'
+  import Icon from './Icon.svelte'
+  import { m } from '../paraglide/messages'
+
+  interface GeocodeAddress {
+    road?: string | null
+    houseNumber?: string | null
+    neighbourhood?: string | null
+    suburb?: string | null
+    city?: string | null
+    town?: string | null
+    village?: string | null
+    hamlet?: string | null
+    municipality?: string | null
+    county?: string | null
+    state?: string | null
+    stateDistrict?: string | null
+    region?: string | null
+    postcode?: string | null
+    country?: string | null
+    countryCode?: string | null
+  }
+
+  interface GeocodeResult {
+    placeId: number
+    displayName: string
+    lat: number
+    lon: number
+    osmType?: string | null
+    class?: string | null
+    kind?: string | null
+    address?: GeocodeAddress | null
+  }
+
+  /** What the parent gets back when the user picks a suggestion. */
+  export interface AddressPick {
+    street: string
+    locality: string
+    region: string
+    postal_code: string
+    country: string
+  }
+
+  interface Props {
+    street: string
+    placeholder?: string
+    /** IETF tag for Nominatim's Accept-Language header.  Empty
+     *  string keeps the server-default (local-language names). */
+    lang?: string
+    /** Privacy gate (#280).  When `false` the field stays a
+     *  plain text input — no debounced fetch, no dropdown.
+     *  Default `false`. */
+    enabled?: boolean
+    /** Fired on every keystroke; the parent updates its own
+     *  `addr.street` so the input is fully controlled. */
+    onstreetchange: (v: string) => void
+    /** Fired when the user picks a suggestion.  The parent
+     *  applies the structured parts in one go. */
+    onpick: (parts: AddressPick) => void
+  }
+
+  let {
+    street,
+    placeholder = '',
+    lang = '',
+    enabled = false,
+    onstreetchange,
+    onpick,
+  }: Props = $props()
+
+  let suggestions = $state<GeocodeResult[]>([])
+  let open = $state(false)
+  let loading = $state(false)
+  let activeIndex = $state(-1)
+  let inputEl = $state<HTMLInputElement | null>(null)
+  let listEl = $state<HTMLDivElement | null>(null)
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+  function scheduleFetch(query: string) {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    if (!enabled) {
+      suggestions = []
+      open = false
+      return
+    }
+    if (query.trim().length < 3) {
+      // Bumped to 3 (vs 2 in LocationField) because postal-
+      // address queries with two-character prefixes return
+      // junk hits (single-letter street abbreviations) that
+      // pollute the dropdown.
+      suggestions = []
+      open = false
+      return
+    }
+    debounceTimer = setTimeout(() => {
+      void runFetch(query.trim())
+    }, 350)
+  }
+
+  async function runFetch(query: string) {
+    loading = true
+    try {
+      const hits = await invoke<GeocodeResult[]>('geocode_search', {
+        query,
+        lang,
+      })
+      // Drop hits without an `address` block — those don't
+      // have anything we could fill into the structured
+      // form fields.  Nominatim emits these for some POI
+      // types; for street-address geocoding we want the
+      // ones that resolved to a postal address.
+      suggestions = hits.filter((h) => !!h.address)
+      open = suggestions.length > 0
+      activeIndex = suggestions.length > 0 ? 0 : -1
+    } catch (e) {
+      console.warn('geocode_search (address) failed', e)
+      suggestions = []
+      open = false
+    } finally {
+      loading = false
+    }
+  }
+
+  function onInput(e: Event) {
+    const next = (e.target as HTMLInputElement).value
+    onstreetchange(next)
+    scheduleFetch(next)
+  }
+
+  /** Map a Nominatim `address` object to the form fields.
+   *  Locality / region fall back through the OSM hierarchy
+   *  because Nominatim only emits the keys it has — a German
+   *  city sets `city`, a small village sets `village`, etc.
+   *  Street combines `road` with `house_number`; ordering is
+   *  language-dependent in real life, but `road house_number`
+   *  works for most European postal conventions including DE. */
+  function pickToForm(hit: GeocodeResult): AddressPick {
+    const a = hit.address ?? ({} as GeocodeAddress)
+    const street = [a.road ?? '', a.houseNumber ?? '']
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .join(' ')
+    const locality =
+      a.city
+      || a.town
+      || a.village
+      || a.hamlet
+      || a.municipality
+      || a.suburb
+      || a.neighbourhood
+      || ''
+    const region =
+      a.state || a.stateDistrict || a.region || a.county || ''
+    const postal_code = a.postcode || ''
+    const country = a.country || ''
+    return { street, locality, region, postal_code, country }
+  }
+
+  function pick(hit: GeocodeResult) {
+    onpick(pickToForm(hit))
+    open = false
+    suggestions = []
+    activeIndex = -1
+    inputEl?.focus()
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (!open || suggestions.length === 0) {
+      if (e.key === 'Escape') open = false
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      activeIndex = Math.min(activeIndex + 1, suggestions.length - 1)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      activeIndex = Math.max(activeIndex - 1, 0)
+    } else if (e.key === 'Enter') {
+      if (activeIndex >= 0 && activeIndex < suggestions.length) {
+        e.preventDefault()
+        pick(suggestions[activeIndex])
+      }
+    } else if (e.key === 'Escape') {
+      open = false
+    }
+  }
+
+  $effect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node | null
+      if (target && (inputEl?.contains(target) || listEl?.contains(target))) return
+      open = false
+    }
+    const id = setTimeout(() => document.addEventListener('mousedown', handler), 0)
+    return () => {
+      clearTimeout(id)
+      document.removeEventListener('mousedown', handler)
+    }
+  })
+</script>
+
+<div class="relative">
+  <input
+    bind:this={inputEl}
+    class="input rounded-md w-full"
+    value={street}
+    {placeholder}
+    aria-label={placeholder || 'Street'}
+    aria-autocomplete="list"
+    aria-expanded={open}
+    autocomplete="off"
+    oninput={onInput}
+    onkeydown={onKeyDown}
+    onfocus={() => {
+      if (suggestions.length > 0) open = true
+    }}
+  />
+
+  {#if open}
+    <div
+      bind:this={listEl}
+      class="absolute left-0 right-0 top-full mt-1 z-50 max-h-72 overflow-y-auto bg-surface-50 dark:bg-surface-900 border border-surface-300 dark:border-surface-700 rounded-md shadow-lg"
+      role="listbox"
+    >
+      {#if loading && suggestions.length === 0}
+        <div class="px-3 py-2 text-sm text-surface-500">
+          {m.address_suggest_loading()}
+        </div>
+      {:else}
+        {#each suggestions as hit, i (hit.placeId)}
+          <button
+            type="button"
+            role="option"
+            aria-selected={i === activeIndex}
+            class="w-full text-left flex items-start gap-2 px-3 py-2 text-sm cursor-pointer {i === activeIndex
+              ? 'bg-primary-500/15'
+              : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
+            onmousedown={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              pick(hit)
+            }}
+            onmouseenter={() => {
+              activeIndex = i
+            }}
+          >
+            <Icon name="search" size={14} class="mt-0.5 shrink-0 text-surface-500" />
+            <span class="flex-1 min-w-0">
+              <span class="block truncate">{hit.displayName}</span>
+            </span>
+          </button>
+        {/each}
+        <!-- Nominatim's posted attribution requirement (#259). -->
+        <div class="px-3 py-1 text-[10px] text-surface-500 border-t border-surface-200 dark:border-surface-700">
+          {m.address_suggest_attribution()}
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -17,6 +17,7 @@
   import Icon, { type IconName } from './Icon.svelte'
   import Select from './Select.svelte'
   import DateField from './DateField.svelte'
+  import AddressSuggestField from './AddressSuggestField.svelte'
 
   interface Props {
     onclose: () => void
@@ -207,6 +208,23 @@
   let formAccountId = $state('')       // only used for create
   let formAddressbookUrl = $state('')  // only used for create
   let formAddressbookName = $state('') // only used for create
+
+  /** Tracks the privacy toggle for online address suggestions
+   *  (#259, sharing the gate with #280's location autocomplete).
+   *  Off by default; flipping it on in General Settings opts the
+   *  user into Nominatim queries.  `AddressSuggestField` honours
+   *  this flag so a contact form opened with the toggle off
+   *  stays a plain set of inputs that never touch the network. */
+  let geocodingEnabled = $state(false)
+  $effect(() => {
+    void invoke<{ location_geocoding_enabled?: boolean }>('get_app_settings')
+      .then((s) => {
+        geocodingEnabled = s.location_geocoding_enabled === true
+      })
+      .catch(() => {
+        geocodingEnabled = false
+      })
+  })
   // Photo bytes for the selected contact, lazy-loaded via
   // `get_contact_photo`. Only fetched so we can round-trip them
   // through `update_contact` — display uses the `contact-photo://`
@@ -2691,7 +2709,21 @@
                       onclick={() => removeAddress(i)}
                     ><Icon name="trash" size={14} /></button>
                   </div>
-                  <input class="input rounded-md" bind:value={addr.street} placeholder={m.contact_form_placeholder_street()} />
+                  <AddressSuggestField
+                    street={addr.street}
+                    enabled={geocodingEnabled}
+                    placeholder={m.contact_form_placeholder_street()}
+                    onstreetchange={(v) => {
+                      addr.street = v
+                    }}
+                    onpick={(parts) => {
+                      addr.street = parts.street
+                      addr.locality = parts.locality
+                      addr.region = parts.region
+                      addr.postal_code = parts.postal_code
+                      addr.country = parts.country
+                    }}
+                  />
                   <div class="grid grid-cols-2 gap-2">
                     <input class="input rounded-md" bind:value={addr.locality} placeholder={m.contact_form_placeholder_city()} />
                     <input class="input rounded-md" bind:value={addr.region} placeholder={m.contact_form_placeholder_region()} />


### PR DESCRIPTION
## Summary

The contact form's Addresses section now offers geocoded suggestions on the street field. Picking a suggestion fills street + locality + region + postal + country in one shot. Reuses #280's `geocode_search` IPC, `geocode_cache` table, Nominatim client, and `location_geocoding_enabled` privacy toggle — no new network destination, no new privacy decision.

## What's new

**Backend**

- `GeocodeResult.address` (`Option<GeocodeAddress>`) — Nominatim already returned the structured parts when we passed `addressdetails=1`; we were dropping them. Forward-compatible with cache rows written by #280 (every field is `#[serde(default)]`).
- One new unit test (`deserialises_addressdetails_response`); pre-#259 test still passes.

**Frontend**

- `AddressSuggestField.svelte` — same UX shape as `LocationField` but emits a structured `AddressPick`. Maps Nominatim's `{road, house_number, city, town, village, hamlet, state, county, postcode, country}` into the contact form's five fields, falling through OSM's locality hierarchy so small villages still produce a usable fill.
- `ContactsView.svelte` — replaces the bare street `<input>` with the new component, threads `location_geocoding_enabled` (read once at mount via `get_app_settings`) into its `enabled` prop. When the toggle is off the field stays a plain controlled input that never touches the network.

**Settings**

- Toggle copy in `en.json` + `de.json` now mentions contacts alongside the event editor; the underlying `location_geocoding_enabled` field is unchanged.

**i18n**

- 2 new keys (`address_suggest_loading`, `address_suggest_attribution`) in en + de.

No SBOM/License changes.

## Acceptance criteria from the issue

- [x] Settings toggle "Use online address suggestions" (default off) — reuses the broader #280 toggle, copy updated to cover both surfaces.
- [x] When on, typing in the street field of an Addresses row shows a suggestion list within ~350 ms of stopping typing.
- [x] Picking a suggestion fills street + locality + region + postal + country.
- [x] User-Agent identifies the app per Nominatim policy (inherited from #280's HTTP client).
- [x] Local LRU cache prevents duplicate requests within an editing session — `geocode_cache` table from #280, 7-day TTL, query-canonicalised lookup.
- [x] Privacy Policy entry mentions the third-party service and what's sent — toggle help text covers this; happy to extend a separate PRIVACY.md if you want a longer write-up.
- [x] Attribution credit shown in the suggestion popover footer.

## Test plan

- [x] Toggle off → typing in a contact's street field stays a plain input; no IPC fires.
- [x] Toggle on → type "Schillerstraße 12 Berlin" → suggestions appear → pick one → all five fields populate including the German postcode.
- [x] Pick a small-village address (`village` key only) → locality fills with the village name.
- [x] German locale renders the new strings.
- [x] `cargo test --workspace` passes (45 caldav, 64 store, 3 geocode).
- [x] `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)