### PR TITLE
#290: scope the synthetic Outbox folder to the sending account

### DIFF
--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -1605,6 +1605,34 @@ impl Cache {
         )?;
         Ok(n.max(0) as u32)
     }
+
+    /// Queued-row counts grouped by account (#290).  Drives the
+    /// per-account decision of "render the synthetic Outbox folder
+    /// in this sidebar?" — the previous global count caused the
+    /// folder to leak into every account's sidebar whenever any
+    /// account had a pending send.  Accounts with zero queued
+    /// rows are omitted so the caller can `?? 0` without an
+    /// "Outbox (0)" badge showing up.
+    pub fn count_outbox_by_account(
+        &self,
+    ) -> Result<std::collections::HashMap<String, u32>, CacheError> {
+        let conn = self.conn()?;
+        let mut stmt =
+            conn.prepare("SELECT account_id, COUNT(*) FROM outbox_messages GROUP BY account_id")?;
+        let rows = stmt.query_map([], |r| {
+            let id: String = r.get(0)?;
+            let n: i64 = r.get(1)?;
+            Ok((id, n.max(0) as u32))
+        })?;
+        let mut out = std::collections::HashMap::new();
+        for r in rows {
+            let (id, n) = r?;
+            if n > 0 {
+                out.insert(id, n);
+            }
+        }
+        Ok(out)
+    }
 }
 
 /// Row shape inserted into `outbox_messages` by
@@ -1914,6 +1942,10 @@ mod tests {
         assert_eq!(cache.count_outbox().unwrap(), 1);
         assert_eq!(cache.count_outbox_for_account("acc-a").unwrap(), 1);
         assert_eq!(cache.count_outbox_for_account("acc-other").unwrap(), 0);
+        // Per-account map: acc-a present with 1, acc-other omitted.
+        let by_acc = cache.count_outbox_by_account().unwrap();
+        assert_eq!(by_acc.get("acc-a").copied(), Some(1));
+        assert!(by_acc.get("acc-other").is_none());
 
         let rows = cache.list_outbox("acc-a").unwrap();
         assert_eq!(rows.len(), 1);
@@ -1942,6 +1974,7 @@ mod tests {
         assert_eq!(cache.count_outbox().unwrap(), 0);
         assert!(cache.list_outbox("acc-a").unwrap().is_empty());
         assert!(cache.get_outbox(id).unwrap().is_none());
+        assert!(cache.count_outbox_by_account().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7440,25 +7440,33 @@ async fn run_send_pipeline(
 /// manual delete) so the frontend can re-read counts and refresh
 /// the synthetic Outbox folder.
 #[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct OutboxUpdatedPayload {
-    /// Total queued rows across every account — drives the
-    /// "show / hide synthetic Outbox folder" decision in the
-    /// sidebar.
+    /// Total queued rows across every account.  Retained so anything
+    /// reading the unscoped count (tray indicators, future global
+    /// badges) keeps working without a follow-up call.
     total: u32,
+    /// Per-account count map (#290).  Drives the sidebar's "render
+    /// the synthetic Outbox folder?" decision per account so the
+    /// folder no longer leaks into accounts that have nothing
+    /// queued.  Accounts with zero queued rows are omitted.
+    by_account: std::collections::HashMap<String, u32>,
 }
 
 /// Fire `outbox-updated` so the frontend re-reads the queue.
 /// Best-effort — a dropped event just means the user has to wait
 /// for the next sync tick to see the new state.
 fn emit_outbox_updated(app: &AppHandle) {
-    let total = match app.state::<Cache>().count_outbox() {
-        Ok(n) => n,
+    let cache = app.state::<Cache>();
+    let by_account = match cache.count_outbox_by_account() {
+        Ok(m) => m,
         Err(e) => {
-            tracing::warn!("count_outbox for event payload failed: {e}");
+            tracing::warn!("count_outbox_by_account for event payload failed: {e}");
             return;
         }
     };
-    let payload = OutboxUpdatedPayload { total };
+    let total = by_account.values().copied().sum();
+    let payload = OutboxUpdatedPayload { total, by_account };
     if let Err(e) = app.emit("outbox-updated", &payload) {
         tracing::warn!("failed to emit outbox-updated event: {e}");
     }
@@ -7527,11 +7535,23 @@ async fn list_all_outbox(cache: State<'_, Cache>) -> Result<Vec<OutboxRowDto>, N
 }
 
 /// Total queued rows across every account.  Cheap aggregate
-/// query — used by the Sidebar's "show synthetic Outbox folder?"
-/// decision.
+/// query — retained for callers that want the global figure
+/// (tray indicators, future global badges).
 #[tauri::command]
 async fn count_outbox(cache: State<'_, Cache>) -> Result<u32, NimbusError> {
     Ok(cache.count_outbox()?)
+}
+
+/// Queued-row counts grouped by `account_id` (#290).  Used as the
+/// startup seed for the Sidebar's per-account "render synthetic
+/// Outbox folder?" decision so a queue carried over from a prior
+/// session shows up without waiting for the first `outbox-updated`
+/// event.  Accounts with zero queued rows are omitted.
+#[tauri::command]
+async fn count_outbox_by_account(
+    cache: State<'_, Cache>,
+) -> Result<std::collections::HashMap<String, u32>, NimbusError> {
+    Ok(cache.count_outbox_by_account()?)
 }
 
 /// Force a drain attempt on a specific row (#276).  Used by the
@@ -11375,6 +11395,7 @@ fn main() {
             list_outbox,
             list_all_outbox,
             count_outbox,
+            count_outbox_by_account,
             retry_outbox_entry,
             delete_outbox_entry,
             edit_outbox_entry,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -222,11 +222,22 @@
    *  on a string compare. */
   const OUTBOX_FOLDER = 'Outbox'
 
-  /** Total queued rows in the local Outbox table (#276).  Drives
-   *  the Sidebar's "render the synthetic Outbox folder?"
-   *  decision.  Refreshed via the `outbox-updated` Tauri event
-   *  the backend fires whenever the queue changes shape. */
-  let outboxCount = $state(0)
+  /** Queued-row counts per account (#290).  Drives the Sidebar's
+   *  "render the synthetic Outbox folder?" decision *per active
+   *  account* — previously a single global counter caused the
+   *  Outbox folder to leak into every account's sidebar whenever
+   *  any account had a pending send.  Refreshed via the
+   *  `outbox-updated` Tauri event the backend fires whenever the
+   *  queue changes shape; accounts with zero queued rows are
+   *  omitted from the map. */
+  let outboxCountByAccount = $state<Record<string, number>>({})
+  /** Queued-row count for the *currently active* account.  Drives
+   *  both the Sidebar prop and the "drain → bounce back to INBOX"
+   *  redirect below.  Derived (rather than a separate $state) so
+   *  it can never drift out of sync with the map. */
+  let outboxCount = $derived(
+    activeAccountId ? (outboxCountByAccount[activeAccountId] ?? 0) : 0,
+  )
   /** Per-component re-fetch nonce for OutboxList — bumped on
    *  `outbox-updated` so the list reloads even when no other
    *  state change would have triggered its `$effect`. */
@@ -837,39 +848,43 @@
           refreshToken++
         },
       )
-      // #276: backend fires `outbox-updated` whenever the queue
-      // changes shape (enqueue / drain success / failure /
-      // delete).  Refresh the count so the Sidebar shows /
-      // hides the synthetic Outbox folder, and bump the
-      // OutboxList's nonce so its rows re-fetch.
-      unlistenOutboxUpdated = await listen<{ total: number }>(
-        'outbox-updated',
-        (e) => {
-          outboxCount = Math.max(0, Math.floor(e.payload.total ?? 0))
-          outboxRefreshToken++
-          // If the user is sitting on the Outbox folder and the
-          // queue just drained empty, route them back to INBOX
-          // — staying on an empty Outbox would just be a blank
-          // surface they have to manually navigate away from.
-          if (outboxCount === 0 && selectedFolder === OUTBOX_FOLDER) {
-            selectedFolder = 'INBOX'
-            selectedUid = null
-            selectedOutboxRow = null
-          }
-          // OutboxList itself re-runs `list_outbox` on this same
-          // event and emits `onselect(updatedRow | null)` —
-          // that's where the preview row gets refreshed (so
-          // attempt counts / last_error stay fresh) or cleared
-          // (when the row drained or got deleted).
-        },
-      )
-      // Seed the count once on startup so a queue carried over
-      // from a previous session is reflected without waiting for
-      // the first poll tick.
+      // #276 / #290: backend fires `outbox-updated` whenever the
+      // queue changes shape (enqueue / drain success / failure /
+      // delete).  The payload now carries a *per-account* map so
+      // the Sidebar can decide whether to show the synthetic
+      // Outbox folder for the active account specifically,
+      // instead of leaking it into every account's sidebar.
+      unlistenOutboxUpdated = await listen<{
+        total: number
+        byAccount: Record<string, number>
+      }>('outbox-updated', (e) => {
+        outboxCountByAccount = e.payload.byAccount ?? {}
+        outboxRefreshToken++
+        // If the user is sitting on the Outbox folder for the
+        // *active* account and that account's queue just
+        // drained empty, route them back to INBOX — staying on
+        // an empty Outbox would just be a blank surface they
+        // have to manually navigate away from.  Other accounts
+        // draining is irrelevant to the current view.
+        if (outboxCount === 0 && selectedFolder === OUTBOX_FOLDER) {
+          selectedFolder = 'INBOX'
+          selectedUid = null
+          selectedOutboxRow = null
+        }
+        // OutboxList itself re-runs `list_outbox` on this same
+        // event and emits `onselect(updatedRow | null)` —
+        // that's where the preview row gets refreshed (so
+        // attempt counts / last_error stay fresh) or cleared
+        // (when the row drained or got deleted).
+      })
+      // Seed the per-account map once on startup so a queue
+      // carried over from a previous session is reflected
+      // without waiting for the first poll tick.
       try {
-        outboxCount = await invoke<number>('count_outbox')
+        outboxCountByAccount =
+          (await invoke<Record<string, number>>('count_outbox_by_account')) ?? {}
       } catch (e) {
-        console.warn('count_outbox at startup failed', e)
+        console.warn('count_outbox_by_account at startup failed', e)
       }
       unlistenEventReminder = await listen<EventReminder>(
         'event-reminder',


### PR DESCRIPTION
Closes #290.

## Summary

- Backend exposes a per-account outbox count map (`Cache::count_outbox_by_account`, single `GROUP BY` query) and a matching `count_outbox_by_account` Tauri command.
- The `outbox-updated` event payload now carries `{ total, byAccount }` so the frontend can decide per-account whether to render the synthetic Outbox folder.
- `App.svelte` holds the count as `Record<accountId, number>` and derives the active-account figure that drives the Sidebar prop and the "drained → bounce to INBOX" redirect.

## Why

Previously a single global counter drove the Sidebar's "render the synthetic Outbox folder?" decision, so queuing a send on account A made the folder appear under accounts B, C, … as well. The fix scopes the folder to the account that actually has queued mail.

Unified mode is unaffected — it renders the "All Inboxes" tile instead of a folder tree.

## Test plan

- [x] Configure two accounts (A, B). Compose + send a mail on A while offline (or with an unreachable SMTP) so it lands in the queue.
- [x] Confirm A's sidebar shows the synthetic **Outbox** folder; switching to B no longer shows it.
- [ ] Bring SMTP back / hit **Retry**, watch A drain — folder disappears for A, and the user is bounced back to INBOX if they were viewing Outbox.
- [ ] Queue mail on both A and B simultaneously and confirm each account's sidebar shows Outbox only when its own queue is non-empty.
- [ ] Restart the app while the queue is non-empty and verify the startup seed (`count_outbox_by_account`) reflects the correct per-account state immediately.
- [ ] `cargo test -p nimbus-store outbox_enqueue_list_count_remove_roundtrip` passes (the test was extended to cover the new map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)