### PR TITLE
#260: /mail and @ mention pickers in the Notes editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ by default, and renders attachments inline where it makes sense.
 - **Calendar** (CalDAV) — RSVP to meeting invites inline. The "Respond
   with meeting" action drops a styled invite card into your reply with
   the time, location, notes, and an optional Talk room.
+- **Notes** — full sync with the Nextcloud Notes app. Real markdown
+  end-to-end (no HTML serializer in the middle) with a side-by-side
+  preview pane. Two cross-feature autocomplete triggers live in the
+  editor:
+  - Type **`@`** followed by a name — a popup opens with matching
+    contacts from your address book. Pick one and a clickable
+    contact reference (`[Name](mailto:address)`) is inserted at the
+    cursor.
+  - Type **`/mail`** *then a space* — a popup opens that searches
+    your cached mail (cross-folder) as you type, with a server-side
+    fallback for the active account's inbox. Pick a message and a
+    clickable mail reference (`[Subject](mail://account/folder/uid)`)
+    is inserted.
+  Mail references opened from a note pop out into a standalone
+  reader window by default so the editor stays put; flip **"Open
+  mails in mail view"** in Settings → General if you'd rather the
+  main view jump to the message instead.
 
 <!--
   GIF: nextcloud-talk
@@ -322,7 +339,6 @@ Tracked in [GitHub Issues](https://github.com/Videothek/nimbus-mail/issues).
 - End-to-end mail encryption (S/MIME + OpenPGP)
 - Calendar invites + RSVP polish
 - AI-assisted reply drafting + RAG over mail
-- Nextcloud Notes integration
 - Drag-and-drop messages between folders
 - HTML body renderer with per-sender remote-image trust
 

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -195,13 +195,13 @@ pub struct AppSettings {
     #[serde(default)]
     pub nominatim_base_url: String,
     /// What happens when the user clicks a `mail://acc/folder/uid`
-    /// reference embedded in a note (#260).  `Popup` (default) spawns
-    /// a standalone webview window with the message — the user keeps
-    /// their place in the Notes view.  `Switch` flips the main view
-    /// over to the inbox, scoped to the referenced account / folder /
-    /// UID, the way clicking a row in the mail list does.
+    /// reference embedded in a note (#260).  Default `false` opens
+    /// the message in a standalone reader window so the user keeps
+    /// their place in the Notes view; flipping it on routes the
+    /// click through the main app's view-switch instead (lands in
+    /// the inbox at that message).
     #[serde(default)]
-    pub notes_mail_link_open: NotesMailLinkBehavior,
+    pub notes_mail_open_in_view: bool,
 }
 
 fn default_logo_style() -> String {
@@ -258,18 +258,6 @@ pub enum ThemeMode {
     Dark,
 }
 
-/// What happens when the user clicks a `mail://acc/folder/uid`
-/// reference embedded in a note (#260).  Default `Popup` so the
-/// click never yanks the user out of the editor they were just
-/// working in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum NotesMailLinkBehavior {
-    #[default]
-    Popup,
-    Switch,
-}
-
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -314,11 +302,11 @@ impl Default for AppSettings {
             // self-hosted URL routes every typed query through
             // the user's own Nominatim instead.
             nominatim_base_url: String::new(),
-            // Default to the popup so a `mail://` click in a note
-            // never tears the user out of the editor.  Users who
-            // prefer the old "switch to inbox" behaviour can flip
-            // this in Settings.
-            notes_mail_link_open: NotesMailLinkBehavior::Popup,
+            // Default off — `mail://` clicks in a note open a
+            // standalone reader so the user keeps their place in
+            // the editor.  Flipping this on routes the click
+            // through the main view-switch instead.
+            notes_mail_open_in_view: false,
         }
     }
 }

--- a/crates/nimbus-core/src/models.rs
+++ b/crates/nimbus-core/src/models.rs
@@ -194,6 +194,14 @@ pub struct AppSettings {
     /// the base (e.g. `https://nominatim.example.com`).
     #[serde(default)]
     pub nominatim_base_url: String,
+    /// What happens when the user clicks a `mail://acc/folder/uid`
+    /// reference embedded in a note (#260).  `Popup` (default) spawns
+    /// a standalone webview window with the message — the user keeps
+    /// their place in the Notes view.  `Switch` flips the main view
+    /// over to the inbox, scoped to the referenced account / folder /
+    /// UID, the way clicking a row in the mail list does.
+    #[serde(default)]
+    pub notes_mail_link_open: NotesMailLinkBehavior,
 }
 
 fn default_logo_style() -> String {
@@ -250,6 +258,18 @@ pub enum ThemeMode {
     Dark,
 }
 
+/// What happens when the user clicks a `mail://acc/folder/uid`
+/// reference embedded in a note (#260).  Default `Popup` so the
+/// click never yanks the user out of the editor they were just
+/// working in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NotesMailLinkBehavior {
+    #[default]
+    Popup,
+    Switch,
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -294,6 +314,11 @@ impl Default for AppSettings {
             // self-hosted URL routes every typed query through
             // the user's own Nominatim instead.
             nominatim_base_url: String::new(),
+            // Default to the popup so a `mail://` click in a note
+            // never tears the user out of the editor.  Users who
+            // prefer the old "switch to inbox" behaviour can flip
+            // this in Settings.
+            notes_mail_link_open: NotesMailLinkBehavior::Popup,
         }
     }
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -204,5 +204,9 @@
   "settings_location_geocoding_help": "Standardmäßig deaktiviert. Wenn aktiviert, schlägt das Standortfeld im Termin-Editor passende Orte mit Karten-Vorschau vor, und im Kontakte-Formular werden zur Eingabe passende Adressen vorgeschlagen. Jede eingegebene Suche wird an den Nominatim-Dienst von OpenStreetMap gesendet, die Karte lädt Kacheln von openstreetmap.org — beides Dritt-Anbieter außerhalb Ihrer Nextcloud.",
   "settings_nominatim_base_url_label": "Nominatim-Endpunkt",
   "settings_nominatim_base_url_reset": "Zurücksetzen",
-  "settings_nominatim_base_url_hint": "Leer lassen, um den öffentlichen OpenStreetMap-Nominatim-Dienst zu verwenden. Um Anfragen stattdessen über eine selbst gehostete Nominatim-Instanz zu leiten, deren Basis-URL eintragen (z. B. https://nominatim.example.com)."
+  "settings_nominatim_base_url_hint": "Leer lassen, um den öffentlichen OpenStreetMap-Nominatim-Dienst zu verwenden. Um Anfragen stattdessen über eine selbst gehostete Nominatim-Instanz zu leiten, deren Basis-URL eintragen (z. B. https://nominatim.example.com).",
+  "settings_notes_mail_link_open_label": "Mail-Links in Notizen öffnen",
+  "settings_notes_mail_link_open_popup": "In neuem Fenster öffnen (in Notizen bleiben)",
+  "settings_notes_mail_link_open_switch": "Zur Mail-Ansicht wechseln",
+  "settings_notes_mail_link_open_help": "Wenn du auf einen mail://-Verweis in einer Notiz klickst, legt diese Einstellung fest, ob die Nachricht in einem eigenständigen Lesefenster geöffnet wird (die Notizen-Ansicht bleibt erhalten) oder ob die Hauptansicht zur entsprechenden Nachricht im Posteingang springt."
 }

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -205,8 +205,6 @@
   "settings_nominatim_base_url_label": "Nominatim-Endpunkt",
   "settings_nominatim_base_url_reset": "Zurücksetzen",
   "settings_nominatim_base_url_hint": "Leer lassen, um den öffentlichen OpenStreetMap-Nominatim-Dienst zu verwenden. Um Anfragen stattdessen über eine selbst gehostete Nominatim-Instanz zu leiten, deren Basis-URL eintragen (z. B. https://nominatim.example.com).",
-  "settings_notes_mail_link_open_label": "Mail-Links in Notizen öffnen",
-  "settings_notes_mail_link_open_popup": "In neuem Fenster öffnen (in Notizen bleiben)",
-  "settings_notes_mail_link_open_switch": "Zur Mail-Ansicht wechseln",
-  "settings_notes_mail_link_open_help": "Wenn du auf einen mail://-Verweis in einer Notiz klickst, legt diese Einstellung fest, ob die Nachricht in einem eigenständigen Lesefenster geöffnet wird (die Notizen-Ansicht bleibt erhalten) oder ob die Hauptansicht zur entsprechenden Nachricht im Posteingang springt."
+  "settings_notes_mail_open_in_view_label": "Mails in der Mail-Ansicht öffnen",
+  "settings_notes_mail_open_in_view_hint": "Wenn aktiviert, wechselt ein Klick auf einen Mail-Link in einer Notiz zur Mail-Ansicht und öffnet die Nachricht dort. Wenn deaktiviert (Standard), wird die Nachricht in einem eigenständigen Lesefenster geöffnet, sodass die Notizen-Ansicht erhalten bleibt."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -204,5 +204,9 @@
   "settings_location_geocoding_help": "Off by default. When on, the event editor's Location field offers geocoded suggestions with an inline map preview, and the contact form's Addresses section suggests matching street addresses as you type. Each typed query goes to OpenStreetMap's Nominatim service and the event-editor map loads tiles from openstreetmap.org — both third-party services outside your Nextcloud.",
   "settings_nominatim_base_url_label": "Nominatim endpoint",
   "settings_nominatim_base_url_reset": "Reset",
-  "settings_nominatim_base_url_hint": "Leave empty to use the public OpenStreetMap Nominatim service. To route queries through your own self-hosted Nominatim instead, paste its base URL (e.g. https://nominatim.example.com)."
+  "settings_nominatim_base_url_hint": "Leave empty to use the public OpenStreetMap Nominatim service. To route queries through your own self-hosted Nominatim instead, paste its base URL (e.g. https://nominatim.example.com).",
+  "settings_notes_mail_link_open_label": "Open mail links inside notes",
+  "settings_notes_mail_link_open_popup": "Open in a new window (stay in Notes)",
+  "settings_notes_mail_link_open_switch": "Switch to the mail view",
+  "settings_notes_mail_link_open_help": "When you click a mail:// reference inside a note, this controls whether the message opens in a standalone reader window (keeping the Notes view open) or whether the main app jumps to the inbox at that message."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -205,8 +205,6 @@
   "settings_nominatim_base_url_label": "Nominatim endpoint",
   "settings_nominatim_base_url_reset": "Reset",
   "settings_nominatim_base_url_hint": "Leave empty to use the public OpenStreetMap Nominatim service. To route queries through your own self-hosted Nominatim instead, paste its base URL (e.g. https://nominatim.example.com).",
-  "settings_notes_mail_link_open_label": "Open mail links inside notes",
-  "settings_notes_mail_link_open_popup": "Open in a new window (stay in Notes)",
-  "settings_notes_mail_link_open_switch": "Switch to the mail view",
-  "settings_notes_mail_link_open_help": "When you click a mail:// reference inside a note, this controls whether the message opens in a standalone reader window (keeping the Notes view open) or whether the main app jumps to the inbox at that message."
+  "settings_notes_mail_open_in_view_label": "Open mails in mail view",
+  "settings_notes_mail_open_in_view_hint": "When on, clicking a mail link inside a note flips the main view to the inbox at that message. When off (default), the message opens in a standalone reader window so the Notes view stays put."
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -515,12 +515,11 @@
      *  safety pill and unsafe clicks confirm.  When false,
      *  links open without interception. */
     link_check_enabled?: boolean
-    /** #260: what happens when the user clicks a `mail://` link
-     *  embedded in a note.  `"popup"` (default) spawns a
-     *  standalone reader window so the user stays in the Notes
-     *  view; `"switch"` flips the main app to the mail view,
-     *  scoped to the referenced message. */
-    notes_mail_link_open?: 'popup' | 'switch'
+    /** #260: when true, clicking a `mail://` link in a note
+     *  flips the main view to the inbox at that message.
+     *  When false (default) the link opens a standalone reader
+     *  window so the user keeps their place in the Notes view. */
+    notes_mail_open_in_view?: boolean
   }
   type CustomTheme = {
     id: string
@@ -1086,27 +1085,24 @@
   }
 
   /** `mail://acc/folder/uid` deep-link handler invoked from the
-   *  Notes preview pane (#260).  Two behaviours, picked by the
-   *  user's `notes_mail_link_open` preference:
+   *  Notes preview pane (#260).  Two behaviours gated by the
+   *  user's `notes_mail_open_in_view` toggle:
    *
-   *    - `"popup"` (default): spawn a standalone reader window
-   *      via the same helper the MailList double-click and the
+   *    - **Off (default)**: spawn a standalone reader window via
+   *      the same helper the MailList double-click and the
    *      MailView pop-out button use.  The user stays in Notes;
    *      the referenced mail opens in its own window.
    *
-   *    - `"switch"`: flip the main view over to the inbox,
-   *      scoped to the referenced account / folder / UID.  Same
-   *      shape as the account switch in `selectAccount`, minus
-   *      the auto-poll — we're opening a known message, not
-   *      asking the server for fresh state.
-   *
-   *  `refreshToken` is bumped in the switch path so MailList
-   *  re-fetches even when the user was already viewing the same
-   *  account / folder (the UID we want may not be in the
-   *  currently-rendered window). */
+   *    - **On**: flip the main view over to the inbox, scoped to
+   *      the referenced account / folder / UID.  Same shape as
+   *      the account switch in `selectAccount`, minus the auto-
+   *      poll — we're opening a known message, not asking the
+   *      server for fresh state.  `refreshToken` is bumped so
+   *      MailList re-fetches even when the user was already
+   *      viewing the same account / folder (the UID we want may
+   *      not be in the currently-rendered window). */
   function openMailRef(accId: string, folder: string, uid: number): void {
-    const mode = appPrefs?.notes_mail_link_open ?? 'popup'
-    if (mode === 'popup') {
+    if (!appPrefs?.notes_mail_open_in_view) {
       void openMailInStandaloneWindow(accId, folder, uid)
       return
     }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -39,6 +39,7 @@
   import FilesView from './lib/FilesView.svelte'
   import TalkView from './lib/TalkView.svelte'
   import NotesView from './lib/NotesView.svelte'
+  import { openMailInStandaloneWindow } from './lib/standaloneMailWindow'
   import EventEditor, { type SavedEvent } from './lib/EventEditor.svelte'
   import { quotedHistoryHtml, type MeetingInvite } from './lib/inviteHtml'
   import SearchBar, {
@@ -514,6 +515,12 @@
      *  safety pill and unsafe clicks confirm.  When false,
      *  links open without interception. */
     link_check_enabled?: boolean
+    /** #260: what happens when the user clicks a `mail://` link
+     *  embedded in a note.  `"popup"` (default) spawns a
+     *  standalone reader window so the user stays in the Notes
+     *  view; `"switch"` flips the main app to the mail view,
+     *  scoped to the referenced message. */
+    notes_mail_link_open?: 'popup' | 'switch'
   }
   type CustomTheme = {
     id: string
@@ -1079,19 +1086,30 @@
   }
 
   /** `mail://acc/folder/uid` deep-link handler invoked from the
-   *  Notes preview pane (#260).  Composes the state changes that
-   *  the user would normally have to do by hand (switch back to
-   *  mail view, flip to the referenced account, open the folder,
-   *  select the UID).  Lives next to `selectAccount` because the
-   *  state surface — `currentView`, `unifiedMode`, `activeAccountId`,
-   *  `selectedFolder`, `selectedUid`, `selectedMessageAccountId` —
-   *  is the same; the only difference is that we land on a
-   *  specific message instead of the inbox top.
+   *  Notes preview pane (#260).  Two behaviours, picked by the
+   *  user's `notes_mail_link_open` preference:
    *
-   *  `refreshToken` is bumped so MailList re-fetches even when the
-   *  user was already viewing the same account/folder (the UID we
-   *  want may not be in the currently-rendered window). */
+   *    - `"popup"` (default): spawn a standalone reader window
+   *      via the same helper the MailList double-click and the
+   *      MailView pop-out button use.  The user stays in Notes;
+   *      the referenced mail opens in its own window.
+   *
+   *    - `"switch"`: flip the main view over to the inbox,
+   *      scoped to the referenced account / folder / UID.  Same
+   *      shape as the account switch in `selectAccount`, minus
+   *      the auto-poll — we're opening a known message, not
+   *      asking the server for fresh state.
+   *
+   *  `refreshToken` is bumped in the switch path so MailList
+   *  re-fetches even when the user was already viewing the same
+   *  account / folder (the UID we want may not be in the
+   *  currently-rendered window). */
   function openMailRef(accId: string, folder: string, uid: number): void {
+    const mode = appPrefs?.notes_mail_link_open ?? 'popup'
+    if (mode === 'popup') {
+      void openMailInStandaloneWindow(accId, folder, uid)
+      return
+    }
     currentView = 'inbox'
     unifiedMode = false
     activeAccountId = accId

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1078,6 +1078,32 @@
     currentView = 'setup'
   }
 
+  /** `mail://acc/folder/uid` deep-link handler invoked from the
+   *  Notes preview pane (#260).  Composes the state changes that
+   *  the user would normally have to do by hand (switch back to
+   *  mail view, flip to the referenced account, open the folder,
+   *  select the UID).  Lives next to `selectAccount` because the
+   *  state surface — `currentView`, `unifiedMode`, `activeAccountId`,
+   *  `selectedFolder`, `selectedUid`, `selectedMessageAccountId` —
+   *  is the same; the only difference is that we land on a
+   *  specific message instead of the inbox top.
+   *
+   *  `refreshToken` is bumped so MailList re-fetches even when the
+   *  user was already viewing the same account/folder (the UID we
+   *  want may not be in the currently-rendered window). */
+  function openMailRef(accId: string, folder: string, uid: number): void {
+    currentView = 'inbox'
+    unifiedMode = false
+    activeAccountId = accId
+    selectedFolder = folder
+    selectedUid = uid
+    selectedMessageAccountId = accId
+    searchQuery = ''
+    searchScope = {}
+    searchFilters = {}
+    refreshToken++
+  }
+
   /** IconRail nav click. Maps the rail's view enum directly to the
    *  router's `currentView` — the old `onSelectIntegration` took
    *  string labels like "Contacts" / "Nextcloud Talk" because the
@@ -2175,7 +2201,12 @@
       </div>
     {:else if currentView === 'notes'}
       <div class="flex-1 min-w-0">
-        <NotesView onclose={goToInbox} oncompose={openCompose} />
+        <NotesView
+          onclose={goToInbox}
+          oncompose={openCompose}
+          mailAccountId={activeAccountId}
+          onopenmail={openMailRef}
+        />
       </div>
     {:else}
       <!-- Mail view: Sidebar (folders) + mail-list column + MailView.

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1202,25 +1202,24 @@
              flips the main view over to the inbox at that
              message.  Wired as a select rather than a toggle
              because the two options aren't on / off — they're
-             two equally valid behaviours. -->
-        <div class="flex items-start gap-3">
-          <div class="flex-1">
-            <label class="block text-sm font-medium mb-1" for="notes-mail-link-open">
-              {m.settings_notes_mail_link_open_label()}
-            </label>
+             two equally valid behaviours.  Sized + spaced to
+             match the Display-language dropdown above so the
+             two controls read as a row of related preferences. -->
+        <div>
+          <label class="flex items-center gap-2 text-sm">
+            <span class="shrink-0">{m.settings_notes_mail_link_open_label()}</span>
             <select
-              id="notes-mail-link-open"
-              class="select"
+              class="select px-2 py-1 text-sm rounded-md flex-1 max-w-65"
               bind:value={appSettings.notes_mail_link_open}
               onchange={() => scheduleSave()}
             >
               <option value="popup">{m.settings_notes_mail_link_open_popup()}</option>
               <option value="switch">{m.settings_notes_mail_link_open_switch()}</option>
             </select>
-            <p class="text-xs text-surface-500 mt-1">
-              {m.settings_notes_mail_link_open_help()}
-            </p>
-          </div>
+          </label>
+          <p class="text-xs text-surface-500 mt-1">
+            {m.settings_notes_mail_link_open_help()}
+          </p>
         </div>
 
         <!-- #280 — location autocomplete + inline map preview.

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -229,6 +229,13 @@
      *  (`https://nominatim.openstreetmap.org`).  Self-hosters
      *  can point this at their own Nominatim instance. */
     nominatim_base_url: string
+    /** #260 — behaviour when the user clicks a `mail://` link
+     *  embedded in a note.  `"popup"` (default) opens the
+     *  referenced message in a standalone reader window;
+     *  `"switch"` navigates the main view to the inbox at that
+     *  message.  Optional because older settings bundles won't
+     *  carry the key. */
+    notes_mail_link_open?: 'popup' | 'switch'
   }
   interface CustomThemeRow {
     id: string
@@ -262,6 +269,7 @@
     ui_locale_auto: true,
     location_geocoding_enabled: false,
     nominatim_base_url: '',
+    notes_mail_link_open: 'popup',
   })
 
   /** The default Nominatim base URL — surfaced in the settings
@@ -1186,6 +1194,33 @@
             onchange={() => scheduleSave()}
           />
           <span>After delete / archive, open the next message automatically</span>
+        </div>
+
+        <!-- #260 — what `mail://` links inside a note do when
+             clicked.  Default opens a standalone reader window so
+             the user keeps their place in Notes; the alternate
+             flips the main view over to the inbox at that
+             message.  Wired as a select rather than a toggle
+             because the two options aren't on / off — they're
+             two equally valid behaviours. -->
+        <div class="flex items-start gap-3">
+          <div class="flex-1">
+            <label class="block text-sm font-medium mb-1" for="notes-mail-link-open">
+              {m.settings_notes_mail_link_open_label()}
+            </label>
+            <select
+              id="notes-mail-link-open"
+              class="select"
+              bind:value={appSettings.notes_mail_link_open}
+              onchange={() => scheduleSave()}
+            >
+              <option value="popup">{m.settings_notes_mail_link_open_popup()}</option>
+              <option value="switch">{m.settings_notes_mail_link_open_switch()}</option>
+            </select>
+            <p class="text-xs text-surface-500 mt-1">
+              {m.settings_notes_mail_link_open_help()}
+            </p>
+          </div>
         </div>
 
         <!-- #280 — location autocomplete + inline map preview.

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -229,13 +229,13 @@
      *  (`https://nominatim.openstreetmap.org`).  Self-hosters
      *  can point this at their own Nominatim instance. */
     nominatim_base_url: string
-    /** #260 — behaviour when the user clicks a `mail://` link
-     *  embedded in a note.  `"popup"` (default) opens the
-     *  referenced message in a standalone reader window;
-     *  `"switch"` navigates the main view to the inbox at that
-     *  message.  Optional because older settings bundles won't
-     *  carry the key. */
-    notes_mail_link_open?: 'popup' | 'switch'
+    /** #260 — when true, a `mail://` click in a note routes
+     *  through the main view-switch so the inbox lands on that
+     *  message.  When false (default) the click opens a
+     *  standalone reader window and the Notes view stays put.
+     *  Optional because older settings bundles won't carry the
+     *  key. */
+    notes_mail_open_in_view?: boolean
   }
   interface CustomThemeRow {
     id: string
@@ -269,7 +269,7 @@
     ui_locale_auto: true,
     location_geocoding_enabled: false,
     nominatim_base_url: '',
-    notes_mail_link_open: 'popup',
+    notes_mail_open_in_view: false,
   })
 
   /** The default Nominatim base URL — surfaced in the settings
@@ -1196,30 +1196,23 @@
           <span>After delete / archive, open the next message automatically</span>
         </div>
 
-        <!-- #260 — what `mail://` links inside a note do when
-             clicked.  Default opens a standalone reader window so
-             the user keeps their place in Notes; the alternate
-             flips the main view over to the inbox at that
-             message.  Wired as a select rather than a toggle
-             because the two options aren't on / off — they're
-             two equally valid behaviours.  Sized + spaced to
-             match the Display-language dropdown above so the
-             two controls read as a row of related preferences. -->
-        <div>
-          <label class="flex items-center gap-2 text-sm">
-            <span class="shrink-0">{m.settings_notes_mail_link_open_label()}</span>
-            <select
-              class="select px-2 py-1 text-sm rounded-md flex-1 max-w-65"
-              bind:value={appSettings.notes_mail_link_open}
-              onchange={() => scheduleSave()}
-            >
-              <option value="popup">{m.settings_notes_mail_link_open_popup()}</option>
-              <option value="switch">{m.settings_notes_mail_link_open_switch()}</option>
-            </select>
-          </label>
-          <p class="text-xs text-surface-500 mt-1">
-            {m.settings_notes_mail_link_open_help()}
-          </p>
+        <!-- #260 — toggle: when a `mail://` reference inside a
+             note is clicked, ON routes through the main view-
+             switch so the inbox lands on that message; OFF
+             (default) opens a standalone reader window and the
+             Notes view stays put. -->
+        <div class="flex items-start gap-3">
+          <Toggle
+            bind:checked={appSettings.notes_mail_open_in_view as boolean}
+            label={m.settings_notes_mail_open_in_view_label()}
+            onchange={() => scheduleSave()}
+          />
+          <span>
+            {m.settings_notes_mail_open_in_view_label()}
+            <span class="block text-xs text-surface-500">
+              {m.settings_notes_mail_open_in_view_hint()}
+            </span>
+          </span>
         </div>
 
         <!-- #280 — location autocomplete + inline map preview.

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -1143,14 +1143,6 @@
           {:else if prefsSaveStatus === 'error'}
             <span class="text-xs text-error-500">Save failed</span>
           {/if}
-          <button
-            class="btn btn-sm preset-outlined-primary-500 inline-flex items-center gap-1.5"
-            disabled={checkNowBusy}
-            onclick={runCheckMailNow}
-          >
-            <Icon name={checkNowBusy ? 'loading' : 'sync'} size={14} />
-            {checkNowBusy ? 'Checking…' : 'Check Mail Now'}
-          </button>
         </div>
       </div>
 

--- a/ui/src/lib/NotesMarkdownEditor.svelte
+++ b/ui/src/lib/NotesMarkdownEditor.svelte
@@ -645,23 +645,18 @@
     font-size: 0.85em;
   }
   /* Render every link — `mailto:`, `mail://`, http(s), NC files —
-     in the theme's primary colour with a soft underline so the
-     user can tell at a glance that the text is clickable.
-     `var(--color-primary-500)` is the Skeleton theme token; it
-     swaps with the active theme automatically.  `text-decoration-
-     color` matches at 60 % alpha to keep the underline calm in
-     long paragraphs, then deepens on hover to invite the click. */
+     in the theme's primary colour so the user can tell at a glance
+     that the text is clickable.  `var(--color-primary-500)` is the
+     Skeleton theme token; it swaps with the active theme
+     automatically.  No underline (per user preference); the colour
+     alone is the affordance, with a subtle brightness shift on
+     hover to confirm the click target. */
   :global(.markdown-editor-preview a) {
     color: var(--color-primary-500);
-    text-decoration: underline;
-    text-decoration-color: color-mix(in srgb, var(--color-primary-500) 60%, transparent);
-    text-underline-offset: 2px;
-    transition:
-      text-decoration-color 100ms ease,
-      text-decoration-thickness 100ms ease;
+    text-decoration: none;
+    transition: filter 100ms ease;
   }
   :global(.markdown-editor-preview a:hover) {
-    text-decoration-color: var(--color-primary-500);
-    text-decoration-thickness: 2px;
+    filter: brightness(1.15);
   }
 </style>

--- a/ui/src/lib/NotesMarkdownEditor.svelte
+++ b/ui/src/lib/NotesMarkdownEditor.svelte
@@ -220,6 +220,14 @@
         syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         highlightActiveLine(),
         markdown(),
+        // Soft-wrap long lines at the editor's right edge instead
+        // of letting them scroll horizontally — markdown notes are
+        // prose first, code second, and a horizontal scrollbar in
+        // a note feels wrong.  Inserted markdown links (especially
+        // `mail://acc/folder/uid` references) can easily overflow
+        // a narrow Notes pane; wrapping keeps the whole link
+        // readable without forcing a scroll.
+        EditorView.lineWrapping,
         keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
         themeCompartment.of(editorTheme),
         // Dispatch every doc-changing transaction back up to the

--- a/ui/src/lib/NotesMarkdownEditor.svelte
+++ b/ui/src/lib/NotesMarkdownEditor.svelte
@@ -644,4 +644,24 @@
     font-family: ui-monospace, SFMono-Regular, monospace;
     font-size: 0.85em;
   }
+  /* Render every link — `mailto:`, `mail://`, http(s), NC files —
+     in the theme's primary colour with a soft underline so the
+     user can tell at a glance that the text is clickable.
+     `var(--color-primary-500)` is the Skeleton theme token; it
+     swaps with the active theme automatically.  `text-decoration-
+     color` matches at 60 % alpha to keep the underline calm in
+     long paragraphs, then deepens on hover to invite the click. */
+  :global(.markdown-editor-preview a) {
+    color: var(--color-primary-500);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--color-primary-500) 60%, transparent);
+    text-underline-offset: 2px;
+    transition:
+      text-decoration-color 100ms ease,
+      text-decoration-thickness 100ms ease;
+  }
+  :global(.markdown-editor-preview a:hover) {
+    text-decoration-color: var(--color-primary-500);
+    text-decoration-thickness: 2px;
+  }
 </style>

--- a/ui/src/lib/NotesMarkdownEditor.svelte
+++ b/ui/src/lib/NotesMarkdownEditor.svelte
@@ -238,6 +238,8 @@
         // mention token; we hand it to the data resolver below.
         createMentionExtension({
           onContextChange: (ctx) => {
+            // Diagnostic logging — remove once verified working.
+            console.debug('[notes-mention] context →', ctx)
             mentionCtx = ctx
             resolvePickerItems(ctx)
           },

--- a/ui/src/lib/NotesMarkdownEditor.svelte
+++ b/ui/src/lib/NotesMarkdownEditor.svelte
@@ -40,6 +40,17 @@
   } from '@codemirror/language'
   import { markdown } from '@codemirror/lang-markdown'
   import { marked } from 'marked'
+  import { invoke, convertFileSrc } from '@tauri-apps/api/core'
+  import {
+    createMentionExtension,
+    insertMention,
+    type MentionContext,
+  } from './notesMentionExtension'
+  import NotesMentionPicker, {
+    type ContactItem,
+    type MailItem,
+    type PickerItem,
+  } from './NotesMentionPicker.svelte'
 
   interface Props {
     /** Markdown source — `bind:value` from the parent.  Updates
@@ -54,16 +65,105 @@
     showPreview?: boolean
     /** Placeholder shown when the document is empty. */
     placeholder?: string
+    /** Active mail account, used to scope the `/mail` IMAP-server
+     *  fallback (#260).  When `null`, the picker still works against
+     *  the cross-folder FTS5 cache — the server fallback just
+     *  no-ops. */
+    accountId?: string | null
+    /** `mail://acc/folder/uid` link click handler (#260).  Called
+     *  when the user clicks a Nimbus-internal mail reference in the
+     *  rendered preview pane.  When absent, link clicks fall
+     *  through to the browser's default (which silently no-ops on
+     *  the unregistered scheme). */
+    onopenmail?: (accountId: string, folder: string, uid: number) => void
   }
   let {
     value = $bindable(''),
     onchange,
     showPreview = false,
     placeholder = 'Start writing — markdown is preserved on the server.',
+    accountId = null,
+    onopenmail,
   }: Props = $props()
 
   let host: HTMLDivElement | undefined = $state()
   let view: EditorView | undefined = $state()
+  let picker: NotesMentionPicker | undefined = $state()
+
+  // ── Mention picker state (#260) ────────────────────────────────
+  //
+  // `mentionCtx` is the live trigger position from the CM6 plugin;
+  // `pickerItems` is the current resolved row list.  Two fields
+  // because the trigger updates synchronously on every keystroke
+  // but the data fetch (debounced + async) lags behind.  The popup
+  // stays mounted while a context exists so the "Searching…" state
+  // is visible while we wait.
+  let mentionCtx = $state<MentionContext | null>(null)
+  let pickerItems = $state<PickerItem[]>([])
+  let pickerLoading = $state(false)
+  /** Per-query nonce so a slow `search_emails` round-trip whose
+   *  query is no longer current can't clobber a fresher response.
+   *  Bumped on every `mentionCtx` change; checked on every async
+   *  resolve before writing into `pickerItems`. */
+  let pickerQueryToken = 0
+  /** Debounce timer for `/mail` searches.  The contact filter
+   *  runs against an in-memory list so it doesn't need one. */
+  let mailDebounce: ReturnType<typeof setTimeout> | null = null
+
+  // ── Contact source (#260) ──────────────────────────────────────
+  //
+  // Same eager-load posture as Compose's `@` picker: pull every
+  // contact once on mount, filter locally on each query.  Failure
+  // is non-fatal — the picker still works for the `/mail` flow.
+  interface ContactKindValue {
+    kind: string
+    value: string
+  }
+  interface ContactRow {
+    id: string
+    nextcloud_account_id: string
+    display_name: string
+    email: ContactKindValue[]
+    phone: ContactKindValue[]
+    organization: string | null
+    photo_mime: string | null
+  }
+  let allContacts = $state<ContactRow[]>([])
+  $effect(() => {
+    void invoke<ContactRow[]>('get_contacts')
+      .then((rows) => {
+        allContacts = rows
+      })
+      .catch((e) => {
+        console.warn('NotesMarkdownEditor: get_contacts failed', e)
+      })
+  })
+
+  // ── Mail search wire shape ─────────────────────────────────────
+  // Matches the SearchHit DTO from `search_emails` (camelCase via
+  // serde rename).  Kept inline because the shape is small and
+  // doesn't warrant a separate types module.
+  interface SearchHit {
+    accountId: string
+    folder: string
+    uid: number
+    from: string
+    subject: string
+    date: string
+    isRead: boolean
+    isStarred: boolean
+    hasAttachments: boolean
+    snippet: string
+  }
+  interface IMAPEnvelope {
+    account_id?: string
+    folder?: string
+    uid: number
+    from: string
+    subject: string
+    date: string
+    is_read?: boolean
+  }
 
   /** Compartments let us reconfigure individual extensions
    *  (theme, read-only, etc.) without rebuilding the whole
@@ -133,8 +233,277 @@
             onchange?.(next)
           }
         }),
+        // #260: trigger detection for `@` and `/mail`.  The plugin
+        // emits a context whenever the cursor sits at the end of a
+        // mention token; we hand it to the data resolver below.
+        createMentionExtension({
+          onContextChange: (ctx) => {
+            mentionCtx = ctx
+            resolvePickerItems(ctx)
+          },
+        }),
       ],
     })
+  }
+
+  /** Look up rows for the current mention context.  Contact lookup
+   *  is synchronous (filter the in-memory `allContacts`).  Mail
+   *  lookup hits `search_emails` (cross-folder FTS5 cache) and
+   *  optionally falls back to `search_imap_server` for the active
+   *  account's INBOX when the cache returns sparse results. */
+  function resolvePickerItems(ctx: MentionContext | null): void {
+    // Cancel any in-flight `/mail` debounce — a fresh context (even
+    // null, meaning "popup closed") supersedes it.
+    if (mailDebounce !== null) {
+      clearTimeout(mailDebounce)
+      mailDebounce = null
+    }
+    pickerQueryToken += 1
+    if (!ctx) {
+      pickerItems = []
+      pickerLoading = false
+      return
+    }
+    if (ctx.type === 'contact') {
+      pickerItems = filterContacts(ctx.query)
+      pickerLoading = false
+      return
+    }
+    // `/mail` — debounce 200 ms (per the issue's note about not
+    // spamming the search on every keystroke).
+    const myToken = pickerQueryToken
+    // Surface a "Searching…" state immediately when there's nothing
+    // to fall back to; otherwise keep the previous result list
+    // visible so the user doesn't lose context while typing.
+    if (pickerItems.length === 0) pickerLoading = true
+    mailDebounce = setTimeout(() => {
+      mailDebounce = null
+      void runMailSearch(ctx.query, myToken)
+    }, 200)
+  }
+
+  /** Filter the eager-loaded address book by a case-insensitive
+   *  substring on display_name + email.  One row per email
+   *  (contacts with multiple addresses each get their own row),
+   *  capped at 8 to keep the popup tight. */
+  function filterContacts(query: string): ContactItem[] {
+    const q = query.trim().toLowerCase()
+    const out: ContactItem[] = []
+    const seen = new Set<string>()
+    for (const c of allContacts) {
+      for (const e of c.email) {
+        const email = e.value
+        if (!email) continue
+        const key = email.toLowerCase()
+        if (seen.has(key)) continue
+        const labelMatch =
+          !q ||
+          c.display_name.toLowerCase().includes(q) ||
+          email.toLowerCase().includes(q)
+        if (!labelMatch) continue
+        seen.add(key)
+        out.push({
+          kind: 'contact',
+          id: email,
+          label: c.display_name || email,
+          email,
+          photoUrl: c.photo_mime ? convertFileSrc(c.id, 'contact-photo') : null,
+          hint: c.organization,
+        })
+        if (out.length >= 8) return out
+      }
+    }
+    return out
+  }
+
+  /** Run the cache-first / server-fallback `/mail` search.  The
+   *  `token` guards against late responses overwriting fresher
+   *  state — every fetch is started against the current
+   *  `pickerQueryToken` and bails if a later context bumped it. */
+  async function runMailSearch(query: string, token: number): Promise<void> {
+    pickerLoading = true
+    let hits: SearchHit[] = []
+    try {
+      // Empty scope / filters = "search everything cached".  The
+      // backend command accepts the operator-prefixed grammar
+      // (FROM:, SUBJECT:, etc.) so power users get the full
+      // syntax for free here too.
+      hits = await invoke<SearchHit[]>('search_emails', { query })
+    } catch (e) {
+      console.warn('NotesMarkdownEditor: search_emails failed', e)
+    }
+    if (token !== pickerQueryToken) return
+    let rows = hits.slice(0, 8).map(hitToMailItem)
+    // Server-side fallback (#260): if the local cache returned
+    // sparse results and we have an active non-JMAP account, also
+    // hit IMAP `UID SEARCH` on its INBOX so recent / unsynced mail
+    // is reachable.  Per-account-INBOX scope is a deliberate
+    // simplification: cross-folder server search is much slower
+    // and the picker has to feel responsive.  Documented limitation.
+    if (
+      rows.length < 5 &&
+      query.trim().length >= 3 &&
+      accountId &&
+      typeof accountId === 'string'
+    ) {
+      try {
+        const fallback = await invoke<IMAPEnvelope[]>('search_imap_server', {
+          accountId,
+          folder: 'INBOX',
+          query,
+          limit: 16,
+        })
+        if (token !== pickerQueryToken) return
+        const seenUids = new Set(rows.map((r) => `${r.accountId}:${r.folder}:${r.uid}`))
+        for (const env of fallback) {
+          const aid = env.account_id ?? accountId
+          const folder = env.folder ?? 'INBOX'
+          const key = `${aid}:${folder}:${env.uid}`
+          if (seenUids.has(key)) continue
+          seenUids.add(key)
+          rows.push({
+            kind: 'mail',
+            id: key,
+            accountId: aid,
+            folder,
+            uid: env.uid,
+            subject: env.subject,
+            from: env.from,
+            date: env.date,
+            isRead: env.is_read ?? true,
+          })
+          if (rows.length >= 12) break
+        }
+      } catch (e) {
+        // JMAP accounts return empty (handled server-side); other
+        // failures (offline, auth) shouldn't break the picker.
+        console.warn('NotesMarkdownEditor: search_imap_server fallback failed', e)
+      }
+    }
+    if (token !== pickerQueryToken) return
+    pickerItems = rows
+    pickerLoading = false
+  }
+
+  function hitToMailItem(h: SearchHit): MailItem {
+    return {
+      kind: 'mail',
+      id: `${h.accountId}:${h.folder}:${h.uid}`,
+      accountId: h.accountId,
+      folder: h.folder,
+      uid: h.uid,
+      subject: h.subject,
+      from: h.from,
+      date: h.date,
+      snippet: h.snippet,
+      isRead: h.isRead,
+    }
+  }
+
+  /** Commit a picked item — replaces the trigger span with a
+   *  markdown link.  Contact picks become `[Name](mailto:email)`;
+   *  mail picks become `[subject](mail://acc/folder/uid)`. */
+  function onPick(item: PickerItem): void {
+    if (!view || !mentionCtx) return
+    let markdown: string
+    if (item.kind === 'contact') {
+      const safeLabel = escapeMarkdownLink(item.label)
+      markdown = `[${safeLabel}](mailto:${item.email})`
+    } else {
+      const safeSubject = escapeMarkdownLink(item.subject || '(no subject)')
+      const folderPart = encodeURIComponent(item.folder)
+      markdown = `[${safeSubject}](mail://${item.accountId}/${folderPart}/${item.uid})`
+    }
+    insertMention(view, mentionCtx, markdown)
+    mentionCtx = null
+    pickerItems = []
+  }
+
+  /** Defensive escape for the link label.  Markdown link syntax
+   *  uses `]` to end the label, so a `]` inside the display name
+   *  would truncate it.  Backslash-escape just the closers; the
+   *  rest stays readable.  Backtick / `*` etc. are allowed by
+   *  GFM inside link text without escaping. */
+  function escapeMarkdownLink(s: string): string {
+    return s.replace(/\\/g, '\\\\').replace(/\]/g, '\\]')
+  }
+
+  /** Editor-level keyboard handler.  Intercepts the picker's keys
+   *  *before* CM6 routes them so Enter inserts the mention rather
+   *  than a newline, Tab commits rather than indents, etc.  Pure
+   *  pass-through when the popup isn't visible. */
+  function onEditorKeyDown(e: KeyboardEvent): void {
+    if (!mentionCtx) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      picker?.selectNext()
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      picker?.selectPrev()
+      return
+    }
+    if (e.key === 'Enter' || e.key === 'Tab') {
+      // Only swallow the key when there's something to pick — an
+      // empty popup (e.g. mid-search with no cache hits yet)
+      // shouldn't trap Enter / Tab.
+      if (pickerItems.length === 0) return
+      e.preventDefault()
+      picker?.pickSelected()
+      return
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      mentionCtx = null
+      pickerItems = []
+    }
+  }
+
+  /** Notes-preview link click delegate (#260).  Intercepts
+   *  `mail://acc/folder/uid` links and routes them through the
+   *  parent's `onopenmail` callback (which composes the account /
+   *  folder / message state changes).  All other links — http(s)
+   *  to NC files, `mailto:` to external mail clients, etc. — fall
+   *  through to the browser's default handling. */
+  function onPreviewClick(e: MouseEvent): void {
+    const target = (e.target as HTMLElement | null)?.closest('a')
+    if (!target) return
+    const href = target.getAttribute('href') ?? ''
+    if (!href.startsWith('mail://')) return
+    e.preventDefault()
+    const parsed = parseMailHref(href)
+    if (!parsed) return
+    onopenmail?.(parsed.accountId, parsed.folder, parsed.uid)
+  }
+
+  /** Parse a `mail://<account_id>/<folder>/<uid>` URL into its
+   *  pieces.  Returns `null` on any malformed input — folder
+   *  segment is `decodeURIComponent`'d so folders with slashes /
+   *  spaces (rare but possible) round-trip cleanly. */
+  function parseMailHref(
+    href: string,
+  ): { accountId: string; folder: string; uid: number } | null {
+    if (!href.startsWith('mail://')) return null
+    const rest = href.slice('mail://'.length)
+    // `accountId / folder / uid` — split into at most three parts
+    // so a folder name containing `/` survives the round-trip.
+    const firstSlash = rest.indexOf('/')
+    if (firstSlash < 0) return null
+    const accountId = rest.slice(0, firstSlash)
+    const lastSlash = rest.lastIndexOf('/')
+    if (lastSlash <= firstSlash) return null
+    const folderRaw = rest.slice(firstSlash + 1, lastSlash)
+    const uidStr = rest.slice(lastSlash + 1)
+    const uid = Number(uidStr)
+    if (!accountId || !folderRaw || !Number.isFinite(uid) || uid <= 0) {
+      return null
+    }
+    return {
+      accountId,
+      folder: decodeURIComponent(folderRaw),
+      uid,
+    }
   }
 
   onMount(() => {
@@ -179,16 +548,47 @@
   })
 </script>
 
+<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="markdown-editor-shell">
-  <div class="markdown-editor-source" class:has-preview={showPreview}>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="markdown-editor-source"
+    class:has-preview={showPreview}
+    onkeydowncapture={onEditorKeyDown}
+    role="presentation"
+  >
     <div bind:this={host} class="markdown-editor-host" data-placeholder={placeholder}></div>
   </div>
   {#if showPreview}
-    <div class="markdown-editor-preview prose prose-sm dark:prose-invert">
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="markdown-editor-preview prose prose-sm dark:prose-invert"
+      onclick={onPreviewClick}
+    >
       {@html previewHtml}
     </div>
   {/if}
 </div>
+
+<!-- Mention picker popup (#260).  Mounted at the editor level so
+     `position: fixed` positioning isn't clipped by the Notes
+     view's overflow boundaries.  Only renders when the CM6 plugin
+     reports an active mention context. -->
+<NotesMentionPicker
+  bind:this={picker}
+  items={pickerItems}
+  visible={mentionCtx !== null}
+  loading={pickerLoading}
+  anchor={mentionCtx
+    ? mentionCtx.coords
+    : { left: 0, top: 0, bottom: 0 }}
+  onpick={onPick}
+  onclose={() => {
+    mentionCtx = null
+    pickerItems = []
+  }}
+/>
 
 <style>
   :global(.markdown-editor-shell) {

--- a/ui/src/lib/NotesMarkdownEditor.svelte
+++ b/ui/src/lib/NotesMarkdownEditor.svelte
@@ -238,8 +238,6 @@
         // mention token; we hand it to the data resolver below.
         createMentionExtension({
           onContextChange: (ctx) => {
-            // Diagnostic logging — remove once verified working.
-            console.debug('[notes-mention] context →', ctx)
             mentionCtx = ctx
             resolvePickerItems(ctx)
           },

--- a/ui/src/lib/NotesMentionPicker.svelte
+++ b/ui/src/lib/NotesMentionPicker.svelte
@@ -1,0 +1,280 @@
+<script lang="ts" module>
+  /**
+   * Row shapes the Notes mention picker (#260) accepts.  Discriminated
+   * union by `kind` so the template can render contact and mail rows
+   * with the same component while keeping each type's data narrow.
+   *
+   * The picker itself is dumb — it shows what it's given and emits a
+   * pick event with the chosen item.  The parent
+   * (`NotesMarkdownEditor`) owns the data sources and turns picks
+   * into editor inserts.
+   */
+  export interface ContactItem {
+    kind: 'contact'
+    /** Stable key — typically the email address. */
+    id: string
+    label: string
+    email: string
+    photoUrl?: string | null
+    hint?: string | null
+  }
+  export interface MailItem {
+    kind: 'mail'
+    /** Stable key — `${accountId}:${folder}:${uid}`. */
+    id: string
+    accountId: string
+    folder: string
+    uid: number
+    subject: string
+    from: string
+    /** ISO date.  Formatted client-side for the row. */
+    date: string
+    snippet?: string | null
+    isRead: boolean
+  }
+  export type PickerItem = ContactItem | MailItem
+</script>
+
+<script lang="ts">
+  /**
+   * NotesMentionPicker — popup for `@` (contact) and `/mail` (mail)
+   * triggers in the Notes markdown editor (#260).
+   *
+   * Rendered into the body via `position: fixed` so the popup escapes
+   * any scroll container the editor lives in.  The parent owns the
+   * `(left, top)` anchor; we just paint there and keep ourselves
+   * inside the viewport.
+   *
+   * The popup is keyboard-driven from the editor:
+   *   - Up / Down cycle `selectedIndex`
+   *   - Enter / Tab commit the highlighted row
+   *   - Escape closes
+   *
+   * The editor wraps a `<div>` around CodeMirror's DOM, intercepts
+   * those keys *before* CM6 sees them, and calls `selectPrev` /
+   * `selectNext` / `pickSelected()` on this component (exposed via
+   * bind:this).  Mousedown on a row commits immediately — we use
+   * mousedown rather than click because the editor would otherwise
+   * lose focus first and `pickSelected` would fire against stale
+   * state.
+   */
+  import { onMount, tick } from 'svelte'
+
+  interface Props {
+    items: PickerItem[]
+    /** Whether the popup should render at all.  Parent flips this
+     *  based on the active mention context. */
+    visible: boolean
+    /** Whether the data source is still resolving — drives the
+     *  empty-state copy so a slow `search_emails` round-trip doesn't
+     *  flash "No matches" before results arrive. */
+    loading?: boolean
+    /** Viewport-relative anchor of the trigger character's *bottom*.
+     *  The popup paints below this point, flipping above when there
+     *  isn't room. */
+    anchor: { left: number; top: number; bottom: number }
+    onpick: (item: PickerItem) => void
+    onclose: () => void
+  }
+  let {
+    items,
+    visible,
+    loading = false,
+    anchor,
+    onpick,
+    onclose,
+  }: Props = $props()
+
+  let selectedIndex = $state(0)
+  let listEl: HTMLUListElement | undefined = $state()
+
+  // Resolved screen position — `anchor.bottom` by default, flipped
+  // above when the popup would clip the bottom of the viewport.
+  // Recomputed reactively on every `anchor` / `items` change.
+  const POPUP_MAX_H = 288 // 18rem == max-h-72; matches the class below.
+  const POPUP_MIN_W = 320 // 20rem == min-w-80
+  let resolved = $derived.by(() => {
+    if (!visible) return { left: 0, top: 0 }
+    // Default below the trigger char, nudged a hair so the row's
+    // baseline aligns with the click target.
+    let top = anchor.bottom + 4
+    let left = anchor.left
+    const vh = typeof window !== 'undefined' ? window.innerHeight : 0
+    const vw = typeof window !== 'undefined' ? window.innerWidth : 0
+    if (vh && top + POPUP_MAX_H > vh && anchor.top - POPUP_MAX_H - 4 >= 0) {
+      // Not enough room below — flip above.
+      top = anchor.top - POPUP_MAX_H - 4
+    }
+    if (vw && left + POPUP_MIN_W > vw) {
+      left = Math.max(8, vw - POPUP_MIN_W - 8)
+    }
+    return { left, top }
+  })
+
+  // Reset the highlight whenever the item list changes shape — a
+  // re-query landing with fewer rows than the previous selection
+  // would otherwise leave us pointing past the end.
+  $effect(() => {
+    if (selectedIndex >= items.length) selectedIndex = 0
+  })
+
+  /** Keep the highlighted row in view as the user arrows through
+   *  a long list.  Called from inside the keyboard handlers below. */
+  async function ensureVisible(): Promise<void> {
+    await tick()
+    const ul = listEl
+    if (!ul) return
+    const row = ul.querySelector<HTMLElement>(
+      `li[data-row-index="${selectedIndex}"]`,
+    )
+    row?.scrollIntoView({ block: 'nearest' })
+  }
+
+  /** Parent-callable: move highlight down.  No-op if list is empty. */
+  export function selectNext(): void {
+    if (items.length === 0) return
+    selectedIndex = (selectedIndex + 1) % items.length
+    void ensureVisible()
+  }
+  /** Parent-callable: move highlight up.  No-op if list is empty. */
+  export function selectPrev(): void {
+    if (items.length === 0) return
+    selectedIndex = (selectedIndex - 1 + items.length) % items.length
+    void ensureVisible()
+  }
+  /** Parent-callable: commit the highlighted row, if any. */
+  export function pickSelected(): boolean {
+    const item = items[selectedIndex]
+    if (!item) return false
+    onpick(item)
+    return true
+  }
+
+  /** Cheap relative-time label for mail rows.  Same shape as the
+   *  MailList row date — minutes / hours for today, weekday for
+   *  this week, locale date string otherwise.  Kept inline rather
+   *  than imported from MailList because that component carries
+   *  multi-row state we don't need. */
+  function formatMailDate(iso: string): string {
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return ''
+    const now = new Date()
+    const sameDay =
+      d.getFullYear() === now.getFullYear() &&
+      d.getMonth() === now.getMonth() &&
+      d.getDate() === now.getDate()
+    if (sameDay) {
+      return d.toLocaleTimeString(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    }
+    const diffDays = (now.getTime() - d.getTime()) / 86_400_000
+    if (diffDays < 7) {
+      return d.toLocaleDateString(undefined, { weekday: 'short' })
+    }
+    return d.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+
+  // Close the popup when the user clicks outside of it.  Registered
+  // only while visible so a closed popup costs nothing.  Uses
+  // `mousedown` for the same reason the row commit handler does —
+  // it lands before focus changes.
+  onMount(() => {
+    function onDocMousedown(e: MouseEvent): void {
+      if (!visible) return
+      const t = e.target as Node | null
+      if (listEl && t && listEl.contains(t)) return
+      onclose()
+    }
+    document.addEventListener('mousedown', onDocMousedown)
+    return () => document.removeEventListener('mousedown', onDocMousedown)
+  })
+</script>
+
+{#if visible}
+  <!-- Fixed-positioned popup so it escapes the Notes editor's
+       scroll container.  z-60 sits above the modal backdrop the
+       Notes view would use for any future dialog. -->
+  <ul
+    bind:this={listEl}
+    class="fixed z-60 max-h-72 min-w-80 overflow-y-auto rounded-md border border-surface-300
+           dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-lg py-1 text-sm"
+    style="left: {resolved.left}px; top: {resolved.top}px;"
+    role="listbox"
+  >
+    {#if loading && items.length === 0}
+      <li class="px-3 py-2 text-xs text-surface-500 italic">Searching…</li>
+    {:else if items.length === 0}
+      <li class="px-3 py-2 text-xs text-surface-500">No matches</li>
+    {:else}
+      {#each items as item, i (item.id)}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <li
+          data-row-index={i}
+          role="option"
+          aria-selected={i === selectedIndex}
+          class="flex items-center gap-3 px-3 py-1.5 cursor-pointer
+                 {i === selectedIndex
+                   ? 'bg-primary-500/15'
+                   : 'hover:bg-surface-200 dark:hover:bg-surface-800'}"
+          onmousedown={(e) => {
+            // mousedown so we commit before the editor sees a
+            // focus-loss and tears the popup down (#260, same
+            // gotcha that bit the Compose mention picker).
+            e.preventDefault()
+            selectedIndex = i
+            onpick(item)
+          }}
+        >
+          {#if item.kind === 'contact'}
+            {#if item.photoUrl}
+              <img
+                src={item.photoUrl}
+                alt=""
+                loading="lazy"
+                class="w-7 h-7 rounded-full object-cover shrink-0"
+              />
+            {:else}
+              <div
+                class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-700
+                       flex items-center justify-center text-[10px] font-semibold shrink-0"
+              >
+                {item.label.trim().charAt(0).toUpperCase() || '?'}
+              </div>
+            {/if}
+            <div class="flex-1 min-w-0">
+              <p class="font-medium truncate">{item.label}</p>
+              <p class="text-xs text-surface-500 truncate">
+                {item.email}{#if item.hint} · {item.hint}{/if}
+              </p>
+            </div>
+          {:else}
+            <!-- Mail row: subject (top) + sender · date (bottom).  Bold
+                 the subject only when the message is unread so the
+                 picker echoes the MailList's read/unread emphasis. -->
+            <div
+              class="w-7 h-7 rounded-md bg-primary-500/10 text-primary-600
+                     dark:text-primary-400 flex items-center justify-center shrink-0"
+              aria-hidden="true"
+            >
+              ✉
+            </div>
+            <div class="flex-1 min-w-0">
+              <p class="truncate {item.isRead ? 'font-normal' : 'font-semibold'}">
+                {item.subject || '(no subject)'}
+              </p>
+              <p class="text-xs text-surface-500 truncate">
+                {item.from} · {formatMailDate(item.date)}
+              </p>
+            </div>
+          {/if}
+        </li>
+      {/each}
+    {/if}
+  </ul>
+{/if}

--- a/ui/src/lib/NotesView.svelte
+++ b/ui/src/lib/NotesView.svelte
@@ -1280,28 +1280,6 @@
               </button>
             </div>
 
-            <!-- Category picker — small unobtrusive row above the
-                 textarea so the user can move the note between
-                 folders without leaving the editor. -->
-            <div class="px-5 py-2 border-b border-surface-200 dark:border-surface-700 flex items-center gap-2 text-xs">
-              <span class="text-surface-500">Folder:</span>
-              <input
-                class="input flex-1 text-xs px-2 py-1 rounded-md"
-                placeholder="(none) — type a folder path, e.g. Work/Project A"
-                bind:value={draftCategory}
-                oninput={scheduleSave}
-                list="notes-folder-suggestions"
-              />
-              <datalist id="notes-folder-suggestions">
-                {#each Array.from(new Set(notes.map((n) => n.category).filter(Boolean))) as cat (cat)}
-                  <option value={cat}></option>
-                {/each}
-                {#each pendingFolders as p (p)}
-                  <option value={p}></option>
-                {/each}
-              </datalist>
-            </div>
-
             <NotesMarkdownEditor
               bind:value={draftContent}
               onchange={() => scheduleSave()}

--- a/ui/src/lib/NotesView.svelte
+++ b/ui/src/lib/NotesView.svelte
@@ -69,8 +69,24 @@
     onclose: () => void
     /** Open Compose with the given prefill (used for "Send as email"). */
     oncompose: (initial: ComposeInitial) => void
+    /** Active *mail* account id (#260).  Distinct from the Notes
+     *  view's own `accountId`, which is a Nextcloud account.  The
+     *  editor's `/mail` picker uses this to scope the IMAP-server
+     *  fallback to whichever inbox the user is currently working
+     *  with.  Null when no mail account is configured / active. */
+    mailAccountId?: string | null
+    /** `mail://acc/folder/uid` link handler (#260).  Called when
+     *  the user clicks an in-Note Nimbus mail reference in the
+     *  preview pane; the parent composes the corresponding view /
+     *  account / folder / message state changes. */
+    onopenmail?: (accountId: string, folder: string, uid: number) => void
   }
-  const { onclose, oncompose }: Props = $props()
+  const {
+    onclose,
+    oncompose,
+    mailAccountId = null,
+    onopenmail,
+  }: Props = $props()
 
   // ── State ───────────────────────────────────────────────────
   let accounts = $state<NextcloudAccount[]>([])
@@ -1290,6 +1306,8 @@
               bind:value={draftContent}
               onchange={() => scheduleSave()}
               {showPreview}
+              accountId={mailAccountId}
+              {onopenmail}
             />
           {/if}
         {/if}

--- a/ui/src/lib/notesMentionExtension.ts
+++ b/ui/src/lib/notesMentionExtension.ts
@@ -153,6 +153,10 @@ export function createMentionExtension(opts: PluginOpts): Extension {
     let last: MentionContext | null = null
     function maybeEmit(): void {
       const next = detect(view)
+      // Diagnostic logging (#260): leave a trail so a missing
+      // popup is visible in DevTools rather than mysterious.
+      // Remove once the picker is confirmed working end-to-end.
+      console.debug('[notes-mention] detect →', next)
       if (sameContext(last, next)) return
       last = next
       opts.onContextChange(next)
@@ -160,6 +164,7 @@ export function createMentionExtension(opts: PluginOpts): Extension {
     // Fire once on construction so the popup is in sync with the
     // initial state — usually a no-op (cursor at start of empty
     // doc), but cheap.
+    console.debug('[notes-mention] ViewPlugin mounted')
     maybeEmit()
     return {
       update(u: ViewUpdate) {

--- a/ui/src/lib/notesMentionExtension.ts
+++ b/ui/src/lib/notesMentionExtension.ts
@@ -85,12 +85,24 @@ function isBoundary(prev: string | null): boolean {
   return /\s|[>([\]]/.test(prev)
 }
 
+/** Trigger metadata before coords are attached.  Split out so the
+ *  inexpensive regex pass can run inside the `update` phase while
+ *  the coords read — which CM6 forbids during update because the
+ *  DOM measure pass hasn't run yet — is deferred to
+ *  `requestMeasure` and stitched on top. */
+interface PartialContext {
+  type: MentionType
+  query: string
+  from: number
+  to: number
+}
+
 /** Run both trigger regexes against the line ending at the cursor;
  *  return the first match that survives the boundary check.  We
  *  prefer the `/mail` match over `@` because `/mail` is a longer
  *  literal and there's no overlap, but the boundary check makes
  *  this academic. */
-function detect(view: EditorView): MentionContext | null {
+function detectPartial(view: EditorView): PartialContext | null {
   const { state } = view
   const sel = state.selection.main
   // Only fire on a collapsed cursor — multi-char selections aren't
@@ -109,16 +121,11 @@ function detect(view: EditorView): MentionContext | null {
     const start = upToCursor.length - mailMatch[0].length
     const prev = start > 0 ? upToCursor[start - 1] : null
     if (isBoundary(prev)) {
-      const from = line.from + start
-      const to = head
-      const coords = view.coordsAtPos(from)
-      if (!coords) return null
       return {
         type: 'mail',
         query: mailMatch[2],
-        from,
-        to,
-        coords: { left: coords.left, top: coords.top, bottom: coords.bottom },
+        from: line.from + start,
+        to: head,
       }
     }
   }
@@ -128,48 +135,88 @@ function detect(view: EditorView): MentionContext | null {
     const start = upToCursor.length - contactMatch[0].length
     const prev = start > 0 ? upToCursor[start - 1] : null
     if (isBoundary(prev)) {
-      const from = line.from + start
-      const to = head
-      const coords = view.coordsAtPos(from)
-      if (!coords) return null
       return {
         type: 'contact',
         query: contactMatch[2],
-        from,
-        to,
-        coords: { left: coords.left, top: coords.top, bottom: coords.bottom },
+        from: line.from + start,
+        to: head,
       }
     }
   }
   return null
 }
 
+function samePartial(
+  a: PartialContext | null,
+  b: PartialContext | null,
+): boolean {
+  if (a === null || b === null) return a === b
+  return (
+    a.type === b.type &&
+    a.query === b.query &&
+    a.from === b.from &&
+    a.to === b.to
+  )
+}
+
 /** Build the CM6 extension.  One ViewPlugin per editor instance
- *  (each Notes editor gets its own).  The plugin keeps a small
- *  "last emitted" cache so we don't fire the callback on
- *  cursor-only moves that don't change the trigger context. */
+ *  (each Notes editor gets its own).  Two layers of de-dupe:
+ *  `lastPartial` short-circuits identical regex results so we
+ *  don't bother scheduling a measure read, and `last` short-
+ *  circuits emits when the resulting coords haven't moved either. */
 export function createMentionExtension(opts: PluginOpts): Extension {
   return ViewPlugin.define((view) => {
     let last: MentionContext | null = null
-    function maybeEmit(): void {
-      const next = detect(view)
-      // Diagnostic logging (#260): leave a trail so a missing
-      // popup is visible in DevTools rather than mysterious.
-      // Remove once the picker is confirmed working end-to-end.
-      console.debug('[notes-mention] detect →', next)
-      if (sameContext(last, next)) return
-      last = next
-      opts.onContextChange(next)
+    let lastPartial: PartialContext | null = null
+    function scheduleEmit(): void {
+      const partial = detectPartial(view)
+      if (samePartial(lastPartial, partial)) return
+      lastPartial = partial
+      if (!partial) {
+        if (last !== null) {
+          last = null
+          opts.onContextChange(null)
+        }
+        return
+      }
+      // Defer the coords read to the measure phase — CM6 throws
+      // "Reading the editor layout isn't allowed during an update"
+      // if we call `coordsAtPos` synchronously from `update`.
+      view.requestMeasure({
+        read(v) {
+          const coords = v.coordsAtPos(partial.from)
+          if (!coords) {
+            if (last !== null) {
+              last = null
+              opts.onContextChange(null)
+            }
+            return
+          }
+          const next: MentionContext = {
+            type: partial.type,
+            query: partial.query,
+            from: partial.from,
+            to: partial.to,
+            coords: {
+              left: coords.left,
+              top: coords.top,
+              bottom: coords.bottom,
+            },
+          }
+          if (sameContext(last, next)) return
+          last = next
+          opts.onContextChange(next)
+        },
+      })
     }
     // Fire once on construction so the popup is in sync with the
     // initial state — usually a no-op (cursor at start of empty
     // doc), but cheap.
-    console.debug('[notes-mention] ViewPlugin mounted')
-    maybeEmit()
+    scheduleEmit()
     return {
       update(u: ViewUpdate) {
         if (u.docChanged || u.selectionSet || u.geometryChanged) {
-          maybeEmit()
+          scheduleEmit()
         }
       },
     }

--- a/ui/src/lib/notesMentionExtension.ts
+++ b/ui/src/lib/notesMentionExtension.ts
@@ -1,0 +1,208 @@
+/**
+ * CodeMirror 6 trigger-detection plugin for the Notes editor (#260).
+ *
+ * Watches the document + selection on every transaction and, if the
+ * cursor sits at the end of a `@<query>` or `/mail <query>` token,
+ * emits a `MentionContext` to the parent (the Svelte editor wrapper).
+ * The parent owns the actual popup UI — keeping the React-vs-Svelte
+ * boundary out of CM6 internals means we can render the picker with
+ * the same component idioms as the rest of the app.
+ *
+ * # Why not `@codemirror/autocomplete`?
+ *
+ * Its built-in popup is a generic vertical list — labels only, no
+ * room for avatars / subject + preview / per-row metadata.  Issue #260
+ * asks the picker to match the Compose `@` picker, which has rich
+ * rows.  Writing our own pin-and-emit plugin and rendering the popup
+ * in Svelte is straightforward; bending CM6's popup to look like the
+ * rest of the app is not.  We still use CM6's `coordsAtPos` to anchor
+ * the popup, so the positioning Just Works through CM6's scroll /
+ * folding logic.
+ *
+ * # Trigger grammar
+ *
+ * - `@<word>`        — `@` immediately preceded by start-of-line OR
+ *                      whitespace.  Avoids firing inside email
+ *                      addresses (`foo@bar.com`) or @-handles inside
+ *                      code blocks.  Stops at the next whitespace.
+ *
+ * - `/mail <words>`  — `/mail` immediately preceded by start-of-line
+ *                      OR whitespace, followed by a single space and
+ *                      an optional query.  Query can contain spaces
+ *                      so the user can type `/mail project budget`;
+ *                      the trigger ends at the line boundary.
+ *
+ * The regexes are intentionally permissive: the popup just stays
+ * closed when there are no items, so a stray `@` in prose doesn't
+ * look broken.
+ */
+
+import { ViewPlugin, type EditorView, type ViewUpdate } from '@codemirror/view'
+import type { Extension } from '@codemirror/state'
+
+export type MentionType = 'contact' | 'mail'
+
+/** What the trigger plugin emits whenever the cursor sits in a
+ *  mention context.  `from`/`to` are document offsets covering the
+ *  trigger plus its query, so the consumer can replace the whole
+ *  span when the user picks an item.  `coords` is the on-screen
+ *  position of the trigger character's left edge — the popup uses
+ *  it as the anchor for its top-left corner. */
+export interface MentionContext {
+  type: MentionType
+  query: string
+  from: number
+  to: number
+  coords: { left: number; top: number; bottom: number }
+}
+
+interface PluginOpts {
+  /** Fired whenever the mention context changes — either a new
+   *  trigger appeared, the query updated, or the trigger went away
+   *  (in which case `ctx` is `null`).  Cheap; called on every
+   *  selection-bearing update. */
+  onContextChange: (ctx: MentionContext | null) => void
+}
+
+/** `@foo` — `@` after start-of-line or whitespace, followed by a
+ *  query of non-whitespace word chars (letters, digits, `_`, `-`,
+ *  `.`, `'`).  Match is anchored with a lookbehind via the
+ *  `before` check in `detect()` since JS regex lookbehind isn't
+ *  fully portable across older WebViews we support. */
+const CONTACT_TRIGGER = /(@)([A-Za-z0-9._'-]*)$/
+
+/** `/mail <query>` — same start-of-token guard, plus the literal
+ *  `mail` + a single space.  Query can contain spaces so we match
+ *  to end-of-line. */
+const MAIL_TRIGGER = /(\/mail) (.*)$/
+
+/** True iff `prev` is a "boundary" character — start of doc,
+ *  whitespace, or one of the markdown punctuation marks that
+ *  reliably separate inline tokens.  Keeps `@foo` and `/mail` from
+ *  firing inside `foo@bar.com` or a URL path like `/home/foo`. */
+function isBoundary(prev: string | null): boolean {
+  if (prev === null) return true
+  return /\s|[>([\]]/.test(prev)
+}
+
+/** Run both trigger regexes against the line ending at the cursor;
+ *  return the first match that survives the boundary check.  We
+ *  prefer the `/mail` match over `@` because `/mail` is a longer
+ *  literal and there's no overlap, but the boundary check makes
+ *  this academic. */
+function detect(view: EditorView): MentionContext | null {
+  const { state } = view
+  const sel = state.selection.main
+  // Only fire on a collapsed cursor — multi-char selections aren't
+  // typing context, they're editing context.
+  if (!sel.empty) return null
+  const head = sel.head
+  const line = state.doc.lineAt(head)
+  const lineText = line.text
+  const offsetInLine = head - line.from
+  const upToCursor = lineText.slice(0, offsetInLine)
+
+  // Try /mail first — its anchor is `/mail<space>` so it can't
+  // ever be confused with an `@` mention.
+  const mailMatch = upToCursor.match(MAIL_TRIGGER)
+  if (mailMatch) {
+    const start = upToCursor.length - mailMatch[0].length
+    const prev = start > 0 ? upToCursor[start - 1] : null
+    if (isBoundary(prev)) {
+      const from = line.from + start
+      const to = head
+      const coords = view.coordsAtPos(from)
+      if (!coords) return null
+      return {
+        type: 'mail',
+        query: mailMatch[2],
+        from,
+        to,
+        coords: { left: coords.left, top: coords.top, bottom: coords.bottom },
+      }
+    }
+  }
+
+  const contactMatch = upToCursor.match(CONTACT_TRIGGER)
+  if (contactMatch) {
+    const start = upToCursor.length - contactMatch[0].length
+    const prev = start > 0 ? upToCursor[start - 1] : null
+    if (isBoundary(prev)) {
+      const from = line.from + start
+      const to = head
+      const coords = view.coordsAtPos(from)
+      if (!coords) return null
+      return {
+        type: 'contact',
+        query: contactMatch[2],
+        from,
+        to,
+        coords: { left: coords.left, top: coords.top, bottom: coords.bottom },
+      }
+    }
+  }
+  return null
+}
+
+/** Build the CM6 extension.  One ViewPlugin per editor instance
+ *  (each Notes editor gets its own).  The plugin keeps a small
+ *  "last emitted" cache so we don't fire the callback on
+ *  cursor-only moves that don't change the trigger context. */
+export function createMentionExtension(opts: PluginOpts): Extension {
+  return ViewPlugin.define((view) => {
+    let last: MentionContext | null = null
+    function maybeEmit(): void {
+      const next = detect(view)
+      if (sameContext(last, next)) return
+      last = next
+      opts.onContextChange(next)
+    }
+    // Fire once on construction so the popup is in sync with the
+    // initial state — usually a no-op (cursor at start of empty
+    // doc), but cheap.
+    maybeEmit()
+    return {
+      update(u: ViewUpdate) {
+        if (u.docChanged || u.selectionSet || u.geometryChanged) {
+          maybeEmit()
+        }
+      },
+    }
+  })
+}
+
+function sameContext(
+  a: MentionContext | null,
+  b: MentionContext | null,
+): boolean {
+  if (a === null || b === null) return a === b
+  return (
+    a.type === b.type &&
+    a.query === b.query &&
+    a.from === b.from &&
+    a.to === b.to &&
+    a.coords.left === b.coords.left &&
+    a.coords.top === b.coords.top
+  )
+}
+
+/** Replace the trigger span with the chosen markdown link and
+ *  position the cursor right after the insertion.  Centralised
+ *  here (rather than in the consumer) so any future change to the
+ *  insertion semantics — trailing space, smart capitalisation,
+ *  etc. — lives next to the trigger grammar that justifies it. */
+export function insertMention(
+  view: EditorView,
+  ctx: MentionContext,
+  markdown: string,
+): void {
+  // Append a trailing space so the user can keep typing without
+  // re-triggering the picker on the very next keystroke (the
+  // boundary check sees the space and stays closed).
+  const insert = `${markdown} `
+  view.dispatch({
+    changes: { from: ctx.from, to: ctx.to, insert },
+    selection: { anchor: ctx.from + insert.length },
+  })
+  view.focus()
+}


### PR DESCRIPTION
Closes #260.

## Summary

- Two new autocomplete triggers in the Notes markdown editor: `@<name>` opens a contact picker, `/mail <query>` opens a mail picker. Both insert plain markdown links that round-trip lossless through Nextcloud Notes.
- Contact picks insert `[Name](mailto:address)`; mail picks insert `[Subject](mail://account/folder/uid)`. The `mail://` link is intercepted in the rendered preview pane and routed through a new `openMailRef` in `App.svelte`.
- New user preference **"Open mails in mail view"** (off by default) controls whether the `mail://` click pops up a standalone reader (off / default) or flips the main app to the inbox at that message (on).
- Picker UI matches the Compose `@` picker: rich rows with avatars / subject + sender + date, keyboard nav, outside-click dismissal.

## Implementation notes

- `notesMentionExtension.ts` is a CodeMirror 6 `ViewPlugin` that detects `@<word>` and `/mail <query>` with a boundary check (so `foo@bar.com` and `/home/foo` don't false-trigger). Trigger detection is split into a synchronous regex pass during `update` and a deferred `requestMeasure` read for the popup anchor — CM6 forbids `coordsAtPos` inside the update phase.
- `NotesMentionPicker.svelte` is a fixed-positioned popup, viewport-aware (flips above when there's no room below), exposes `selectNext` / `selectPrev` / `pickSelected` so the editor's capture-phase keydown handler can drive it.
- `NotesMarkdownEditor.svelte` owns the data sources. Contacts come from the same eager `get_contacts` load Compose uses. Mail goes through `search_emails` (cross-folder FTS5 cache, 200 ms debounce) with a `search_imap_server` INBOX fallback for the active account when the cache returns < 5 results and the query is ≥ 3 chars. Per-query token guards against late responses clobbering fresher state.
- Soft line-wrap is enabled in the editor (`EditorView.lineWrapping`) so long `mail://` URLs in the source pane stay readable without horizontal scroll.
- Preview-pane links paint in `var(--color-primary-500)` (theme-aware, no underline) with a subtle hover brightness bump.
- Inline "Folder:" picker above the editor is removed — sidebar tree + right-click "Move…" already cover that flow and the duplicate just ate vertical space.
- Duplicate "Check Mail Now" button removed from the General settings header (it stays on Mail preferences where it belongs).

## Settings

- New `AppSettings::notes_mail_open_in_view: bool` (default `false`). Surfaces as a Toggle in Settings → General. EN + DE strings added via paraglide.

## Mail link handler scope

In-app interception only. `mail://` is not registered as a Tauri custom protocol — external clicks (NC web UI on phone, system browser) fall through to the browser's default, which silently no-ops on the unregistered scheme. Adding the OS-level handler is a clean follow-up if anyone reports needing it.

## Test plan

- [x] In a Notes editor, type `@` at the start of a word — picker opens with contact suggestions.
- [x] Type a few letters of a known contact name; rows filter in real time. Up/Down navigate, Enter inserts `[Name](mailto:address) ` at the cursor.
- [x] Type `/mail ` (with the trailing space) — picker opens, shows "Searching…" briefly, then mail results.
- [x] Type a query that matches cached mail; results appear within ~200 ms. Pick one — inserts `[Subject](mail://acc/folder/uid) `.
- [x] Toggle preview pane on. Click the inserted `mail://` link — by default a standalone reader window opens; the Notes view stays put.
- [x] Flip the new "Open mails in mail view" toggle in Settings → General. Click the same link — main view now switches to the inbox at that message.
- [x] Toggle off again, click an inserted `mailto:` link — the OS mail handler opens (browser default), Notes view stays put.
- [x] Long `mail://` URL in the source pane wraps at the editor's right edge (no horizontal scroll).
- [x] Preview links render in the theme's primary colour; hover bumps brightness; switching themes (cerberus → modern → pine) updates the link colour live.
- [x] Inline "Folder:" picker row above the editor is gone; right-click "Move to folder" on a note in the sidebar still works.
- [x] Settings → General no longer has a "Check Mail Now" button; Settings → Mail still does.
- [x] `cargo test -p nimbus-store` and `npm run check` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)