### PR TITLE
#288: drag-to-resize the mail / calendar / contacts / notes sidebars

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -206,5 +206,7 @@
   "settings_nominatim_base_url_reset": "Zurücksetzen",
   "settings_nominatim_base_url_hint": "Leer lassen, um den öffentlichen OpenStreetMap-Nominatim-Dienst zu verwenden. Um Anfragen stattdessen über eine selbst gehostete Nominatim-Instanz zu leiten, deren Basis-URL eintragen (z. B. https://nominatim.example.com).",
   "settings_notes_mail_open_in_view_label": "Mails in der Mail-Ansicht öffnen",
-  "settings_notes_mail_open_in_view_hint": "Wenn aktiviert, wechselt ein Klick auf einen Mail-Link in einer Notiz zur Mail-Ansicht und öffnet die Nachricht dort. Wenn deaktiviert (Standard), wird die Nachricht in einem eigenständigen Lesefenster geöffnet, sodass die Notizen-Ansicht erhalten bleibt."
+  "settings_notes_mail_open_in_view_hint": "Wenn aktiviert, wechselt ein Klick auf einen Mail-Link in einer Notiz zur Mail-Ansicht und öffnet die Nachricht dort. Wenn deaktiviert (Standard), wird die Nachricht in einem eigenständigen Lesefenster geöffnet, sodass die Notizen-Ansicht erhalten bleibt.",
+
+  "chrome_sidebar_resize_handle_label": "Seitenleiste anpassen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -206,5 +206,7 @@
   "settings_nominatim_base_url_reset": "Reset",
   "settings_nominatim_base_url_hint": "Leave empty to use the public OpenStreetMap Nominatim service. To route queries through your own self-hosted Nominatim instead, paste its base URL (e.g. https://nominatim.example.com).",
   "settings_notes_mail_open_in_view_label": "Open mails in mail view",
-  "settings_notes_mail_open_in_view_hint": "When on, clicking a mail link inside a note flips the main view to the inbox at that message. When off (default), the message opens in a standalone reader window so the Notes view stays put."
+  "settings_notes_mail_open_in_view_hint": "When on, clicking a mail link inside a note flips the main view to the inbox at that message. When off (default), the message opens in a standalone reader window so the Notes view stays put.",
+
+  "chrome_sidebar_resize_handle_label": "Resize sidebar"
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -40,6 +40,7 @@
   import TalkView from './lib/TalkView.svelte'
   import NotesView from './lib/NotesView.svelte'
   import { openMailInStandaloneWindow } from './lib/standaloneMailWindow'
+  import { resizableSidebar } from './lib/resizableSidebar'
   import EventEditor, { type SavedEvent } from './lib/EventEditor.svelte'
   import { quotedHistoryHtml, type MeetingInvite } from './lib/inviteHtml'
   import SearchBar, {
@@ -2245,7 +2246,10 @@
            searching while unified is enabled scopes back to the
            active account, which is the safer default than silently
            returning nothing. -->
-      <div class="flex flex-col w-80 shrink-0 border-r border-surface-200 dark:border-surface-700">
+      <div
+        class="flex flex-col shrink-0 border-r border-surface-200 dark:border-surface-700"
+        use:resizableSidebar={{ key: 'mail.listColumn', defaultWidth: 320, min: 240, max: 600 }}
+      >
         {#if selectedFolder !== OUTBOX_FOLDER}
           <!-- Hide the search input when the user is sitting on the
                local-only Outbox folder (#276) — there's nothing

--- a/ui/src/lib/CalendarView.svelte
+++ b/ui/src/lib/CalendarView.svelte
@@ -36,6 +36,7 @@
   import Icon from './Icon.svelte'
   import EventEditor, { type SavedEvent } from './EventEditor.svelte'
   import Select from './Select.svelte'
+  import { resizableSidebar } from './resizableSidebar'
 
   interface Props {
     onclose: () => void
@@ -1285,8 +1286,13 @@
            coloured swatch is the calendar's own colour from Nextcloud,
            so it matches the event blocks 1:1. -->
       <aside
-        class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100/60 dark:bg-surface-800/40 overflow-y-auto p-3"
+        class="shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100/60 dark:bg-surface-800/40 flex flex-col"
+        use:resizableSidebar={{ key: 'calendar.calendarsSidebar', defaultWidth: 224, min: 160, max: 480 }}
       >
+        <!-- Inner scroll container so the aside-level resize handle
+             stays pinned to the right edge instead of scrolling with
+             the calendar list. -->
+        <div class="flex-1 overflow-y-auto p-3">
         <!-- Section header. The `+` mirrors the Mail sidebar's
              "new folder" affordance so the add-calendar UX lives
              where the user already expects to look for it. Clicking
@@ -1389,6 +1395,7 @@
         {#if calendarOpError}
           <p class="mt-2 px-1 text-xs text-red-500 wrap-break-word">{calendarOpError}</p>
         {/if}
+        </div>
       </aside>
 
       <!-- Main grid area. Both header and time grid live in a single

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -18,6 +18,7 @@
   import Select from './Select.svelte'
   import DateField from './DateField.svelte'
   import AddressSuggestField from './AddressSuggestField.svelte'
+  import { resizableSidebar } from './resizableSidebar'
 
   interface Props {
     onclose: () => void
@@ -1482,7 +1483,10 @@
        sidebar stays mounted on the Mailing lists tab so the
        tab strip + heading don't move; only the navigation
        sections collapse. ───────────────────────────────────── -->
-  <aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col">
+  <aside
+    class="shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col"
+    use:resizableSidebar={{ key: 'contacts.navSidebar', defaultWidth: 224, min: 160, max: 480 }}
+  >
     <!-- Primary action — same shape + filled-primary preset as
          the mail Compose CTA / Notes' "New note" button.  Back
          navigation lives in the app-wide IconRail; the per-tab
@@ -1869,7 +1873,10 @@
   <!-- ── Middle column: contact list / mailing-list catalogue.
        The shell heading + tab strip moved into the sidebar
        above, so this column's job is just the list itself. ─ -->
-  <aside class="w-80 shrink-0 border-r border-surface-200 dark:border-surface-700 flex flex-col">
+  <aside
+    class="shrink-0 border-r border-surface-200 dark:border-surface-700 flex flex-col"
+    use:resizableSidebar={{ key: 'contacts.listColumn', defaultWidth: 320, min: 240, max: 600 }}
+  >
     {#if activeTab === 'contacts'}
     <!-- Search bar — same shape as `SearchBar.svelte` in the mail
          view + the Notes UI: pill `.input` field with a magnifier

--- a/ui/src/lib/NotesView.svelte
+++ b/ui/src/lib/NotesView.svelte
@@ -36,6 +36,7 @@
   import type { ComposeInitial } from './Compose.svelte'
   import Icon from './Icon.svelte'
   import NotesMarkdownEditor from './NotesMarkdownEditor.svelte'
+  import { resizableSidebar } from './resizableSidebar'
 
   interface NextcloudAccount {
     id: string
@@ -903,7 +904,10 @@
     <!-- Sidebar: New-note CTA + virtuals + folder tree + add-folder.
          Layout mirrors the mail Sidebar (Compose at top, navigation
          tree below) so the two views feel coherent. -->
-    <aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col text-sm">
+    <aside
+      class="shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col text-sm"
+      use:resizableSidebar={{ key: 'notes.navSidebar', defaultWidth: 224, min: 160, max: 480 }}
+    >
       <!-- Primary action — same shape + filled-primary preset as
            the mail Compose CTA.  Plus glyph matches the per-row
            "+ Add …" pattern used elsewhere in the app (no
@@ -1077,7 +1081,10 @@
     <!-- List pane: account picker + refresh strip + scrollable
          note list.  Account picker only shows when more than one
          NC account is connected; refresh is always there. -->
-    <div class="w-72 shrink-0 border-r border-surface-200 dark:border-surface-700 flex flex-col">
+    <div
+      class="shrink-0 border-r border-surface-200 dark:border-surface-700 flex flex-col"
+      use:resizableSidebar={{ key: 'notes.listColumn', defaultWidth: 288, min: 220, max: 600 }}
+    >
       <!-- Search bar — same shape as `SearchBar.svelte` in the
            mail view: pill `.input` field with the magnifier
            icon as a left adornment and a clear-X on the right

--- a/ui/src/lib/Sidebar.svelte
+++ b/ui/src/lib/Sidebar.svelte
@@ -22,6 +22,7 @@
   import { formatError } from './errors'
   import EmojiPicker from './EmojiPicker.svelte'
   import Icon, { type IconName } from './Icon.svelte'
+  import { resizableSidebar } from './resizableSidebar'
 
   interface Folder {
     name: string
@@ -795,7 +796,10 @@
   )
 </script>
 
-<aside class="w-56 shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col">
+<aside
+  class="shrink-0 border-r border-surface-200 dark:border-surface-700 bg-surface-100 dark:bg-surface-800 flex flex-col"
+  use:resizableSidebar={{ key: 'mail.folderSidebar', defaultWidth: 224, min: 160, max: 480 }}
+>
   <!-- Compose CTA. Emoji makes the primary action visually anchored —
        matches Nick's ask for "nice emoji" on the button. -->
   <div class="p-3">

--- a/ui/src/lib/resizableSidebar.ts
+++ b/ui/src/lib/resizableSidebar.ts
@@ -1,0 +1,218 @@
+// Drag-to-resize for vertical sidebars (#288).
+//
+// Applied as a Svelte action on any element that should function as
+// a resizable left sidebar:
+//
+//     <aside class="shrink-0 border-r ... flex flex-col"
+//            use:resizableSidebar={{
+//              key: 'mail.folderSidebar',
+//              defaultWidth: 224,
+//              min: 160,
+//              max: 480,
+//            }}>
+//
+// The action takes over the element's `width` and `position` inline
+// styles, appends an absolutely-positioned drag handle on the right
+// edge, and persists the user's chosen width to localStorage under
+// `nimbus.resize.<key>`.  On the next mount the saved width is read
+// back and clamped to the current [min, max] bounds.
+//
+// IMPORTANT: don't keep a tailwind `w-*` class on the host element
+// when this action is used — the inline style would still win, but
+// removing the class avoids a one-frame flash to the wrong width
+// before mount.  Keep `shrink-0` so the element doesn't get squeezed
+// when its siblings demand space.
+//
+// The handle is 4px wide visually, but the hit-target extends 4px
+// either side via negative offsets + transparent padding so users
+// don't have to be pixel-precise.  Hover and active states fade the
+// primary-500 accent in, matching the rest of the chrome.
+
+import { m } from '../paraglide/messages'
+
+const STORAGE_PREFIX = 'nimbus.resize.'
+
+export interface ResizableSidebarOptions {
+  /** Stable identifier — becomes `nimbus.resize.<key>` in localStorage.
+   *  Pick one that won't collide across sidebars (e.g. `mail.folderSidebar`,
+   *  `notes.notesList`). */
+  key: string
+  /** Width applied when no saved value exists yet, in CSS pixels. */
+  defaultWidth: number
+  /** Lower clamp.  Defaults to 140px — narrow enough for an icon-only
+   *  collapse but wide enough that a single Tailwind `w-1` border
+   *  doesn't dominate the column. */
+  min?: number
+  /** Upper clamp.  Defaults to 600px — past that the sidebar starts
+   *  eating real estate the main pane needs. */
+  max?: number
+}
+
+interface State {
+  options: Required<ResizableSidebarOptions>
+  handle: HTMLDivElement
+  onPointerDown: (e: PointerEvent) => void
+  cleanupDrag: (() => void) | null
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+function readPersisted(key: string): number | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_PREFIX + key)
+    if (raw === null) return null
+    const n = Number.parseFloat(raw)
+    return Number.isFinite(n) ? n : null
+  } catch {
+    return null
+  }
+}
+
+function writePersisted(key: string, width: number): void {
+  try {
+    localStorage.setItem(STORAGE_PREFIX + key, String(Math.round(width)))
+  } catch {
+    /* storage unavailable — silent */
+  }
+}
+
+function applyDefaults(o: ResizableSidebarOptions): Required<ResizableSidebarOptions> {
+  return {
+    key: o.key,
+    defaultWidth: o.defaultWidth,
+    min: o.min ?? 140,
+    max: o.max ?? 600,
+  }
+}
+
+function buildHandle(): HTMLDivElement {
+  const handle = document.createElement('div')
+  handle.setAttribute('role', 'separator')
+  handle.setAttribute('aria-orientation', 'vertical')
+  handle.setAttribute('aria-label', m.chrome_sidebar_resize_handle_label())
+  // The visible 4px bar sits flush with the right edge; the
+  // transparent padding extends the pointer hit-target 4px in
+  // either direction so the user doesn't have to land on a hairline.
+  handle.style.cssText = [
+    'position: absolute',
+    'top: 0',
+    'bottom: 0',
+    'right: -4px',
+    'width: 8px',
+    'cursor: col-resize',
+    'z-index: 20',
+    'touch-action: none',
+    'user-select: none',
+    // The accent stripe is a 4px inner span we paint via a CSS
+    // pseudo using ::before-style — but inside inline styles we
+    // fake it with a box-shadow inset on hover via a hover handler.
+    'background: transparent',
+    'transition: background-color 120ms ease',
+  ].join(';')
+  // Hover / active states: tint the right 4px slice.  Done with
+  // direct event handlers since we can't attach `:hover` rules
+  // through inline styles.
+  const setActive = (active: boolean) => {
+    handle.style.backgroundImage = active
+      ? 'linear-gradient(to right, transparent 0, transparent 4px, var(--color-primary-500, #6366f1) 4px, var(--color-primary-500, #6366f1) 8px)'
+      : 'none'
+  }
+  handle.addEventListener('mouseenter', () => setActive(true))
+  handle.addEventListener('mouseleave', () => {
+    if (!handle.dataset.dragging) setActive(false)
+  })
+  return handle
+}
+
+export function resizableSidebar(
+  el: HTMLElement,
+  rawOptions: ResizableSidebarOptions,
+): { update(next: ResizableSidebarOptions): void; destroy(): void } {
+  const state: State = {
+    options: applyDefaults(rawOptions),
+    handle: buildHandle(),
+    onPointerDown: () => {},
+    cleanupDrag: null,
+  }
+
+  const ensurePositioned = () => {
+    const computed = getComputedStyle(el).position
+    if (computed === 'static') el.style.position = 'relative'
+  }
+
+  const applyWidth = (w: number) => {
+    const clamped = clamp(w, state.options.min, state.options.max)
+    el.style.width = `${clamped}px`
+    el.style.flexShrink = '0'
+    return clamped
+  }
+
+  // Initial width: persisted value if any, otherwise the caller's
+  // default.  Either way we clamp so a stale stored value from an
+  // older min/max never escapes the new bounds.
+  const persisted = readPersisted(state.options.key)
+  applyWidth(persisted ?? state.options.defaultWidth)
+
+  ensurePositioned()
+  el.appendChild(state.handle)
+
+  state.onPointerDown = (e: PointerEvent) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+    e.stopPropagation()
+    state.handle.dataset.dragging = 'true'
+    state.handle.setPointerCapture(e.pointerId)
+
+    const startX = e.clientX
+    const startWidth = el.getBoundingClientRect().width
+
+    // Lock cursor + selection globally so dragging across other
+    // panes doesn't snap to a text-select cursor mid-drag.
+    const prevBodyCursor = document.body.style.cursor
+    const prevBodyUserSelect = document.body.style.userSelect
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+
+    const onMove = (ev: PointerEvent) => {
+      const dx = ev.clientX - startX
+      applyWidth(startWidth + dx)
+    }
+    const onUp = () => {
+      const finalWidth = el.getBoundingClientRect().width
+      writePersisted(state.options.key, finalWidth)
+      teardown()
+    }
+    const teardown = () => {
+      document.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerup', onUp)
+      document.removeEventListener('pointercancel', onUp)
+      document.body.style.cursor = prevBodyCursor
+      document.body.style.userSelect = prevBodyUserSelect
+      delete state.handle.dataset.dragging
+      state.handle.style.backgroundImage = 'none'
+      state.cleanupDrag = null
+    }
+    state.cleanupDrag = teardown
+
+    document.addEventListener('pointermove', onMove)
+    document.addEventListener('pointerup', onUp)
+    document.addEventListener('pointercancel', onUp)
+  }
+
+  state.handle.addEventListener('pointerdown', state.onPointerDown)
+
+  return {
+    update(next: ResizableSidebarOptions) {
+      state.options = applyDefaults(next)
+      // Re-clamp the current width to the (possibly new) bounds.
+      applyWidth(el.getBoundingClientRect().width)
+    },
+    destroy() {
+      state.cleanupDrag?.()
+      state.handle.removeEventListener('pointerdown', state.onPointerDown)
+      state.handle.remove()
+    },
+  }
+}


### PR DESCRIPTION
Closes #288.

## Summary

- New reusable Svelte action `resizableSidebar` that turns any element into a drag-resizable sidebar.  Appends a 4px right-edge handle (8px hit-target), clamps to per-sidebar min/max, and persists the chosen width to `localStorage` under `nimbus.resize.<key>` so the choice survives restarts.
- Wired into all seven content sidebars: mail folder list, mail-list column, calendar sidebar, contacts nav + list columns, notes nav + list columns.  IconRail stays a fixed-width nav — resizing a 14-tailwind icon strip would only waste space.
- Calendar sidebar's `overflow-y-auto` was moved off the resized element onto an inner wrapper so the handle stays pinned to the right edge instead of scrolling away with the calendar list.

## Test plan

- [ ] Mail view: drag the right edge of the folder list — width changes smoothly, persists across reload, clamps to 160–480px.
- [ ] Mail view: drag the right edge of the envelope list column — same, clamps to 240–600px.
- [ ] Calendar view: drag the calendar sidebar — list still scrolls inside, handle stays pinned right.
- [ ] Contacts view: both the nav aside and the list column drag independently.
- [ ] Notes view: nav aside + notes-list column drag independently.
- [ ] Reload after resizing — widths are restored from localStorage.
- [ ] Switch language to German — the handle's `aria-label` reads "Seitenleiste anpassen".

🤖 Generated with [Claude Code](https://claude.com/claude-code)