### PR TITLE
Auto-evict stale envelopes when fetch_message can't find the UID

### DIFF
--- a/crates/nimbus-core/src/error.rs
+++ b/crates/nimbus-core/src/error.rs
@@ -18,6 +18,16 @@ pub enum NimbusError {
     #[error("Protocol error: {0}")]
     Protocol(String),
 
+    /// Fetch (IMAP/JMAP) returned no results for a UID we asked for —
+    /// the message no longer exists on the server (deleted by another
+    /// client, expunged by a server-side rule, or invalidated by a
+    /// UIDVALIDITY reset).  Distinct from `Protocol` so the Tauri
+    /// command layer can evict the dead envelope from the cache + the
+    /// frontend can auto-advance to the next neighbour instead of
+    /// surfacing a raw "No message with UID 3056" string.
+    #[error("Message no longer exists on the server")]
+    MessageGone,
+
     #[error("Storage error: {0}")]
     Storage(String),
 

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -747,10 +747,7 @@ impl ImapClient {
         // No fetch row back means the server's expunged this UID
         // since we cached the envelope — surface `MessageGone` so the
         // Tauri layer can evict the dead row + the UI can auto-advance.
-        let fetch = fetches
-            .into_iter()
-            .next()
-            .ok_or(NimbusError::MessageGone)?;
+        let fetch = fetches.into_iter().next().ok_or(NimbusError::MessageGone)?;
 
         let raw = fetch
             .body()

--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -744,10 +744,13 @@ impl ImapClient {
             .await
             .map_err(|e| NimbusError::Protocol(format!("Failed to read UID FETCH: {e}")))?;
 
+        // No fetch row back means the server's expunged this UID
+        // since we cached the envelope — surface `MessageGone` so the
+        // Tauri layer can evict the dead row + the UI can auto-advance.
         let fetch = fetches
             .into_iter()
             .next()
-            .ok_or_else(|| NimbusError::Protocol(format!("No message with UID {uid}")))?;
+            .ok_or(NimbusError::MessageGone)?;
 
         let raw = fetch
             .body()

--- a/crates/nimbus-jmap/src/client.rs
+++ b/crates/nimbus-jmap/src/client.rs
@@ -411,11 +411,14 @@ impl JmapClient {
         let result: GetResult<JmapEmail> = serde_json::from_value(args.clone())
             .map_err(|e| NimbusError::Protocol(format!("Failed to parse Email/get: {e}")))?;
 
+        // No Email/get hit means the message was deleted/moved
+        // between resolve_jmap_id and the body fetch — surface
+        // `MessageGone` so the Tauri layer can evict the dead row.
         let email = result
             .list
             .into_iter()
             .next()
-            .ok_or_else(|| NimbusError::Protocol(format!("No email with ID '{jmap_id}'")))?;
+            .ok_or(NimbusError::MessageGone)?;
 
         let from = email
             .from
@@ -912,11 +915,12 @@ impl JmapClient {
             .enumerate()
             .find(|(i, e)| synthetic_uid(&e.id, *i) == uid)
             .map(|(_, e)| e.id.clone())
-            .ok_or_else(|| {
-                NimbusError::Protocol(format!(
-                    "No JMAP email found for synthetic UID {uid} in '{folder}'"
-                ))
-            })
+            // The synthetic UID didn't resolve to any JMAP ID — the
+            // server's view of the mailbox no longer contains this
+            // message.  `MessageGone` so the Tauri layer can evict
+            // the dead envelope rather than surfacing a raw protocol
+            // string to the user.
+            .ok_or(NimbusError::MessageGone)
     }
 
     /// Find the JMAP Identity ID for a given email address.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6434,8 +6434,17 @@ async fn poll_folder(
 }
 
 /// Fetch a full message (headers + body) by folder + UID.
+///
+/// When the inner call returns `MessageGone` — meaning the server has
+/// no message under this UID anymore (deleted/moved/expunged by
+/// another client, or UIDVALIDITY reset) — we evict the dead envelope
+/// from the local cache and fire `mail-flags-updated` so MailList
+/// drops the stale row.  The error still propagates to the frontend
+/// so MailView can route it through its existing `onmessageremoved`
+/// auto-advance flow.
 #[tauri::command]
 async fn fetch_message(
+    app: AppHandle,
     account_id: String,
     folder: String,
     uid: u32,
@@ -6443,6 +6452,17 @@ async fn fetch_message(
 ) -> Result<Email, NimbusError> {
     match fetch_message_inner(&account_id, &folder, uid, &cache).await {
         Ok(email) => Ok(email),
+        Err(NimbusError::MessageGone) => {
+            tracing::info!(
+                "fetch_message: UID {uid} in '{account_id}'/'{folder}' is gone on the server; \
+                 evicting cached envelope"
+            );
+            if let Err(e) = cache.remove_envelope(&account_id, &folder, uid) {
+                tracing::warn!("remove_envelope after MessageGone failed: {e}");
+            }
+            emit_mail_flags_updated(&app, &account_id, &folder);
+            Err(NimbusError::MessageGone)
+        }
         Err(e) => {
             tracing::error!("fetch_message failed: {e}");
             Err(e)

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -208,5 +208,7 @@
   "settings_notes_mail_open_in_view_label": "Mails in der Mail-Ansicht öffnen",
   "settings_notes_mail_open_in_view_hint": "Wenn aktiviert, wechselt ein Klick auf einen Mail-Link in einer Notiz zur Mail-Ansicht und öffnet die Nachricht dort. Wenn deaktiviert (Standard), wird die Nachricht in einem eigenständigen Lesefenster geöffnet, sodass die Notizen-Ansicht erhalten bleibt.",
 
-  "chrome_sidebar_resize_handle_label": "Seitenleiste anpassen"
+  "chrome_sidebar_resize_handle_label": "Seitenleiste anpassen",
+
+  "mail_view_message_gone": "Diese Nachricht existiert nicht mehr auf dem Server."
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -208,5 +208,7 @@
   "settings_notes_mail_open_in_view_label": "Open mails in mail view",
   "settings_notes_mail_open_in_view_hint": "When on, clicking a mail link inside a note flips the main view to the inbox at that message. When off (default), the message opens in a standalone reader window so the Notes view stays put.",
 
-  "chrome_sidebar_resize_handle_label": "Resize sidebar"
+  "chrome_sidebar_resize_handle_label": "Resize sidebar",
+
+  "mail_view_message_gone": "This message no longer exists on the server."
 }

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -13,6 +13,7 @@
   import { save } from '@tauri-apps/plugin-dialog'
   import DOMPurify from 'dompurify'
   import { formatError } from './errors'
+  import { m } from '../paraglide/messages'
   import NextcloudFilePicker from './NextcloudFilePicker.svelte'
   import MoveFolderPicker from './MoveFolderPicker.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
@@ -355,7 +356,23 @@
         email = fresh
       }
     } catch (e: any) {
-      if (email == null) {
+      // `MessageGone` (#288 sibling): the cached envelope is a
+      // ghost — the message no longer exists on the server.  The
+      // backend has already evicted the cache row and fired
+      // `mail-flags-updated`; we hand the gone UID up so the parent
+      // auto-advances to the next neighbour (App.svelte's
+      // `onMessageRemoved` does the splice + selection move).  The
+      // cached body, if any, is now misleading — clear it so the
+      // user doesn't see "(deleted) reply to this thread" affordances
+      // on a dead message.  Pane briefly shows the friendly note
+      // until the parent picks the next UID.
+      if (e === 'MessageGone') {
+        email = null
+        error = m.mail_view_message_gone()
+        if (id === accountId && f === folder && u === uid) {
+          onmessageremoved?.(u)
+        }
+      } else if (email == null) {
         error = formatError(e) || 'Failed to load message'
       } else {
         console.warn('fetch_message failed (showing cached):', e)


### PR DESCRIPTION
## Summary

- Clicking a cached envelope row whose message has been deleted / expunged / UIDVALIDITY-reset on the server used to surface a raw `Protocol: No message with UID 3056` string in the reading pane while leaving the dead row in MailList for the user to click again.
- New typed error variant `NimbusError::MessageGone` distinguishes "message no longer exists" from generic protocol errors.  IMAP `fetch_message` and JMAP `fetch_message` + `resolve_jmap_id` return it when their lookup yields zero results.
- The Tauri `fetch_message` handler catches it, evicts the cache row via `remove_envelope`, and fires `mail-flags-updated` so MailList drops the stale entry.  MailView routes the error through the existing `onmessageremoved` auto-advance flow used by delete/move — the parent picks the next neighbour, the user keeps moving through their inbox, and a friendly localised note ("This message no longer exists on the server" / "Diese Nachricht existiert nicht mehr auf dem Server.") shows briefly until the next UID takes over.

Scope intentionally limited to `fetch_message`.  `fetch_attachment` and `fetch_inline_calendar` carry the same pattern but only run after a successful `fetch_message`, so the dead-row scenario is much rarer there — left for a follow-up if it ever bites.

## Test plan

- [ ] In a folder with a message that's been deleted externally (web UI, another client) but still appears in MailList, click the dead row: row disappears, reading pane auto-advances to the next neighbour, brief "no longer exists" note appears, no raw protocol error.
- [ ] If the dead row is the last in the list, the reading pane shows the empty state instead of an error.
- [ ] Other `fetch_message` failures (auth, network drop) still surface as before — only `MessageGone` triggers the evict path.
- [ ] `cargo check --workspace` and `npm run check` both green.
- [ ] DE locale: friendly note renders the German translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)