### PR TITLE
#289: thread orphan replies, fix dblclick popout, sweep whole thread on head move/archive

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7129,6 +7129,105 @@ async fn move_messages(
     Ok(uids)
 }
 
+/// Batch variant of `archive_message` (#289 follow-up): every message
+/// in `uids` is archived from the same source folder in a single IMAP
+/// session, so dragging an archive action on a thread head can
+/// archive every member of the conversation in one round-trip.
+///
+/// Mechanically identical to `move_messages` once the destination is
+/// known — the only thing this command adds is the up-front
+/// `pick_archive_folder` resolution.  Returns the list of UIDs the
+/// server confirmed gone so the frontend's optimistic-flow rollback
+/// has a definite success set to work against.
+#[tauri::command]
+async fn archive_messages(
+    account_id: String,
+    folder: String,
+    uids: Vec<u32>,
+    cache: State<'_, Cache>,
+) -> Result<Vec<u32>, NimbusError> {
+    if uids.is_empty() {
+        return Ok(vec![]);
+    }
+    let account = load_account(&cache, &account_id)?;
+
+    if uses_jmap(&account) {
+        return Err(NimbusError::Other(
+            "Archive via JMAP is not yet implemented — this account uses JMAP".into(),
+        ));
+    }
+
+    let archive = match pick_archive_folder(&account_id, &cache) {
+        Some(name) => name,
+        None => {
+            return Err(NimbusError::Other(
+                "No archive folder found on this account — cannot archive.".into(),
+            ));
+        }
+    };
+
+    if archive.eq_ignore_ascii_case(&folder) {
+        // Archive-to-self: already there.  No-op rather than tripping
+        // the IMAP server with a move that would either bump UIDs
+        // pointlessly or be rejected outright.
+        return Ok(vec![]);
+    }
+
+    let password = credentials::get_imap_password(&account.id)?;
+
+    // Optimistic-UI tombstones — same shape as the move-batch path,
+    // marking each row pending before the IMAP round-trip means a
+    // folder switch mid-batch won't briefly resurrect the archived
+    // rows in their old folder.
+    let pending = format!("move:{archive}");
+    for uid in &uids {
+        if let Err(e) = cache.mark_message_pending(&account_id, &folder, *uid, &pending) {
+            tracing::warn!("mark_message_pending(archive-batch) failed: {e}");
+        }
+    }
+
+    let connect_result = ImapClient::connect(
+        &account.imap_host,
+        account.imap_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await;
+    let mut client = match connect_result {
+        Ok(c) => c,
+        Err(e) => {
+            for uid in &uids {
+                if let Err(c) = cache.clear_message_pending(&account_id, &folder, *uid) {
+                    tracing::warn!(
+                        "clear_message_pending after archive-batch connect failure: {c}"
+                    );
+                }
+            }
+            return Err(e);
+        }
+    };
+    let result = client.move_messages_batch(&folder, &uids, &archive).await;
+    let _ = client.logout().await;
+
+    if let Err(e) = result {
+        for uid in &uids {
+            if let Err(c) = cache.clear_message_pending(&account_id, &folder, *uid) {
+                tracing::warn!("clear_message_pending after archive-batch failure: {c}");
+            }
+        }
+        return Err(e);
+    }
+
+    for uid in &uids {
+        if let Err(e) = cache.remove_envelope(&account_id, &folder, *uid) {
+            tracing::warn!("remove_envelope after archive_messages failed: {e}");
+        }
+    }
+
+    Ok(uids)
+}
+
 /// Locate the account's Archive folder via the IMAP `\Archive`
 /// special-use attribute or a name-based fallback. Same strategy as
 /// `pick_sent_folder` / `pick_drafts_folder`.
@@ -11422,6 +11521,7 @@ fn main() {
             save_draft,
             delete_message,
             archive_message,
+            archive_messages,
             move_message,
             move_messages,
             get_cached_envelopes,

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -217,6 +217,28 @@
   // Bumped to force child lists to re-fetch (manual refresh, mark-as-read).
   let refreshToken = $state(0)
 
+  /** UIDs of every member of the thread the currently-open message
+   *  belongs to (#289 follow-up), but **only when the open message
+   *  is the head row** (the one carrying the count badge).  `null`
+   *  for non-head rows, single-row messages, or no selection.
+   *  Threaded through to MailView so its archive button can sweep
+   *  the whole conversation in one batched IMAP move.  Same-folder
+   *  guarantee holds today because cross-folder threading isn't in
+   *  scope yet — if/when it lands, this derivation may need to
+   *  filter by folder before returning. */
+  let currentThreadMemberUids = $derived.by((): number[] | null => {
+    if (selectedUid == null) return null
+    const accId = selectedMessageAccountId ?? activeAccountId
+    const fld = selectedFolder
+    const key = `${accId}::${fld}::${selectedUid}`
+    const members = mailListThreadMembers.get(key)
+    if (!members || members.length <= 1) return null
+    // Only expand for the head row — opening a sibling and
+    // archiving it shouldn't pull the rest of the thread along.
+    if (members[0].uid !== selectedUid) return null
+    return members.map((m) => m.uid)
+  })
+
   /** Synthetic local-only Outbox folder name (#276).  Mirror of
    *  the constant in Sidebar.svelte; same name means selecting
    *  the synthetic sidebar entry routes through the existing
@@ -281,6 +303,12 @@
     account_id: string
   }
   let mailListEnvelopes = $state<MailListEnvelope[]>([])
+  /** Mirror of MailList's post-merge thread membership map (#289
+   *  follow-up).  Used to give MailView's archive button the full
+   *  set of member UIDs when the open mail is a thread head, so a
+   *  single archive click sweeps the whole conversation.  Keyed by
+   *  `${account_id}::${folder}::${uid}`. */
+  let mailListThreadMembers = $state<Map<string, MailListEnvelope[]>>(new Map())
 
   // Network-refresh state for the IconRail's active-account
   // avatar spinner (#161).  Each child component (MailList,
@@ -2301,6 +2329,7 @@
               onselect={selectMessage}
               bind:envelopes={mailListEnvelopes}
               bind:refreshing={mailListRefreshing}
+              bind:threadMembersByEnv={mailListThreadMembers}
               onmessagemoved={onMessageRemoved}
             />
           {/if}
@@ -2324,6 +2353,7 @@
           forceWhiteBackground={appPrefs?.mail_html_white_background ?? true}
           autoLoadRemoteImages={appPrefs?.auto_load_remote_images ?? false}
           linkCheckEnabled={appPrefs?.link_check_enabled ?? true}
+          threadMemberUids={currentThreadMemberUids}
           onread={onMessageRead}
           onreply={onReply}
           onreplyall={onReplyAll}

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -190,7 +190,16 @@
     threadKey: string
   }
 
-  let renderRows = $derived.by((): RenderRow[] => {
+  /** Stable identity key for an envelope across the bound list.  UID
+   *  alone collides across folders / accounts in unified mode, so we
+   *  combine all three.  Used by `threadMembersByEnv` lookups in
+   *  `affectedEnvelopes` (#289 follow-up). */
+  function envKey(e: EmailEnvelope): string {
+    return `${e.account_id}::${e.folder}::${e.uid}`
+  }
+
+  const threadView = $derived.by(():
+    | { rows: RenderRow[]; threadMembersByEnv: Map<string, EmailEnvelope[]> } => {
     // Bucket envelopes by thread key, preserving the bucket
     // order in which the *first* member appears (envelopes are
     // already date-sorted newest-first).
@@ -354,8 +363,24 @@
         }
       }
     }
-    return out
+    // Build a side-map from envelope identity to its post-merge
+    // bucket (#289 follow-up).  `affectedEnvelopes` consults this
+    // when the user drags or right-clicks a thread head so the
+    // move expands to every member of the thread, not just the
+    // visible head row.  The map is built in the same pass as the
+    // rows so we don't pay a second bucketing for the side
+    // affordance.
+    const threadMembersByEnv = new Map<string, EmailEnvelope[]>()
+    for (const env of envelopes) {
+      const key = effectiveKey(env)
+      const bucket = groups.get(key)
+      if (bucket) threadMembersByEnv.set(envKey(env), bucket)
+    }
+    return { rows: out, threadMembersByEnv }
   })
+
+  let renderRows = $derived(threadView.rows)
+  let threadMembersByEnv = $derived(threadView.threadMembersByEnv)
 
   /** Short label for the per-row account chip in unified mode. We
       prefer the display name and fall back to the email's local part
@@ -437,15 +462,62 @@
   }
 
   /** Envelopes that should be acted on for an operation triggered
-   *  on `env`.  When `env` is part of a multi-select group with
-   *  more than one row, we operate on the whole group; otherwise
-   *  it's just `env` (this matches the standard mail-client
-   *  right-click + drag behaviour). */
-  function affectedEnvelopes(env: EmailEnvelope): EmailEnvelope[] {
-    if (multiSelectedUids.size > 1 && multiSelectedUids.has(env.uid)) {
-      return envelopes.filter((e) => multiSelectedUids.has(e.uid))
+   *  on `env`.  Two affordances stack:
+   *
+   *  1. **Multi-select expansion** — when `env` is part of a
+   *     multi-select group with more than one row, we operate on the
+   *     whole group, matching the standard mail-client right-click
+   *     + drag behaviour.
+   *  2. **Thread-head expansion** (#289 follow-up) — when
+   *     `opts.expandThread` is true and the targeted envelope is the
+   *     head of a multi-member thread (the row that carries the
+   *     count badge), we expand to every member of that thread so a
+   *     move-via-drag or move-via-picker on the head moves the whole
+   *     conversation, not just the visible row.  Layered on top of
+   *     multi-select: each selected head's thread is expanded in
+   *     turn, deduped by `(account_id, folder, uid)` so a sibling
+   *     that's also separately selected isn't moved twice.
+   *
+   *  `expandThread` defaults to `false` so destructive paths (delete)
+   *  and per-row toggles (read / unread) keep the previous one-row-
+   *  at-a-time semantics.  Move-shaped paths (drag, right-click "Move
+   *  to folder") opt in. */
+  function affectedEnvelopes(
+    env: EmailEnvelope,
+    opts: { expandThread?: boolean } = {},
+  ): EmailEnvelope[] {
+    const expand = opts.expandThread === true
+    /** Walk an envelope's thread membership and decide whether to
+     *  expand: only when the envelope is the head (members[0]) of
+     *  a multi-member bucket.  Returns the bucket when expanding,
+     *  `[env]` otherwise.  Reference equality on `members[0]` is
+     *  safe because the bucket holds the same envelope references
+     *  from the bound list. */
+    const expandIfHead = (e: EmailEnvelope): EmailEnvelope[] => {
+      if (!expand) return [e]
+      const members = threadMembersByEnv.get(envKey(e))
+      if (members && members.length > 1 && members[0] === e) {
+        return members
+      }
+      return [e]
     }
-    return [env]
+
+    if (multiSelectedUids.size > 1 && multiSelectedUids.has(env.uid)) {
+      const selected = envelopes.filter((e) => multiSelectedUids.has(e.uid))
+      if (!expand) return selected
+      const out: EmailEnvelope[] = []
+      const seen = new Set<string>()
+      for (const e of selected) {
+        for (const m of expandIfHead(e)) {
+          const k = envKey(m)
+          if (seen.has(k)) continue
+          seen.add(k)
+          out.push(m)
+        }
+      }
+      return out
+    }
+    return expandIfHead(env)
   }
 
   // ── Move-to-folder picker (#89) — opened via the right-click
@@ -552,7 +624,15 @@
     // user.  The affectedEnvelopes() rule already does the right
     // thing: it only expands to the group when the dragged row is
     // a member.
-    const group = affectedEnvelopes(env)
+    //
+    // Dragging a thread head, however, should sweep the whole
+    // conversation into the move (#289 follow-up) — the head row
+    // is the user's primary handle for the thread, and dragging
+    // it without its siblings would silently leave them behind in
+    // the source folder.  `expandThread: true` opts this drag into
+    // that behaviour; multi-drag preview's "[+] N" badge then
+    // reflects the actual total moved.
+    const group = affectedEnvelopes(env, { expandThread: true })
     const payload = group.map((g) => {
       const { accountId: src, folder: srcFolder } = srcCoordinates(g)
       return { accountId: src, folder: srcFolder, uid: g.uid }
@@ -1146,8 +1226,10 @@
     // quick-action move is just a 1-element group from its
     // perspective.  affectedEnvelopes does the right thing here:
     // when this row is part of a multi-select group, the picker
-    // moves the whole group; otherwise just the one row.
-    movingGroup = affectedEnvelopes(env)
+    // moves the whole group; otherwise just the one row.  When the
+    // targeted row is a thread head, expand to all members so the
+    // picker move sweeps the whole conversation (#289 follow-up).
+    movingGroup = affectedEnvelopes(env, { expandThread: true })
   }
 
   async function toggleEnvelopeRead(env: EmailEnvelope) {
@@ -1440,8 +1522,23 @@
 </div>
 
 {#if contextMenu}
+  <!-- Two affordance scopes per right-click row (#289 follow-up):
+       • `ctxGroup` — multi-select expansion only.  Drives read /
+         unread (per-row toggle that converges on the right-clicked
+         row's state) and Delete (which stays per-row by user
+         preference — a stray whole-thread delete is hard to undo).
+       • `ctxGroupForMove` — also expands a thread head to its
+         full member list.  Drives "Move to folder…" so the user
+         can sweep an entire conversation into another folder by
+         right-clicking the head row.
+       The two coexist because move is the only action where
+       whole-thread expansion is the natural expectation. -->
   {@const ctxGroup = affectedEnvelopes(contextMenu.env)}
+  {@const ctxGroupForMove = affectedEnvelopes(contextMenu.env, {
+    expandThread: true,
+  })}
   {@const groupSize = ctxGroup.length}
+  {@const moveGroupSize = ctxGroupForMove.length}
   <!-- Right-click menu. Stop propagation so a click *inside* the menu
        doesn't reach the window-level dismiss listener and close it
        before the action handler runs. `role="menu"` keeps screen
@@ -1491,14 +1588,14 @@
       class="flex w-full items-center gap-2 text-left px-3 py-1.5 hover:bg-surface-200 dark:hover:bg-surface-800"
       onclick={() => {
         if (!contextMenu) return
-        movingGroup = ctxGroup
+        movingGroup = ctxGroupForMove
         closeContextMenu()
       }}
     >
       <Icon name="move-to-folder" size={16} />
       <span>
-        {#if groupSize > 1}
-          Move {groupSize} messages to folder…
+        {#if moveGroupSize > 1}
+          Move {moveGroupSize} messages to folder…
         {:else}
           Move to folder…
         {/if}

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -103,9 +103,9 @@
 
   // ── Conversation-view grouping (#277) ───────────────────────
   // Bundles every envelope that shares an RFC 5322 thread root
-  // into a single inbox row, the way iPhone Mail / Thunderbird
-  // do.  The thread head is the *newest* message; siblings are
-  // hidden until the user clicks the count chevron.
+  // into a single inbox row — the standard conversation-view
+  // pattern.  The thread head is the *newest* message; siblings
+  // are hidden until the user clicks the count chevron.
   //
   // `threadKeyOf` picks the most-stable identifier we have:
   //
@@ -158,9 +158,9 @@
    *  Message-ID anchor across the wire.  Merge them.
    *
    *  Floor of 4 chars on the canonical subject so trivial subjects
-   *  (`"hi"`, `"?"`) don't cause a merge cascade.  Everything else
-   *  Apple Mail / Thunderbird / Outlook also fall back to this
-   *  rule — see [JWZ threading
+   *  (`"hi"`, `"?"`) don't cause a merge cascade.  This is the
+   *  same subject-fallback rule every major conversation grouper
+   *  implements — see [JWZ threading
    *  §5.B.iii](https://www.jwz.org/doc/threading.html). */
   function isReplyOrForward(subject: string): boolean {
     return /^(re|fwd?|aw|wg|sv)\s*(\[\d+\])?\s*:/i.test(subject || '')
@@ -212,9 +212,9 @@
     // rewrite Message-IDs on delivery (local-SMTP test rigs and
     // a few Exchange configs we've seen) so the inbox copy
     // anchors a different ID than the reply's `In-Reply-To`
-    // points at.  This is exactly the case where Thunderbird /
-    // Apple Mail still thread correctly — they fall back to
-    // subject matching.  Match Nimbus to that behaviour.
+    // points at.  Standard practice in conversation groupers is
+    // to fall back to subject matching when the header chain
+    // breaks — Nimbus does the same.
     //
     // For every reply-shaped bucket head (`Re:` / `Fwd:` / …),
     // look for another bucket whose head has the same canonical
@@ -259,6 +259,57 @@
       keyRedirect.set(key, targetKey)
     }
     for (const key of mergedAway) groups.delete(key)
+
+    // Orphan-reply merge pass (#289).  The pass above only fires
+    // when there's a non-reply head to anchor the canonical-subject
+    // group on.  When the original got archived or deleted on the
+    // server, every remaining bucket head is a reply (`Re: Foo`) and
+    // none of them get picked as the byCanonicalRoot anchor, so
+    // two genuinely-same-thread reply buckets stay separate even
+    // though their canonical subjects match.  Fix: walk the
+    // surviving buckets, and for any canonical subject that appears
+    // on multiple reply-shaped heads, pick the *oldest* bucket
+    // (largest internal date span — the one most likely to be the
+    // closest-to-root surviving copy) as the anchor and fold the
+    // rest into it.  Same ≥4-char floor; we still skip canon
+    // subjects that already won an anchor in the first pass, so
+    // trivial subjects never cascade.
+    const orphanAnchor = new Map<string, string>() // canon → group key
+    for (const [key, arr] of groups) {
+      const head = arr[arr.length - 1]
+      if (!head || !isReplyOrForward(head.subject)) continue
+      const canon = canonicalSubject(head.subject)
+      if (canon.length < 4) continue
+      if (byCanonicalRoot.has(canon)) continue // pass-1 already handled this canon
+      const existing = orphanAnchor.get(canon)
+      if (!existing) {
+        orphanAnchor.set(canon, key)
+        continue
+      }
+      // Pick the bucket whose oldest member is older — that's the
+      // surviving anchor; merge the other into it.
+      const existingArr = groups.get(existing)
+      if (!existingArr) {
+        orphanAnchor.set(canon, key)
+        continue
+      }
+      const existingOldest = new Date(
+        existingArr[existingArr.length - 1].date,
+      ).getTime()
+      const candidateOldest = new Date(arr[arr.length - 1].date).getTime()
+      const anchorKey = candidateOldest < existingOldest ? key : existing
+      const mergeKey = anchorKey === key ? existing : key
+      const anchorArr = groups.get(anchorKey)
+      const mergeArr = groups.get(mergeKey)
+      if (!anchorArr || !mergeArr) continue
+      anchorArr.push(...mergeArr)
+      anchorArr.sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      )
+      groups.delete(mergeKey)
+      keyRedirect.set(mergeKey, anchorKey)
+      orphanAnchor.set(canon, anchorKey)
+    }
 
     /** Resolve an envelope's natural threadKey through the
      *  redirect chain to the post-merge canonical key. */
@@ -1279,12 +1330,16 @@
                        primary tint, primary-coloured count, and
                        an inline SVG chevron that rotates 180° on
                        expand.  Click toggles the thread below;
-                       `stopPropagation` so the row click (which
-                       opens the head message) doesn't fire
-                       alongside.  Inline SVG instead of an Icon
-                       registry entry — `chevron-down` isn't a
-                       stock icon in Icon.svelte and a 12 px path
-                       is too small to justify a new file. -->
+                       `stopPropagation` on click AND dblclick so
+                       neither the row's click (which opens the
+                       head message) nor its dblclick (which pops
+                       the message out to a standalone window) fire
+                       through the button — the count badge is for
+                       expanding the thread, full stop.
+                       Inline SVG instead of an Icon registry entry —
+                       `chevron-down` isn't a stock icon in
+                       Icon.svelte and a 12 px path is too small
+                       to justify a new file. -->
                   <button
                     type="button"
                     class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-primary-500/10 text-primary-600 dark:text-primary-400 hover:bg-primary-500/20 transition-colors"
@@ -1295,6 +1350,7 @@
                       e.stopPropagation()
                       toggleThread(row.threadKey)
                     }}
+                    ondblclick={(e) => e.stopPropagation()}
                   >
                     <span>{row.siblingCount + 1}</span>
                     <svg

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -87,6 +87,16 @@
      *  the active-account avatar in the IconRail (#161) — the
      *  inline "Refreshing…" strip used to live here. */
     refreshing?: boolean
+    /** Bindable mirror of the post-merge thread membership map
+     *  (#289 follow-up).  Keyed by `${account_id}::${folder}::${uid}`,
+     *  value is every envelope in that thread's bucket newest-first
+     *  (head is `[0]`).  App.svelte reads this to give MailView's
+     *  archive button the thread member UIDs when the open mail is
+     *  a thread head, so a single archive click can sweep the whole
+     *  conversation.  Bindable rather than callback so the parent
+     *  always sees the latest map without one-shot fire-and-forget
+     *  semantics. */
+    threadMembersByEnv?: Map<string, EmailEnvelope[]>
   }
   let {
     accounts = [],
@@ -99,6 +109,7 @@
     envelopes = $bindable([]),
     onmessagemoved,
     refreshing = $bindable(false),
+    threadMembersByEnv = $bindable(new Map<string, EmailEnvelope[]>()),
   }: Props = $props()
 
   // ── Conversation-view grouping (#277) ───────────────────────
@@ -380,7 +391,14 @@
   })
 
   let renderRows = $derived(threadView.rows)
-  let threadMembersByEnv = $derived(threadView.threadMembersByEnv)
+  // Mirror the derived map into the bindable prop so App.svelte sees
+  // each fresh bucketing pass.  `$effect` (not `$derived`) because
+  // we already declared `threadMembersByEnv` as a bindable prop
+  // above — derive-into-prop isn't supported, but a one-line effect
+  // achieves the same observable behaviour.
+  $effect(() => {
+    threadMembersByEnv = threadView.threadMembersByEnv
+  })
 
   /** Short label for the per-row account chip in unified mode. We
       prefer the display name and fall back to the email's local part

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -131,6 +131,16 @@
      *  MailList's flag and shows a calm spinner on the
      *  IconRail's active-account avatar (#161). */
     refreshing?: boolean
+    /** UIDs of every member of the thread the open message
+     *  belongs to (#289 follow-up).  Populated only when the
+     *  open message is the *head* of a multi-member thread
+     *  (the row that carries the count badge in MailList); `null`
+     *  otherwise.  When non-null, the archive button sweeps the
+     *  whole conversation in a single batched IMAP move instead
+     *  of archiving only the head row.  Move-to-folder is handled
+     *  in MailList already (via `affectedEnvelopes`), so this
+     *  prop only drives archive here. */
+    threadMemberUids?: number[] | null
   }
   let {
     accountId,
@@ -152,6 +162,7 @@
     linkCheckEnabled = true,
     onmailto,
     refreshing = $bindable(false),
+    threadMemberUids = null,
   }: Props = $props()
 
   let email = $state<Email | null>(null)
@@ -1289,6 +1300,32 @@
     const removedUid = uid
     const acc = email.account_id
     const fld = email.folder
+    // Whole-thread archive (#289 follow-up): when the parent's
+    // selection-aware derivation has handed us a member-UID list,
+    // the open message is the head of a multi-member thread and a
+    // single archive click should sweep every member.  We fire
+    // `onmessageremoved` for each UID FIRST (so MailList's
+    // bound-envelope splice and the auto-advance logic both run
+    // against the still-populated list), then dispatch the batched
+    // backend call.  Falls back to the single-UID path otherwise
+    // — no need to invoke the batch IPC for a single message.
+    const members =
+      threadMemberUids && threadMemberUids.length > 1
+        ? threadMemberUids
+        : null
+    if (members) {
+      for (const u of members) onmessageremoved?.(u)
+      try {
+        await invoke('archive_messages', {
+          accountId: acc,
+          folder: fld,
+          uids: members,
+        })
+      } catch (e) {
+        error = formatError(e) || 'Failed to archive'
+      }
+      return
+    }
     onmessageremoved?.(removedUid)
     try {
       await invoke('archive_message', {


### PR DESCRIPTION
## Summary
Closes 3 of 4 bullets in #289 (with two bonus enhancements on top), and defers the fourth to a follow-up.

- **Orphan-reply merge** in `MailList.renderRows`: when every surviving bucket for a canonical subject is reply-shaped (`Re: Foo`) — typically because the original got archived or deleted server-side — the existing subject-merge pass had no non-reply root to anchor on and left the buckets separate. A new pass picks the oldest reply bucket as the anchor and folds the rest into it. Same 4-char canonical-subject floor as the first-pass merge to avoid cascading on trivial subjects.
- **Count-button dblclick**: the conversation-count badge now stops `ondblclick` propagation, so double-clicking the count no longer bubbles to the row's dblclick handler and pops the head message into a standalone window. The button is for expanding the thread, full stop.
- **Whole-thread move from the head row**: dragging the thread-head row to a folder, or right-click "Move to folder…" on it, now sweeps every member of the conversation along with it instead of leaving hidden siblings behind. Powered by a new `threadMembersByEnv` derived published alongside `renderRows`, consumed by an `expandThread` option on `affectedEnvelopes`. Stacks cleanly with multi-select — each selected head's thread is swept in turn, deduped by envelope key.
- **Whole-thread archive from the head row**: symmetric counterpart in MailView's archive button. New batched `archive_messages` IPC mirrors `move_messages` but resolves the archive folder once. MailList exposes `threadMembersByEnv` as a bindable prop; App.svelte derives `currentThreadMemberUids` for the open mail (only when it's the head row) and threads it to MailView, which dispatches the batch when present.
- Delete and read/unread keep their per-row scope — delete because it's destructive and an accidental whole-thread delete is hard to undo; read/unread because the existing converge-on-right-clicked-state semantics fit the per-row model.
- **Comment cleanups** in the surrounding threading code per the CLAUDE.md no-other-mail-client rule (retroactive).

## What was tried and dropped
Cross-folder thread partners (the fourth #289 bullet) were prototyped end-to-end: a `get_thread_partners` cache method, anchor collection, a settings toggle, folder chip rendering, `selectedMessageFolder` routing, a `mail-moved` Tauri event to dodge the post-move race. Even after fixing the race, the moved row reliably failed to appear as a sibling — the failure modes (cache-reconciliation timing, server-side header preservation across COPY, anchor coverage when the only remaining peer is in the target folder) were broader than fits in this PR. Reverted to keep the scope honest. Follow-up issue recommended.

## Test plan
- [x] Inbox with two mails whose subjects are `Re: Project plan` and `Re: Project plan` but no `In-Reply-To`/`References` chain joining them → they bucket together as one thread.
- [x] Inbox with `Foo` (root) + `Re: Foo` (reply) → still threads as before (first-pass merge handles this; orphan pass skipped because pass-1 won the canon).
- [ ] Trivial canonical subjects (`hi`, `?`) don't cascade-merge unrelated threads.
- [x] Thread with 2+ siblings → single-click the count badge expands/collapses (unchanged).
- [x] Thread with 2+ siblings → **double-click the count badge** does *not* pop out the head message in a standalone window.
- [x] Double-click any other part of the row → still pops the message out as before.
- [x] **Drag a thread head row to another folder in the sidebar** → all members of the thread move, including hidden siblings.
- [x] **Right-click a thread head → "Move to folder…"** → label shows the expanded count (`Move 3 messages to folder…`), and the picker move sweeps every member.
- [x] **Open a thread head + click Archive in MailView** → all members of the thread archive in one batched move; auto-advance lands on the next row below the (now-gone) thread.
- [x] Open a sibling row (with the thread expanded) + click Archive → only that sibling archives.
- [x] Open a single mail (no thread) + click Archive → still archives the one mail via the existing single-UID IPC.
- [x] Right-click a thread head → "Delete" → only the head row deletes (siblings stay).
- [x] Right-click a thread head → "Mark as read/unread" → only the head row toggles (siblings stay).
- [x] Multi-select two thread heads + drag → both threads move in full (each head's siblings included), deduped.
- [x] Drag / move-picker on a sibling row (with the thread expanded) → only that sibling moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)