### PR TITLE
#295: persist trusted-senders allow-list across NC settings sync

### DIFF
--- a/License.md
+++ b/License.md
@@ -57,7 +57,7 @@ The following packages are distributed under the MIT License:
 `@skeletonlabs/skeleton-svelte`, `@sveltejs/vite-plugin-svelte`,
 `@tailwindcss/typography`, `@tailwindcss/vite`, `@tsconfig/svelte`,
 `@types/dompurify`, `@types/node`, `@inlang/paraglide-js`,
-`svelte`, `svelte-check`, `tailwindcss`, `vite`.
+`svelte`, `svelte-check`, `tailwindcss`, `vite`, `vitest`.
 
 Several of these are dual-licensed `MIT OR Apache-2.0`; we list each
 package only under its first applicable section here.

--- a/SBOM.md
+++ b/SBOM.md
@@ -113,7 +113,7 @@ strong-copyleft licence stronger than what we already have (e.g.
 AGPL-3.0) is a project-level decision, not a routine PR. See
 [CLAUDE.md](CLAUDE.md) for the AI-assistant version of this rule.
 
-Last manual reconciliation: 2026-05-06 (CodeMirror 6 + `marked` added for the Notes UI overhaul, #138 — both MIT, no licence pressure).
+Last manual reconciliation: 2026-05-15 (`vitest` added for frontend pure-function tests, #295 — MIT, devDependency only, no licence pressure).
 
 ---
 
@@ -224,6 +224,7 @@ don't affect distribution. Still worth knowing what's in the toolchain:
 | `tailwindcss` | MIT | CSS framework. |
 | `typescript` | Apache-2.0 | TS compiler. |
 | `vite` | MIT | Build tool / dev server. |
+| `vitest` | MIT | Frontend unit-test runner (#295). Runs pure-function tests via `npm test`; not wired into CI yet — local-only smoke for now. |
 
 ---
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -57,7 +57,8 @@
         "svelte-check": "^4.4.6",
         "tailwindcss": "^4.2.2",
         "typescript": "~6.0.2",
-        "vite": "^8.0.4"
+        "vite": "^8.0.4",
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -835,6 +836,13 @@
       "bin": {
         "sqlite-wasm": "bin/index.js"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
@@ -1789,6 +1797,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/dompurify": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
@@ -1820,6 +1846,119 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@zag-js/accordion": {
       "version": "1.39.0",
@@ -2460,6 +2599,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2467,6 +2616,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -2542,6 +2701,13 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -2639,6 +2805,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -2674,6 +2847,26 @@
         "@typescript-eslint/types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -3115,6 +3308,13 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3381,6 +3581,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3402,6 +3609,20 @@
       "peerDependencies": {
         "kysely": "*"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -3501,6 +3722,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3516,6 +3754,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3688,6 +3936,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -3700,6 +4038,23 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "npm run paraglide:compile && svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
-    "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide"
+    "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@inlang/paraglide-js": "^2.18.0",
@@ -24,7 +25,8 @@
     "svelte-check": "^4.4.6",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.2",
-    "vite": "^8.0.4"
+    "vite": "^8.0.4",
+    "vitest": "^4.1.6"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.2",

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -41,6 +41,10 @@
     uploadBundle,
     type SettingsSyncStateView,
   } from './settingsBundle'
+  import {
+    listTrustedSenders,
+    removeTrustedSender,
+  } from './trustedSenders'
 
   // Friendly labels for the locale picker.  Keep the codes in
   // lockstep with `project.inlang/settings.json`.  Native
@@ -279,6 +283,21 @@
    *  fetching it via IPC because it's stable, public, and
    *  changing it would be a breaking change in any case. */
   const DEFAULT_NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org'
+
+  // ── Trusted senders (#295) ──────────────────────────────────
+  // Mirrors the localStorage allow-list maintained by
+  // `trustedSenders.ts`.  Loaded once on mount and refreshed
+  // after each remove — the list is small (typically a handful
+  // of entries) so a full re-read is cheaper than threading a
+  // subscription through.
+  let trustedSenders = $state<string[]>([])
+  $effect(() => {
+    trustedSenders = listTrustedSenders()
+  })
+  function onRemoveTrustedSender(addr: string) {
+    removeTrustedSender(addr)
+    trustedSenders = listTrustedSenders()
+  }
 
   // ── Logo / app-icon picker (Issue #X) ───────────────────────
   // Each entry is one slug the Rust side knows: the image source
@@ -1416,29 +1435,6 @@
         </div>
       </div>
       <div class="space-y-3 text-sm">
-        <!-- Auto-load remote images (#197).  Off by default —
-             every loaded remote image is a tracking signal back
-             to the sender ("yes, this address is alive and the
-             user read it at $time").  When on, the per-message
-             "Remote images are blocked" banner is hidden and
-             every HTML mail renders with its remote images
-             loaded. Per-message "Show images" and per-sender
-             trust still work the same way regardless. -->
-        <div class="flex items-start gap-3">
-          <Toggle
-            bind:checked={appSettings.auto_load_remote_images}
-            label="Auto-load remote images in HTML mail"
-            onchange={() => scheduleSave()}
-          />
-          <div>
-            <span>Auto-load remote images in HTML mail</span>
-            <p class="text-xs text-surface-400 mt-0.5">
-              Off (default) blocks remote images and shows a "Show images" banner per message — protects against tracking pixels.
-              On loads every image automatically and hides the banner.
-            </p>
-          </div>
-        </div>
-
         <!-- #165 — URLhaus link checker.  When on, every link in
              a rendered email gets a green "Safe" / red "Unsafe"
              pill, and a click on an Unsafe link goes through a
@@ -1522,6 +1518,65 @@
             onchange={() => scheduleSave()}
           />
           <span>Show desktop notifications for new mail</span>
+        </div>
+
+        <!-- Auto-load remote images (#197).  Off by default —
+             every loaded remote image is a tracking signal back
+             to the sender ("yes, this address is alive and the
+             user read it at $time").  When on, the per-message
+             "Remote images are blocked" banner is hidden and
+             every HTML mail renders with its remote images
+             loaded. Per-message "Show images" and per-sender
+             trust still work the same way regardless.  Sits
+             directly above the trusted-senders list so the two
+             remote-image controls read as a pair. -->
+        <div class="flex items-start gap-3">
+          <Toggle
+            bind:checked={appSettings.auto_load_remote_images}
+            label="Auto-load remote images in HTML mail"
+            onchange={() => scheduleSave()}
+          />
+          <div>
+            <span>Auto-load remote images in HTML mail</span>
+            <p class="text-xs text-surface-400 mt-0.5">
+              Off (default) blocks remote images and shows a "Show images" banner per message — protects against tracking pixels.
+              On loads every image automatically and hides the banner.
+            </p>
+          </div>
+        </div>
+
+        <!-- Trusted senders (#295).  Per-sender allow-list driven
+             by the "Always show from X" button on the in-message
+             blocked-images banner.  Listing the entries here lets
+             users review what they've trusted and revoke individual
+             addresses without having to reset the whole list. -->
+        <div class="pt-2">
+          <h3 class="text-sm font-medium mb-1">Trusted senders</h3>
+          <p class="text-xs text-surface-400 mb-2">
+            Addresses you've chosen "Always show from" for.  Remote images
+            from these senders load automatically even when the auto-load
+            toggle is off.
+          </p>
+          {#if trustedSenders.length === 0}
+            <p class="text-xs text-surface-500 italic">
+              No trusted senders yet.  Open a message with blocked images
+              and use "Always show from [sender]" on the banner to add one.
+            </p>
+          {:else}
+            <ul class="divide-y divide-surface-200 dark:divide-surface-700 rounded-md border border-surface-200 dark:border-surface-700 max-w-xl">
+              {#each trustedSenders as addr (addr)}
+                <li class="flex items-center gap-3 px-3 py-2">
+                  <span class="flex-1 min-w-0 truncate text-sm font-mono">{addr}</span>
+                  <button
+                    class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-red-500/15 hover:text-red-500 hover:border-red-500/40"
+                    title="Remove trusted sender"
+                    aria-label="Remove trusted sender {addr}"
+                    onclick={() => onRemoveTrustedSender(addr)}
+                  ><Icon name="trash" size={14} /></button>
+                </li>
+              {/each}
+            </ul>
+          {/if}
         </div>
       </div>
     </div>
@@ -1914,21 +1969,19 @@
                   </div>
                 </div>
               </div>
-              <div class="flex flex-col items-end gap-1">
+              <div class="flex items-center gap-1">
                 <button
-                  class="btn btn-sm preset-outlined-surface-500 px-2 py-1 inline-flex items-center justify-center"
+                  class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center"
                   title="Connection settings — edit server hostnames, ports, password, and trust certificates"
                   aria-label="Connection settings"
                   onclick={() => openServerEdit(account)}
-                >
-                  <Icon name="settings" size={18} />
-                </button>
+                ><Icon name="settings" size={16} /></button>
                 <button
-                  class="btn btn-sm preset-outlined-error-500"
+                  class="btn btn-sm preset-outlined-surface-500 inline-flex items-center justify-center hover:bg-red-500/15 hover:text-red-500 hover:border-red-500/40"
+                  title="Remove account"
+                  aria-label="Remove account {account.email}"
                   onclick={() => removeAccount(account.id, account.email)}
-                >
-                  Remove
-                </button>
+                ><Icon name="trash" size={16} /></button>
               </div>
             </div>
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -27,6 +27,11 @@
     isPdfAttachment,
     openAttachment,
   } from './attachmentOpen'
+  import {
+    addTrustedSender,
+    getSenderAddress,
+    isSenderTrusted,
+  } from './trustedSenders'
 
   interface EmailAttachment {
     filename: string
@@ -436,37 +441,6 @@
   // ── Per-sender image trust (persisted in localStorage) ──────────────
   // senders the user has chosen "always show images from" live here.
   // Key format: ["user@example.com", ...] — lower-cased bare addresses.
-
-  const TRUSTED_SENDERS_KEY = 'nimbus-trusted-senders'
-
-  function getSenderAddress(from: string): string {
-    const m = from.match(/<([^>]+)>/)
-    return (m ? m[1] : from).trim().toLowerCase()
-  }
-
-  function isSenderTrusted(from: string): boolean {
-    try {
-      const raw = localStorage.getItem(TRUSTED_SENDERS_KEY)
-      const list: string[] = raw ? JSON.parse(raw) : []
-      return list.includes(getSenderAddress(from))
-    } catch {
-      return false
-    }
-  }
-
-  function addTrustedSender(from: string) {
-    try {
-      const raw = localStorage.getItem(TRUSTED_SENDERS_KEY)
-      const list: string[] = raw ? JSON.parse(raw) : []
-      const addr = getSenderAddress(from)
-      if (!list.includes(addr)) {
-        list.push(addr)
-        localStorage.setItem(TRUSTED_SENDERS_KEY, JSON.stringify(list))
-      }
-    } catch {
-      console.warn('Failed to persist trusted sender')
-    }
-  }
 
   // Per-message "Show images" toggle; reset to false on every new message.
   let showImagesForMessage = $state(false)

--- a/ui/src/lib/trustedSenders.test.ts
+++ b/ui/src/lib/trustedSenders.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+// The settings-bundle module pulls in Tauri runtime APIs that
+// don't exist in node.  We only care that the notify hook
+// fires after each mutation — stubbing the whole module keeps
+// the test environment minimal (no jsdom, no Tauri shims).
+const notifyMock = vi.fn(async () => {})
+vi.mock('./settingsBundle', () => ({
+  notifySettingsChanged: notifyMock,
+}))
+
+// In-memory localStorage stub.  vitest's default `environment:
+// 'node'` doesn't ship one; we set this on `globalThis` before
+// importing the module under test so the import-time module
+// init sees it the same way the browser would.
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value)
+  }
+  removeItem(key: string): void {
+    this.store.delete(key)
+  }
+  clear(): void {
+    this.store.clear()
+  }
+}
+
+let storage: MemoryStorage
+beforeEach(() => {
+  storage = new MemoryStorage()
+  ;(globalThis as unknown as { localStorage: MemoryStorage }).localStorage = storage
+  notifyMock.mockClear()
+})
+afterEach(() => {
+  delete (globalThis as unknown as { localStorage?: MemoryStorage }).localStorage
+})
+
+// Dynamic import inside each test so module init re-runs
+// against the fresh storage stub — top-level imports would
+// bind to the first stub and leak state across tests.
+async function importModule() {
+  return await import('./trustedSenders')
+}
+
+describe('getSenderAddress', () => {
+  test('extracts the angle-bracketed address from a full From header', async () => {
+    const { getSenderAddress } = await importModule()
+    expect(getSenderAddress('"Jane Doe" <jane@example.org>')).toBe('jane@example.org')
+  })
+
+  test('lower-cases the result so case-only variations collapse', async () => {
+    const { getSenderAddress } = await importModule()
+    expect(getSenderAddress('Sender@Example.COM')).toBe('sender@example.com')
+  })
+
+  test('falls back to the whole string when no brackets are present', async () => {
+    const { getSenderAddress } = await importModule()
+    expect(getSenderAddress(' alex@example.com ')).toBe('alex@example.com')
+  })
+})
+
+describe('addTrustedSender', () => {
+  test('persists the address and notifies the sync worker', async () => {
+    const { addTrustedSender, isSenderTrusted } = await importModule()
+    addTrustedSender('"Alex Morgan" <alex@example.com>')
+    expect(isSenderTrusted('alex@example.com')).toBe(true)
+    expect(notifyMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('is a no-op (and skips notify) when the address is already trusted', async () => {
+    const { addTrustedSender } = await importModule()
+    addTrustedSender('jane@example.org')
+    notifyMock.mockClear()
+    addTrustedSender('"Jane Doe" <jane@example.org>')
+    expect(notifyMock).not.toHaveBeenCalled()
+  })
+
+  test('treats case-only variations as the same address', async () => {
+    const { addTrustedSender, listTrustedSenders } = await importModule()
+    addTrustedSender('Jane@Example.Org')
+    addTrustedSender('jane@example.org')
+    expect(listTrustedSenders()).toEqual(['jane@example.org'])
+  })
+})
+
+describe('removeTrustedSender', () => {
+  test('removes a previously-added address and notifies', async () => {
+    const { addTrustedSender, removeTrustedSender, isSenderTrusted } = await importModule()
+    addTrustedSender('alex@example.com')
+    notifyMock.mockClear()
+    removeTrustedSender('alex@example.com')
+    expect(isSenderTrusted('alex@example.com')).toBe(false)
+    expect(notifyMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('accepts a full From header and normalises before removing', async () => {
+    const { addTrustedSender, removeTrustedSender, isSenderTrusted } = await importModule()
+    addTrustedSender('jane@example.org')
+    removeTrustedSender('"Jane Doe" <Jane@Example.org>')
+    expect(isSenderTrusted('jane@example.org')).toBe(false)
+  })
+
+  test('is a no-op when the address is not present', async () => {
+    const { removeTrustedSender } = await importModule()
+    removeTrustedSender('ghost@example.com')
+    expect(notifyMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('listTrustedSenders', () => {
+  test('returns the addresses sorted alphabetically', async () => {
+    const { addTrustedSender, listTrustedSenders } = await importModule()
+    addTrustedSender('charlie@example.com')
+    addTrustedSender('alex@example.com')
+    addTrustedSender('Bob@example.com')
+    expect(listTrustedSenders()).toEqual([
+      'alex@example.com',
+      'bob@example.com',
+      'charlie@example.com',
+    ])
+  })
+
+  test('returns an empty array when the key is unset', async () => {
+    const { listTrustedSenders } = await importModule()
+    expect(listTrustedSenders()).toEqual([])
+  })
+})

--- a/ui/src/lib/trustedSenders.ts
+++ b/ui/src/lib/trustedSenders.ts
@@ -1,0 +1,93 @@
+// Trusted-senders allow-list for the "Always show images from
+// [sender]" affordance.
+//
+// Stored in `localStorage` under `nimbus-trusted-senders` as a
+// JSON array of lower-cased bare email addresses.  The key is
+// listed in `settingsBundle.ts#SYNCED_LOCAL_STORAGE_KEYS`, so it
+// rides along with every settings-bundle write (manual export +
+// Nextcloud auto-sync) and is restored on import.
+//
+// Every mutation calls `notifySettingsChanged()` so the
+// auto-sync worker picks up the change immediately — otherwise
+// the list lives only in the local browser until some *other*
+// settings mutation happens to push the bundle, and a Nextcloud
+// restore in between would wipe the entry (#295).
+
+import { notifySettingsChanged } from './settingsBundle'
+
+const TRUSTED_SENDERS_KEY = 'nimbus-trusted-senders'
+
+/**
+ * Strip the angle-bracketed address out of an RFC 5322 `From:`
+ * string and lower-case it.  `"Jane Doe" <jane@example.org>` →
+ * `jane@example.org`.  When the input has no brackets we treat
+ * the whole string as an address.
+ */
+export function getSenderAddress(from: string): string {
+  const m = from.match(/<([^>]+)>/)
+  return (m ? m[1] : from).trim().toLowerCase()
+}
+
+function readList(): string[] {
+  try {
+    const raw = localStorage.getItem(TRUSTED_SENDERS_KEY)
+    return raw ? (JSON.parse(raw) as string[]) : []
+  } catch {
+    return []
+  }
+}
+
+function writeList(list: string[]): boolean {
+  try {
+    localStorage.setItem(TRUSTED_SENDERS_KEY, JSON.stringify(list))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** All trusted addresses, sorted alphabetically for stable UI display. */
+export function listTrustedSenders(): string[] {
+  return readList().slice().sort()
+}
+
+/** Whether the given `From:` header's address is on the allow-list. */
+export function isSenderTrusted(from: string): boolean {
+  return readList().includes(getSenderAddress(from))
+}
+
+/**
+ * Add a sender's address to the allow-list.  No-op when already
+ * present.  After a successful write, pings the settings-sync
+ * worker so the change reaches Nextcloud before a restore could
+ * overwrite it.
+ */
+export function addTrustedSender(from: string): void {
+  const addr = getSenderAddress(from)
+  if (!addr) return
+  const list = readList()
+  if (list.includes(addr)) return
+  list.push(addr)
+  if (writeList(list)) {
+    void notifySettingsChanged()
+  } else {
+    console.warn('Failed to persist trusted sender')
+  }
+}
+
+/**
+ * Remove an address from the allow-list.  Accepts either a bare
+ * address or a full `From:` header — both are normalised through
+ * `getSenderAddress`.  No-op when not present.
+ */
+export function removeTrustedSender(fromOrAddr: string): void {
+  const addr = getSenderAddress(fromOrAddr)
+  const list = readList()
+  const next = list.filter((a) => a !== addr)
+  if (next.length === list.length) return
+  if (writeList(next)) {
+    void notifySettingsChanged()
+  } else {
+    console.warn('Failed to update trusted senders')
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,4 +1,8 @@
-import { defineConfig } from 'vite'
+// `defineConfig` from `vitest/config` is a thin superset of vite's
+// — it adds the `test` field's type so the tsc step in `npm run
+// check` accepts our test config block.  Behaves identically to
+// vite's `defineConfig` for the build / dev paths.
+import { defineConfig } from 'vitest/config'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { paraglideVitePlugin } from '@inlang/paraglide-js'
@@ -30,5 +34,13 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+  },
+  // Vitest config — pure-function tests only.  Stays on node
+  // (no jsdom) and stubs `globalThis.localStorage` per test;
+  // adding component tests later would need a DOM environment
+  // opted in via `// @vitest-environment` comments.
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- Wire `notifySettingsChanged()` into the trusted-senders allow-list so "Always show from [sender]" survives a Nextcloud bundle restore. The key was already part of the synced bundle, but without notify it only made it to NC when *some other* settings mutation happened to push first — a restore in between would drop the entry.
- Extract the helpers from `MailView.svelte` into a new `ui/src/lib/trustedSenders.ts` (notify-on-mutate, plus `listTrustedSenders` / `removeTrustedSender` for the management UI).
- Add a "Trusted senders" section to the Mail preferences panel: lists every trusted address with an icon-only trash button per row. Auto-load remote images toggle moved next to it so the two image-related controls read as a pair. Mail-account row's "Remove" text button was switched to the same trash-icon affordance for consistency.
- Bring up vitest for frontend pure-function tests (node env, no jsdom). 11 unit tests cover the new module and verify the notify hook fires on every mutation.

Closes #295

## Test plan
- [x] `cd ui && npm test` — all 11 tests pass
- [x] `cd ui && npm run check` — typecheck clean
- [x] `cargo fmt --check && cargo check --workspace` — clean
- [x] Manual: open a message with blocked remote images → click "Always show from X" → quit the app → reopen → reopen the same message → banner stays gone and the address is listed in Settings ▸ E-Mail ▸ Trusted senders.
- [x] Manual: open Settings ▸ E-Mail ▸ Trusted senders → click the trash icon next to an address → row disappears → next message from that sender shows the blocked-images banner again.
- [x] Manual: mail-account row's trash button still prompts for confirmation and removes the account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)