### PR TITLE
#292: shrink compose into a tab bar, persist drafts across the lifecycle

### DIFF
--- a/crates/nimbus-imap/src/client.rs
+++ b/crates/nimbus-imap/src/client.rs
@@ -1296,6 +1296,55 @@ impl ImapClient {
         Ok(())
     }
 
+    /// Look up the UID of a just-APPENDed message by its `Message-ID`
+    /// header.
+    ///
+    /// The `APPEND` command in `async-imap` 0.10 doesn't surface the
+    /// server's `APPENDUID` response, so we can't learn the assigned
+    /// UID directly from the APPEND result. For the minimize-as-draft
+    /// flow (#292) we need that UID so a subsequent save can use
+    /// `replaceSource` to atomically supersede the previous copy in
+    /// place of leaving a trail of duplicate drafts behind.
+    ///
+    /// `Message-ID` works as a stable handle because lettre stamps
+    /// every outgoing message with a UUID-anchored `<uuid@host>` value
+    /// (see `build_outgoing_message`), so the search criterion is
+    /// effectively unique. Returns the highest matching UID — on the
+    /// unlikely event of a collision the most recent server-assigned
+    /// UID is the one we just wrote.
+    ///
+    /// `message_id` is the bare header value including the angle
+    /// brackets (e.g. `<abc@host>`), matching what the IMAP server
+    /// stored.
+    pub async fn find_uid_by_message_id(
+        &mut self,
+        folder: &str,
+        message_id: &str,
+    ) -> Result<Option<u32>, NimbusError> {
+        let _ = self.select_folder(folder).await?;
+        let session = self
+            .session
+            .as_mut()
+            .ok_or_else(|| NimbusError::Protocol("Session is closed".into()))?;
+
+        // IMAP quoted strings only need to escape `\` and `"` — the
+        // Message-ID's `<uuid@host>` shape contains neither, but
+        // escape defensively anyway in case a future caller passes
+        // a less well-behaved value through.
+        let escaped = message_id.replace('\\', "\\\\").replace('"', "\\\"");
+        let criterion = format!("HEADER \"Message-ID\" \"{escaped}\"");
+        let uids: Vec<u32> = session
+            .uid_search(&criterion)
+            .await
+            .map_err(|e| {
+                NimbusError::Protocol(format!("UID SEARCH HEADER Message-ID failed: {e}"))
+            })?
+            .into_iter()
+            .collect();
+
+        Ok(uids.into_iter().max())
+    }
+
     /// Move a message between folders via `UID COPY` + delete.
     ///
     /// Why not `UID MOVE` (RFC 6851)? MOVE is cleaner but requires the

--- a/crates/nimbus-store/src/cache/mod.rs
+++ b/crates/nimbus-store/src/cache/mod.rs
@@ -861,6 +861,70 @@ impl Cache {
         Ok(())
     }
 
+    /// Same as [`mark_message_pending`] but creates a placeholder
+    /// row when the target UID isn't cached yet (#292 follow-up).
+    ///
+    /// The minimize-save path APPENDs to IMAP without writing the
+    /// new envelope into the cache — `save_draft` only invokes
+    /// `remove_envelope` on the replaced source, never `upsert` on
+    /// the freshly-APPENDed copy.  A subsequent send that targets
+    /// the minimize-saved UID hits a tombstone-via-UPDATE that
+    /// silently misses (zero rows updated), so the next
+    /// `poll_folder` re-fetches the row from IMAP and INSERTs it
+    /// without a `pending_action`, causing the row to flash back
+    /// into the visible list until the real IMAP DELETE catches
+    /// up.
+    ///
+    /// This variant guarantees the tombstone lands: UPDATE first,
+    /// and if no row matched, INSERT a placeholder carrying the
+    /// pending flag.  `get_envelopes` filters out any row with
+    /// `pending_action IS NOT NULL`, so the placeholder is
+    /// invisible.  When `poll_folder`'s upsert later writes the
+    /// real envelope, the `ON CONFLICT … DO UPDATE` clause
+    /// deliberately *doesn't* touch `pending_action`, so the
+    /// tombstone survives the merge.  On IMAP success the row
+    /// gets dropped entirely via `remove_envelope`; on IMAP
+    /// failure `clear_message_pending` un-tombstones, which
+    /// briefly exposes the placeholder's empty fields — accepted
+    /// as a rare edge case since the next poll fills them in.
+    pub fn upsert_message_pending(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+        action: &str,
+    ) -> Result<(), CacheError> {
+        let conn = self.conn()?;
+        let updated = conn.execute(
+            "UPDATE messages SET pending_action = ?4
+             WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+            params![account_id, folder, uid as i64, action],
+        )?;
+        if updated > 0 {
+            return Ok(());
+        }
+        // Row missing — insert a placeholder.  `INSERT OR IGNORE`
+        // covers the race where a concurrent poll inserts the
+        // real row between our UPDATE-found-nothing and this
+        // INSERT; in that case we'd need a second UPDATE to flip
+        // pending_action on, so we re-run the UPDATE
+        // unconditionally below.
+        let now = Utc::now().timestamp();
+        conn.execute(
+            "INSERT OR IGNORE INTO messages
+                (account_id, folder, uid, internal_date, cached_at, pending_action)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![account_id, folder, uid as i64, now, now, action],
+        )?;
+        conn.execute(
+            "UPDATE messages SET pending_action = ?4
+             WHERE account_id = ?1 AND folder = ?2 AND uid = ?3
+                   AND pending_action IS NULL",
+            params![account_id, folder, uid as i64, action],
+        )?;
+        Ok(())
+    }
+
     /// Reverse of `mark_message_pending` — called when the IMAP
     /// action errors so the row reappears in the next list pull
     /// without the user having to restart anything.
@@ -1471,6 +1535,40 @@ impl Cache {
     /// Push a fresh outgoing message onto the queue.  Returns the
     /// generated row id so the caller (`send_email`) can hand it
     /// to the spawned drain task.
+    /// Atomic claim of a queued outbox row for the duration of a
+    /// single drain attempt (#292 follow-up).
+    ///
+    /// Both [`send_email`]'s spawned drain task and the periodic
+    /// `drain_outbox_sweep` operate on the same `outbox_messages`
+    /// table, and `try_drain_outbox_entry` was previously a plain
+    /// read-then-act with no exclusion.  If those two paths
+    /// happened to overlap (e.g. the user clicked Send a few
+    /// seconds before a sweep tick), both would read the row,
+    /// both would push the message through SMTP + APPEND-to-Sent,
+    /// and the recipient would receive the same mail twice.
+    ///
+    /// This is a CAS: bump `last_attempt_at` to `now` only when
+    /// no other drain has touched the row inside the last
+    /// `claim_ttl_secs` seconds.  Returns `true` when the caller
+    /// won the claim and should proceed, `false` when another
+    /// drain holds the row.  The TTL means that even if a drain
+    /// task panics or the process dies mid-send the row isn't
+    /// permanently stuck — the next sweep past the TTL boundary
+    /// reclaims it.
+    pub fn claim_outbox_for_drain(&self, id: i64, claim_ttl_secs: i64) -> Result<bool, CacheError> {
+        let conn = self.conn()?;
+        let now = Utc::now().timestamp();
+        let threshold = now - claim_ttl_secs;
+        let updated = conn.execute(
+            "UPDATE outbox_messages
+             SET last_attempt_at = ?1
+             WHERE id = ?2
+               AND (last_attempt_at IS NULL OR last_attempt_at < ?3)",
+            params![now, id, threshold],
+        )?;
+        Ok(updated > 0)
+    }
+
     pub fn enqueue_outbox(&self, input: &OutboxEnqueue) -> Result<i64, CacheError> {
         let conn = self.conn()?;
         let now = Utc::now().timestamp();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7422,6 +7422,28 @@ async fn send_email(
 /// missing local-side bookkeeping will reconcile on the next
 /// envelope fetch).
 async fn try_drain_outbox_entry(app: &AppHandle, cache: &Cache, entry_id: i64) {
+    // Claim the row before doing any real work (#292 follow-up).
+    // Without this guard, the spawned drain `send_email` kicks off
+    // and the periodic `drain_outbox_sweep` can both reach this
+    // function for the same `entry_id` — each reads the row, each
+    // pushes it through SMTP + APPEND-to-Sent, and the recipient
+    // receives the same mail twice.  A 30 s TTL is comfortable for
+    // any healthy SMTP roundtrip and short enough that a crashed
+    // drain stops blocking retries quickly.
+    match cache.claim_outbox_for_drain(entry_id, 30) {
+        Ok(true) => {}
+        Ok(false) => {
+            tracing::debug!(
+                "try_drain_outbox_entry: skipping entry {entry_id}, claim held by another drain"
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::warn!("claim_outbox_for_drain({entry_id}) failed: {e}");
+            return;
+        }
+    }
+
     let row = match cache.get_outbox(entry_id) {
         Ok(Some(r)) => r,
         Ok(None) => return, // Already removed (manual delete, race with another drain).
@@ -7847,6 +7869,54 @@ struct DraftReplaceSource {
     uid: u32,
 }
 
+/// What `save_draft` reports back to the caller (#292).
+///
+/// `folder` is the IMAP folder we APPENDed into (either the
+/// `replace_source.folder` when editing, or the result of
+/// `pick_drafts_folder` for a fresh draft). `uid` is the new
+/// server-assigned UID discovered via a `UID SEARCH HEADER
+/// Message-ID` round-trip after the APPEND — `None` when the
+/// search failed or returned no hits, in which case the caller
+/// has to treat the next save as a fresh APPEND and accept that
+/// the previous copy will remain in Drafts as a duplicate.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SavedDraft {
+    folder: String,
+    uid: Option<u32>,
+}
+
+/// Pull the `Message-ID` header value out of a raw RFC 822 message.
+///
+/// Returns the bare bracketed form (e.g. `<uuid@host>`) so the
+/// caller can hand it straight to `find_uid_by_message_id`, which
+/// SEARCHes on the literal header value the IMAP server stored.
+///
+/// Tolerant of casing variants (`Message-ID:` / `Message-Id:` /
+/// `message-id:`) since RFC 5322 header field names are case-
+/// insensitive. Folded continuation lines aren't expected for
+/// Message-ID values (lettre emits a single short line) but the
+/// scanner stops at the first match and bails on the first blank
+/// line, which is the conventional header/body separator.
+fn extract_message_id(raw: &[u8]) -> Option<String> {
+    let header_end = raw.windows(4).position(|w| w == b"\r\n\r\n")?;
+    let headers = std::str::from_utf8(&raw[..header_end]).ok()?;
+    for line in headers.split("\r\n") {
+        let prefix_len = if line.len() >= "Message-ID:".len()
+            && line[..="Message-ID:".len() - 1].eq_ignore_ascii_case("Message-ID:")
+        {
+            "Message-ID:".len()
+        } else {
+            continue;
+        };
+        let value = line[prefix_len..].trim();
+        if !value.is_empty() {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
 /// Save an in-progress message to the account's IMAP Drafts folder.
 ///
 /// Mirrors `send_email` structurally (same `OutgoingEmail` input, same
@@ -7870,7 +7940,7 @@ async fn save_draft(
     email: OutgoingEmail,
     replace_source: Option<DraftReplaceSource>,
     cache: State<'_, Cache>,
-) -> Result<(), NimbusError> {
+) -> Result<SavedDraft, NimbusError> {
     let account = load_account(&cache, &account_id)?;
 
     if uses_jmap(&account) {
@@ -7881,6 +7951,11 @@ async fn save_draft(
 
     let message = build_outgoing_message(&email)?;
     let raw = message.formatted();
+    // Pulled before APPEND so the post-APPEND SEARCH has a value
+    // to match against even if some later step (e.g. the replace
+    // delete) panics — `None` here just means we can't dedup the
+    // next save, not that the user's draft was lost.
+    let message_id = extract_message_id(&raw);
 
     // Prefer the source folder when replacing an existing draft so
     // APPEND and DELETE both target the folder the user actually
@@ -7893,15 +7968,53 @@ async fn save_draft(
         })?,
     };
 
+    // Optimistic-UI tombstone (#292 follow-up): mark the source
+    // draft as pending-delete BEFORE the IMAP roundtrip so any
+    // mid-flight `fetch_envelopes` (folder switch, sync tick) sees
+    // the cached row already filtered out.  Without this the
+    // frontend's `mergeEnvelopes` keeps the old UID alive in
+    // `existing` (it preserves rows the fresh batch didn't return,
+    // to support pagination) so the user briefly sees both copies
+    // until the eventual sync evicts the stale one.  Mirrors the
+    // pattern in `delete_message`.
+    //
+    // `upsert_message_pending` (not plain `mark_message_pending`)
+    // because chained minimize-saves leave the source UID without
+    // a corresponding cache row: the first minimize APPENDs uid N
+    // but never writes the envelope into the cache, so a second
+    // minimize trying to tombstone uid N as a UPDATE finds zero
+    // rows and silently misses.  A concurrent `poll_folder` mid-
+    // save then inserts the row from IMAP with `pending_action`
+    // NULL and the draft pops back into the visible list.
+    if let Some(src) = replace_source.as_ref()
+        && let Err(e) = cache.upsert_message_pending(&account_id, &src.folder, src.uid, "delete")
+    {
+        tracing::warn!("save_draft upsert_message_pending(delete) failed: {e}");
+    }
+
     let password = credentials::get_imap_password(&account.id)?;
-    let mut client = ImapClient::connect(
+    let connect_result = ImapClient::connect(
         &account.imap_host,
         account.imap_port,
         &account.email,
         &password,
         &account.trusted_certs,
     )
-    .await?;
+    .await;
+    let mut client = match connect_result {
+        Ok(c) => c,
+        Err(e) => {
+            // IMAP unreachable: un-tombstone the row so the user
+            // doesn't lose sight of their existing draft while
+            // we couldn't even attempt the replace.
+            if let Some(src) = replace_source.as_ref()
+                && let Err(c) = cache.clear_message_pending(&account_id, &src.folder, src.uid)
+            {
+                tracing::warn!("clear_message_pending after save_draft connect failure: {c}");
+            }
+            return Err(e);
+        }
+    };
 
     // `\Draft` marks the message as an unfinished draft. `\Seen`
     // keeps it out of the unread badge — there's no point notifying
@@ -7909,6 +8022,16 @@ async fn save_draft(
     let append_result = client
         .append_message(&target_folder, &raw, &["\\Draft", "\\Seen"])
         .await;
+
+    // APPEND failure: the new copy never landed, so the old draft
+    // is still authoritative — un-tombstone it so the user can
+    // see (and retry from) their unchanged source.
+    if append_result.is_err()
+        && let Some(src) = replace_source.as_ref()
+        && let Err(c) = cache.clear_message_pending(&account_id, &src.folder, src.uid)
+    {
+        tracing::warn!("clear_message_pending after save_draft APPEND failure: {c}");
+    }
 
     // Only attempt the delete if the APPEND actually succeeded —
     // otherwise a flaky APPEND would have us destroy the user's
@@ -7918,13 +8041,25 @@ async fn save_draft(
     // envelope left over from a previous expunge) — either way the
     // cached row is wrong and hanging onto it just makes the next
     // edit attempt fail the same way.
-    let result = if append_result.is_ok() {
-        if let Some(src) = replace_source {
+    let delete_result = if append_result.is_ok() {
+        if let Some(src) = replace_source.as_ref() {
             let delete_result = client.delete_message(&src.folder, src.uid).await;
-            if should_clean_cache_for_delete(&delete_result)
-                && let Err(e) = cache.remove_envelope(&account_id, &src.folder, src.uid)
+            let should_clean = should_clean_cache_for_delete(&delete_result);
+            if should_clean && let Err(e) = cache.remove_envelope(&account_id, &src.folder, src.uid)
             {
                 tracing::warn!("remove_envelope after save_draft replace failed: {e}");
+            }
+            // Real DELETE failure (not the stale-UID case the cleanup
+            // heuristic absorbs): the old draft is still on the
+            // server even though APPEND succeeded.  Un-tombstone so
+            // the user sees it again — the new copy is also in
+            // place, so the result is two visible drafts and the
+            // user can manually discard whichever they want.
+            if !should_clean
+                && delete_result.is_err()
+                && let Err(c) = cache.clear_message_pending(&account_id, &src.folder, src.uid)
+            {
+                tracing::warn!("clear_message_pending after save_draft DELETE failure: {c}");
             }
             match delete_result {
                 Ok(()) => Ok(()),
@@ -7940,8 +8075,181 @@ async fn save_draft(
         append_result
     };
 
+    // SEARCH the target folder for the just-APPENDed message by
+    // Message-ID so the caller can pass the new UID as
+    // `replace_source` on the next save (#292) — keeps Drafts
+    // pruned to one copy per in-flight Compose instead of letting
+    // every minimize stack a fresh duplicate. Best-effort: a
+    // missing Message-ID, a server that rejects the SEARCH, or a
+    // server that hasn't yet indexed the new mail all collapse
+    // back to `uid: None`, and the caller treats the next save as
+    // a fresh APPEND.
+    let new_uid = if delete_result.is_ok() {
+        match &message_id {
+            Some(id) => match client.find_uid_by_message_id(&target_folder, id).await {
+                Ok(uid) => uid,
+                Err(e) => {
+                    tracing::warn!("SEARCH after save_draft APPEND failed: {e}");
+                    None
+                }
+            },
+            None => {
+                tracing::warn!(
+                    "save_draft: could not extract Message-ID from raw bytes; \
+                     next save will not be able to replace this copy"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let _ = client.logout().await;
-    result
+    delete_result.map(|()| SavedDraft {
+        folder: target_folder,
+        uid: new_uid,
+    })
+}
+
+/// Synchronously tombstone a Drafts row that's about to be expunged
+/// by the send pipeline (#292 follow-up).
+///
+/// Compose's `send()` closes the modal immediately (#156's instant-
+/// close UX) and bumps `refreshToken` via the parent's
+/// `closeCompose`.  That bump triggers MailList's `load()` BEFORE
+/// the background `runSendPipeline` reaches its
+/// `invoke('delete_message')` call — so without an upfront
+/// tombstone, the fresh fetch returns the source draft and
+/// `mergeEnvelopes` puts it back in the visible list, where it
+/// hangs around until the next sync evicts it.
+///
+/// Calling this from the frontend BEFORE `onclose()` plants the
+/// tombstone in time: `get_cached_envelopes` filters on
+/// `pending_action IS NULL`, and `upsert_envelopes_for_account`
+/// doesn't include `pending_action` in its ON CONFLICT UPDATE list,
+/// so a concurrent sync writing the same row preserves the
+/// tombstone.  The eventual `delete_message` call still does the
+/// real IMAP work and either removes the row entirely (success)
+/// or clears the tombstone (real failure) — same semantics as
+/// calling `delete_message` alone, just split so the cache flag
+/// lands before the visible refresh.
+#[tauri::command]
+async fn tombstone_draft_for_expunge(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    // `upsert_message_pending` (not plain `mark_message_pending`)
+    // because a minimize-saved draft lives on the IMAP server
+    // without a corresponding cache row — `save_draft` only
+    // touches the cache on the replace path.  Without the upsert,
+    // an UPDATE-only tombstone would miss those UIDs entirely
+    // and the next poll would re-insert them sans `pending_action`,
+    // flashing the row back into the visible list (#292 follow-up).
+    cache
+        .upsert_message_pending(&account_id, &folder, uid, "delete")
+        .map_err(Into::into)
+}
+
+/// Permanently expunge a Drafts UID after the user sent its
+/// contents (#292 follow-up).
+///
+/// Different from the user-facing `delete_message` command in two
+/// important ways:
+///
+/// 1. **Skips move-to-Trash.**  `delete_message` routes "delete from
+///    a non-Trash folder" through a `UID COPY` to Trash followed by
+///    an EXPUNGE of the source.  That's right for a manual delete
+///    (user can recover from Trash) but wrong here: the draft was
+///    *consumed* by the send, depositing a duplicate in Trash
+///    would just clutter the user's mailbox.  Matches the inline
+///    expunge the `save_draft` replace path uses for the same
+///    reason.
+///
+/// 2. **Keeps the tombstone on IMAP failure.**  `delete_message`
+///    clears `pending_action` on real failures so the row reappears
+///    on the next poll — which is correct for a delete that the
+///    user can retry from the visible list, but produces the
+///    "draft flicks back into Drafts after sending" symptom here:
+///    the mail itself shipped, so the user expects the draft to
+///    be gone whether or not the cleanup IMAP DELETE landed.  We
+///    leave the tombstone in place; if the row really survived on
+///    the server, a folder-wipe reconcile or a fresh poll will
+///    eventually re-surface it, but the immediate post-send
+///    experience is correct.
+#[tauri::command]
+async fn expunge_draft_after_send(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    cache: State<'_, Cache>,
+) -> Result<(), NimbusError> {
+    let account = load_account(&cache, &account_id)?;
+
+    if uses_jmap(&account) {
+        return Err(NimbusError::Other(
+            "Expunging drafts via JMAP is not yet implemented — this account uses JMAP".into(),
+        ));
+    }
+
+    // Tombstone the row (creating a placeholder if absent — the
+    // minimize-saved UID case where the cache row doesn't exist
+    // yet) so any concurrent poll keeps the row hidden across the
+    // IMAP roundtrip.
+    if let Err(e) = cache.upsert_message_pending(&account_id, &folder, uid, "delete") {
+        tracing::warn!("expunge_draft_after_send upsert_message_pending failed: {e}");
+    }
+
+    let password = credentials::get_imap_password(&account.id)?;
+    let connect_result = ImapClient::connect(
+        &account.imap_host,
+        account.imap_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await;
+    let mut client = match connect_result {
+        Ok(c) => c,
+        Err(e) => {
+            // No tombstone clear here — see fn docs for the
+            // post-send UX rationale.  The user already shipped
+            // the mail; surfacing a half-deleted source draft
+            // doesn't help them.
+            return Err(e);
+        }
+    };
+
+    let delete_result = client.delete_message(&folder, uid).await;
+    let _ = client.logout().await;
+
+    // Deliberately *not* dropping the cache row on success here
+    // (#292 follow-up).  Some IMAP servers (Gmail, certain
+    // Exchange variants) take a moment to propagate an EXPUNGE
+    // to fresh sessions — long enough that a `poll_folder` racing
+    // ahead of the propagation will re-fetch the just-deleted UID,
+    // and if the row is already gone from the cache the INSERT
+    // path of `upsert_envelopes_for_account` writes a fresh row
+    // *without* `pending_action`, so the draft pops back into the
+    // visible list.  Leaving the tombstone planted keeps the row
+    // hidden across that window — the next reconcile pass in
+    // `poll_folder` removes it cleanly once the server confirms
+    // it's gone from `list_all_uids`.
+    //
+    // The stale-UID case ("isn't in folder") is also fine to
+    // leave tombstoned: the row already isn't on the server, so
+    // reconcile will drop it on the next poll.
+    //
+    // Real IMAP failure (server unreachable mid-EXPUNGE,
+    // permission error, etc.) → tombstone also stays.  The
+    // user already shipped the mail; surfacing a half-deleted
+    // source draft would just confuse.  If the server really
+    // never removed the message, a future poll's reconcile keeps
+    // the row cached and tombstoned; that's a soft leak but
+    // user-invisible.
+    delete_result
 }
 
 /// Pick the most likely Drafts folder name from the cached folder list.
@@ -11683,6 +11991,8 @@ fn main() {
             delete_outbox_entry,
             edit_outbox_entry,
             save_draft,
+            tombstone_draft_for_expunge,
+            expunge_draft_after_send,
             delete_message,
             archive_message,
             archive_messages,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -77,6 +77,14 @@
   "compose_attachment_warning_body": "Fügen Sie vor dem Senden eine Datei hinzu oder schließen Sie diese Warnung, falls es ein Fehlalarm ist.",
   "compose_attachment_warning_dismiss": "Schließen",
 
+  "compose_button_minimize_aria_label": "Minimieren",
+  "compose_button_minimize_title": "Entwurf in die Leiste minimieren",
+  "compose_minimized_bar_aria_label": "Minimierte Entwürfe",
+  "compose_minimized_no_subject": "(kein Betreff)",
+  "compose_minimized_item_title": "Entwurf wiederherstellen: {subject}",
+  "compose_minimized_item_close_aria_label": "Entwurf verwerfen",
+  "compose_minimized_item_close_title": "Diesen Entwurf verwerfen",
+
   "contact_form_avatar_title": "Zum Hochladen eines Fotos klicken",
   "contact_form_avatar_aria": "Kontaktfoto ändern",
   "contact_form_avatar_overlay": "Hochladen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -77,6 +77,14 @@
   "compose_attachment_warning_body": "Add a file before sending, or dismiss this warning if it's a false alarm.",
   "compose_attachment_warning_dismiss": "Dismiss",
 
+  "compose_button_minimize_aria_label": "Minimize",
+  "compose_button_minimize_title": "Minimize draft to bar",
+  "compose_minimized_bar_aria_label": "Minimized drafts",
+  "compose_minimized_no_subject": "(no subject)",
+  "compose_minimized_item_title": "Restore draft: {subject}",
+  "compose_minimized_item_close_aria_label": "Discard draft",
+  "compose_minimized_item_close_title": "Discard this draft",
+
   "contact_form_avatar_title": "Click to upload a photo",
   "contact_form_avatar_aria": "Change contact photo",
   "contact_form_avatar_overlay": "Upload",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -30,6 +30,7 @@
     type ComposeInitial,
     type SendFailurePayload,
   } from './lib/Compose.svelte'
+  import ShrunkenComposesBar from './lib/ShrunkenComposesBar.svelte'
   import ContactsView from './lib/ContactsView.svelte'
   import CalendarView from './lib/CalendarView.svelte'
   import { openReminderInStandaloneWindow } from './lib/reminderPopupWindow'
@@ -208,9 +209,55 @@
   // the row's `account_id` so MailView opens the right message even
   // though the folder picker isn't pointing at that account.
   let selectedMessageAccountId = $state<string | null>(null)
-  // Compose modal: `null` = closed. When open, carries a (possibly empty)
-  // initial prefill for reply / reply-all / forward.
-  let composeInitial = $state<ComposeInitial | null>(null)
+  // Compose modals (#292).  Each user-triggered Compose pushes a
+  // new entry; the entry with `id === activeComposeId` is the one
+  // currently rendered as a full-screen modal, everyone else sits
+  // dormant (display:none) so their Tiptap editor, attachments,
+  // Talk-room token, and share-link bookkeeping survive the
+  // minimise round-trip without re-mount.  When `activeComposeId`
+  // is null every entry is minimised — the shrunken-composes bar
+  // surfaces them as buttons in the mail view's bottom-right.
+  interface ComposeEntry {
+    id: string
+    accountId: string
+    initial: ComposeInitial
+    initialError: string
+    /** Live mirror of the Compose's subject field (#292).  Seeded
+     *  from `initial.subject`, then kept in sync via Compose's
+     *  `onsubjectchange` callback so the shrunken-bar tab label
+     *  follows the user's typing.  Reading from `initial.subject`
+     *  alone would freeze the label at open time. */
+    currentSubject: string
+    /** Stable handle on this Compose's internal `cancel` function
+     *  (#292).  Wired up by `oncancelref` at mount.  Lets the
+     *  shrunken-bar × discard a draft without restoring the modal
+     *  first — `cancel` runs the Talk-room delete + share-link
+     *  cleanup + draft-source expunge that a naive entry-removal
+     *  would skip. */
+    cancelFn?: () => void
+    /** Live mirror of the Compose's internal `currentDraftSource`
+     *  pointer (#292 follow-up).  Seeded from `initial.draftSource`
+     *  and updated via Compose's `ondraftsourcechange` after every
+     *  successful save.  Lets `openCompose` dedup against existing
+     *  entries when "Edit draft" is invoked on a UID that's
+     *  already represented by an in-flight Compose — without this,
+     *  re-opening a minimised draft from the Drafts folder pushes
+     *  a second Compose for the same UID, and the next minimise
+     *  on either copy creates a duplicate in IMAP. */
+    currentDraftSource:
+      | { accountId: string; folder: string; uid: number }
+      | null
+    /** Snapshot of "did this Compose start as an edit-from-outbox?"
+     *  captured at open time.  Compose's `onclose` fires
+     *  immediately on Send (#156's instant-close) before the async
+     *  send pipeline reaches `invoke('send_email')`, so by the
+     *  time `onsentenqueued` fires the entry has already been
+     *  removed from `composes` via the per-instance closure — we
+     *  close over this flag rather than relying on lookup. */
+    openedAsEditOfOutbox: boolean
+  }
+  let composes = $state<ComposeEntry[]>([])
+  let activeComposeId = $state<string | null>(null)
   // Default to INBOX — the Sidebar replaces this as soon as the user
   // picks a folder, or could switch it automatically if INBOX is absent.
   let selectedFolder = $state<string>('INBOX')
@@ -274,17 +321,10 @@
    *  response if the row is updated by a retry / failure
    *  recording while the user has it open. */
   let selectedOutboxRow = $state<OutboxRowDto | null>(null)
-  /** Snapshot of "did the currently-open Compose start as an
-   *  edit-from-outbox?".  Captured at `openCompose` time
-   *  because Compose's `onclose` fires immediately on Send
-   *  (#156's instant-close) before its async send pipeline
-   *  reaches `invoke('send_email')` — so by the time we'd want
-   *  to inspect `composeInitial.outboxSource`, the modal has
-   *  already cleared it.  Set on open, consumed by
-   *  `onsentenqueued`, cleared by a fresh `openCompose` of any
-   *  kind so a subsequent non-edit send can't accidentally
-   *  inherit it. */
-  let composeOpenedAsEditOfOutbox = $state(false)
+  // The per-Compose edit-from-outbox snapshot now lives on each
+  // ComposeEntry (see `openedAsEditOfOutbox` in `composes` above),
+  // captured at open time and consumed by `onsentenqueued` via a
+  // per-instance closure on the mount block.
 
   // Bindable mirror of MailList's currently-rendered envelope rows.
   // Used by the auto-advance-after-delete flow (#99) to pick the
@@ -1316,19 +1356,119 @@
     // the genuine refresh path; this one's purely local.
   }
 
-  // Open the Compose modal. Called with no arg for a blank new message,
-  // or with a prefill for reply/reply-all/forward.
-  function openCompose(initial: ComposeInitial = {}) {
-    // A fresh open shouldn't carry over the error banner from a
-    // previous failed background send (#156).
-    composeSendError = ''
-    composeInitial = initial
-    // Snapshot whether this Compose started life as an
-    // edit-from-outbox — onsentenqueued reads it later (#276
-    // follow-up).  Re-set on every open so a fresh non-edit
-    // compose can't inherit the arming from a previous edit
-    // that the user cancelled.
-    composeOpenedAsEditOfOutbox = initial.outboxSource != null
+  /** A Compose has told us it's about to expunge a Drafts UID —
+   *  either the replaceSource path of save_draft, or the post-send
+   *  draft cleanup (#292 follow-up).  Optimistically splice the
+   *  row out of MailList's bound state so the user doesn't briefly
+   *  see the about-to-be-deleted row alongside its successor.  The
+   *  splice is only meaningful when the user is currently viewing
+   *  the same folder + account the draft lives in — otherwise the
+   *  bound list isn't showing that folder anyway, so the call is
+   *  a no-op (and could even mis-evict an unrelated row that
+   *  happens to share the UID in another folder, since UIDs are
+   *  per-folder). */
+  function onDraftExpunged(src: {
+    accountId: string
+    folder: string
+    uid: number
+  }) {
+    if (selectedFolder !== src.folder) return
+    if (
+      !unifiedMode
+      && selectedMessageAccountId !== src.accountId
+      && activeAccountId !== src.accountId
+    ) {
+      return
+    }
+    onMessageRemoved(src.uid)
+  }
+
+  // Open a Compose modal.  Called with no arg for a blank new
+  // message, or with a prefill for reply / reply-all / forward /
+  // edit-draft / mailto / etc.  Each call pushes a new entry and
+  // makes it the active (visible) modal — any previously-active
+  // Compose gets auto-minimised into the shrunken-composes bar
+  // (#292), preserving its draft.
+  //
+  // `options` covers the two paths that need to override defaults:
+  //   - `accountId`: the send-failure recovery flow re-opens with
+  //     the original sending account, which may differ from the
+  //     current `activeAccountId` (the user could have switched
+  //     accounts in the meantime);
+  //   - `initialError`: same flow, surfaces the failure reason in
+  //     the modal's banner the moment it re-appears.
+  function openCompose(
+    initial: ComposeInitial = {},
+    options: { accountId?: string; initialError?: string } = {},
+  ): string {
+    // Dedup the "Edit draft from the Drafts folder while a Compose
+    // for that exact UID is already mounted" case (#292 follow-up).
+    // Without this guard the user ends up with two Compose
+    // instances both pointing at the same Drafts UID; the next
+    // minimise on either one APPENDs a fresh copy and the
+    // server-side dedup falls apart.  We compare against each
+    // entry's *live* `currentDraftSource` (post-save UID), not
+    // its frozen `initial.draftSource`, so the match still works
+    // after an in-flight save has assigned a new UID.
+    if (initial.draftSource) {
+      const existing = composes.find(
+        (c) =>
+          c.currentDraftSource &&
+          c.currentDraftSource.accountId ===
+            initial.draftSource!.accountId &&
+          c.currentDraftSource.folder === initial.draftSource!.folder &&
+          c.currentDraftSource.uid === initial.draftSource!.uid,
+      )
+      if (existing) {
+        activeComposeId = existing.id
+        return existing.id
+      }
+    }
+
+    const id = crypto.randomUUID()
+    composes.push({
+      id,
+      accountId: options.accountId ?? activeAccountId ?? '',
+      initial,
+      initialError: options.initialError ?? '',
+      currentSubject: initial.subject ?? '',
+      currentDraftSource: initial.draftSource ?? null,
+      openedAsEditOfOutbox: initial.outboxSource != null,
+    })
+    activeComposeId = id
+    return id
+  }
+
+  /** Shrink the given Compose into the bar — only the active one
+   *  has a visible surface, so this just clears `activeComposeId`
+   *  when the caller matches.  The component stays mounted so its
+   *  internal state survives. */
+  function minimizeCompose(id: string) {
+    if (activeComposeId === id) activeComposeId = null
+  }
+
+  /** Restore a minimised Compose: make it the active one.  Any
+   *  previously-active Compose flips to minimised automatically
+   *  on the next render because the modal-vs-minimised state is
+   *  derived from `id === activeComposeId`. */
+  function restoreCompose(id: string) {
+    activeComposeId = id
+  }
+
+  /** Close-from-bar (#292): hit the × on a minimised tab.  Routes
+   *  through Compose's own `cancel` so Talk-room delete + share-
+   *  link cleanup + draft-source expunge all run, just like the
+   *  modal-header × button does.  Defensive fallback to
+   *  `closeCompose` covers the rare race where the entry exists
+   *  but its `cancelFn` hasn't been wired yet (component is mid-
+   *  mount) — better to drop the entry than to leak the click. */
+  function closeComposeFromBar(id: string) {
+    const entry = composes.find((c) => c.id === id)
+    if (entry?.cancelFn) {
+      entry.cancelFn()
+    } else {
+      closeCompose(id)
+    }
   }
 
   /** Re-open a queued Outbox message in Compose for editing
@@ -1388,8 +1528,9 @@
     })
   }
 
-  function closeCompose() {
-    composeInitial = null
+  function closeCompose(id: string) {
+    composes = composes.filter((c) => c.id !== id)
+    if (activeComposeId === id) activeComposeId = null
     // Force the mail list + sidebar to re-query the server. Compose's
     // save-draft / send paths modify the Drafts and Sent folders
     // (APPEND + expunge) without touching the envelope cache, so the
@@ -1404,13 +1545,28 @@
   // submission fails after the modal is gone we surface the
   // error here AND re-open Compose pre-filled with the user's
   // draft so they can retry without retyping.
-  let composeSendError = $state<string>('')
-  function onComposeSendFailed(payload: SendFailurePayload) {
-    composeSendError = payload.errorMessage
-    // Re-open Compose with the original draft.  Setting
-    // `composeInitial` triggers the mount in the same shell-
-    // level branch the original Compose lived in.
-    composeInitial = payload.draft
+  //
+  // `failedOpenedAsEditOfOutbox` rides through from the per-instance
+  // closure that wraps the original Compose's `onsendfailed` —
+  // preserves the outbox-edit arming across the recovery push so a
+  // successful retry still routes to the OutboxView (#276
+  // follow-up).
+  function onComposeSendFailed(
+    failedOpenedAsEditOfOutbox: boolean,
+    payload: SendFailurePayload,
+  ) {
+    const newId = openCompose(payload.draft, {
+      accountId: payload.fromAccountId,
+      initialError: payload.errorMessage,
+    })
+    // Re-arm the outbox-edit flag on the recovery entry when the
+    // failed one was itself an outbox edit.  The draft snapshot
+    // doesn't carry `outboxSource` (Compose's runSendPipeline
+    // omits it), so we can't recover this from the draft alone.
+    if (failedOpenedAsEditOfOutbox) {
+      const entry = composes.find((c) => c.id === newId)
+      if (entry) entry.openedAsEditOfOutbox = true
+    }
     // Try to also fire an OS-level notification so the user
     // notices the failure even if their attention has drifted
     // off the Nimbus window.  Best-effort — silently ignore on
@@ -1451,9 +1607,11 @@
    *      select behaviour, the row's status updates in place
    *      via the `outbox-updated` listener as the drain
    *      finishes. */
-  async function onComposeSentEnqueued(newRowId: number) {
-    if (!composeOpenedAsEditOfOutbox) return
-    composeOpenedAsEditOfOutbox = false
+  async function onComposeSentEnqueued(
+    entry: ComposeEntry,
+    newRowId: number,
+  ) {
+    if (!entry.openedAsEditOfOutbox) return
     // Stay on the Outbox folder (the user was here when they
     // clicked Edit; switching away would be confusing).
     selectedFolder = OUTBOX_FOLDER
@@ -1671,6 +1829,12 @@
       body: mail.body_html ?? mail.body_text ?? '',
       attachments,
       draftSource: { accountId: mail.account_id, folder: mail.folder, uid },
+      // The saved draft body already carries the signature Compose
+      // appended on its previous save — re-stamping a fresh one
+      // here would stack signatures on every edit/save round-trip
+      // (#292 follow-up).  Same idiom the edit-from-outbox path
+      // uses (#276): treat the persisted body as authoritative.
+      skipSignatureInsert: true,
     })
   }
 
@@ -1777,10 +1941,13 @@
   async function onRespondWithMeeting(mail: ReplyableMail) {
     // Defensive: if a previous flow left state behind (e.g. a
     // Compose modal whose overlay would z-index over the new
-    // editor), clear it so the EventEditor lands on top of an
-    // empty surface.
+    // editor), drop the *active* one out of view so the
+    // EventEditor lands on top of an empty surface.  We don't
+    // tear the Compose entries down — any minimised drafts the
+    // user has stashed in the shrunken-composes bar (#292)
+    // remain alive and reachable once the meeting editor closes.
     meetingDraft = null
-    composeInitial = null
+    activeComposeId = null
 
     // Top-level try/catch so any unhandled rejection surfaces as
     // a visible alert instead of leaving the user staring at a
@@ -2455,22 +2622,49 @@
           bind:refreshing={mailViewRefreshing}
         />
       {/if}
+
+      <!-- Shrunken-composes bar (#292).  Lives inside the mail-view
+           branch so it disappears the moment the user navigates to
+           Calendar / Contacts / Settings etc.  The minimised
+           Compose components themselves remain mounted at the
+           app-level overlay below, so the user can still find
+           their drafts on return. -->
+      {#if composes.some((c) => c.id !== activeComposeId)}
+        <ShrunkenComposesBar
+          items={composes
+            .filter((c) => c.id !== activeComposeId)
+            .map((c) => ({ id: c.id, subject: c.currentSubject }))}
+          onrestore={restoreCompose}
+          onclose={closeComposeFromBar}
+        />
+      {/if}
     {/if}
 
-    {#if composeInitial !== null}
+    <!-- Compose overlays (#292).  Every open Compose stays mounted —
+         the one with `id === activeComposeId` is visible, the rest
+         render with `display:none` so their Tiptap editor and
+         in-flight state survive the minimise round-trip.  Per-
+         instance closures wrap the callbacks so each Compose's
+         outbox-edit snapshot and recovery-push routing stay tied
+         to *that* instance, not whoever happens to be active when
+         the async send pipeline resolves. -->
+    {#each composes as c (c.id)}
       <Compose
         accounts={accounts}
-        accountId={activeAccountId ?? ''}
-        initial={composeInitial}
-        initialError={composeSendError}
-        onclose={() => {
-          composeSendError = ''
-          closeCompose()
-        }}
-        onsendfailed={onComposeSendFailed}
-        onsentenqueued={onComposeSentEnqueued}
+        accountId={c.accountId}
+        initial={c.initial}
+        initialError={c.initialError}
+        minimized={c.id !== activeComposeId}
+        onminimize={() => minimizeCompose(c.id)}
+        onclose={() => closeCompose(c.id)}
+        onsendfailed={(p) => onComposeSendFailed(c.openedAsEditOfOutbox, p)}
+        onsentenqueued={(rowId) => onComposeSentEnqueued(c, rowId)}
+        onsubjectchange={(s) => (c.currentSubject = s)}
+        oncancelref={(fn) => (c.cancelFn = fn)}
+        ondraftsourcechange={(src) => (c.currentDraftSource = src)}
+        ondraftexpunged={onDraftExpunged}
       />
-    {/if}
+    {/each}
   </div>
 {/if}
 

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -224,6 +224,62 @@
      *  the new row up and surface it as the selected Outbox
      *  preview after an edit-from-outbox send. */
     onsentenqueued?: (newRowId: number) => void
+    /** When true, the modal wrapper is hidden (display:none) so the
+     *  parent can stash the Compose into a "shrunken" bar (#292)
+     *  without losing in-flight state (editor body, attachments,
+     *  Talk-room token, share-link bookkeeping).  Component stays
+     *  mounted; only its visual surface and event listeners go
+     *  dormant.  No-op in standalone-window mode — the OS window
+     *  itself is the minimise surface there. */
+    minimized?: boolean
+    /** Fires when the user clicks the header's "minimise" button.
+     *  Parent should flip its `activeComposeId` (or equivalent) so
+     *  this instance's `minimized` prop becomes true on the next
+     *  render.  Omitted when the parent doesn't support shrinking
+     *  (e.g. standalone window) — the button is hidden in that
+     *  case. */
+    onminimize?: () => void
+    /** Fires whenever the subject field changes (#292).  Used by
+     *  App.svelte to keep the shrunken-composes bar label in sync
+     *  as the user types — the bar only sees the entry-level
+     *  snapshot, not Compose's internal state, so without this
+     *  the tab would freeze on whatever subject was set at open
+     *  time. */
+    onsubjectchange?: (subject: string) => void
+    /** One-shot callback handing the parent a reference to this
+     *  Compose's `cancel` function (#292).  Lets the shrunken-bar
+     *  × close-tab gesture trigger the full cancel flow (Talk-room
+     *  delete, share-link cleanup, draft-source expunge) without
+     *  the user having to restore the modal first.  Fires once on
+     *  mount; the function reference is stable for the lifetime
+     *  of the component. */
+    oncancelref?: (cancel: () => void) => void
+    /** Fires whenever this Compose's tracked Drafts-folder pointer
+     *  changes (#292).  Seeded from `initial.draftSource` and
+     *  updated after every successful `save_draft` round-trip with
+     *  the new server-assigned UID.  App.svelte mirrors it onto the
+     *  per-entry state so the "Edit draft" path can detect "I
+     *  already have a Compose mounted for this UID" and restore
+     *  the existing tab instead of pushing a duplicate. */
+    ondraftsourcechange?: (
+      src: { accountId: string; folder: string; uid: number } | null,
+    ) => void
+    /** Fires the moment we kick off an IMAP operation that will
+     *  expunge a previously-saved draft — the replaceSource path of
+     *  `save_draft` and the post-send draft cleanup (#292 follow-up).
+     *  Used by App.svelte to splice the row out of the mail list
+     *  immediately so the user doesn't briefly see both the
+     *  about-to-be-deleted draft and its successor (MailList's
+     *  `mergeEnvelopes` preserves rows the fresh batch didn't
+     *  return, to support pagination, so a passive refresh leaves
+     *  the stale row visible).  Optimistic: if the IMAP delete
+     *  later fails, the row reappears on next sync from the
+     *  backend tombstone-clear path. */
+    ondraftexpunged?: (src: {
+      accountId: string
+      folder: string
+      uid: number
+    }) => void
   }
   let {
     accounts,
@@ -234,6 +290,12 @@
     initialError = '',
     inStandaloneWindow = false,
     onsentenqueued,
+    minimized = false,
+    onminimize,
+    onsubjectchange,
+    oncancelref,
+    ondraftsourcechange,
+    ondraftexpunged,
   }: Props = $props()
 
   /**
@@ -291,8 +353,30 @@
   // leave it alone.
   $effect(() => {
     if (!wrapperEl) return
+    // Don't steal focus while minimised — the wrapper is
+    // display:none so this would visibly do nothing, but it
+    // also moves focus *off* whatever the user just clicked
+    // (e.g. a button in the shrunken-composes bar), which
+    // would be jarring.
+    if (minimized) return
     const id = setTimeout(() => {
       // If focus is already inside the wrapper, don't steal it.
+      if (wrapperEl?.contains(document.activeElement)) return
+      wrapperEl?.focus({ preventScroll: true })
+    }, 0)
+    return () => clearTimeout(id)
+  })
+
+  // Re-focus the wrapper whenever we transition out of
+  // minimised state — `display:none` removes the modal from
+  // the focus tree, so on restore we need to grab focus back
+  // (Esc handling depends on it).  Separate effect from the
+  // mount one so a restore re-fires without the wrapperEl
+  // identity changing.
+  $effect(() => {
+    if (minimized) return
+    if (!wrapperEl) return
+    const id = setTimeout(() => {
       if (wrapperEl?.contains(document.activeElement)) return
       wrapperEl?.focus({ preventScroll: true })
     }, 0)
@@ -302,8 +386,12 @@
   // Layer 3: global window-capture listener.  Fires regardless
   // of where focus is — covers the path between Compose mount
   // and our autofocus actually landing, plus any future
-  // refactor that keeps focus outside Compose.
+  // refactor that keeps focus outside Compose.  Gated on
+  // `minimized` so Esc on a minimised Compose doesn't cancel
+  // the draft; with multiple instances mounted at once (#292)
+  // we'd otherwise have every instance fight to handle Esc.
   $effect(() => {
+    if (minimized) return
     function onKey(e: KeyboardEvent) {
       if (e.key !== 'Escape') return
       if (showNcPicker || showNcImagePicker || showTalkModal) return
@@ -365,10 +453,61 @@
   let bcc = $state(initial?.bcc ?? '')
   // svelte-ignore state_referenced_locally
   let subject = $state(initial?.subject ?? '')
+  // Push subject changes up to the parent so the shrunken-composes
+  // bar's tab label tracks the user's typing in real time (#292).
+  // No-op when the parent doesn't subscribe (popout window etc.).
+  $effect(() => {
+    onsubjectchange?.(subject)
+  })
   // svelte-ignore state_referenced_locally
   let body = $state(initial?.body ?? '')
   // svelte-ignore state_referenced_locally
   let attachments = $state<Attachment[]>(initial?.attachments ?? [])
+  /** Promise of the currently-in-flight `persistDraftToImap` call,
+   *  or `null` when no save is running.  `send()` and concurrent
+   *  saves both await this before proceeding so the
+   *  `currentDraftSource` reassignment that a save performs at the
+   *  end of its IPC roundtrip can't shift the target UID out from
+   *  under a send that started mid-save (#292 follow-up).
+   *
+   *  Without this lock the symptom is: save captures `src` = uid X
+   *  and fires `ondraftexpunged(X)`, then awaits the IMAP
+   *  APPEND+DELETE; meanwhile the user clicks Send, whose
+   *  `snap.draftSource` reads `currentDraftSource` while still X;
+   *  save returns and reassigns `currentDraftSource` to uid Y;
+   *  the send's later reads of `snap.draftSource.uid` resolve to
+   *  Y (Svelte 5 keeps object state deeply reactive, so a property
+   *  read through the captured reference reflects the live inner
+   *  value).  The tombstone fired against X and the expunge fires
+   *  against Y, so the row never actually gets marked
+   *  pending-delete in the cache and the next poll re-surfaces it. */
+  let persistPromise: Promise<void> | null = null
+
+  /** The Drafts-folder pointer this Compose's saves should
+   *  supersede (#292).  Seeded from `initial.draftSource` (the
+   *  edit-existing-draft entry point); each successful save_draft
+   *  updates it with the newly-APPENDed UID returned by the
+   *  backend.  Without this, repeated minimize-saves would APPEND
+   *  fresh copies and leave the Drafts folder full of duplicates
+   *  for one in-flight compose.  `null` means "no previous copy
+   *  to expunge" — first save of a brand-new draft.
+   *
+   *  Local state (not a prop) because Compose owns it for the
+   *  whole lifetime of the modal: the parent doesn't need to know,
+   *  and re-deriving from `initial.draftSource` would lose the
+   *  post-save UID. */
+  // svelte-ignore state_referenced_locally
+  let currentDraftSource = $state<
+    { accountId: string; folder: string; uid: number } | null
+  >(initial?.draftSource ?? null)
+  // Mirror the current draft pointer up to the parent so
+  // `openCompose` can detect "the user is opening a draft I
+  // already have a Compose for" and restore that tab rather than
+  // pushing a duplicate (#292 follow-up).  Fires on mount with
+  // the initial pointer and on every post-save update.
+  $effect(() => {
+    ondraftsourcechange?.(currentDraftSource)
+  })
   // Pre-warm thumb caches for any attachments seeded by the
   // host (FilesView's "New mail with attachment", reply-with-
   // attachment paths) so the `/` picker is instant on its
@@ -593,6 +732,19 @@
       double-stamping breaklines or a signature. */
   function initialBodyHtml(): string {
     if (initial?.draftSource) {
+      // Saved draft body already carries the signature from the
+      // user's previous save — pin `insertedSignatureHtml` to the
+      // current account's signature so the late-load `$effect`
+      // below knows "the signature is already there, don't splice
+      // another one in".  Without this pin, every edit/save round-
+      // trip would stack a fresh signature on top of the prior
+      // one because the effect's `insertedSignatureHtml === null`
+      // branch would re-stamp on every re-open (#292 follow-up).
+      // Mirrors the `skipSignatureInsert` else-branch below.
+      const embeddedSig = signatureBlock(
+        (accounts.find((a) => a.id === accountId) ?? accounts[0])?.signature,
+      )
+      if (embeddedSig) insertedSignatureHtml = embeddedSig
       return textToHtml(body)
     }
 
@@ -1220,32 +1372,7 @@
     error = ''
     sending = true
     try {
-      // `replaceSource` lets the backend APPEND + EXPUNGE in a single
-      // IMAP session — critical for "edit an existing draft" because
-      // two separate commands were sometimes leaving the original
-      // copy behind (server hadn't flushed the APPEND before the
-      // DELETE ran on a fresh connection). Letting the backend batch
-      // the two also guarantees APPEND and DELETE target the *same*
-      // folder (the one the user opened the draft from), even on
-      // servers where `pick_drafts_folder` would otherwise choose a
-      // different `\Drafts`-attributed mailbox than the one the user
-      // is looking at.
-      const src = initial?.draftSource
-      await invoke('save_draft', {
-        accountId: src?.accountId ?? fromAccountId,
-        email: {
-          from: fromHeader,
-          to: splitAddrs(to),
-          cc: splitAddrs(cc),
-          bcc: splitAddrs(bcc),
-          reply_to: null,
-          subject,
-          body_text: htmlToText(bodyHtmlForSubmission()),
-          body_html: bodyHtmlForSubmission() || null,
-          attachments,
-        },
-        replaceSource: src ? { folder: src.folder, uid: src.uid } : null,
-      })
+      await persistDraftToImap()
       // Disarm the share-cleanup branch in cancel() (#193): the
       // draft we just persisted has the share URLs baked into its
       // body, so the user expects them to keep working when they
@@ -1259,6 +1386,124 @@
       error = formatError(e) || 'Failed to save draft'
     } finally {
       sending = false
+    }
+  }
+
+  /** Save-then-minimise (#292).  Same backend call as `saveDraft`
+   *  but doesn't run `onclose` afterwards — the Compose stays
+   *  mounted (display:none from the `minimized` prop the parent
+   *  flips) so the user can keep editing on restore.  We disarm
+   *  the share-cleanup branch on success for the same reason
+   *  `saveDraft` does: the persisted draft references the share
+   *  URLs, so they must keep working until the user explicitly
+   *  closes the compose.
+   *
+   *  Errors don't surface a banner — by the time this fires the
+   *  modal is already hidden behind the minimize.  We log them to
+   *  the console and leave the in-memory draft intact so the user
+   *  can restore and retry. */
+  async function minimizeAndSave() {
+    // Trigger the hide first so the user gets instant feedback —
+    // the persist runs in the background.  Calling `onminimize`
+    // before the await means the modal closes before the IMAP
+    // round-trip rather than after it.
+    onminimize?.()
+    try {
+      await persistDraftToImap()
+      // Same disarm rationale as `saveDraft`: the persisted copy
+      // references any minted shares, so a later cancel() must
+      // not nuke them.
+      createdShares = []
+    } catch (e: any) {
+      console.warn(
+        'save_draft on minimize failed (in-memory draft preserved):',
+        e,
+      )
+    }
+  }
+
+  /** APPEND the current Compose state to the user's Drafts folder
+   *  and update `currentDraftSource` with the new (folder, uid) so
+   *  the next save can EXPUNGE this copy via `replaceSource`.
+   *
+   *  `replaceSource` lets the backend APPEND + EXPUNGE in a single
+   *  IMAP session — critical for "edit an existing draft" because
+   *  two separate commands were sometimes leaving the original
+   *  copy behind (server hadn't flushed the APPEND before the
+   *  DELETE ran on a fresh connection). Letting the backend batch
+   *  the two also guarantees APPEND and DELETE target the *same*
+   *  folder (the one the user opened the draft from), even on
+   *  servers where `pick_drafts_folder` would otherwise choose a
+   *  different `\Drafts`-attributed mailbox than the one the user
+   *  is looking at.
+   *
+   *  The backend returns the SEARCH-discovered UID of the newly-
+   *  APPENDed message; a `null` uid means we couldn't find it (no
+   *  Message-ID in the raw, SEARCH failed, server hasn't indexed
+   *  yet) and the caller should accept that the next save will
+   *  leave a duplicate.  Throws on any backend error — callers
+   *  decide how to surface it. */
+  async function persistDraftToImap(): Promise<void> {
+    // Coalesce against any concurrent persist so two near-simultaneous
+    // saves don't both try to APPEND + DELETE the same source UID
+    // (the second would hit a 'isn't in folder' error after the first
+    // already expunged it).  Also lets `send()` await the in-flight
+    // persist before reading `currentDraftSource` so the snap can't
+    // capture an about-to-be-stale UID.
+    if (persistPromise) {
+      await persistPromise
+    }
+    persistPromise = persistDraftToImapInner()
+    try {
+      await persistPromise
+    } finally {
+      persistPromise = null
+    }
+  }
+
+  async function persistDraftToImapInner(): Promise<void> {
+    const src = currentDraftSource
+    // Optimistically tell the parent the old Drafts row is gone
+    // BEFORE the IMAP roundtrip — without this the mail-list's
+    // `mergeEnvelopes` keeps the soon-to-be-deleted UID visible
+    // until the eventual sync evicts it, and the user briefly sees
+    // (and can click!) both the old and new copies in the Drafts
+    // folder (#292 follow-up).  Backend's tombstone covers the
+    // cache side; this covers the in-memory list.  If the save
+    // ultimately fails, the row reappears on the next sync /
+    // refresh from the backend's tombstone-clear path.
+    if (src) ondraftexpunged?.(src)
+    const result = await invoke<{ folder: string; uid: number | null }>(
+      'save_draft',
+      {
+        accountId: src?.accountId ?? fromAccountId,
+        email: {
+          from: fromHeader,
+          to: splitAddrs(to),
+          cc: splitAddrs(cc),
+          bcc: splitAddrs(bcc),
+          reply_to: null,
+          subject,
+          body_text: htmlToText(bodyHtmlForSubmission()),
+          body_html: bodyHtmlForSubmission() || null,
+          attachments,
+        },
+        replaceSource: src ? { folder: src.folder, uid: src.uid } : null,
+      },
+    )
+    // Update the pointer for the next save.  `result.uid === null`
+    // means SEARCH didn't find the new copy; clear `currentDraftSource`
+    // so the next save APPENDs fresh rather than re-deleting the
+    // *old* UID (which is now gone — the server already EXPUNGEd
+    // it as part of this save).
+    if (result.uid !== null) {
+      currentDraftSource = {
+        accountId: src?.accountId ?? fromAccountId,
+        folder: result.folder,
+        uid: result.uid,
+      }
+    } else {
+      currentDraftSource = null
     }
   }
 
@@ -1517,11 +1762,49 @@
   }
 
   async function send() {
+    // Re-entrancy guard (#292 follow-up): `send()` is async and the
+    // first `await invoke('tombstone_draft_for_expunge', …)` yields
+    // for an IPC round-trip before `onclose()` removes the modal.
+    // If the user double-clicks Send (or some other event re-fires
+    // the click within that window) the second invocation would
+    // race the first — both call `invoke('send_email')` which is
+    // an outright enqueue, so the recipient gets the mail twice
+    // and the draft cleanup runs against a UID that's already
+    // gone.  `sending = true` immediately disables the Send button
+    // (it's gated on this flag) and short-circuits any in-flight
+    // re-entry.  Leave it `true` for the rest of the function
+    // since the modal unmounts via `onclose()` anyway.
+    // Temporary diagnostic for the "mail sent twice" report — we
+    // need to see whether the guard is actually triggering or
+    // whether `send_email` is being invoked twice via a different
+    // path.  Cheap (a few console lines per click) and removable.
+    if (sending) return
+    sending = true
+
     error = ''
     const toList = splitAddrs(to)
     if (toList.length === 0) {
       error = 'At least one recipient is required.'
+      sending = false
       return
+    }
+
+    // Wait for any in-flight save to complete before snapshotting
+    // `currentDraftSource` (#292 follow-up).  If a save is mid-IPC
+    // the source UID is about to change from X to Y; capturing
+    // either value out of order leaves us tombstoning one UID and
+    // expunging another (the cache marker lands on a row that
+    // already got expunged, and the next poll surfaces the new
+    // row that was never marked).
+    if (persistPromise) {
+      try {
+        await persistPromise
+      } catch (e) {
+        console.warn(
+          'in-flight persistDraftToImap threw during send; continuing',
+          e,
+        )
+      }
     }
 
     // #156: close the modal immediately and run the IMAP
@@ -1550,7 +1833,30 @@
       ncAccountId,
       accountsAtSend: accounts,
       initialAtSend: initial,
-      draftSource: initial?.draftSource ?? null,
+      // Use `currentDraftSource` (the LIVE pointer) instead of
+      // `initial.draftSource` (frozen at mount) — without this, a
+      // user who minimised the Compose (which APPENDs to Drafts
+      // and updates `currentDraftSource` to the new UID) and then
+      // restored + sent would leave their Drafts copy behind: the
+      // send pipeline would have no source UID to expunge because
+      // the mount-time pointer was null for a brand-new compose.
+      // (#292 follow-up).
+      //
+      // Spread the fields into a plain object so the snapshot is
+      // frozen at this moment.  Svelte 5 keeps object state deeply
+      // reactive, and storing the reactive reference in `snap`
+      // would let any later mutation of `currentDraftSource`
+      // (e.g. a concurrent save reassigning to a new UID) leak
+      // into reads of `snap.draftSource.uid` further down in
+      // `runSendPipeline`, causing tombstone and expunge to
+      // target different UIDs.
+      draftSource: currentDraftSource
+        ? {
+            accountId: currentDraftSource.accountId,
+            folder: currentDraftSource.folder,
+            uid: currentDraftSource.uid,
+          }
+        : null,
       // #152 — staged meeting event.  Snapshotted here so the
       // background pipeline can fire `create_calendar_event`
       // *after* `send_email` succeeds.  We clear the in-scope
@@ -1576,6 +1882,32 @@
     // event; the background pipeline will create it on
     // send-success.
     stagedEvent = null
+
+    // Tombstone the source draft BEFORE `onclose()` (#292
+    // follow-up).  `onclose` triggers the parent's `refreshToken`
+    // bump which immediately schedules a `fetch_envelopes`; the
+    // background `runSendPipeline` doesn't reach its
+    // `invoke('delete_message')` for another ~30-100ms, so without
+    // this upfront mark the fresh batch comes back carrying the
+    // about-to-be-expunged UID and `mergeEnvelopes` puts it back in
+    // the visible list (it lingers until the next sync evicts it).
+    // We also fire `ondraftexpunged` here so the in-memory mail
+    // list state is spliced in the same beat — covers the cache-
+    // hit phase of MailList's load() too.  Both are best-effort:
+    // a failure leaves the row visible briefly but doesn't undo
+    // the send.
+    if (snap.draftSource) {
+      try {
+        await invoke('tombstone_draft_for_expunge', {
+          accountId: snap.draftSource.accountId,
+          folder: snap.draftSource.folder,
+          uid: snap.draftSource.uid,
+        })
+      } catch (e) {
+        console.warn('tombstone_draft_for_expunge before send onclose failed', e)
+      }
+      ondraftexpunged?.(snap.draftSource)
+    }
 
     onclose()
 
@@ -1787,9 +2119,30 @@
     // exactly one version of the message.  Best-effort post-
     // close: a failure leaves a stale draft which the user can
     // discard manually, but it doesn't undo the send.
+    //
+    // Routes through `expunge_draft_after_send` (not the user-
+    // facing `delete_message`) for two reasons:
+    //
+    //   1. `delete_message` moves Drafts UIDs to Trash by default
+    //      — leaving a copy of every sent draft in the user's
+    //      Trash folder.  Wrong semantics for "the draft was
+    //      consumed by send"; matches what the inline
+    //      save_draft replace path does.
+    //   2. On a real IMAP DELETE failure, `delete_message` clears
+    //      the cache tombstone so the row reappears in Drafts.
+    //      That's right for a user-initiated delete (they can
+    //      retry) but wrong here: the mail already shipped, so
+    //      the user expects the draft to disappear regardless
+    //      of cleanup status.  The dedicated IPC keeps the
+    //      tombstone planted (#292 follow-up).
+    //
+    // `ondraftexpunged` fires BEFORE the invoke so the mail-list
+    // splices the row out immediately, instead of letting it
+    // linger in the Drafts folder until the next sync.
     if (snap.draftSource) {
+      ondraftexpunged?.(snap.draftSource)
       try {
-        await invoke('delete_message', {
+        await invoke('expunge_draft_after_send', {
           accountId: snap.draftSource.accountId,
           folder: snap.draftSource.folder,
           uid: snap.draftSource.uid,
@@ -1823,7 +2176,13 @@
           in_reply_to: initial?.in_reply_to ?? null,
           nextcloudLinks: initial?.nextcloudLinks,
           talkLink: initial?.talkLink,
-          draftSource: initial?.draftSource,
+          // Use the live `currentDraftSource` so a popout after a
+          // minimize-save points at the post-APPEND UID, not the
+          // mount-time pointer (which is null for a brand-new
+          // compose).  Without this the popped-out window would
+          // re-save without `replaceSource` and leave a duplicate
+          // in Drafts.
+          draftSource: currentDraftSource ?? undefined,
         },
       })
     } catch (e) {
@@ -1835,6 +2194,16 @@
     // which is harmless here.
     onclose()
   }
+
+  // Hand the parent a stable reference to `cancel` so the
+  // shrunken-composes bar's × close-tab gesture can run the full
+  // cleanup flow (Talk room, share links, draft-source expunge)
+  // without first restoring the modal (#292).  Fires once on mount
+  // — the function reference doesn't change across re-renders, so
+  // a one-shot register is sufficient.
+  $effect(() => {
+    oncancelref?.(cancel)
+  })
 
   function cancel() {
     // No local persistence — if the user wants to resume later they
@@ -1938,11 +2307,19 @@
     {@render composeBody()}
   </div>
 {:else}
+  <!-- `minimized` flips the wrapper to display:none so the
+       Compose instance can sit alongside any number of other
+       Composes without their backdrops stacking.  The Tiptap
+       editor, attachments, Talk-room token, and share-link
+       bookkeeping all live in component state so they survive
+       the round-trip without re-mount (#292). -->
   <div
     bind:this={wrapperEl}
     class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 outline-none"
+    class:hidden={minimized}
     role="dialog"
     aria-modal="true"
+    aria-hidden={minimized}
     tabindex="-1"
     onkeydowncapture={onComposeKeydownCapture}
   >
@@ -1977,6 +2354,22 @@
             onclick={() => void popoutCompose()}
             title="Open this draft in a separate window"
           ><Icon name="full-screen" size={14} /> Pop out</button>
+        {/if}
+        {#if !inStandaloneWindow && onminimize}
+          <!-- Minimise this draft into the shrunken-composes bar
+               (#292).  Routes through `minimizeAndSave` rather than
+               `onminimize` directly so the in-flight draft also
+               lands in the user's Drafts folder — minimise is the
+               "park this for later" gesture, and "later" might be
+               a different device.  Hidden in standalone-window mode
+               because the OS window itself is the minimise surface
+               there. -->
+          <button
+            class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100 px-1 text-lg leading-none"
+            onclick={() => void minimizeAndSave()}
+            aria-label={m.compose_button_minimize_aria_label()}
+            title={m.compose_button_minimize_title()}
+          >–</button>
         {/if}
         <button class="text-surface-500 hover:text-surface-900 dark:hover:text-surface-100" onclick={cancel} aria-label="Close">✕</button>
       </div>

--- a/ui/src/lib/ShrunkenComposesBar.svelte
+++ b/ui/src/lib/ShrunkenComposesBar.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  /**
+   * ShrunkenComposesBar — browser-style tab strip docked to the
+   * bottom-right of the mail view for any Compose modals the user
+   * has minimised (#292).
+   *
+   * Each tab carries:
+   *   - the compose icon + the draft's live subject (parent pipes
+   *     Compose's `onsubjectchange` into the entry so the label
+   *     tracks user typing in real time, with "(no subject)" as
+   *     the fallback);
+   *   - a × close button on the right, hover-revealed to keep
+   *     resting tabs visually quiet — matches the CLAUDE.md "row
+   *     actions are opacity-0 by default" convention.
+   *
+   * Clicking the tab body restores that draft to a full-screen
+   * modal; clicking × routes through the Compose's own `cancel`
+   * function (handed up via `oncancelref` at mount) so Talk-room
+   * delete + share-link cleanup + draft-source expunge all run,
+   * the same as the modal-header × button does.
+   *
+   * Mounted only inside the mail view branch — the parent gates on
+   * `currentView` so navigating to Calendar / Contacts / Settings
+   * hides the bar without touching the underlying drafts.
+   */
+
+  import Icon from './Icon.svelte'
+  import { m } from '../paraglide/messages'
+
+  interface BarItem {
+    id: string
+    subject: string
+  }
+
+  interface Props {
+    items: BarItem[]
+    onrestore: (id: string) => void
+    onclose: (id: string) => void
+  }
+
+  let { items, onrestore, onclose }: Props = $props()
+</script>
+
+<!-- Outer wrapper anchors the strip to the bottom-right corner.
+     `pointer-events-none` lets clicks fall through the gaps
+     between tabs to the underlying mail UI; each tab re-enables
+     events with `pointer-events-auto`.  `z-40` sits just under the
+     Compose modal overlay (`z-50`) so an active modal still covers
+     the bar instead of leaving phantom tabs poking out. -->
+<div
+  class="fixed bottom-0 right-4 z-40 max-w-[85vw] overflow-x-auto pointer-events-none"
+  aria-label={m.compose_minimized_bar_aria_label()}
+>
+  <div class="flex items-end gap-1 pt-2 pb-0 px-1">
+    {#each items as item (item.id)}
+      <!-- `group` lets the × peer animate on hover; rounded-t-lg
+           gives the tab its "rising from the bottom edge" shape
+           without bottom rounding so the tab visually anchors to
+           the viewport edge. -->
+      <div
+        class="group pointer-events-auto inline-flex items-center gap-2 px-3 py-2
+               rounded-t-lg min-w-44 max-w-65 shadow-md
+               bg-surface-100 dark:bg-surface-800
+               border border-b-0 border-surface-300 dark:border-surface-700
+               hover:bg-surface-200 dark:hover:bg-surface-700
+               transition-colors"
+      >
+        <button
+          type="button"
+          class="flex-1 min-w-0 inline-flex items-center gap-2 text-left text-sm font-medium
+                 text-surface-900 dark:text-surface-50 cursor-pointer"
+          title={m.compose_minimized_item_title({
+            subject: item.subject || m.compose_minimized_no_subject(),
+          })}
+          onclick={() => onrestore(item.id)}
+        >
+          <Icon name="compose" size={16} />
+          <span class="truncate">
+            {item.subject || m.compose_minimized_no_subject()}
+          </span>
+        </button>
+        <button
+          type="button"
+          class="shrink-0 px-1 -mr-1 text-base leading-none cursor-pointer
+                 text-surface-500 hover:text-surface-900 dark:hover:text-surface-100
+                 opacity-0 group-hover:opacity-100 focus-visible:opacity-100
+                 transition-opacity"
+          aria-label={m.compose_minimized_item_close_aria_label()}
+          title={m.compose_minimized_item_close_title()}
+          onclick={(e) => {
+            e.stopPropagation()
+            onclose(item.id)
+          }}
+        >×</button>
+      </div>
+    {/each}
+  </div>
+</div>


### PR DESCRIPTION
Closes #292.

## Summary
- **Shrink/minimize Compose**: new `–` button in the modal header docks the Compose into a browser-style tab strip anchored to the bottom-right of the mail view. Each tab shows the compose icon + the draft's live subject, with a hover-revealed × that runs the full cancel cleanup (Talk room delete + share-link teardown + draft-source expunge).
- **Multiple drafts at once**: `composes[]` + `activeComposeId` replace the old single `composeInitial` slot. Opening a new Compose auto-minimises whatever was active. Minimized Composes stay mounted (`display:none`) so the Tiptap editor, attachments, Talk-room token, and share-link bookkeeping all survive the round-trip without re-mount.
- **Minimize saves to Drafts**: minimizing also APPENDs the in-flight body to the IMAP Drafts folder, so the user can resume the same draft from another device. Subsequent saves on the same Compose reuse the post-APPEND UID (looked up via `UID SEARCH HEADER Message-ID` since async-imap 0.10 doesn't surface APPENDUID) as `replace_source`, so Drafts holds exactly one copy per in-flight Compose.
- **Dedup against in-flight UIDs**: `openCompose` now restores an existing Compose when Edit Draft is triggered on a UID that's already represented in the bar — avoids the "two tabs for the same draft" symptom.
- **Race fixes** that surfaced during testing:
  - Send pipeline switched from the user-facing `delete_message` (which routed Drafts → Trash and cleared the cache tombstone on IMAP failure) to a dedicated `expunge_draft_after_send` that does a permanent low-level delete and **keeps the tombstone planted** — so IMAP servers with delayed EXPUNGE propagation (Gmail, some Exchange variants) can't have a racing poll re-insert the UID without `pending_action`.
  - `claim_outbox_for_drain` adds a 30 s CAS claim on `last_attempt_at` at the start of `try_drain_outbox_entry`, so the spawned drain from `send_email` and the periodic `drain_outbox_sweep` can't both process the same outbox row — fixes the recipient receiving the mail twice when their windows overlapped.
  - `send()` re-entrancy guard + coalescing `persistPromise` serialise concurrent saves vs sends, so the snap captured at send-time can't reference a UID that's about to change.
  - `snap.draftSource` is captured as a plain primitive object (spread, not the Svelte 5 deep-proxy reference) so subsequent reads can't observe a mutation that happened mid-flight.
- **Signature stacking fix** for edit-draft → save round-trips: `onEditDraft` passes `skipSignatureInsert: true`, and `initialBodyHtml`'s draft-source early-return pins `insertedSignatureHtml` to the embedded signature so the late-load `$effect` doesn't stamp another one on top.

## Test plan
- [x] Open new Compose → minimize → tab appears at bottom-right with subject. Restore via tab.
- [x] Open multiple Composes (Sidebar New / Edit Draft / Reply) → minimize all → multiple tabs in bar, each restores its own state.
- [x] Click × on a tab → confirm Talk-room + share-link cleanup still runs.
- [x] Verify each minimize creates / replaces exactly one draft in the IMAP Drafts folder.
- [x] Edit Draft → Save → Edit again → confirm the signature isn't doubled.
- [x] Edit Draft → Send → confirm the draft is gone from Drafts and stays gone (no flicker).
- [x] Minimize a draft, then click Edit Draft on that same UID in the Drafts folder — confirm the existing tab is restored rather than a duplicate Compose appearing.
- [x] Verify the recipient receives the mail exactly once (no duplicate from a sweep race).
- [x] Quick double-click Send — only one outbox row enqueued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)