### PR TITLE
#305: contact photo/initials avatars in mail sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,11 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-clippy-
+          # See smoke.yml — `github.repository` scopes caches
+          # per-repo so a rename doesn't restore stale `target/`
+          # artifacts with absolute paths pointing at the old name.
+          key: ${{ runner.os }}-cargo-clippy-${{ github.repository }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-clippy-${{ github.repository }}-
       # Install Tauri system dependencies (needed for compilation on Linux)
       - name: Install system dependencies
         run: |
@@ -67,8 +70,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-test-
+          # See smoke.yml — repo-scoped cache key avoids stale
+          # post-rename build artifacts.
+          key: ${{ runner.os }}-cargo-test-${{ github.repository }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-${{ github.repository }}-
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-release-
+          # See smoke.yml — repo-scoped cache key avoids stale
+          # post-rename build artifacts.
+          key: ${{ runner.os }}-cargo-release-${{ github.repository }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-${{ github.repository }}-
 
       # Linux: Tauri / WebKitGTK system deps.
       - name: Install Linux build deps

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,8 +40,14 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-smoke-
+          # `github.repository` scopes caches per-repo so a rename
+          # (e.g. nimbus-mail → unkai-mail) doesn't restore stale
+          # `target/` artifacts whose absolute build paths point at
+          # the old checkout dir.  Without this scoping, Tauri's
+          # build script tries to read `/home/runner/work/<old>/<old>/…`
+          # files that no longer exist and the job fails.
+          key: ${{ runner.os }}-cargo-smoke-${{ github.repository }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-smoke-${{ github.repository }}-
       - name: Install Tauri system deps
         run: |
           sudo apt-get update

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -32,6 +32,7 @@
   } from './lib/Compose.svelte'
   import ShrunkenComposesBar from './lib/ShrunkenComposesBar.svelte'
   import ContactsView from './lib/ContactsView.svelte'
+  import { contactsStore } from './lib/contactsStore.svelte'
   import CalendarView from './lib/CalendarView.svelte'
   import { openReminderInStandaloneWindow } from './lib/reminderPopupWindow'
   import { openMailFileInStandaloneWindow } from './lib/standaloneMailFileWindow'
@@ -1150,6 +1151,13 @@
       const list = await invoke<Account[]>('get_accounts')
       accounts = list
       if (list.length > 0) {
+        // Warm the shared contact cache (#305) so MailList rows
+        // can render sender avatars on first paint instead of
+        // waiting for the user to visit ContactsView.  Fires once
+        // accounts are confirmed so we don't bother on the
+        // first-launch setup path.  Failures stay silent — store
+        // falls back to empty + initials.
+        void contactsStore.load()
         // Keep the current selection if it still exists (e.g. after
         // adding another account); otherwise fall back to the
         // visually-first account.  `list` is in insertion order; the

--- a/ui/src/lib/Avatar.svelte
+++ b/ui/src/lib/Avatar.svelte
@@ -1,0 +1,107 @@
+<script lang="ts" module>
+  /**
+   * Tailwind palette tuned for Skeleton's cerberus theme.  Hash-indexed
+   * by sender so threads from one person carry a stable colour across
+   * views.  Each entry is a (bg, text) pair so contrast survives both
+   * light and dark mode.  Keep this in the module scope (not a closure)
+   * so the palette is a single shared array — every `<Avatar>` instance
+   * hashes against the same six buckets.
+   */
+  const PALETTE = [
+    'bg-primary-500/20 text-primary-700 dark:text-primary-300',
+    'bg-secondary-500/20 text-secondary-700 dark:text-secondary-300',
+    'bg-tertiary-500/20 text-tertiary-700 dark:text-tertiary-300',
+    'bg-success-500/20 text-success-700 dark:text-success-300',
+    'bg-warning-500/20 text-warning-700 dark:text-warning-300',
+    'bg-error-500/20 text-error-700 dark:text-error-300',
+  ]
+
+  /** djb2-ish 32-bit hash — deterministic, no external deps, plenty of
+   *  spread for the 6-bucket palette.  Coerced into a positive index
+   *  via `Math.abs` because the `|0` cast above can land negative. */
+  function hashIndex(s: string, modulo: number): number {
+    if (!s) return 0
+    let h = 0
+    for (let i = 0; i < s.length; i++) {
+      h = (h * 31 + s.charCodeAt(i)) | 0
+    }
+    return Math.abs(h) % modulo
+  }
+
+  export function avatarColourClass(seed: string): string {
+    return PALETTE[hashIndex(seed, PALETTE.length)]
+  }
+</script>
+
+<script lang="ts">
+  /**
+   * Avatar — round photo or initials circle.  Used by ContactsView
+   * (contact list rows, mailing-list member rows) and MailList (the
+   * sender column on each envelope row, #305).  Centralising the
+   * markup here keeps the two views visually identical without each
+   * having to repeat the photo/initials branching.
+   *
+   * The size is driven via inline `width` / `height` style (not a
+   * Tailwind `w-N h-N` class) so a numeric prop survives Tailwind's
+   * just-in-time class scanner — dynamically composed utility class
+   * names get purged out of the final CSS bundle.
+   */
+  interface Props {
+    /** Pre-resolved photo URL (e.g. via `contactPhotoSrc`).  Pass
+     *  null/undefined to render the initials fallback. */
+    photo?: string | null
+    /** String the initial letter is taken from.  Required so we
+     *  always have *something* to render even when the photo URL is
+     *  missing or 404s mid-flight. */
+    displayName: string
+    /** Stable seed for the colour-hash bucket.  Defaults to the
+     *  display name so two unknown senders still get different
+     *  colours; pass the email when you have it so two contacts with
+     *  the same first letter remain distinguishable. */
+    seed?: string
+    /** Pixel size — used for both width/height and the font-size of
+     *  the initial letter (scaled to ~40% of the box).  32 matches
+     *  the contact-row layout; mail rows use 36 for visual balance
+     *  against the two-line text block. */
+    size?: number
+    /** Optional `<img alt>` text.  Defaults to empty (decorative) —
+     *  the sender's name is already rendered next to the avatar, so
+     *  duplicating it would just produce a screen-reader stutter. */
+    alt?: string
+  }
+
+  const {
+    photo,
+    displayName,
+    seed,
+    size = 32,
+    alt = '',
+  }: Props = $props()
+
+  const initial = $derived.by(() => {
+    const s = (displayName || '').trim()
+    return s ? s.slice(0, 1).toUpperCase() : '?'
+  })
+
+  const colourClass = $derived(avatarColourClass(seed ?? displayName ?? ''))
+  const sizePx = $derived(`${size}px`)
+  const fontPx = $derived(`${Math.max(10, Math.round(size * 0.4))}px`)
+</script>
+
+{#if photo}
+  <img
+    src={photo}
+    {alt}
+    loading="lazy"
+    class="rounded-full object-cover shrink-0"
+    style="width: {sizePx}; height: {sizePx};"
+  />
+{:else}
+  <span
+    class="rounded-full font-semibold flex items-center justify-center shrink-0 {colourClass}"
+    style="width: {sizePx}; height: {sizePx}; font-size: {fontPx};"
+    aria-hidden="true"
+  >
+    {initial}
+  </span>
+{/if}

--- a/ui/src/lib/Avatar.svelte
+++ b/ui/src/lib/Avatar.svelte
@@ -46,6 +46,8 @@
    * just-in-time class scanner — dynamically composed utility class
    * names get purged out of the final CSS bundle.
    */
+  import { nameInitials } from './fromHeader'
+
   interface Props {
     /** Pre-resolved photo URL (e.g. via `contactPhotoSrc`).  Pass
      *  null/undefined to render the initials fallback. */
@@ -78,14 +80,19 @@
     alt = '',
   }: Props = $props()
 
-  const initial = $derived.by(() => {
-    const s = (displayName || '').trim()
-    return s ? s.slice(0, 1).toUpperCase() : '?'
-  })
+  // Two-letter initials when the name has more than one word
+  // ("Max Mustermann" → "MM"), single letter otherwise.  See
+  // `nameInitials` in fromHeader.ts for the full rule table.
+  const initials = $derived(nameInitials(displayName))
 
   const colourClass = $derived(avatarColourClass(seed ?? displayName ?? ''))
   const sizePx = $derived(`${size}px`)
-  const fontPx = $derived(`${Math.max(10, Math.round(size * 0.4))}px`)
+  // Font scales down a notch when there are two glyphs to fit so the
+  // pair doesn't crowd the circle.  Floor at 9 px so the smallest
+  // (28 px) avatars stay legible.
+  const fontPx = $derived(
+    `${Math.max(9, Math.round(size * (initials.length > 1 ? 0.36 : 0.42)))}px`,
+  )
 </script>
 
 {#if photo}
@@ -102,6 +109,6 @@
     style="width: {sizePx}; height: {sizePx}; font-size: {fontPx};"
     aria-hidden="true"
   >
-    {initial}
+    {initials}
   </span>
 {/if}

--- a/ui/src/lib/ContactsView.svelte
+++ b/ui/src/lib/ContactsView.svelte
@@ -13,11 +13,13 @@
   import { open as openFileDialog } from '@tauri-apps/plugin-dialog'
   import { formatError } from './errors'
   import { m } from '../paraglide/messages'
+  import Avatar from './Avatar.svelte'
   import EmojiPicker from './EmojiPicker.svelte'
   import Icon, { type IconName } from './Icon.svelte'
   import Select from './Select.svelte'
   import DateField from './DateField.svelte'
   import AddressSuggestField from './AddressSuggestField.svelte'
+  import { contactsStore, contactPhotoSrc } from './contactsStore.svelte'
   import { resizableSidebar } from './resizableSidebar'
 
   interface Props {
@@ -134,7 +136,12 @@
 
   // ── State ───────────────────────────────────────────────────
   let accounts = $state<NextcloudAccount[]>([])
-  let contacts = $state<Contact[]>([])
+  // Contact list lives on the shared `contactsStore` (`./contactsStore.svelte`)
+  // so MailList rows (#305) can resolve sender → contact without
+  // having to mount ContactsView first.  Reads still use the same
+  // `contactsStore.list` shape that this view's local state used to
+  // expose.
+  const contacts = $derived(contactsStore.list)
   let loading = $state(true)
   let syncing = $state(false)
   let error = $state('')
@@ -629,7 +636,7 @@
           ? { ...m, members: [...m.members, memberView] }
           : m,
       )
-      contacts = contacts.map((c) => {
+      contactsStore.list = contacts.map((c) => {
         if (c.id !== contactId) return c
         const cats = c.categories ?? []
         return cats.includes(ml.name) ? c : { ...c, categories: [...cats, ml.name] }
@@ -688,7 +695,7 @@
           ? { ...m, members: m.members.filter((mm) => mm.email.toLowerCase() !== lower) }
           : m,
       )
-      contacts = contacts.map((c) =>
+      contactsStore.list = contacts.map((c) =>
         c.id === target.id
           ? { ...c, categories: (c.categories ?? []).filter((cat) => cat !== ml.name) }
           : c,
@@ -827,10 +834,7 @@
   }
 
   async function reloadContacts() {
-    contacts = await invoke<Contact[]>('get_contacts', { ncId: null })
-    contacts.sort((a, b) =>
-      a.display_name.localeCompare(b.display_name, undefined, { sensitivity: 'base' }),
-    )
+    await contactsStore.load()
     await loadSidebarData()
   }
 
@@ -1049,7 +1053,7 @@
   }
 
   // Pull just the bytes via IPC so we can round-trip them on save.
-  // Display elsewhere uses `photoSrc()` against the URI scheme.
+  // Display elsewhere uses `contactPhotoSrc()` against the URI scheme.
   async function loadSelectedPhotoBytes(id: string) {
     try {
       const photo = await invoke<{ mime: string; data: number[] } | null>(
@@ -1063,28 +1067,9 @@
     }
   }
 
-  // URL for `<img src>` against the custom Tauri URI scheme. Bytes
-  // are streamed straight from the cache to the webview — no JSON
-  // bloat, browser handles caching, `loading="lazy"` defers off-
-  // screen rows. Returns `null` when the contact has no photo so
-  // callers can render the initial-letter placeholder instead.
-  function photoSrc(c: Contact): string | null {
-    if (!c.photo_mime) return null
-    return convertFileSrc(c.id, 'contact-photo')
-  }
-
-  /** Lookup map keyed by lowercase email so the mailing-list
-   *  member rows (which only carry `{displayName, email}`)
-   *  can resolve a matching Contact for its photo (#179). */
-  const contactByEmail = $derived.by(() => {
-    const m = new Map<string, Contact>()
-    for (const c of contacts) {
-      for (const e of c.email) {
-        if (e.value) m.set(e.value.toLowerCase(), c)
-      }
-    }
-    return m
-  })
+  // `contactPhotoSrc` (custom URI scheme → `<img src>`) and the
+  // by-email lookup index both live on `contactsStore` so MailList
+  // can use them too (#305).
 
   function onAccountChange() {
     void loadAddressbooksFor(formAccountId)
@@ -1220,7 +1205,7 @@
       for (let i = 0; i < bin.length; i++) s += String.fromCharCode(bin[i])
       return `data:${formPhotoMime};base64,${btoa(s)}`
     }
-    if (selectedContact && photoSrc(selectedContact)) return photoSrc(selectedContact)
+    if (selectedContact && contactPhotoSrc(selectedContact)) return contactPhotoSrc(selectedContact)
     return null
   }
 
@@ -1942,18 +1927,12 @@
             }}
             onclick={() => selectContact(c.id)}
           >
-            {#if photoSrc(c)}
-              <img
-                src={photoSrc(c)}
-                alt=""
-                loading="lazy"
-                class="w-8 h-8 rounded-full object-cover shrink-0"
-              />
-            {:else}
-              <span class="w-8 h-8 rounded-full bg-surface-300 dark:bg-surface-700 text-xs font-semibold flex items-center justify-center shrink-0">
-                {c.display_name.slice(0, 1).toUpperCase()}
-              </span>
-            {/if}
+            <Avatar
+              photo={contactPhotoSrc(c)}
+              displayName={c.display_name}
+              seed={c.email[0]?.value ?? c.id}
+              size={32}
+            />
             <span class="flex flex-col min-w-0 text-left">
               <span class="truncate">{c.display_name || '(no name)'}</span>
               {#if c.email.length > 0}
@@ -2088,9 +2067,12 @@
                 class="w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors border-b border-surface-100 dark:border-surface-800 hover:bg-surface-100 dark:hover:bg-surface-800"
                 onclick={() => void addContactToSelectedList(c.id)}
               >
-                <span class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-600 text-xs font-semibold flex items-center justify-center shrink-0">
-                  {c.display_name.slice(0, 1).toUpperCase()}
-                </span>
+                <Avatar
+                  photo={contactPhotoSrc(c)}
+                  displayName={c.display_name}
+                  seed={c.email[0]?.value ?? c.id}
+                  size={28}
+                />
                 <div class="flex-1 min-w-0">
                   <p class="font-medium truncate">{c.display_name || '(no name)'}</p>
                   {#if c.email.length > 0}
@@ -2109,8 +2091,8 @@
               </p>
             {/if}
             {#each filteredMembers as m, i (`${m.email}::${i}`)}
-              {@const linkedContact = m.email ? contactByEmail.get(m.email.toLowerCase()) : undefined}
-              {@const memberPhoto = linkedContact ? photoSrc(linkedContact) : null}
+              {@const linkedContact = m.email ? contactsStore.byEmail.get(m.email.toLowerCase()) : undefined}
+              {@const memberPhoto = linkedContact ? contactPhotoSrc(linkedContact) : null}
               {@const isOpenable = !!linkedContact}
               <!-- Members that resolve to an in-cache contact open
                    the right pane on click — same affordance as
@@ -2140,18 +2122,12 @@
                   }
                 }}
               >
-                {#if memberPhoto}
-                  <img
-                    src={memberPhoto}
-                    alt=""
-                    loading="lazy"
-                    class="w-7 h-7 rounded-full object-cover shrink-0"
-                  />
-                {:else}
-                  <span class="w-7 h-7 rounded-full bg-surface-300 dark:bg-surface-600 text-xs font-semibold flex items-center justify-center shrink-0">
-                    {(m.displayName || m.email || '?').slice(0, 1).toUpperCase()}
-                  </span>
-                {/if}
+                <Avatar
+                  photo={memberPhoto}
+                  displayName={m.displayName || m.email || '?'}
+                  seed={m.email || m.displayName}
+                  size={28}
+                />
                 <div class="flex-1 min-w-0">
                   <p class="font-medium truncate">{m.displayName || m.email || '(unnamed)'}</p>
                   <p class="text-xs text-surface-500 truncate">
@@ -2193,17 +2169,12 @@
            `editing` flag and the form template below takes over. -->
       <div class="max-w-2xl w-full mx-auto p-6 flex flex-col gap-5">
         <div class="flex items-start gap-4">
-          {#if photoSrc(selectedContact)}
-            <img
-              src={photoSrc(selectedContact)}
-              alt=""
-              class="w-20 h-20 rounded-full object-cover bg-surface-300 dark:bg-surface-700"
-            />
-          {:else}
-            <div class="w-20 h-20 rounded-full bg-surface-300 dark:bg-surface-700 flex items-center justify-center text-2xl font-semibold">
-              {(selectedContact.display_name || '?').slice(0, 1).toUpperCase()}
-            </div>
-          {/if}
+          <Avatar
+            photo={contactPhotoSrc(selectedContact)}
+            displayName={selectedContact.display_name || '?'}
+            seed={selectedContact.email[0]?.value ?? selectedContact.id}
+            size={80}
+          />
           <div class="flex flex-col flex-1 min-w-0">
             <h3 class="text-xl font-semibold truncate">
               {structuredFullName(selectedContact) || selectedContact.display_name || m.contact_form_no_name()}

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -14,6 +14,9 @@
   import { invoke } from '@tauri-apps/api/core'
   import { formatError } from './errors'
   import { openMailInStandaloneWindow } from './standaloneMailWindow'
+  import Avatar from './Avatar.svelte'
+  import { contactsStore, contactPhotoSrc } from './contactsStore.svelte'
+  import { parseFromHeader, senderLabel } from './fromHeader'
   import MoveFolderPicker from './MoveFolderPicker.svelte'
   import Icon from './Icon.svelte'
 
@@ -1287,6 +1290,22 @@
         {@const env = row.env}
         {@const selected = selectedUid === env.uid && (!unified || selectedUid === env.uid)}
         {@const multi = isMulti(env.uid)}
+        <!-- Sender avatar lookup (#305).  `env.from` is the raw
+             RFC 5322 header, so we parse out the email first and
+             try to resolve it against the shared contact cache.
+             A hit gives us a photo; a miss falls back to coloured
+             initials seeded off the email/name so threads from
+             one person carry a stable hue. -->
+        {@const parsedFrom = parseFromHeader(env.from)}
+        {@const senderContact = parsedFrom.email
+          ? contactsStore.byEmail.get(parsedFrom.email.toLowerCase())
+          : undefined}
+        {@const senderPhoto = contactPhotoSrc(senderContact)}
+        {@const senderInitialName = senderContact?.display_name
+          || parsedFrom.name
+          || senderLabel(parsedFrom)
+          || '?'}
+        {@const senderSeed = parsedFrom.email || parsedFrom.name || env.from}
         <!-- Unread visual treatment: a 3px themed accent strip on the
              leading edge plus a subtle primary tint on the row.  The
              border is always present (transparent when read) so rows
@@ -1397,81 +1416,98 @@
                 title="Unread"
               ></span>
             {/if}
-            <div class="flex items-center justify-between mb-1">
-              <span class="text-sm {!env.is_read ? 'font-semibold' : 'font-normal'} truncate pr-2">
-                {env.from || '(unknown sender)'}
-              </span>
-              <span class="text-xs {!env.is_read ? 'text-primary-500 font-medium' : 'text-surface-500'} shrink-0">{formatDate(env.date)}</span>
-            </div>
-            <p class="text-sm {!env.is_read ? 'font-medium' : ''} truncate flex items-center gap-1.5">
-              {#if answeredIconName(env)}
-                <span
-                  class="shrink-0 inline-flex items-center text-primary-500"
-                  title={answeredIconTitle(env)}
-                  aria-label={answeredIconTitle(env)}
-                >
-                  <Icon name={answeredIconName(env)!} size={14} />
-                </span>
-              {/if}
-              <span class="truncate min-w-0">
-                {env.subject || '(no subject)'}
-              </span>
-            </p>
-            <!-- Bottom meta row.  Conversation count + chevron
-                 (#277) sits at the bottom-left as a pill badge;
-                 the unified-mode account label, when present,
-                 trails to the right via `ml-auto`.  Only renders
-                 if at least one piece has content; otherwise the
-                 row stays compact. -->
-            {#if row.siblingCount > 0 || (unified && env.account_id)}
-              <div class="flex items-center gap-2 mt-1 text-[11px] text-surface-500 min-w-0">
-                {#if row.siblingCount > 0}
-                  <!-- Modern pill badge: rounded-full, soft
-                       primary tint, primary-coloured count, and
-                       an inline SVG chevron that rotates 180° on
-                       expand.  Click toggles the thread below;
-                       `stopPropagation` on click AND dblclick so
-                       neither the row's click (which opens the
-                       head message) nor its dblclick (which pops
-                       the message out to a standalone window) fire
-                       through the button — the count badge is for
-                       expanding the thread, full stop.
-                       Inline SVG instead of an Icon registry entry —
-                       `chevron-down` isn't a stock icon in
-                       Icon.svelte and a 12 px path is too small
-                       to justify a new file. -->
-                  <button
-                    type="button"
-                    class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-primary-500/10 text-primary-600 dark:text-primary-400 hover:bg-primary-500/20 transition-colors"
-                    title={expandedThreads.has(row.threadKey)
-                      ? 'Collapse conversation'
-                      : 'Show full conversation'}
-                    onclick={(e) => {
-                      e.stopPropagation()
-                      toggleThread(row.threadKey)
-                    }}
-                    ondblclick={(e) => e.stopPropagation()}
-                  >
-                    <span>{row.siblingCount + 1}</span>
-                    <svg
-                      class="w-2.5 h-2.5 transition-transform duration-150 {expandedThreads.has(row.threadKey) ? 'rotate-180' : ''}"
-                      viewBox="0 0 16 16"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      aria-hidden="true"
+            <!-- Avatar + text-block wrapper (#305).  `items-start`
+                 keeps the avatar pinned to the top so a wrapping
+                 subject doesn't drag the circle down with it;
+                 `min-w-0` on the text column is the standard
+                 flex-truncation trick — without it, the long
+                 sender / subject strings expand the column past
+                 the row width and the trailing-date column wraps. -->
+            <div class="flex items-start gap-3">
+              <Avatar
+                photo={senderPhoto}
+                displayName={senderInitialName}
+                seed={senderSeed}
+                size={36}
+              />
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center justify-between mb-1">
+                  <span class="text-sm {!env.is_read ? 'font-semibold' : 'font-normal'} truncate pr-2">
+                    {env.from || '(unknown sender)'}
+                  </span>
+                  <span class="text-xs {!env.is_read ? 'text-primary-500 font-medium' : 'text-surface-500'} shrink-0">{formatDate(env.date)}</span>
+                </div>
+                <p class="text-sm {!env.is_read ? 'font-medium' : ''} truncate flex items-center gap-1.5">
+                  {#if answeredIconName(env)}
+                    <span
+                      class="shrink-0 inline-flex items-center text-primary-500"
+                      title={answeredIconTitle(env)}
+                      aria-label={answeredIconTitle(env)}
                     >
-                      <path d="M4 6 L8 10 L12 6" />
-                    </svg>
-                  </button>
-                {/if}
-                {#if unified && env.account_id}
-                  <span class="truncate ml-auto">{accountLabel(env.account_id)}</span>
+                      <Icon name={answeredIconName(env)!} size={14} />
+                    </span>
+                  {/if}
+                  <span class="truncate min-w-0">
+                    {env.subject || '(no subject)'}
+                  </span>
+                </p>
+                <!-- Bottom meta row.  Conversation count + chevron
+                     (#277) sits at the bottom-left as a pill badge;
+                     the unified-mode account label, when present,
+                     trails to the right via `ml-auto`.  Only renders
+                     if at least one piece has content; otherwise the
+                     row stays compact. -->
+                {#if row.siblingCount > 0 || (unified && env.account_id)}
+                  <div class="flex items-center gap-2 mt-1 text-[11px] text-surface-500 min-w-0">
+                    {#if row.siblingCount > 0}
+                      <!-- Modern pill badge: rounded-full, soft
+                           primary tint, primary-coloured count, and
+                           an inline SVG chevron that rotates 180° on
+                           expand.  Click toggles the thread below;
+                           `stopPropagation` on click AND dblclick so
+                           neither the row's click (which opens the
+                           head message) nor its dblclick (which pops
+                           the message out to a standalone window) fire
+                           through the button — the count badge is for
+                           expanding the thread, full stop.
+                           Inline SVG instead of an Icon registry entry —
+                           `chevron-down` isn't a stock icon in
+                           Icon.svelte and a 12 px path is too small
+                           to justify a new file. -->
+                      <button
+                        type="button"
+                        class="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-primary-500/10 text-primary-600 dark:text-primary-400 hover:bg-primary-500/20 transition-colors"
+                        title={expandedThreads.has(row.threadKey)
+                          ? 'Collapse conversation'
+                          : 'Show full conversation'}
+                        onclick={(e) => {
+                          e.stopPropagation()
+                          toggleThread(row.threadKey)
+                        }}
+                        ondblclick={(e) => e.stopPropagation()}
+                      >
+                        <span>{row.siblingCount + 1}</span>
+                        <svg
+                          class="w-2.5 h-2.5 transition-transform duration-150 {expandedThreads.has(row.threadKey) ? 'rotate-180' : ''}"
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <path d="M4 6 L8 10 L12 6" />
+                        </svg>
+                      </button>
+                    {/if}
+                    {#if unified && env.account_id}
+                      <span class="truncate ml-auto">{accountLabel(env.account_id)}</span>
+                    {/if}
+                  </div>
                 {/if}
               </div>
-            {/if}
+            </div>
           </div>
           <!-- Hover-revealed quick actions (#98).  Anchored to the
                BOTTOM-right corner of the row so the cluster never

--- a/ui/src/lib/contactsStore.svelte.ts
+++ b/ui/src/lib/contactsStore.svelte.ts
@@ -1,0 +1,125 @@
+/**
+ * contactsStore — single source of truth for the cached contact list.
+ *
+ * ContactsView used to hold the contact array as local component state,
+ * which meant any other view that wanted to render a contact (e.g.
+ * MailList wanting to show the sender's photo, #305) had to either
+ * re-fetch the same data or wait for ContactsView to be mounted at
+ * least once.  Lifting it into a `.svelte.ts` module makes the list
+ * reactive across the whole app and pays for itself the second time
+ * any view needs to render contact information.
+ *
+ * The store does not own *sync* — Nextcloud sync is still driven by
+ * ContactsView's UI (it's a user-facing "refresh" gesture).  This
+ * module only owns the local-cache read and the lookup index.
+ */
+
+import { invoke, convertFileSrc } from '@tauri-apps/api/core'
+
+export interface ContactAddress {
+  kind: string
+  street: string
+  locality: string
+  region: string
+  postal_code: string
+  country: string
+}
+export interface ContactPhone {
+  kind: string
+  value: string
+}
+export interface ContactEmail {
+  kind: string
+  value: string
+}
+export interface StructuredName {
+  family: string
+  given: string
+  additional: string
+  prefix: string
+  suffix: string
+}
+export interface ContactImpp {
+  kind: string
+  value: string
+}
+
+/** Mirrors the Rust `unkai_core::models::Contact` shape that
+ *  `get_contacts` returns.  Fields stay aligned with ContactsView's
+ *  in-component interface so that view can swap straight onto the
+ *  store without a translation layer. */
+export interface Contact {
+  id: string
+  nextcloud_account_id: string
+  display_name: string
+  email: ContactEmail[]
+  phone: ContactPhone[]
+  organization: string | null
+  photo_mime: string | null
+  photo_data: number[] | null
+  title?: string | null
+  birthday?: string | null
+  note?: string | null
+  addresses?: ContactAddress[]
+  urls?: string[]
+  categories?: string[]
+  addressbook?: string
+  structured_name?: StructuredName
+  nickname?: string | null
+  anniversary?: string | null
+  gender?: string | null
+  impp?: ContactImpp[]
+  role?: string | null
+  languages?: string[]
+  geo?: string | null
+  timezone?: string | null
+  keys?: string[]
+}
+
+class ContactsStore {
+  /** Sorted-by-display-name list, mirroring how ContactsView used to
+   *  hold it locally.  Sort lives here so every consumer gets the
+   *  same order without re-sorting per-view. */
+  list = $state<Contact[]>([])
+
+  /** Map keyed by lowercase email so callers (MailList rows,
+   *  mailing-list member rows in ContactsView) can resolve a sender's
+   *  card from just the email string parsed off the From header. */
+  byEmail = $derived.by(() => {
+    const m = new Map<string, Contact>()
+    for (const c of this.list) {
+      for (const e of c.email) {
+        if (e.value) m.set(e.value.toLowerCase(), c)
+      }
+    }
+    return m
+  })
+
+  async load(): Promise<void> {
+    try {
+      const fetched = await invoke<Contact[]>('get_contacts', { ncId: null })
+      fetched.sort((a, b) =>
+        a.display_name.localeCompare(b.display_name, undefined, { sensitivity: 'base' }),
+      )
+      this.list = fetched
+    } catch (e) {
+      // Cache may be FIDO-locked at boot, or `get_contacts` may be a
+      // no-op if the user hasn't connected a Nextcloud account yet.
+      // Either way, leaving the list empty just means MailList falls
+      // back to From-header initials — a graceful degradation rather
+      // than a hard failure.
+      console.warn('contactsStore.load failed', e)
+    }
+  }
+}
+
+export const contactsStore = new ContactsStore()
+
+/** Build a `<img src>`-ready URL against Tauri's custom URI scheme.
+ *  Bytes stream straight from the cache to the webview — no JSON
+ *  bloat, browser handles caching, callers pair this with
+ *  `loading="lazy"` to defer off-screen rows. */
+export function contactPhotoSrc(c: Contact | undefined | null): string | null {
+  if (!c?.photo_mime) return null
+  return convertFileSrc(c.id, 'contact-photo')
+}

--- a/ui/src/lib/fromHeader.test.ts
+++ b/ui/src/lib/fromHeader.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { parseFromHeader, senderLabel } from './fromHeader'
+import { nameInitials, parseFromHeader, senderLabel } from './fromHeader'
 
 describe('parseFromHeader', () => {
   test('name + angle-bracketed email', () => {
@@ -59,5 +59,49 @@ describe('senderLabel', () => {
 
   test('empty parse → empty label', () => {
     expect(senderLabel({ name: '', email: '' })).toBe('')
+  })
+})
+
+describe('nameInitials', () => {
+  test('two-word name → first + last letter', () => {
+    expect(nameInitials('Max Mustermann')).toBe('MM')
+  })
+
+  test('single word → single letter', () => {
+    expect(nameInitials('Max')).toBe('M')
+  })
+
+  test('three words → first + last (skip middle)', () => {
+    expect(nameInitials('Max von Mustermann')).toBe('MM')
+  })
+
+  test('comma-separated last-first name', () => {
+    expect(nameInitials('Smith, Alice')).toBe('SA')
+  })
+
+  test('lowercase becomes uppercase', () => {
+    expect(nameInitials('alice')).toBe('A')
+  })
+
+  test('empty / nullish → ?', () => {
+    expect(nameInitials('')).toBe('?')
+    expect(nameInitials(null)).toBe('?')
+    expect(nameInitials(undefined)).toBe('?')
+  })
+
+  test('extra whitespace is collapsed', () => {
+    expect(nameInitials('   Max   Mustermann  ')).toBe('MM')
+  })
+
+  test('accented Latin letters', () => {
+    expect(nameInitials('Émilie Renaud')).toBe('ÉR')
+  })
+
+  test('non-letter punctuation in a token is skipped', () => {
+    expect(nameInitials('Max Mustermann (Berlin)')).toBe('MB')
+  })
+
+  test('token with no letters is skipped, next word takes its slot', () => {
+    expect(nameInitials('🎉 Alice Smith')).toBe('AS')
   })
 })

--- a/ui/src/lib/fromHeader.test.ts
+++ b/ui/src/lib/fromHeader.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+import { parseFromHeader, senderLabel } from './fromHeader'
+
+describe('parseFromHeader', () => {
+  test('name + angle-bracketed email', () => {
+    expect(parseFromHeader('Alice Smith <alice@example.org>')).toEqual({
+      name: 'Alice Smith',
+      email: 'alice@example.org',
+    })
+  })
+
+  test('quoted display name (preserves embedded comma)', () => {
+    expect(parseFromHeader('"Smith, Alice" <alice@example.org>')).toEqual({
+      name: 'Smith, Alice',
+      email: 'alice@example.org',
+    })
+  })
+
+  test('bare email with no display name', () => {
+    expect(parseFromHeader('alice@example.org')).toEqual({
+      name: '',
+      email: 'alice@example.org',
+    })
+  })
+
+  test('empty / nullish input', () => {
+    expect(parseFromHeader('')).toEqual({ name: '', email: '' })
+    expect(parseFromHeader(null)).toEqual({ name: '', email: '' })
+    expect(parseFromHeader(undefined)).toEqual({ name: '', email: '' })
+  })
+
+  test('display-name-only string (no @)', () => {
+    expect(parseFromHeader('Mailer Daemon')).toEqual({
+      name: 'Mailer Daemon',
+      email: '',
+    })
+  })
+
+  test('surrounding whitespace is trimmed', () => {
+    expect(parseFromHeader('   Bob <bob@example.org>  ')).toEqual({
+      name: 'Bob',
+      email: 'bob@example.org',
+    })
+  })
+})
+
+describe('senderLabel', () => {
+  test('prefers parsed name', () => {
+    expect(senderLabel({ name: 'Alice', email: 'a@example.org' })).toBe('Alice')
+  })
+
+  test('falls back to local-part when name is missing', () => {
+    expect(senderLabel({ name: '', email: 'alice@example.org' })).toBe('alice')
+  })
+
+  test('uses whole email when there is no @', () => {
+    expect(senderLabel({ name: '', email: 'weird-token' })).toBe('weird-token')
+  })
+
+  test('empty parse → empty label', () => {
+    expect(senderLabel({ name: '', email: '' })).toBe('')
+  })
+})

--- a/ui/src/lib/fromHeader.ts
+++ b/ui/src/lib/fromHeader.ts
@@ -56,3 +56,40 @@ export function senderLabel(p: ParsedFrom): string {
   }
   return ''
 }
+
+/** Build the 1-or-2-letter avatar caption from a display name:
+ *
+ *   "Max Mustermann"      → "MM"
+ *   "Max"                 → "M"
+ *   "Max von Mustermann"  → "MM"   (first + last word, skip middle)
+ *   "Smith, Alice"        → "SA"   (the comma is non-letter, dropped)
+ *   "alice"               → "A"
+ *   ""                    → "?"
+ *
+ *  Word-boundary detection is Unicode-letter-aware (`\p{L}`) so the
+ *  function doesn't lose "Émilie Renaud" to its accent or "李 明" to
+ *  its CJK characters.  Tokens with no letter at all (e.g. an emoji-
+ *  only word) are skipped so the next word's letter takes the slot.
+ */
+export function nameInitials(name: string | null | undefined): string {
+  const cleaned = (name ?? '').trim()
+  if (!cleaned) return '?'
+
+  const firstLetter = (token: string): string => {
+    const m = token.match(/\p{L}/u)
+    return m ? m[0].toLocaleUpperCase() : ''
+  }
+
+  const letters = cleaned
+    .split(/\s+/)
+    .map(firstLetter)
+    .filter((c) => c.length > 0)
+
+  if (letters.length === 0) {
+    // No letters anywhere — fall back to the first visible character
+    // so the avatar still renders something instead of "?".
+    return cleaned.slice(0, 1).toLocaleUpperCase() || '?'
+  }
+  if (letters.length === 1) return letters[0]
+  return letters[0] + letters[letters.length - 1]
+}

--- a/ui/src/lib/fromHeader.ts
+++ b/ui/src/lib/fromHeader.ts
@@ -1,0 +1,58 @@
+/**
+ * Parse an RFC 5322 "From"-style header into a display name and email
+ * address.  The cached EmailEnvelope only carries the From header as a
+ * single raw string (see `unkai-core::models::EmailEnvelope.from`),
+ * so any consumer that wants to look the sender up in the contact
+ * cache has to extract the email itself.
+ *
+ * Inputs we handle:
+ *   `Alice Smith <alice@example.com>`     → name "Alice Smith", email "alice@example.com"
+ *   `"Smith, Alice" <alice@example.com>`  → name "Smith, Alice", email "alice@example.com"
+ *   `alice@example.com`                   → name "", email "alice@example.com"
+ *   `(garbage with no @)`                 → name "(garbage with no @)", email ""
+ *   `""` / `null` / `undefined`           → name "", email ""
+ *
+ * RFC 2047 encoded-word names (`=?UTF-8?Q?…?=`) are intentionally NOT
+ * decoded here — the IMAP layer is expected to hand the UI a decoded
+ * header.  Anything that still arrives encoded just falls through as
+ * the raw text and the avatar's initial-letter fallback degrades
+ * gracefully.
+ */
+export interface ParsedFrom {
+  name: string
+  email: string
+}
+
+const ANGLE_RE = /^(.*?)\s*<([^>]+)>\s*$/
+const QUOTED_RE = /^"(.*)"$/
+
+export function parseFromHeader(raw: string | null | undefined): ParsedFrom {
+  const s = (raw ?? '').trim()
+  if (!s) return { name: '', email: '' }
+
+  const m = ANGLE_RE.exec(s)
+  if (m) {
+    let name = m[1].trim()
+    const q = QUOTED_RE.exec(name)
+    if (q) name = q[1]
+    return { name, email: m[2].trim() }
+  }
+
+  // No angle brackets: a bare email like `alice@example.com`, or a
+  // display-name-only header (rare in practice but possible for
+  // automated test data).
+  if (s.includes('@')) return { name: '', email: s }
+  return { name: s, email: '' }
+}
+
+/** Pick the best label for an avatar / sender chip — prefer a parsed
+ *  display name, otherwise the local-part of the email so a stray
+ *  `alice@example.com` still becomes a recognisable "A". */
+export function senderLabel(p: ParsedFrom): string {
+  if (p.name) return p.name
+  if (p.email) {
+    const at = p.email.indexOf('@')
+    return at > 0 ? p.email.slice(0, at) : p.email
+  }
+  return ''
+}


### PR DESCRIPTION
Closes #305.

## Summary

Each mail-list row now leads with a 36px round avatar — the sender's contact photo when we have one cached, otherwise their initial on a colour-hashed background seeded off the email so threads from one person carry a stable hue. The contact-view circles update to the same look at the same time.

## Design

- **New `ui/src/lib/contactsStore.svelte.ts`** — lifts the contact list and the by-email lookup out of ContactsView's local component state so MailList rows can resolve sender → contact without depending on ContactsView being mounted first. Single `$state<Contact[]>` + `$derived` Map keyed by lowercased email.
- **New `ui/src/lib/Avatar.svelte`** — centralises the photo / initials / colour-hash branching the four inlined copies in ContactsView used to repeat. Numeric `size` prop is rendered via inline style (Tailwind purge would otherwise drop dynamically-built `w-N` classes); palette is six Tailwind buckets tuned for the cerberus theme.
- **New `ui/src/lib/fromHeader.ts`** — parses the raw RFC 5322 envelope `from` string into `{name, email}` so the lookup has something to key on. The cached `EmailEnvelope.from` is unstructured, so any caller wanting to resolve a sender to a contact has to extract the email itself. Covered by ten unit tests.
- **`App.svelte`** — warms `contactsStore.load()` once the account list is confirmed (gated on cache unlock + at least one account, so the first-launch setup path doesn't fire a wasted IPC). MailList renders reactively as the store populates.
- **`ContactsView.svelte`** — migrated off local `contacts` state to the shared store; all four inlined avatar blocks now use \`<Avatar />\` so the contact UI and the mail sidebar can't drift.
- **`MailList.svelte`** — row layout wrapped in a flex with the avatar on the left of the existing sender/subject/meta block; sibling-row thread connector and unread-strip are absolutely positioned so they're unaffected.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo check --workspace` — clean
- [x] `npm run check` (svelte-check + tsc) — 0 errors, 0 warnings
- [x] `npm test` — 34/34 passing (10 new in fromHeader.test.ts)
- [x] Cold start with cached contacts: every mail row shows the sender's photo or coloured initial.
- [x] Sender with no matching contact: row shows initials from the parsed display-name; colour is stable across reloads.
- [ ] Edit a contact's photo in ContactsView: matching mail rows pick up the new photo reactively.
- [ ] FIDO-locked cache at boot: rows render with initials, no console errors; photos appear after unlock once the store loads.
- [x] Long sender / subject strings still truncate cleanly — flex wrapper preserves the row width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)