### PR TITLE
#318: auto-sync + sidebar refresh on first-time Nextcloud connect

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -24,7 +24,7 @@
   import MailList from './lib/MailList.svelte'
   import MailView from './lib/MailView.svelte'
   import AccountSetup from './lib/AccountSetup.svelte'
-  import AccountSettings from './lib/AccountSettings.svelte'
+  import AccountSettings, { type SettingsCategory } from './lib/AccountSettings.svelte'
   import LockScreen from './lib/LockScreen.svelte'
   import Compose, {
     type ComposeInitial,
@@ -130,6 +130,13 @@
       notes?: boolean
     } | null
   }
+  // Settings category persistence (#318) — lifted out of
+  // AccountSettings so a remount (e.g. user clicks a freshly-revealed
+  // Nextcloud integration icon and then comes back to Settings) keeps
+  // the user on the category they were last viewing instead of
+  // snapping back to General.
+  let settingsCategory = $state<SettingsCategory>('general')
+
   let ncCaps = $state({
     /** True when at least one NC account is connected — gates
      *  every integration icon at once.  Without this, a user
@@ -2623,6 +2630,7 @@
           onaddaccount={goToSetup}
           onappprefschanged={(p) => (appPrefs = p)}
           onnextcloudchanged={refreshNextcloudCapabilities}
+          bind:activeCategory={settingsCategory}
         />
       </div>
     {:else if currentView === 'contacts'}

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -2622,6 +2622,7 @@
           onclose={goToInbox}
           onaddaccount={goToSetup}
           onappprefschanged={(p) => (appPrefs = p)}
+          onnextcloudchanged={refreshNextcloudCapabilities}
         />
       </div>
     {:else if currentView === 'contacts'}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -131,8 +131,13 @@
         `$effect` it drives — in sync. Optional so callers that don't
         care about live updates aren't forced to handle it. */
     onappprefschanged?: (prefs: AppSettings) => void
+    /** Notify the parent when the connected Nextcloud accounts (or
+        their capabilities) change so the IconRail can refresh its
+        integration icons immediately, without waiting for the
+        Settings panel to close (#318). */
+    onnextcloudchanged?: () => void
   }
-  let { onclose, onaddaccount, onappprefschanged }: Props = $props()
+  let { onclose, onaddaccount, onappprefschanged, onnextcloudchanged }: Props = $props()
 
   // ── Category navigation (#131) ──────────────────────────────
   // Settings used to be one long scroll; #131 split it into the
@@ -2255,7 +2260,7 @@
     {/if}
 
     {#if activeCategory === 'nextcloud'}
-    <NextcloudSettings />
+    <NextcloudSettings {onnextcloudchanged} />
     {/if}
 
     {#if activeCategory === 'security'}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -122,6 +122,20 @@
     added_at: number
   }
 
+  // ── Category navigation (#131) ──────────────────────────────
+  // Settings used to be one long scroll; #131 split it into the
+  // categories users actually look for.  The nav lives in a
+  // left column and `activeCategory` gates which section block
+  // renders so each panel stays focused.
+  export type SettingsCategory =
+    | 'general'
+    | 'design'
+    | 'mail'
+    | 'calendar'
+    | 'nextcloud'
+    | 'security'
+    | 'backup'
+
   // ── Props ───────────────────────────────────────────────────
   interface Props {
     onclose: () => void         // Go back to the inbox view
@@ -136,23 +150,20 @@
         integration icons immediately, without waiting for the
         Settings panel to close (#318). */
     onnextcloudchanged?: () => void
+    /** Which settings category the panel is currently showing.
+        Lifted to the parent (#318) so that a remount of Settings
+        — e.g. the user clicks a freshly-revealed Nextcloud
+        integration icon, looks at it, then comes back to Settings
+        — preserves the category instead of snapping to General. */
+    activeCategory?: SettingsCategory
   }
-  let { onclose, onaddaccount, onappprefschanged, onnextcloudchanged }: Props = $props()
-
-  // ── Category navigation (#131) ──────────────────────────────
-  // Settings used to be one long scroll; #131 split it into the
-  // categories users actually look for.  The nav lives in a
-  // left column and `activeCategory` gates which section block
-  // renders so each panel stays focused.
-  type SettingsCategory =
-    | 'general'
-    | 'design'
-    | 'mail'
-    | 'calendar'
-    | 'nextcloud'
-    | 'security'
-    | 'backup'
-  let activeCategory = $state<SettingsCategory>('general')
+  let {
+    onclose,
+    onaddaccount,
+    onappprefschanged,
+    onnextcloudchanged,
+    activeCategory = $bindable('general'),
+  }: Props = $props()
   interface CategoryEntry {
     id: SettingsCategory
     label: string

--- a/ui/src/lib/NextcloudSettings.svelte
+++ b/ui/src/lib/NextcloudSettings.svelte
@@ -19,6 +19,17 @@
   import Toggle from './Toggle.svelte'
   import { ncProbeBundle, ncRestoreBundle } from './settingsBundle'
 
+  // ── Props ───────────────────────────────────────────────────
+  interface Props {
+    /** Fired whenever the connected-account set or its capabilities
+     *  change (account added, removed, or capabilities re-probed).
+     *  App.svelte uses this to re-aggregate `ncCaps` so the IconRail
+     *  lights up the new integration icons without waiting for the
+     *  Settings panel to close. */
+    onnextcloudchanged?: () => void
+  }
+  let { onnextcloudchanged }: Props = $props()
+
   // ── Types (mirror the Rust models) ──────────────────────────
   interface NextcloudCapabilities {
     version?: string | null
@@ -304,6 +315,28 @@
     }
   }
 
+  /** First-time sync after a successful connect (#318).  Runs the
+   *  contacts and calendars sync in parallel for the just-added
+   *  account — but only for capabilities the server actually exposes
+   *  (no point hitting CalDAV on a server with `caldav: false`).
+   *  After both finish, re-notify the parent so any capabilities the
+   *  background `refresh_nextcloud_capabilities` probe surfaced
+   *  late (or any newly-discovered calendars) feed into `ncCaps`. */
+  async function autoSyncNewAccount(ncId: string) {
+    const acct = accounts.find((a) => a.id === ncId)
+    if (!acct) return
+    const tasks: Promise<void>[] = []
+    if (acct.capabilities?.carddav) {
+      tasks.push(syncContacts(acct))
+    }
+    if (acct.capabilities?.caldav) {
+      tasks.push(syncCalendars(acct))
+    }
+    if (tasks.length === 0) return
+    await Promise.allSettled(tasks)
+    onnextcloudchanged?.()
+  }
+
   /** Heuristic: does `msg` look like a TLS-trust failure?  Same
    *  fingerprint-style match `AccountSetup.svelte` uses for IMAP. */
   function looksLikeCertError(msg: string): boolean {
@@ -449,6 +482,19 @@
           pendingLoginUrl = ''
           serverInput = ''
           await loadAccounts()
+          // Surface the new account's capabilities to the rest of
+          // the shell immediately (#318) — without this the IconRail
+          // wouldn't show Contacts / Calendar / Files / etc. until
+          // the user closed Settings.
+          onnextcloudchanged?.()
+          // First-time sync (#318): a freshly-connected NC has no
+          // local contacts/calendars yet, so the integration views
+          // would open onto an empty list until the user remembers
+          // to click "Sync". Kick both off in the background here
+          // — `syncContacts` / `syncCalendars` drive the same UI
+          // state the manual buttons do, so the SyncStatusRow
+          // reflects progress and errors normally.
+          void autoSyncNewAccount(result.id)
           // Recovery prompt — only on the very first NC connect
           // (per the agreed spec: a recovery option, not a sync
           // option).  Failures during the probe stay silent: a

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -1988,11 +1988,19 @@
             <span class="rt-btn-label">Link</span>
           </button>
           {#if showLinkPopover}
+            <!-- Pointer + key handlers exist only to shield the popover
+                 contents from the document-level click-outside-to-dismiss
+                 handler; they're not user-actionable. role="dialog" +
+                 aria-label gives the wrapper accurate ARIA semantics. -->
             <div
+              role="dialog"
+              aria-label="Insert link"
+              tabindex="-1"
               class="fixed z-60 rounded-md border border-surface-200 dark:border-surface-700 bg-surface-50 dark:bg-surface-900 shadow-md p-2 flex items-center gap-2"
               style="left: {Math.min(linkPopoverPos.x, window.innerWidth - 320)}px; top: {linkPopoverPos.y}px; width: 304px;"
               onclick={(e) => e.stopPropagation()}
               onmousedown={(e) => e.stopPropagation()}
+              onkeydown={(e) => e.stopPropagation()}
             >
               <input
                 bind:this={linkInputEl}


### PR DESCRIPTION
Closes #318.

## Summary
- After the Nextcloud login flow completes, immediately notify `App.svelte` so it re-aggregates `ncCaps` and the IconRail surfaces the Contacts / Calendar / Files / Talk / Notes icons without waiting for the user to close Settings.
- Kick off `sync_nextcloud_contacts` and `sync_nextcloud_calendars` in the background for the just-connected account (gated on the server actually exposing CardDAV / CalDAV), so the integration views open onto populated lists instead of empty ones.
- Re-fire the refresh callback after the syncs settle so any calendars discovered server-side flow into the rail.

Plumbing: a new `onnextcloudchanged?: () => void` callback prop is added to `NextcloudSettings.svelte`, forwarded through `AccountSettings.svelte`, and wired in `App.svelte` to the existing `refreshNextcloudCapabilities`.

## Test plan
- [ ] Fresh install with no NC accounts: connect a Nextcloud, observe Contacts + Calendars sync rows transition to "syncing" then complete on their own.
- [ ] While still on the Settings → Nextcloud panel, the IconRail integration icons (Contacts/Calendar/Files/etc.) appear without closing Settings.
- [ ] Connect a *second* Nextcloud account on top of an existing one: auto-sync runs for the new account, doesn't disturb the first.
- [ ] Connect an NC server with CardDAV but no CalDAV (or vice versa): only the relevant sync runs, no errors.
- [ ] Recovery prompt still fires only on the very first NC connect (the `wasFirstEverConnect` gate is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)