### PR TITLE
#319: forward HTML mails with original formatting preserved

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1973,7 +1973,13 @@
             'base', 'meta', 'link', 'style',
           ],
         })
-      : htmlOrEscape(mail.body_text ?? '')
+      : // Plain-text forwards have no inline margins of their own,
+        // so the empty <p> between the header lines and the body
+        // collapses to almost nothing and the two clumps read as
+        // one paragraph.  Wrap in a top-margined div so the body
+        // sits visibly below the header.  HTML mails carry their
+        // own block spacing and don't need this.
+        `<div style="margin-top:16px;">${htmlOrEscape(mail.body_text ?? '')}</div>`
     const block = forwardedMailHtml({
       fromHeader: mail.from,
       whenText: new Date(mail.date).toLocaleString(),

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -13,6 +13,7 @@
 
   import { invoke } from '@tauri-apps/api/core'
   import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+  import DOMPurify from 'dompurify'
   import {
     isPermissionGranted,
     requestPermission,
@@ -46,7 +47,11 @@
   import { openEventEditorInStandaloneWindow } from './lib/standaloneEventEditorWindow'
   import { resizableSidebar } from './lib/resizableSidebar'
   import EventEditor, { type SavedEvent } from './lib/EventEditor.svelte'
-  import { quotedHistoryHtml, type MeetingInvite } from './lib/inviteHtml'
+  import {
+    forwardedMailHtml,
+    quotedHistoryHtml,
+    type MeetingInvite,
+  } from './lib/inviteHtml'
   import { parseMailtoUrl } from './lib/mailtoUrl'
   import SearchBar, {
     type SearchScope,
@@ -1781,6 +1786,7 @@
     cc: string[]
     subject: string
     body_text: string | null
+    body_html?: string | null
     date: string
     /** RFC 5322 threading anchors (#277).  Optional because
      *  older cached payloads predate the parser; absent values
@@ -1948,25 +1954,36 @@
   }
 
   function buildForwardInitial(mail: OpenMail): ComposeInitial {
-    // Forwards use the same blockquote treatment as replies so the
-    // original message sits inside a visually distinct container.
-    // Unlike reply, we prefix with a small header block that states
-    // the original From/Date/Subject so the recipient can see the
-    // chain even if they collapse the quote.
-    const esc = (s: string) =>
-      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    const when = new Date(mail.date).toLocaleString()
-    const header =
-      `<p><strong>---------- Forwarded message ----------</strong></p>` +
-      `<p>From: ${esc(mail.from)}<br>` +
-      `Date: ${esc(when)}<br>` +
-      `Subject: ${esc(mail.subject)}</p>`
-    const body = htmlOrEscape(mail.body_text ?? '')
+    // Forwards preserve the original message verbatim inside an
+    // UnkaiBlock atom (#319) so the editor doesn't reflow the
+    // sender's table layout, strip their inline styles, or
+    // duplicate <img> nodes while reconciling the HTML against
+    // Tiptap's block schema.  The header bar marks the chunk as a
+    // forward; the body below renders with the original CSS
+    // intact.  Sanitise via DOMPurify with the same posture
+    // MailView uses so scripts / iframes / style blocks from the
+    // sender don't ride along into our editor (and from there
+    // into the outgoing message).
+    const bodyHtml = mail.body_html
+      ? DOMPurify.sanitize(mail.body_html, {
+          FORBID_TAGS: [
+            'script', 'noscript', 'object', 'embed', 'applet',
+            'iframe', 'frame', 'frameset',
+            'form', 'input', 'textarea', 'select', 'button',
+            'base', 'meta', 'link', 'style',
+          ],
+        })
+      : htmlOrEscape(mail.body_text ?? '')
+    const block = forwardedMailHtml({
+      fromHeader: mail.from,
+      whenText: new Date(mail.date).toLocaleString(),
+      subjectText: mail.subject,
+      toHeader: mail.to.join(', '),
+      bodyHtml,
+    })
     return {
       subject: forwardSubject(mail.subject),
-      body:
-        `<p></p><p></p>` +
-        `<blockquote>${header}${body}</blockquote>`,
+      body: `<p></p><p></p>${block}`,
     }
   }
 

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1973,13 +1973,7 @@
             'base', 'meta', 'link', 'style',
           ],
         })
-      : // Plain-text forwards have no inline margins of their own,
-        // so the empty <p> between the header lines and the body
-        // collapses to almost nothing and the two clumps read as
-        // one paragraph.  Wrap in a top-margined div so the body
-        // sits visibly below the header.  HTML mails carry their
-        // own block spacing and don't need this.
-        `<div style="margin-top:16px;">${htmlOrEscape(mail.body_text ?? '')}</div>`
+      : htmlOrEscape(mail.body_text ?? '')
     const block = forwardedMailHtml({
       fromHeader: mail.from,
       whenText: new Date(mail.date).toLocaleString(),

--- a/ui/src/lib/inviteHtml.ts
+++ b/ui/src/lib/inviteHtml.ts
@@ -342,3 +342,62 @@ export function quotedHistoryHtml(args: {
 </div>
 `.trim()
 }
+
+// ── Forwarded-mail wrapper (#319) ───────────────────────────────
+
+/** Wrap a forwarded message's body so the original formatting
+ *  is preserved verbatim and the header matches the long-standing
+ *  forwarded-mail convention every receiving mail client knows.
+ *
+ *  The header is the de-facto-standard plain-text delimiter
+ *  (`---------- Forwarded message ----------`) followed by
+ *  bold-labelled `From:` / `Date:` / `Subject:` / `To:` lines.
+ *  This is the same shape virtually every other mail client emits,
+ *  so the recipient's client renders the forward the way they
+ *  expect rather than seeing a bespoke chrome from us.
+ *
+ *  The `data-unkai-block` wrapper carries no visual styling — it
+ *  exists purely so the editor's `UnkaiBlock` extension captures
+ *  the whole chunk as an atom node. Without that, Tiptap's
+ *  StarterKit schema unwraps the wrapper, strips the original
+ *  message's inline styles, and can duplicate `<img>` nodes while
+ *  reconciling complex `<table>` / `<picture>` markup against its
+ *  block schema (the original visual symptom on #319). Inside the
+ *  atom Tiptap doesn't parse the interior, so the email's table
+ *  layout, inline styles, and `<img>` elements survive untouched.
+ *  The chunk is non-editable; users add their note above it and
+ *  remove it as a unit with one Backspace if they don't want it.
+ *
+ *  `toHeader` is optional because the field is occasionally
+ *  missing on cached payloads — when absent we just omit the line
+ *  rather than print an empty `To:`. */
+export function forwardedMailHtml(args: {
+  fromHeader: string
+  whenText: string
+  subjectText: string
+  toHeader?: string
+  bodyHtml: string
+}): string {
+  const { fromHeader, whenText, subjectText, toHeader, bodyHtml } = args
+  const esc = (s: string) =>
+    s
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+  const lines = [
+    `<div><b>From:</b> ${esc(fromHeader)}</div>`,
+    `<div><b>Date:</b> ${esc(whenText)}</div>`,
+    `<div><b>Subject:</b> ${esc(subjectText)}</div>`,
+  ]
+  if (toHeader && toHeader.trim()) {
+    lines.push(`<div><b>To:</b> ${esc(toHeader)}</div>`)
+  }
+  return `
+<div data-unkai-block="forwarded-mail">
+  <p>---------- Forwarded message ----------</p>
+  ${lines.join('\n  ')}
+  <p></p>
+  ${bodyHtml}
+</div>
+`.trim()
+}


### PR DESCRIPTION
Closes #319.

## Summary
- Forwards now read `body_html` (preferred) with `body_text` as fallback, so HTML mail no longer arrives at the recipient as plain text.
- The forwarded chunk lives inside an `UnkaiBlock` atom (`data-unkai-block="forwarded-mail"`), so Tiptap leaves the interior alone. Without that, the editor was unwrapping the container, stripping inline styles, and duplicating `<img>` nodes while reconciling table / `<picture>` markup against its block schema — the two visible symptoms beyond the missing HTML.
- Header uses the standard `---------- Forwarded message ----------` delimiter with bold-labelled `From:` / `Date:` / `Subject:` / `To:` lines — the same shape every receiving client knows. No bespoke chrome on the wire.
- Body is DOMPurify-sanitised against the same FORBID_TAGS list `MailView.processEmailHtml` uses (script, iframe, form, style, ...), so foreign markup doesn't ride along into the editor or the outgoing message.
- One trade-off worth flagging: the forwarded chunk is non-editable inside the editor (Backspace removes it as a unit). Same model the "Previous conversation" reply block already uses — there's no way to keep arbitrary email HTML intact while letting Tiptap parse it.

## Test plan
- [x] Forward an HTML mail (marketing newsletter / styled message) → recipient sees original colours, tables, images.
- [x] Forward a plain-text-only mail → still works via the `body_text` fallback.
- [x] Forwarded chunk renders as one selectable atom in the editor; Backspace removes the whole thing.
- [x] Receiving the forward in a third-party client shows the standard `---------- Forwarded message ----------` header (not the previous boxed chrome).
- [ ] Pop-out-mail → Forward → Compose path (the `compose-from-mail` listener) works the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)