### PR TITLE
#330: collapse quoted / forwarded blocks in MailView display

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1749,9 +1749,34 @@
    *  the editor body — Tiptap's schema unwraps generic <div>
    *  wrappers and strips inline styles, so we keep this out of
    *  the editor and let Compose render it as its own read-only
-   *  preview block + splice it in at send time. */
-  function quoteBody(from: string, date: string, body: string | null): string {
-    const bodyHtml = htmlOrEscape(body ?? '')
+   *  preview block + splice it in at send time.
+   *
+   *  Prefers `body_html` when present so HTML content (forwarded
+   *  newsletters, rich signatures, table-based layouts) survives
+   *  into the quoted history.  Falls back to escaping `body_text`
+   *  for plain-text mail.  Sanitises via DOMPurify with the same
+   *  FORBID_TAGS list `MailView.processEmailHtml` uses, so foreign
+   *  scripts / iframes / style blocks from the original sender
+   *  don't ride along into the editor and outgoing message.  The
+   *  outer `quotedHistoryHtml` wrapper carries a `data-unkai-block`
+   *  attribute so Tiptap's `UnkaiBlock` extension treats the whole
+   *  chunk as an atom node and leaves the interior untouched. */
+  function quoteBody(
+    from: string,
+    date: string,
+    bodyText: string | null,
+    bodyHtmlSource?: string | null,
+  ): string {
+    const bodyHtml = bodyHtmlSource
+      ? DOMPurify.sanitize(bodyHtmlSource, {
+          FORBID_TAGS: [
+            'script', 'noscript', 'object', 'embed', 'applet',
+            'iframe', 'frame', 'frameset',
+            'form', 'input', 'textarea', 'select', 'button',
+            'base', 'meta', 'link', 'style',
+          ],
+        })
+      : htmlOrEscape(bodyText ?? '')
     const when = new Date(date).toLocaleString()
     return quotedHistoryHtml({
       fromHeader: from,
@@ -1819,7 +1844,7 @@
     return {
       to: mail.from,
       subject: replySubject(mail.subject),
-      body: quoteBody(mail.from, mail.date, mail.body_text),
+      body: quoteBody(mail.from, mail.date, mail.body_text, mail.body_html),
       repliedTo: {
         accountId: mail.account_id,
         folder: mail.folder,
@@ -1843,7 +1868,7 @@
       to: mail.from,
       cc: others.join(', '),
       subject: replySubject(mail.subject),
-      body: quoteBody(mail.from, mail.date, mail.body_text),
+      body: quoteBody(mail.from, mail.date, mail.body_text, mail.body_html),
       repliedTo: {
         accountId: mail.account_id,
         folder: mail.folder,
@@ -2256,7 +2281,12 @@
       // Body holds the styled quoted-history block; the meeting
       // card lands above it via `initialBodyHtml` in Compose,
       // which prepends `meetingInvite`-rendered HTML.
-      body: quoteBody(original.from, original.date, original.body_text),
+      body: quoteBody(
+        original.from,
+        original.date,
+        original.body_text,
+        original.body_html,
+      ),
       meetingInvite,
       // #255 — flag the original as `\Answered` once the meeting
       // reply lands.  The icon distinguishes "respond with

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -106,3 +106,141 @@ body {
 .email-html-body a:hover {
   opacity: 0.8;
 }
+
+/* ── Collapsible quoted / forwarded blocks (#330) ──────────────────────
+   Display-time disclosure card MailView wraps around every standard
+   "this is quoted / forwarded" marker (our own data-unkai-block, the
+   cite-blockquote convention, gmail_quote, moz-cite-prefix, the
+   `---------- Forwarded message ----------` delimiter, etc.).  The raw
+   email body is untouched on the wire — the card lives entirely in
+   the rendered DOM. */
+.email-html-body details.quoted-collapse {
+  margin: 12px 0;
+  border: 1px solid #e2e8f0;       /* slate-200 */
+  border-radius: 8px;
+  background: #f8fafc;              /* slate-50 */
+  color: #1e293b;                   /* slate-800 — readable dark text on light bg */
+  overflow: hidden;
+}
+
+[data-mode='dark'] .email-html-body details.quoted-collapse {
+  border-color: #475569;            /* slate-600 */
+  background: #1e293b;              /* slate-800 */
+  color: #f1f5f9;                   /* slate-100 — readable light text on dark bg */
+}
+
+/* "Always white" mode forces the email pane to a white card; the
+   chrome below must also stay light (regardless of app theme) so the
+   text inside the card stays readable against the slate-50 background.
+   This selector wins over the [data-mode='dark'] rule above via
+   specificity (both have one class + one attribute … here the white
+   selector is declared later so cascade order tips it). */
+.email-html-body--white details.quoted-collapse {
+  border-color: #e2e8f0;
+  background: #f8fafc;
+  color: #1e293b;
+}
+
+.email-html-body details.quoted-collapse > summary.quoted-collapse__summary {
+  display: block;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: #64748b;                   /* slate-500 — muted on light bg */
+  user-select: none;
+  list-style: none; /* hide default ▶ marker; we draw our own ▾ */
+}
+
+[data-mode='dark'] .email-html-body details.quoted-collapse > summary.quoted-collapse__summary {
+  color: #94a3b8;                   /* slate-400 — muted on dark bg */
+}
+
+.email-html-body--white details.quoted-collapse > summary.quoted-collapse__summary {
+  color: #64748b;
+}
+
+.email-html-body details.quoted-collapse > summary.quoted-collapse__summary::-webkit-details-marker {
+  display: none;
+}
+
+.email-html-body details.quoted-collapse > summary.quoted-collapse__summary::before {
+  content: '▸ ';
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+
+.email-html-body details.quoted-collapse[open] > summary.quoted-collapse__summary::before {
+  content: '▾ ';
+}
+
+.email-html-body details.quoted-collapse > summary.quoted-collapse__summary:hover {
+  background: #f1f5f9;              /* slate-100 */
+}
+
+[data-mode='dark'] .email-html-body details.quoted-collapse > summary.quoted-collapse__summary:hover {
+  background: #334155;              /* slate-700 */
+}
+
+.email-html-body--white details.quoted-collapse > summary.quoted-collapse__summary:hover {
+  background: #f1f5f9;
+}
+
+.email-html-body details.quoted-collapse .quoted-collapse__content {
+  padding: 12px 14px;
+  border-top: 1px solid #e2e8f0;    /* slate-200 */
+}
+
+[data-mode='dark'] .email-html-body details.quoted-collapse .quoted-collapse__content {
+  border-top-color: #475569;        /* slate-600 */
+}
+
+.email-html-body--white details.quoted-collapse .quoted-collapse__content {
+  border-top-color: #e2e8f0;
+}
+
+/* Styled mini-header for our own forwarded-mail wrapper.  Two-column
+   key-value layout (label / value) for the From / Date / Subject /
+   To rows we extracted from the source HTML. */
+.email-html-body details.quoted-collapse .quoted-collapse__header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 2px;
+  margin-bottom: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px dashed #e2e8f0; /* slate-200 */
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+[data-mode='dark'] .email-html-body details.quoted-collapse .quoted-collapse__header {
+  border-bottom-color: #475569;     /* slate-600 */
+}
+
+.email-html-body--white details.quoted-collapse .quoted-collapse__header {
+  border-bottom-color: #e2e8f0;
+}
+
+.email-html-body details.quoted-collapse .quoted-collapse__field {
+  display: contents; /* let the field's children sit directly in the grid */
+}
+
+.email-html-body details.quoted-collapse .quoted-collapse__label {
+  font-weight: 600;
+  color: #64748b;                   /* slate-500 */
+  text-align: right;
+}
+
+[data-mode='dark'] .email-html-body details.quoted-collapse .quoted-collapse__label {
+  color: #94a3b8;                   /* slate-400 */
+}
+
+.email-html-body--white details.quoted-collapse .quoted-collapse__label {
+  color: #94a3b8;
+}
+
+.email-html-body details.quoted-collapse .quoted-collapse__value {
+  color: inherit;
+  word-break: break-word;
+}

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -545,6 +545,477 @@
     }
   }
 
+  // ── Collapse quoted / forwarded blocks (#330) ────────────────────────
+  //
+  // Display-only transformation: every standard "this is a quoted /
+  // forwarded chunk" marker the wild collection of mail clients
+  // emits is folded into a native <details>/<summary> disclosure
+  // card so the reader sees the user's fresh content first and can
+  // expand the previous conversation on demand.  The raw
+  // `email.body_html` is never touched — Reply / Forward continue
+  // to read the unmodified body and emit the same wire format every
+  // other mail client expects.
+  //
+  // Markers handled, most-specific first.  Each pass skips elements
+  // already inside a `.quoted-collapse` to avoid double-wrapping
+  // nested matches (e.g. a `<blockquote type="cite">` inside our
+  // own `data-unkai-block="quoted-history"`).
+  //
+  //   1. `div[data-unkai-block="forwarded-mail"]` — our own forward
+  //      wrapper.  Parses the embedded From / Date / Subject / To
+  //      lines into a styled mini-header card; the body lands
+  //      below.
+  //   2. `div[data-unkai-block="quoted-history"]` — our own reply
+  //      wrapper.  Collapsed without re-styling — the inner
+  //      blockquote already has the muted-grey treatment.
+  //   3. `blockquote[type="cite"]` — the cite-blockquote
+  //      convention used by Apple Mail, Thunderbird, and the
+  //      RFC-3676 reply quoting style.
+  //   4. `div.gmail_quote`, `div.gmail_quote_container` — the
+  //      class names the dominant webmail emits on its reply
+  //      blocks.
+  //   5. `div.moz-cite-prefix` + the immediately-following
+  //      `<blockquote>` — Thunderbird splits the citation line
+  //      from the quoted body across two siblings; we wrap them
+  //      together.
+  //   6. The plain-text delimiter `---------- Forwarded message
+  //      ----------` followed by the rest of the body.  This is
+  //      the de-facto convention used when the sender's client
+  //      doesn't wrap forwards in a class-bearing div (and it's
+  //      what our own outgoing forwards emit, on top of the
+  //      data-unkai-block wrapper, so a receiving client without
+  //      the wrapper still recognises the chunk).
+  //
+  // The styled mini-header for case (1) is intentionally scoped to
+  // markers we own.  Universal multi-format parsing across every
+  // client's idiosyncratic header shape (Apple Mail's single
+  // line, Gmail's "On X at Y, Z wrote:", Thunderbird's table) is
+  // its own feature; for v1 the non-Unkai cases just collapse
+  // without restyling.
+
+  /** Does this element carry any visible content?  We treat empty
+   *  `<blockquote>` / `<div>` shells (common as line-spacers in mail
+   *  forwarded between clients) as "no content" so we don't render
+   *  empty disclosure cards over them.  Whitespace-only text doesn't
+   *  count; an `<img>` / `<video>` etc. does. */
+  function hasVisibleContent(el: Element): boolean {
+    if ((el.textContent ?? '').trim().length > 0) return true
+    return el.querySelector('img, video, audio, picture, canvas, svg') !== null
+  }
+
+  // Disclosure summary labels by chunk kind.  Replies show
+  // "conversation history"; forwards show "forwarded messages".
+  // For the ambiguous `<blockquote type="cite">` / `gmail_quote`
+  // markers (both clients use the same wrapper for replies AND
+  // forwards) we sniff the chunk text against forward-preamble
+  // markers below to pick the right label.
+  const REPLY_SUMMARY = 'Show conversation history'
+  const FORWARD_SUMMARY = 'Show forwarded messages'
+
+  // Multilingual forward-preamble markers used both to label
+  // ambiguous chunks as forwards and to recognise forward
+  // metadata in the body's outside-text for the auto-open
+  // heuristic.  Kept broad on purpose because different mail
+  // clients localise the preamble line and split the field
+  // labels differently.
+  const FORWARD_PREAMBLE_RE =
+    /(?:begin\s+forwarded\s+message|forwarded\s+message|anfang\s+der\s+weitergeleiteten\s+nachricht|weitergeleitete\s+nachricht|mensaje\s+reenviado|message\s+transféré|messaggio\s+inoltrato)/i
+  const FROM_LABEL_RE = /\b(?:from|von|de|fra|od):/i
+  const DATE_LABEL_RE =
+    /\b(?:date|datum|sent|fecha|envoyé|data|inviato|gesendet):/i
+  const SUBJECT_LABEL_RE =
+    /\b(?:subject|betreff|asunto|objet|oggetto):/i
+
+  /** Looks at the chunk's plain text and decides whether it's a
+   *  forward (preamble marker, or a From: + Date:/Subject: header
+   *  cluster) or a reply (default).  Used to pick the disclosure
+   *  summary label for the ambiguous wrapper markers — Apple Mail
+   *  / Thunderbird `<blockquote type="cite">` and Gmail's
+   *  `gmail_quote` both wrap replies AND forwards. */
+  function classifyChunk(text: string): 'forward' | 'reply' {
+    if (FORWARD_PREAMBLE_RE.test(text)) return 'forward'
+    if (
+      FROM_LABEL_RE.test(text) &&
+      (DATE_LABEL_RE.test(text) || SUBJECT_LABEL_RE.test(text))
+    ) {
+      return 'forward'
+    }
+    return 'reply'
+  }
+
+  function summaryFor(text: string): string {
+    return classifyChunk(text) === 'forward' ? FORWARD_SUMMARY : REPLY_SUMMARY
+  }
+
+  /** Build a native disclosure card around the given inner HTML.
+   *  The `<details>` element is closed by default, click on
+   *  `<summary>` toggles.  We mark the wrapper with a class so the
+   *  outer click handler (which delegates anchor / attachment-ref
+   *  clicks) can recognise descendants and skip the summary
+   *  toggle path entirely — and so the nested-collapse pass
+   *  skips elements already inside a wrapped block. */
+  function buildCollapseCard(
+    doc: Document,
+    summaryText: string,
+    headerHtml: string,
+    bodyHtml: string,
+  ): HTMLDetailsElement {
+    const details = doc.createElement('details')
+    details.className = 'quoted-collapse'
+    const summary = doc.createElement('summary')
+    summary.className = 'quoted-collapse__summary'
+    summary.textContent = summaryText
+    details.appendChild(summary)
+    const content = doc.createElement('div')
+    content.className = 'quoted-collapse__content'
+    if (headerHtml) {
+      const header = doc.createElement('div')
+      header.className = 'quoted-collapse__header'
+      header.innerHTML = headerHtml
+      content.appendChild(header)
+    }
+    const body = doc.createElement('div')
+    body.className = 'quoted-collapse__body'
+    body.innerHTML = bodyHtml
+    content.appendChild(body)
+    details.appendChild(content)
+    return details
+  }
+
+  /** For our own `data-unkai-block="forwarded-mail"` wrappers,
+   *  pull the embedded From / Date / Subject / To rows out of the
+   *  source HTML and rebuild them as a styled key-value list.
+   *  Everything *after* those rows is treated as the forwarded
+   *  body.  The shape we emit (see `forwardedMailHtml` in
+   *  `inviteHtml.ts`) is:
+   *
+   *      <p>---------- Forwarded message ----------</p>
+   *      <div><b>From:</b> …</div>
+   *      <div><b>Date:</b> …</div>
+   *      <div><b>Subject:</b> …</div>
+   *      <div><b>To:</b> …</div>
+   *      [body]
+   *
+   *  After DOMPurify the structure round-trips intact, so this
+   *  parser is a direct DOM walk.  Defensive fallback: if no
+   *  header rows are found (e.g. an older format we predate),
+   *  return the whole interior as body with no styled header. */
+  function parseOurForwardedHeaders(
+    el: Element,
+  ): { headerHtml: string; bodyHtml: string } {
+    const esc = (s: string) =>
+      s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+    interface Field {
+      label: string
+      value: string
+    }
+    const fields: Field[] = []
+    const LABEL_RE = /^(From|Date|Subject|To|Cc):\s*/i
+    let bodyStartIdx = -1
+    const kids = Array.from(el.children)
+    for (let i = 0; i < kids.length; i++) {
+      const child = kids[i]
+      const text = (child.textContent ?? '').trim()
+      // Skip the literal "---------- Forwarded message ----------" line.
+      if (/^-{5,}\s*forwarded message\s*-{5,}$/i.test(text)) continue
+      const m = text.match(LABEL_RE)
+      if (m && child.querySelector('b')) {
+        fields.push({
+          label: m[1],
+          value: text.slice(m[0].length),
+        })
+        continue
+      }
+      // First child that isn't a header row marks the body start.
+      bodyStartIdx = i
+      break
+    }
+    if (fields.length === 0) {
+      return { headerHtml: '', bodyHtml: el.innerHTML }
+    }
+    const headerHtml = fields
+      .map(
+        (f) =>
+          `<div class="quoted-collapse__field"><span class="quoted-collapse__label">${esc(f.label)}</span><span class="quoted-collapse__value">${esc(f.value)}</span></div>`,
+      )
+      .join('')
+    let bodyHtml = ''
+    if (bodyStartIdx !== -1) {
+      const wrapper = el.ownerDocument.createElement('div')
+      for (let i = bodyStartIdx; i < kids.length; i++) {
+        wrapper.appendChild(kids[i].cloneNode(true))
+      }
+      bodyHtml = wrapper.innerHTML
+    }
+    return { headerHtml, bodyHtml }
+  }
+
+  /** Find the text node containing the `---------- Forwarded
+   *  message ----------` delimiter (if any) and return both the
+   *  delimiter node and its containing block element (the element
+   *  that's a direct child of `<body>`).  Returns `null` when no
+   *  delimiter is present, or when it's already inside a
+   *  `.quoted-collapse` wrapper from an earlier pass. */
+  function findForwardedDelimiter(
+    doc: Document,
+  ): { containerBlock: Element } | null {
+    const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT)
+    let node: Node | null
+    while ((node = walker.nextNode())) {
+      const text = node.textContent ?? ''
+      if (!/-{5,}\s*forwarded message\s*-{5,}/i.test(text)) continue
+      const el = node.parentElement
+      if (!el) continue
+      if (el.closest('.quoted-collapse')) return null
+      // Walk up to the direct child of <body> so we wrap from the
+      // delimiter's block, not just its inline <strong> or <span>.
+      let block: Element = el
+      while (block.parentElement && block.parentElement !== doc.body) {
+        block = block.parentElement
+      }
+      return { containerBlock: block }
+    }
+    return null
+  }
+
+  /** Greedy run-collector: take a starting element and walk its
+   *  next siblings, absorbing any further matches plus filler
+   *  (whitespace text nodes, empty elements like `<br>` or empty
+   *  `<p>`).  Stops at the first sibling that is meaningful but
+   *  isn't a match — that's the boundary between this quoted run
+   *  and whatever follows it.  Returns the collected nodes; the
+   *  starting element is always first.
+   *
+   *  Used to coalesce mail clients that split a single logical
+   *  forwarded chunk across multiple sibling elements (e.g. Apple
+   *  Mail emits one `<blockquote type="cite">` for the embedded
+   *  headers and a second for the body — without this we'd render
+   *  them as two adjacent disclosure cards). */
+  function collectMatchRun(
+    start: Element,
+    isMatch: (el: Element) => boolean,
+  ): Node[] {
+    const run: Node[] = [start]
+    let cursor: Node | null = start.nextSibling
+    while (cursor) {
+      if (cursor.nodeType === Node.TEXT_NODE) {
+        if ((cursor.textContent ?? '').trim().length === 0) {
+          run.push(cursor)
+          cursor = cursor.nextSibling
+          continue
+        }
+        break // non-whitespace text breaks the run
+      }
+      if (cursor.nodeType !== Node.ELEMENT_NODE) {
+        cursor = cursor.nextSibling
+        continue
+      }
+      const el = cursor as Element
+      if (isMatch(el) || !hasVisibleContent(el)) {
+        run.push(el)
+        cursor = cursor.nextSibling
+        continue
+      }
+      break // meaningful non-match content ends the run
+    }
+    return run
+  }
+
+  /** Wrap a run of nodes (returned by `collectMatchRun`) in a
+   *  single collapse card, replacing the first node and detaching
+   *  the rest. */
+  function wrapRun(
+    doc: Document,
+    run: Node[],
+    summaryText: string,
+    headerHtml: string,
+  ): void {
+    const wrapper = doc.createElement('div')
+    for (const node of run) wrapper.appendChild(node.cloneNode(true))
+    const card = buildCollapseCard(doc, summaryText, headerHtml, wrapper.innerHTML)
+    const [first, ...rest] = run as [Element, ...Node[]]
+    first.replaceWith(card)
+    for (const node of rest) {
+      if (node.parentNode) node.parentNode.removeChild(node)
+    }
+  }
+
+  function collapseQuotedBlocks(doc: Document) {
+    // Pass 1 — our own forwarded-mail wrapper (with mini-header).
+    doc
+      .querySelectorAll('div[data-unkai-block="forwarded-mail"]')
+      .forEach((el) => {
+        if (el.closest('.quoted-collapse')) return
+        if (!hasVisibleContent(el)) return
+        const { headerHtml, bodyHtml } = parseOurForwardedHeaders(el)
+        el.replaceWith(
+          buildCollapseCard(doc, FORWARD_SUMMARY, headerHtml, bodyHtml),
+        )
+      })
+
+    // Pass 2 — our own quoted-history (reply) wrapper.
+    doc
+      .querySelectorAll('div[data-unkai-block="quoted-history"]')
+      .forEach((el) => {
+        if (el.closest('.quoted-collapse')) return
+        if (!hasVisibleContent(el)) return
+        el.replaceWith(
+          buildCollapseCard(doc, REPLY_SUMMARY, '', el.innerHTML),
+        )
+      })
+
+    // Pass 3 — standard cite-blockquote.  Coalesces adjacent
+    // siblings into one card so the embedded-header blockquote and
+    // the body blockquote a forward gets split into render as a
+    // single card rather than two.  Summary label is chosen by
+    // sniffing the merged chunk for forward-preamble markers —
+    // the same `<blockquote type="cite">` wrapper carries both
+    // reply quotes and forwarded chunks across mail clients.
+    const isCiteBq = (el: Element) =>
+      el.tagName.toLowerCase() === 'blockquote' &&
+      el.getAttribute('type')?.toLowerCase() === 'cite'
+    for (const bq of Array.from(doc.querySelectorAll('blockquote[type="cite"]'))) {
+      if (!bq.isConnected) continue // already absorbed into an earlier run
+      if (bq.closest('.quoted-collapse')) continue
+      if (!hasVisibleContent(bq)) continue
+      const run = collectMatchRun(bq, isCiteBq)
+      const runText = run
+        .map((n) => n.textContent ?? '')
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+      wrapRun(doc, run, summaryFor(runText), '')
+    }
+
+    // Pass 4 — webmail "gmail_quote" / "gmail_quote_container" divs.
+    const isGmailQuote = (el: Element) =>
+      el.tagName.toLowerCase() === 'div' &&
+      (el.classList.contains('gmail_quote') ||
+        el.classList.contains('gmail_quote_container'))
+    for (const el of Array.from(
+      doc.querySelectorAll('div.gmail_quote, div.gmail_quote_container'),
+    )) {
+      if (!el.isConnected) continue
+      if (el.closest('.quoted-collapse')) continue
+      if (!hasVisibleContent(el)) continue
+      const run = collectMatchRun(el, isGmailQuote)
+      const runText = run
+        .map((n) => n.textContent ?? '')
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+      wrapRun(doc, run, summaryFor(runText), '')
+    }
+
+    // Pass 5 — moz-cite-prefix + following blockquote (paired).
+    doc.querySelectorAll('div.moz-cite-prefix').forEach((prefix) => {
+      if (prefix.closest('.quoted-collapse')) return
+      const next = prefix.nextElementSibling
+      if (!next || next.tagName.toLowerCase() !== 'blockquote') return
+      if (!hasVisibleContent(prefix) && !hasVisibleContent(next)) return
+      const wrapper = doc.createElement('div')
+      wrapper.appendChild(prefix.cloneNode(true))
+      wrapper.appendChild(next.cloneNode(true))
+      const runText = ((prefix.textContent ?? '') + ' ' + (next.textContent ?? ''))
+        .replace(/\s+/g, ' ')
+        .trim()
+      const card = buildCollapseCard(
+        doc,
+        summaryFor(runText),
+        '',
+        wrapper.innerHTML,
+      )
+      next.remove()
+      prefix.replaceWith(card)
+    })
+
+    // Pass 6 — plain-text "---------- Forwarded message ----------"
+    // delimiter.  Wraps the delimiter block plus every sibling
+    // that follows it, so a forward without a wrapping div still
+    // collapses.  Runs last so the structured-wrapper passes
+    // above (which produce a `.quoted-collapse` ancestor) get
+    // first dibs on the delimiter and we don't double-wrap.  By
+    // construction this is always a forward.
+    const hit = findForwardedDelimiter(doc)
+    if (hit) {
+      const wrapper = doc.createElement('div')
+      let cursor: Element | null = hit.containerBlock
+      const toMove: Element[] = []
+      while (cursor) {
+        toMove.push(cursor)
+        cursor = cursor.nextElementSibling
+      }
+      for (const el of toMove) wrapper.appendChild(el)
+      if (hasVisibleContent(wrapper)) {
+        const card = buildCollapseCard(
+          doc,
+          FORWARD_SUMMARY,
+          '',
+          wrapper.innerHTML,
+        )
+        doc.body.appendChild(card)
+      }
+    }
+
+    // Pure-forward / pure-quote case: when the body's *outside*
+    // content (everything not in a collapse card) is either tiny,
+    // looks like forward preamble metadata, or is overwhelmed by
+    // the collapsed content size-wise, the user's primary interest
+    // IS the collapsed chunk (a mail forwarded to them, a thread
+    // where they have no fresh reply on top, etc).  Open every
+    // collapse by default; the toggle is still there if they want
+    // to fold it away.
+    //
+    // Three OR'd conditions, in increasing leniency:
+    //
+    //   1. outside text < 60 chars — clearly a pure forward with
+    //      nothing else around it.
+    //   2. outside text looks like forward preamble — detected via
+    //      multilingual marker strings ("Begin forwarded message",
+    //      "Anfang der weitergeleiteten Nachricht", From: + Date:
+    //      / Subject: cluster) — and is bounded in length so a
+    //      reply that happens to quote those words in passing
+    //      doesn't false-positive.
+    //   3. collapsed content is ≥ 85% of total body text — the
+    //      catch-all for very large forwarded chunks (newsletters,
+    //      long signatures) where the outside metadata bumps past
+    //      the preamble check but is still negligible relative to
+    //      the actual content.
+    const allCollapses = Array.from(
+      doc.querySelectorAll('details.quoted-collapse'),
+    ) as HTMLDetailsElement[]
+    if (allCollapses.length > 0) {
+      const clone = doc.body.cloneNode(true) as HTMLElement
+      clone
+        .querySelectorAll('details.quoted-collapse')
+        .forEach((d) => d.remove())
+      const outsideText = (clone.textContent ?? '').replace(/\s+/g, ' ').trim()
+      const insideText = allCollapses.reduce(
+        (sum, d) =>
+          sum + (d.textContent ?? '').replace(/\s+/g, ' ').trim().length,
+        0,
+      )
+      const totalText = outsideText.length + insideText
+
+      // Reuses the same `classifyChunk` heuristic that picks the
+      // summary label, so any text outside the collapses that
+      // looks like forward preamble doesn't block auto-open.
+      const looksLikePreamble = classifyChunk(outsideText) === 'forward'
+
+      const shouldOpen =
+        outsideText.length < 60 ||
+        (outsideText.length < 500 && looksLikePreamble) ||
+        (totalText > 100 && insideText / totalText >= 0.85)
+
+      if (shouldOpen) {
+        for (const d of allCollapses) d.setAttribute('open', '')
+      }
+    }
+  }
+
   function processEmailHtml(
     html: string,
     showImages: boolean,
@@ -622,6 +1093,13 @@
           }
         })
       }
+
+      // Fold quoted / forwarded chunks into collapsible cards (#330).
+      // Runs after the link / image passes so anything inside a
+      // collapsed block has already been annotated and image-blocked;
+      // the URLhaus second-pass that walks `<a href>` later will see
+      // the links inside the (still-in-DOM, just-hidden) block too.
+      collapseQuotedBlocks(doc)
 
       return { html: doc.body.innerHTML, hadBlocked }
     } catch (e) {

--- a/ui/src/lib/inviteHtml.ts
+++ b/ui/src/lib/inviteHtml.ts
@@ -296,49 +296,43 @@ ${nextcloudFooter("You'll be invited via Nextcloud — accepting in your mail cl
 
 // ── Quoted-history wrapper (#195 follow-up) ─────────────────────
 
-/** Wrap a reply's quoted history in a styled container.  Visually
- *  pushes the previous thread back so the user's fresh reply
- *  reads first: muted background, smaller type, soft left border,
- *  generous padding.  Same subdued grey palette across light and
- *  dark themes — designed to read as "old context" rather than
- *  competing with the new content.
+/** Wrap a reply's quoted history in the long-standing standard
+ *  reply format every receiving mail client recognises: an `On
+ *  {date}, {from} wrote:` attribution line followed by a
+ *  `<blockquote type="cite">` carrying the original body.
+ *  Receiving clients render this natively (indent, vertical-bar
+ *  accent, or their own collapse affordance) — no bespoke chrome
+ *  from us on the wire.
  *
- *  The outer `data-unkai-block` attribute lets the editor's
- *  `UnkaiBlock` extension capture this as an atom node so the
- *  styled wrapper survives Tiptap's schema (which would otherwise
- *  unwrap the `<div>` and strip the inline styles).
- *
- *  The inner content is also wrapped in a `<blockquote
- *  type="cite">` (#277).  Standard mail clients use blockquote
- *  as the canonical "this is quoted from a previous mail"
- *  signal — Apple Mail, Thunderbird, Gmail, Outlook each render
- *  blockquoted content with their own indent / collapse
- *  affordance ("Show original", a vertical bar, etc.).  The
- *  `type="cite"` attribute is the long-standing convention for
- *  email-quoted blockquotes (vs. literary citations); it does
- *  nothing visual but a couple of clients use it as a stronger
- *  signal that the block is a mail quote.  We zero out the
- *  blockquote's default browser indent so it doesn't double
- *  up with the styled div's own padding. */
+ *  The outer `data-unkai-block="quoted-history"` wrapper carries
+ *  no visual styling — it exists purely so the editor's
+ *  `UnkaiBlock` extension captures the whole chunk as an atom
+ *  node.  Without that, Tiptap's StarterKit schema would unwrap
+ *  the wrapper, strip the original message's inline styles, and
+ *  can duplicate `<img>` nodes while reconciling complex
+ *  `<table>` / `<picture>` markup against its block schema (same
+ *  failure mode #319 hit for forwards).  Inside the atom Tiptap
+ *  doesn't parse the interior, so the email's layout, inline
+ *  styles, and embedded images survive untouched.  Unkai's own
+ *  MailView display-time renderer (#330) detects the wrapper via
+ *  the `data-unkai-block` attribute and folds it into the
+ *  collapsible "Show conversation history" card; recipients on
+ *  other clients see the standard reply convention. */
 export function quotedHistoryHtml(args: {
   fromHeader: string
   whenText: string
   bodyHtml: string
 }): string {
   const { fromHeader, whenText, bodyHtml } = args
-  const escAttr = (s: string) =>
+  const esc = (s: string) =>
     s
       .replace(/&/g, '&amp;')
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;')
-  const meta = `On ${escAttr(whenText)}, ${escAttr(fromHeader)} wrote:`
   return `
-<div data-unkai-block="quoted-history" style="margin:24px 0 0 0;padding:14px 18px;background:#f1f5f9;border-left:3px solid #cbd5e1;border-radius:8px;color:#64748b;font-size:13px;line-height:1.55;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-  <div style="font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#94a3b8;margin-bottom:8px;">Previous conversation</div>
-  <div style="font-size:12px;color:#475569;margin-bottom:10px;">${meta}</div>
-  <blockquote type="cite" style="margin:0;padding:0;border:0;color:#64748b;">${bodyHtml}</blockquote>
+<div data-unkai-block="quoted-history">
+  <div>On ${esc(whenText)}, ${esc(fromHeader)} wrote:</div>
+  <blockquote type="cite">${bodyHtml}</blockquote>
 </div>
 `.trim()
 }


### PR DESCRIPTION
Closes #330.

## Summary

Display-only transformation in `MailView.processEmailHtml` that folds every standard "this is quoted / forwarded" marker into a native `<details>`/`<summary>` disclosure card. Readers see fresh content first and expand previous conversation on demand. The raw `email.body_html` is never touched — Reply / Forward keep reading the unmodified body and emit the same wire format every other mail client expects.

Also picks up a couple of related wire-format alignments along the way (see below).

## What's in the box

- **Six detection passes** (most-specific first, with `.quoted-collapse` ancestor check to avoid double-wrap):
  - `div[data-unkai-block="forwarded-mail"]` — our own forward wrapper. Parses the embedded `From` / `Date` / `Subject` / `To` lines into a styled mini-header card; the body lands below.
  - `div[data-unkai-block="quoted-history"]` — our own reply wrapper.
  - `blockquote[type="cite"]` — the cite-blockquote convention.
  - `div.gmail_quote`, `div.gmail_quote_container`.
  - `div.moz-cite-prefix` + the following `<blockquote>` (Thunderbird pair).
  - `---------- Forwarded message ----------` text-node delimiter → wraps from there to end of body.
- **Coalescing**: adjacent sibling cite-blockquotes (or `gmail_quote`s) — possibly with whitespace / empty filler between them — merge into a single disclosure. Apple Mail splits header-and-body into two siblings; without this they rendered as two adjacent cards.
- **Empty-skip**: empty blockquote / div shells (common as line-spacers in forwards between clients) no longer render empty disclosures.
- **Summary labels**: `classifyChunk(text)` sniffs multilingual forward-preamble markers (`Begin forwarded message`, `Anfang der weitergeleiteten Nachricht`, etc.) and `From:` + `Date:`/`Subject:` clusters to decide. Replies → "Show conversation history". Forwards → "Show forwarded messages".
- **Auto-open heuristic** uses the same classifier: a body whose outside-collapse content looks like forward preamble (or is small in absolute / relative terms) opens disclosures by default — pure forwards land visible, real replies with a fresh greeting stay collapsed.
- **URLhaus link safety** still walks anchors inside collapsed blocks (they're in the DOM, just hidden).

## Wire-format alignments along the way

- Forwards already emitted standard `---------- Forwarded message ----------` since #319.
- **Replies now do the same**: standard `On {date}, {from} wrote:` attribution + `<blockquote type="cite">`, inside an invisible `data-unkai-block="quoted-history"` wrapper. The previous "Previous conversation" styled chrome that appeared as a boxed block in other clients (Apple Mail in particular) is gone. The wrapper exists only so Tiptap's `UnkaiBlock` atom keeps the interior verbatim.
- **`quoteBody` now prefers `body_html`** via DOMPurify when present, so HTML content survives into replies. This was the same `body_text`-only bug that #319 fixed for forwards.

## Test plan
- [x] Open a reply thread with quoted history (Unkai-formatted) → "Show conversation history" card, closed by default for a real reply with fresh content on top.
- [x] Open a forwarded mail (Unkai-formatted) → "Show forwarded messages" card with styled mini-header, opened by default.
- [x] Open a forwarded mail from Apple Mail / Gmail / Thunderbird → one card (not multiple), opened by default, summary label is "Show forwarded messages".
- [x] Open a reply received from another client → "Show conversation history", closed by default.
- [x] Reply to an HTML newsletter → quoted history preserves the original formatting (colors, tables, images) instead of being stripped to plain text.
- [x] Toggle the per-message white-background button → card chrome stays readable in white-canvas mode.
- [x] Light mode + dark mode → card text and background colours both readable in both.
- [x] Inbound mail with empty blockquote line-spacers → no empty disclosure cards.
- [x] URLhaus pills appear next to links inside expanded blocks.
- [x] Receiving an Unkai-composed reply in another mail client → standard reply rendering (no Unkai chrome box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)