### PR TITLE
#320: fix insert positions for compose integration blocks

### DIFF
--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -1211,47 +1211,11 @@
       description: saved.description ?? null,
       talkUrl: isUrl ? loc : null,
     }
-    const html = meetingInviteHtml(invite)
-    if (!editorApi) return
-    // Body order we want, from top to bottom:
-    //   1. lead spacer
-    //   2. **meeting card**            ← new
-    //   3. signature
-    //   4. (Talk / file-share cards)
-    //   5. quoted history (replies / forwards)
-    //
-    // The signature is a plain `<p>-- <br>...</p>` (no
-    // UnkaiBlock wrapper), so `insertBeforeUnkaiBlock` can't
-    // target it.  We do a string splice on `bodyHtml` instead:
-    // find the previously-inserted signature substring and
-    // splice the card just before it.  Fallback paths cover
-    // every shape the body might be in:
-    //
-    //   - signature present in source → splice before it.
-    //   - signature missing (no signature configured, or the
-    //     signature `$effect` hasn't run yet) → splice after
-    //     the lead spacer so future signature insertion still
-    //     lands below the card.
-    //   - neither marker found (e.g. an opened draft with a
-    //     bespoke shape) → fall back to the existing
-    //     before-quoted-history target so the card still
-    //     reads above the reply quote.
-    if (insertedSignatureHtml && bodyHtml.includes(insertedSignatureHtml)) {
-      const idx = bodyHtml.indexOf(insertedSignatureHtml)
-      const replaced = bodyHtml.slice(0, idx) + html + bodyHtml.slice(idx)
-      editorApi.setHtml(replaced)
-      bodyHtml = replaced
-      return
-    }
-    const leadIdx = bodyHtml.indexOf('<p></p><p></p>')
-    if (leadIdx !== -1) {
-      const after = leadIdx + '<p></p><p></p>'.length
-      const replaced = bodyHtml.slice(0, after) + html + bodyHtml.slice(after)
-      editorApi.setHtml(replaced)
-      bodyHtml = replaced
-      return
-    }
-    editorApi.insertBeforeUnkaiBlock(html, 'quoted-history')
+    // The editor walks its own ProseMirror doc to find the top
+    // of the signoff region; new cards stack above any existing
+    // ones so a later insert isn't buried below a previously
+    // dropped block (#320 + follow-up).
+    editorApi?.insertAboveSignature(meetingInviteHtml(invite))
   }
 
   /** Combined To + Cc list as bare/RFC-formatted address strings,
@@ -1261,19 +1225,15 @@
   }
 
   /** Insert a Talk invite card into the editor body when the
-      user creates a Talk room mid-compose.  The new
-      `insertBeforeUnkaiBlock` editor API drops the card just
-      above any existing quoted-history block (so reading order
-      is card → reply text → previous conversation); on a fresh
-      compose with no quote it appends at the end. The card is
-      parsed by the editor's `UnkaiBlock` extension into an
-      atom node, so a single Backspace deletes the whole thing
-      if the user changes their mind. */
+      user creates a Talk room mid-compose.  Lands the card at
+      the top of the signoff region, above any existing
+      integration cards so the newest insert is the most visible
+      (#320 + follow-up).  The card is parsed by the editor's
+      `UnkaiBlock` extension into an atom node, so a single
+      Backspace deletes the whole thing if the user changes
+      their mind. */
   function injectTalkBlock(link: { name: string; url: string }) {
-    const html = talkInviteHtml(link)
-    if (editorApi) {
-      editorApi.insertBeforeUnkaiBlock(html, 'quoted-history')
-    }
+    editorApi?.insertAboveSignature(talkInviteHtml(link))
   }
 
   function onTalkRoomCreated(room: TalkRoom, participants: string[]) {
@@ -2700,23 +2660,11 @@
         )
         .join('')
       const block = `<p><strong>Shared via Nextcloud:</strong></p>${items}`
-      // Splice the block ABOVE an auto-inserted signature when one
-      // is sitting at the end of the body so the share renders
-      // inline with the message rather than below the user's
-      // sign-off.  Same pattern the Talk-link injection uses
-      // earlier in this component.
-      if (
-        insertedSignatureHtml
-        && bodyHtml.endsWith(insertedSignatureHtml)
-        && editorApi
-      ) {
-        const without = bodyHtml.slice(0, bodyHtml.length - insertedSignatureHtml.length)
-        const replaced = without + block + insertedSignatureHtml
-        editorApi.setHtml(replaced)
-        bodyHtml = replaced
-      } else {
-        editorApi?.appendHtml(block)
-      }
+      // Land the block at the top of the signoff region — a
+      // short share-link paragraph reads above any existing
+      // meeting / Talk card so it isn't buried beneath the big
+      // styled chrome (#320 + follow-up).
+      editorApi?.insertAboveSignature(block)
     }}
     onclose={() => (showNcPicker = false)}
   />

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -65,13 +65,22 @@
      *  from Nextcloud" flow: the parent opens the file picker,
      *  downloads bytes, converts to a data URL, and calls this. */
     insertImage: (src: string) => void
-    /** Insert HTML at the position just before the first
-     *  `unkaiBlock` atom node carrying the given `kind` attr.
-     *  Used by Compose's mid-compose Talk-room creation so the
-     *  new invite card lands *above* the quoted-history block on
-     *  a reply. Falls back to appending at the end when no
-     *  matching block exists (fresh compose). */
-    insertBeforeUnkaiBlock: (html: string, kind: string) => void
+    /** Insert HTML at the **top** of the user's sign-off region.
+     *
+     *  The signoff region is everything between the lead-spacer
+     *  typing area and the signature (a `<p>` whose text starts
+     *  with the RFC 3676 `-- ` separator).  New blocks stack
+     *  *above* any existing `unkaiBlock` cards already sitting in
+     *  that region, so a freshly inserted share-link paragraph
+     *  isn't buried beneath a previously inserted meeting card
+     *  (#320 follow-up).  Falls back to just-above-signature when
+     *  the region is empty, then to just-above the first
+     *  `unkaiBlock` overall (signature absent → quoted-history is
+     *  the only landmark), then to appending at the end (fresh
+     *  compose).  Used by Compose's mid-compose meeting / Talk /
+     *  Nextcloud-share block injection — all three want the same
+     *  landing zone. */
+    insertAboveSignature: (html: string) => void
   }
 
   interface Props {
@@ -985,24 +994,52 @@
           // the document and the image lands in the wrong place.
           ed.chain().focus().setImage({ src }).run()
         },
-        insertBeforeUnkaiBlock: (html: string, kind: string) => {
-          let pos: number | null = null
+        insertAboveSignature: (html: string) => {
+          // Single doc walk collects the two landmark positions
+          // we need: the topmost `unkaiBlock` (any kind —
+          // meeting / Talk / share-card or quoted-history) and
+          // the signature paragraph.  RFC 3676 separator is
+          // exactly `-- ` (dash-dash-space) on its own line;
+          // Tiptap may strip the trailing space on parse so we
+          // accept both `-- ` and a bare `--` paragraph as the
+          // signature marker.
+          let firstBlockPos: number | null = null
+          let sigPos: number | null = null
           ed.state.doc.descendants((node, p) => {
-            if (pos !== null) return false
-            if (
-              node.type.name === 'unkaiBlock'
-              && (node.attrs as { kind?: string }).kind === kind
-            ) {
-              pos = p
-              return false
+            if (firstBlockPos === null && node.type.name === 'unkaiBlock') {
+              firstBlockPos = p
+            }
+            if (sigPos === null && node.type.name === 'paragraph') {
+              const text = node.textContent
+              if (text === '--' || text.startsWith('-- ')) {
+                sigPos = p
+              }
             }
             return true
           })
-          if (pos !== null) {
-            ed.chain().insertContentAt(pos, html).run()
+
+          // Land at the top of the signoff region so new blocks
+          // stack ABOVE previously inserted cards (a tiny share
+          // link otherwise disappears beneath a big meeting card
+          // — #320).  Cases:
+          //
+          //   - unkaiBlock sitting above sig (or sig absent) →
+          //     insert at that block's position so the new
+          //     content reads first.
+          //   - sig present, no block above it → insert at sig
+          //     position (first card in the signoff region).
+          //   - neither found → append at end (fresh compose
+          //     with no signature and no cards yet — the block
+          //     lands below the lead-spacer typing area).
+          let pos: number
+          if (firstBlockPos !== null && (sigPos === null || firstBlockPos < sigPos)) {
+            pos = firstBlockPos
+          } else if (sigPos !== null) {
+            pos = sigPos
           } else {
-            ed.chain().insertContentAt(ed.state.doc.content.size, html).run()
+            pos = ed.state.doc.content.size
           }
+          ed.chain().insertContentAt(pos, html).run()
         },
       })
     }


### PR DESCRIPTION
## Summary

- Adds `insertAboveSignature` to the rich-text editor: a single primitive that walks the live ProseMirror doc and lands new content at the **top** of the user's sign-off region — above any previously inserted UnkaiBlock card.
- Routes Compose's meeting / Talk / Nextcloud-share insertion paths through that primitive, replacing the brittle `bodyHtml` string heuristics that drifted out of sync with Tiptap's HTML normalisation.
- New blocks stack: a freshly inserted share-link paragraph now reads above an existing meeting card instead of being buried beneath it.

## Root cause

- Talk's path only targeted the `quoted-history` UnkaiBlock, so on a fresh compose (no quote) it appended at the document end — below the signature.
- Meeting and NC share matched `insertedSignatureHtml` against the serialised `bodyHtml`, which fails once Tiptap re-emits the signature with normalised attribute ordering / whitespace.
- Even after the substring match worked, all three slotted just-above-signature, so a second insert landed *between* the previous card and the signature — burying short links beneath big styled cards.

## Test plan

- [ ] Fresh compose, no signature configured: insert meeting → insert Talk → insert share link. Each new block stacks above the previous.
- [x] Fresh compose, signature configured: same sequence. Each new block stacks above all existing cards and above the signature.
- [x] Reply (signature + quoted-history both present): insert meeting → insert Talk → insert share link. Each lands above existing cards, still above the signature, still above the quoted history.
- [ ] Reply, no signature configured: each new block lands above the quoted-history block.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)