### PR TITLE
#324: add expiration date picker for Nextcloud share links

### DIFF
--- a/crates/unkai-nextcloud/src/shares.rs
+++ b/crates/unkai-nextcloud/src/shares.rs
@@ -144,16 +144,18 @@ pub async fn create_public_share(
     password: Option<&str>,
     label: Option<&str>,
     permissions: u8,
+    expire_date: Option<&str>,
     trusted_certs: &[TrustedCert],
 ) -> Result<PublicShare, UnkaiError> {
     let server = client::normalize_server_url(server_url);
     let url = format!("{server}/ocs/v2.php/apps/files_sharing/api/v1/shares?format=json");
 
     tracing::debug!(
-        "POST {url} for path {path} (password: {}, label: {}, permissions: {})",
+        "POST {url} for path {path} (password: {}, label: {}, permissions: {}, expiry: {})",
         if password.is_some() { "yes" } else { "no" },
         if label.is_some() { "yes" } else { "no" },
-        permissions
+        permissions,
+        if expire_date.is_some() { "yes" } else { "no" }
     );
 
     let http = client::build(trusted_certs)?;
@@ -179,6 +181,17 @@ pub async fn create_public_share(
         && !lbl.is_empty()
     {
         form.push(("label", lbl));
+    }
+    // `expireDate` accepts `YYYY-MM-DD` -- the same format our
+    // `DateField` component emits.  Once the date passes the
+    // recipient sees a "Link expired" page instead of the file
+    // contents.  Server-side default-expiration policies (admin
+    // configured) may still clamp this down to a shorter window;
+    // the OCS response surfaces that case via `meta.message`.
+    if let Some(exp) = expire_date
+        && !exp.is_empty()
+    {
+        form.push(("expireDate", exp));
     }
 
     let resp = http

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -797,6 +797,10 @@ struct NextcloudShareResult {
 /// - `permissions`: Nextcloud's permission bitmask
 ///   (1=read, 2=update, 4=create, 8=delete, 16=share).  The Compose
 ///   share modal exposes the common combinations as a dropdown.
+/// - `expire_date`: optional `YYYY-MM-DD` after which Nextcloud
+///   refuses to serve the link (#324).  Omitting / `None` leaves the
+///   share open until manually revoked (subject to any server-side
+///   default-expiration policy the admin has configured).
 #[tauri::command]
 async fn create_nextcloud_share(
     nc_id: String,
@@ -804,6 +808,7 @@ async fn create_nextcloud_share(
     password: Option<String>,
     label: Option<String>,
     permissions: Option<u8>,
+    expire_date: Option<String>,
 ) -> Result<NextcloudShareResult, UnkaiError> {
     let account = load_nextcloud_account(&nc_id)?;
     let app_password = credentials::get_nextcloud_password(&nc_id)?;
@@ -815,6 +820,7 @@ async fn create_nextcloud_share(
         password.as_deref(),
         label.as_deref(),
         permissions.unwrap_or(unkai_nextcloud::shares::PERM_READ_ONLY),
+        expire_date.as_deref(),
         &account.trusted_certs,
     )
     .await?;

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -92,6 +92,10 @@
   "compose_attachment_warning_body": "Fügen Sie vor dem Senden eine Datei hinzu oder schließen Sie diese Warnung, falls es ein Fehlalarm ist.",
   "compose_attachment_warning_dismiss": "Schließen",
 
+  "nc_share_set_expiration_label": "Ablaufdatum festlegen",
+  "nc_share_expiration_aria": "Ablaufdatum für den Freigabelink auswählen",
+  "nc_share_expiration_hint": "Empfänger können den Link nach diesem Datum nicht mehr öffnen.",
+
   "compose_button_minimize_aria_label": "Minimieren",
   "compose_button_minimize_title": "Entwurf in die Leiste minimieren",
   "compose_minimized_bar_aria_label": "Minimierte Entwürfe",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -91,6 +91,10 @@
   "compose_attachment_warning_body": "Add a file before sending, or dismiss this warning if it's a false alarm.",
   "compose_attachment_warning_dismiss": "Dismiss",
 
+  "nc_share_set_expiration_label": "Set expiration date",
+  "nc_share_expiration_aria": "Pick expiration date for the share link",
+  "nc_share_expiration_hint": "Recipients can't open the link after this date.",
+
   "compose_button_minimize_aria_label": "Minimize",
   "compose_button_minimize_title": "Minimize draft to bar",
   "compose_minimized_bar_aria_label": "Minimized drafts",

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -31,7 +31,8 @@
     type ExtraTab,
   } from './RichTextEditor.svelte'
   import AddressAutocomplete from './AddressAutocomplete.svelte'
-  import NextcloudFilePicker, { type ShareLink } from './NextcloudFilePicker.svelte'
+  import NextcloudFilePicker from './NextcloudFilePicker.svelte'
+  import { type ShareLink } from './NextcloudShareDialog.svelte'
   import Icon from './Icon.svelte'
   import FileTypeIcon from './FileTypeIcon.svelte'
   import AttachmentThumb, { prewarm as prewarmAttachmentThumb } from './AttachmentThumb.svelte'

--- a/ui/src/lib/FilesView.svelte
+++ b/ui/src/lib/FilesView.svelte
@@ -29,6 +29,9 @@
     type FileEntry,
     type NextcloudAccount,
   } from './NextcloudFileBrowser.svelte'
+  import NextcloudShareDialog, {
+    type ShareLink,
+  } from './NextcloudShareDialog.svelte'
   import type { ComposeInitial } from './Compose.svelte'
 
   interface Attachment {
@@ -56,36 +59,18 @@
   let error = $state('')
 
   let attaching = $state(false)
-  let sharing = $state(false)
-
-  // Same password-prompt shape as NextcloudFilePicker — see commit
-  // notes there. Snapshot the selection at click time so toggling
-  // the file tree behind the modal can't change what gets shared.
-  // `permissions` is the OCS bitfield value; `hasFolders` drives
-  // the dropdown's folder-only options.
-  let sharePrompt = $state<{
+  // Snapshot of the selection at the moment "New mail with link" was
+  // clicked.  The shared `NextcloudShareDialog` owns the form state
+  // (password / permissions / expiry); we just hand off paths +
+  // hasFolders and wait for `onresolve` / `oncancel`.
+  let shareTarget = $state<{
     paths: string[]
-    password: string
-    permissions: number
     hasFolders: boolean
   } | null>(null)
-
-  /** Permission combinations Nextcloud's own share UI exposes.
-   *  Same shape as NextcloudFilePicker — kept in lockstep so the
-   *  two surfaces' Share dialogs offer identical choices. */
-  const PERMISSION_OPTIONS = [
-    { value: 1, label: 'View only', hint: 'Recipient can read / download.', folderOnly: false },
-    { value: 3, label: 'View and edit', hint: 'Recipient can edit the file in Nextcloud.', folderOnly: false },
-    { value: 15, label: 'View, edit, upload, delete', hint: 'Folder share with full read-write — recipient can drop files in and modify existing ones.', folderOnly: true },
-    { value: 4, label: 'File drop (upload only)', hint: 'Folder share where recipients can upload but not see the contents.', folderOnly: true },
-  ] as const
-
-  function visiblePermissionOptions(hasFolders: boolean) {
-    return PERMISSION_OPTIONS.filter((o) => !o.folderOnly || hasFolders)
-  }
-  function permHint(value: number): string {
-    return PERMISSION_OPTIONS.find((o) => o.value === value)?.hint ?? ''
-  }
+  // True while the share dialog is mounted.  The dialog blocks
+  // clicks behind it via its backdrop, so this just gates the
+  // footer buttons + the Esc handler.
+  let sharing = $derived(shareTarget !== null)
 
   let selectedFileCount = $derived.by(() => {
     let n = 0
@@ -161,66 +146,42 @@
     }
   }
 
-  /** Mint a public link for every selection (files *and* folders) and
-      open Compose with them rendered into the body as a "Shared via
-      Nextcloud" block — same shape Compose already produces when the
-      share button inside the picker is used. */
+  /** Open the share dialog instead of jumping straight to OCS.
+      The dialog lets the user opt into password / permissions /
+      expiry before any link is minted. */
   function sendAsLink() {
     if (selected.size === 0) return
-    const hasFolders = entries.some((e) => e.is_dir && selected.has(e.path)) || selectedFolderCount > 0
-    sharePrompt = {
+    const hasFolders =
+      entries.some((e) => e.is_dir && selected.has(e.path)) ||
+      selectedFolderCount > 0
+    shareTarget = {
       paths: Array.from(selected),
-      password: '',
-      permissions: 1,
       hasFolders,
     }
     error = ''
   }
 
-  /** Mint the share links with the password + permissions the
-      user picked (empty password = unprotected, omitted from the
-      OCS form on the Rust side) and hand them off to Compose.
-      Same error shape as the previous one-click flow. */
-  async function commitShare() {
-    if (!sharePrompt) return
-    const { paths, password, permissions } = sharePrompt
-    sharing = true
-    error = ''
-    try {
-      const pw = password.trim() ? password : null
-      const links = await Promise.all(
-        paths.map(async (p) => {
-          const url = await invoke<string>('create_nextcloud_share', {
-            ncId: accountId,
-            path: p,
-            password: pw,
-            permissions,
-          })
-          return { filename: basename(p), url }
-        }),
-      )
-      sharePrompt = null
-      oncompose({ nextcloudLinks: links })
-    } catch (e) {
-      error = formatError(e) || 'Failed to create share link(s)'
-    } finally {
-      sharing = false
-    }
+  /** Dialog resolved with freshly-minted share links.  Project the
+      result down to the `{filename, url}` shape `ComposeInitial`
+      expects and open Compose pre-filled with the link block. */
+  function onShareResolved(links: ShareLink[]) {
+    shareTarget = null
+    oncompose({
+      nextcloudLinks: links.map((l) => ({ filename: l.filename, url: l.url })),
+    })
   }
 
   /**
-   * Esc handler for the share prompt (#192).  Wired via
-   * `<svelte:window onkeydown>` in the template so the key
-   * works wherever focus is in the modal — the existing
-   * input-level handler at line 385 only catches the password
-   * field.  Inert while `sharing` is in flight.
+   * Esc handler for the share dialog (#192).  Wired via
+   * `<svelte:window onkeydown>` in the template so the key works
+   * wherever focus is in the dialog — the dialog's own input-level
+   * handler only catches the password field.
    */
   function onSharePromptKeydown(e: KeyboardEvent) {
     if (e.key !== 'Escape') return
-    if (!sharePrompt) return
-    if (sharing) return
+    if (!shareTarget) return
     e.preventDefault()
-    sharePrompt = null
+    shareTarget = null
   }
 </script>
 
@@ -367,82 +328,19 @@
   </div>
 </div>
 
-<!-- Password prompt for the public share link. Same UX as the
-     equivalent modal inside NextcloudFilePicker — Enter / "Create
-     with password" gates the share, blank input + "Share without
-     password" preserves the previous one-click flow. -->
-{#if sharePrompt}
-  <div
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-    role="dialog"
-    aria-modal="true"
-    tabindex="-1"
-    onmousedown={(e) => { if (e.target === e.currentTarget && !sharing) sharePrompt = null }}
-  >
-    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-[28rem] max-w-full p-5">
-      <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
-      <p class="text-xs text-surface-500 mb-3">
-        {sharePrompt.paths.length === 1
-          ? 'Anyone with the link can open the file.'
-          : `Anyone with each link can open ${sharePrompt.paths.length} files.`}
-        Setting a password gates the recipient behind it; leave it empty
-        to share without one.
-      </p>
-
-      <label class="block text-xs text-surface-500 mb-1" for="files-share-pw">Password (optional)</label>
-      <!-- svelte-ignore a11y_autofocus -->
-      <input
-        id="files-share-pw"
-        type="password"
-        class="input w-full text-sm px-2 py-1.5 rounded-md mb-3"
-        placeholder="Leave blank for no password"
-        bind:value={sharePrompt.password}
-        disabled={sharing}
-        autofocus
-        onkeydown={(e) => {
-          if (e.key === 'Enter') { e.preventDefault(); void commitShare() }
-          else if (e.key === 'Escape' && !sharing) { e.preventDefault(); sharePrompt = null }
-        }}
-      />
-
-      <!-- Permissions dropdown — mirrors the NextcloudFilePicker
-           share-prompt so both surfaces' Share dialogs offer the
-           same set of choices.  Folder-only options are filtered
-           out when the selection is purely files. -->
-      <label class="block text-xs text-surface-500 mb-1" for="files-share-perms">Permissions</label>
-      <select
-        id="files-share-perms"
-        class="input w-full text-sm px-2 py-1.5 rounded-md mb-1"
-        bind:value={sharePrompt.permissions}
-        disabled={sharing}
-      >
-        {#each visiblePermissionOptions(sharePrompt.hasFolders) as opt}
-          <option value={opt.value}>{opt.label}</option>
-        {/each}
-      </select>
-      <p class="text-[11px] text-surface-500 mb-3">
-        {permHint(sharePrompt.permissions)}
-      </p>
-
-      {#if error}
-        <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
-      {/if}
-
-      <div class="flex justify-end gap-2">
-        <button
-          class="btn preset-outlined-surface-500 shrink-0"
-          disabled={sharing}
-          onclick={() => (sharePrompt = null)}
-        >Cancel</button>
-        <button
-          class="btn preset-filled-primary-500 shrink-0 whitespace-nowrap"
-          disabled={sharing}
-          onclick={() => void commitShare()}
-        >{#if sharing}Sharing…{:else}Share{/if}</button>
-      </div>
-    </div>
-  </div>
-{/if}
+<!-- Share dialog (password / permissions / expiry).  Shared with
+     the Compose-side picker — see NextcloudShareDialog.svelte for
+     the modal body itself.  z-50 because no other modal sits
+     behind this surface. -->
+<NextcloudShareDialog
+  open={shareTarget !== null}
+  accountId={accountId}
+  paths={shareTarget?.paths ?? []}
+  hasFolders={shareTarget?.hasFolders ?? false}
+  zIndex={50}
+  onresolve={onShareResolved}
+  oncancel={() => (shareTarget = null)}
+/>
 
 <style>
   /* Indeterminate per-file progress head (#160).  Animates

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -18,8 +18,10 @@
    */
 
   import { invoke } from '@tauri-apps/api/core'
+  import DateField from './DateField.svelte'
   import { formatError } from './errors'
   import Icon from './Icon.svelte'
+  import { m } from '../paraglide/messages'
   import NextcloudFileBrowser, {
     type FileEntry,
     type NextcloudAccount,
@@ -154,7 +156,30 @@
      *  "File drop" only make sense for folder shares (file shares
      *  can't have new files dropped into them by definition). */
     hasFolders: boolean
+    /** Whether an expiration date should be sent to the OCS endpoint
+     *  (#324).  Off by default — matches Nextcloud's own share UI
+     *  where a separate "Set expiration date" toggle gates the
+     *  picker.  Lets the user share without an expiry in a single
+     *  click. */
+    setExpiration: boolean
+    /** ISO `YYYY-MM-DD` from the DateField.  Empty when `setExpiration`
+     *  is off; only sent to the backend when the toggle is on AND
+     *  the field is non-empty (commitShare guards both). */
+    expireDate: string
   } | null>(null)
+
+  /** Default expiration suggestion when the user first ticks the
+   *  "Set expiration date" toggle — 7 days out, in the same
+   *  `YYYY-MM-DD` shape DateField round-trips through.  Picked over
+   *  "today" so the recipient has a usable window without further
+   *  clicks; the user can still drill to any date via the calendar
+   *  popover. */
+  function defaultExpiry(): string {
+    const d = new Date()
+    d.setDate(d.getDate() + 7)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+  }
 
   /** Common public-link permission combinations Nextcloud's own
    *  share UI exposes.  The bitfield (1 read, 2 update, 4 create,
@@ -285,6 +310,8 @@
       password: '',
       permissions: 1, // View-only by default — matches Nextcloud's own picker.
       hasFolders,
+      setExpiration: false,
+      expireDate: '',
     }
     error = ''
   }
@@ -295,11 +322,17 @@
       direct flow. */
   async function commitShare() {
     if (!sharePrompt || !onlinks) return
-    const { paths, password, permissions } = sharePrompt
+    const { paths, password, permissions, setExpiration, expireDate } =
+      sharePrompt
     sharing = true
     error = ''
     try {
       const pw = password.trim() ? password : null
+      // Only send `expireDate` when the user actually opted into it.
+      // An empty `expireDate=` posted to OCS is parsed as a bad date
+      // and rejects the whole share, so the toggle-off path must
+      // omit the field entirely.
+      const exp = setExpiration && expireDate ? expireDate : null
       const results = await Promise.all(
         paths.map(async (p) => {
           const r = await invoke<{ id: string; url: string }>(
@@ -310,6 +343,7 @@
               password: pw,
               label: shareLabel?.trim() || null,
               permissions,
+              expireDate: exp,
             },
           )
           return {
@@ -553,6 +587,40 @@
       <p class="text-[11px] text-surface-500 mb-3">
         {permHint(sharePrompt.permissions)}
       </p>
+
+      <!-- Expiration date (#324).  Nextcloud's OCS endpoint takes an
+           optional `expireDate=YYYY-MM-DD`; after that date the
+           public link returns a "Link expired" page.  We gate the
+           DateField behind a checkbox so the no-expiry default
+           stays one click away, matching Nextcloud's own UI. -->
+      <label class="flex items-center gap-2 mb-2 text-xs text-surface-700 dark:text-surface-300 cursor-pointer">
+        <input
+          type="checkbox"
+          class="checkbox"
+          bind:checked={sharePrompt.setExpiration}
+          disabled={sharing}
+          onchange={() => {
+            // Seed a sensible default the first time the user opts in,
+            // otherwise reopening the toggle would land on an empty
+            // field that DateField renders as "Pick a date".
+            if (sharePrompt && sharePrompt.setExpiration && !sharePrompt.expireDate) {
+              sharePrompt.expireDate = defaultExpiry()
+            }
+          }}
+        />
+        <span>{m.nc_share_set_expiration_label()}</span>
+      </label>
+      {#if sharePrompt.setExpiration}
+        <div class="mb-3">
+          <DateField
+            bind:value={sharePrompt.expireDate}
+            ariaLabel={m.nc_share_expiration_aria()}
+          />
+          <p class="text-[11px] text-surface-500 mt-1">
+            {m.nc_share_expiration_hint()}
+          </p>
+        </div>
+      {/if}
 
       {#if error}
         <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>

--- a/ui/src/lib/NextcloudFilePicker.svelte
+++ b/ui/src/lib/NextcloudFilePicker.svelte
@@ -18,32 +18,20 @@
    */
 
   import { invoke } from '@tauri-apps/api/core'
-  import DateField from './DateField.svelte'
   import { formatError } from './errors'
   import Icon from './Icon.svelte'
-  import { m } from '../paraglide/messages'
   import NextcloudFileBrowser, {
     type FileEntry,
     type NextcloudAccount,
   } from './NextcloudFileBrowser.svelte'
+  import NextcloudShareDialog, {
+    type ShareLink,
+  } from './NextcloudShareDialog.svelte'
 
   interface Attachment {
     filename: string
     content_type: string
     data: number[]
-  }
-  /** A "share as link" result.
-   *
-   *  - `filename` / `url` — what the body block needs.
-   *  - `id` / `ncId`     — what `update_nextcloud_share_label`
-   *    needs so Compose can re-PUT the label whenever the
-   *    recipient list changes after the share was minted (#91).
-   */
-  export interface ShareLink {
-    filename: string
-    url: string
-    id: string
-    ncId: string
   }
 
   interface Props {
@@ -95,9 +83,9 @@
   function onPickerKeydown(e: KeyboardEvent) {
     if (e.key !== 'Escape') return
     if (sharing) return
-    if (sharePrompt) {
+    if (shareTarget) {
       e.preventDefault()
-      sharePrompt = null
+      shareTarget = null
       return
     }
     e.preventDefault()
@@ -119,7 +107,21 @@
   let error = $state('')
 
   let downloading = $state(false)
-  let sharing = $state(false)
+  // Snapshot of the selection at the moment "Share as link" was
+  // clicked — toggling the file tree behind the dialog can't change
+  // what gets shared.  The dialog component owns its own form state
+  // (password / permissions / expiry); we hand off paths +
+  // hasFolders and wait for `onresolve` / `oncancel`.
+  let shareTarget = $state<{
+    paths: string[]
+    hasFolders: boolean
+  } | null>(null)
+  // True while the share dialog is mounted — used by the picker's
+  // own buttons + Esc handler to stay inert while the user is
+  // mid-share-flow.  The actual in-flight IPC state lives inside
+  // the dialog; from the picker's perspective "dialog open" is
+  // close enough — the dialog backdrop blocks any clicks anyway.
+  let sharing = $derived(shareTarget !== null)
 
   /** Per-file download status surfaced as a progress strip while
    *  `attachSelected` runs (#160).  Keys are the full NC paths
@@ -136,93 +138,6 @@
     const next = new Map(downloadStatus)
     next.set(path, status)
     downloadStatus = next
-  }
-
-  // Password-protect-the-share modal. `null` = the prompt isn't open;
-  // `paths` is the snapshot of selection at the moment the user
-  // clicked "Share as link" so toggling the file tree behind the
-  // modal can't change what gets shared. `password` is the in-flight
-  // input — empty means "no password" (omitted from the OCS request,
-  // which keeps the share open as before).  `permissions` is the
-  // OCS bitfield value chosen via the dropdown — defaults to
-  // read-only so existing flows behave the same when the user
-  // clicks straight through.
-  let sharePrompt = $state<{
-    paths: string[]
-    password: string
-    permissions: number
-    /** Whether any of the selected paths is a folder.  Drives which
-     *  permission options the dropdown shows — "Upload + edit" and
-     *  "File drop" only make sense for folder shares (file shares
-     *  can't have new files dropped into them by definition). */
-    hasFolders: boolean
-    /** Whether an expiration date should be sent to the OCS endpoint
-     *  (#324).  Off by default — matches Nextcloud's own share UI
-     *  where a separate "Set expiration date" toggle gates the
-     *  picker.  Lets the user share without an expiry in a single
-     *  click. */
-    setExpiration: boolean
-    /** ISO `YYYY-MM-DD` from the DateField.  Empty when `setExpiration`
-     *  is off; only sent to the backend when the toggle is on AND
-     *  the field is non-empty (commitShare guards both). */
-    expireDate: string
-  } | null>(null)
-
-  /** Default expiration suggestion when the user first ticks the
-   *  "Set expiration date" toggle — 7 days out, in the same
-   *  `YYYY-MM-DD` shape DateField round-trips through.  Picked over
-   *  "today" so the recipient has a usable window without further
-   *  clicks; the user can still drill to any date via the calendar
-   *  popover. */
-  function defaultExpiry(): string {
-    const d = new Date()
-    d.setDate(d.getDate() + 7)
-    const pad = (n: number) => String(n).padStart(2, '0')
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-  }
-
-  /** Common public-link permission combinations Nextcloud's own
-   *  share UI exposes.  The bitfield (1 read, 2 update, 4 create,
-   *  8 delete, 16 share) gets sent to the OCS endpoint verbatim. */
-  /** Permission combinations Nextcloud's own share UI exposes.
-   *  `folderOnly` entries are filtered out when the selection is
-   *  pure files — "Upload + edit" and "File drop" semantically
-   *  only make sense for folder shares; offering them for a file
-   *  share would surface a Nextcloud-side rejection ("invalid
-   *  permissions"). */
-  const PERMISSION_OPTIONS = [
-    {
-      value: 1,
-      label: 'View only',
-      hint: 'Recipient can read / download.',
-      folderOnly: false,
-    },
-    {
-      value: 3,
-      label: 'View and edit',
-      hint: 'Recipient can edit the file in Nextcloud.',
-      folderOnly: false,
-    },
-    {
-      value: 15,
-      label: 'View, edit, upload, delete',
-      hint: 'Folder share with full read-write — recipient can drop files in and modify existing ones.',
-      folderOnly: true,
-    },
-    {
-      value: 4,
-      label: 'File drop (upload only)',
-      hint: 'Folder share where recipients can upload but not see the contents.',
-      folderOnly: true,
-    },
-  ] as const
-
-  function visiblePermissionOptions(hasFolders: boolean) {
-    return PERMISSION_OPTIONS.filter((o) => !o.folderOnly || hasFolders)
-  }
-
-  function permHint(value: number): string {
-    return PERMISSION_OPTIONS.find((o) => o.value === value)?.hint ?? ''
   }
 
   // Selection split by entry type. Folders can be shared as public
@@ -295,73 +210,28 @@
     }
   }
 
-  /** Open the password prompt instead of jumping straight to OCS.
-      The modal lets the user opt into a password (or skip with
-      Enter / "Share without password") before any link is minted —
-      no way to forget the password gate, no need to delete + recreate
-      a share if the user changes their mind mid-click. */
+  /** Open the share dialog instead of jumping straight to OCS.
+      The dialog lets the user opt into a password, permissions
+      bitmask, and expiry before any link is minted — no way to
+      forget those gates, no need to delete + recreate a share
+      if the user changes their mind mid-click. */
   function shareSelected() {
     if (selected.size === 0 || !onlinks) return
     // `selectedDirs` is the source of truth for "is any of the
     // ticked paths a folder" — survives folder navigation.
-    const hasFolders = selectedDirs.size > 0
-    sharePrompt = {
+    shareTarget = {
       paths: Array.from(selected),
-      password: '',
-      permissions: 1, // View-only by default — matches Nextcloud's own picker.
-      hasFolders,
-      setExpiration: false,
-      expireDate: '',
+      hasFolders: selectedDirs.size > 0,
     }
     error = ''
   }
 
-  /** Run the actual create_nextcloud_share calls with the password
-      the user picked (empty string = no password, omitted from the
-      OCS form on the Rust side). Same error-surface as the previous
-      direct flow. */
-  async function commitShare() {
-    if (!sharePrompt || !onlinks) return
-    const { paths, password, permissions, setExpiration, expireDate } =
-      sharePrompt
-    sharing = true
-    error = ''
-    try {
-      const pw = password.trim() ? password : null
-      // Only send `expireDate` when the user actually opted into it.
-      // An empty `expireDate=` posted to OCS is parsed as a bad date
-      // and rejects the whole share, so the toggle-off path must
-      // omit the field entirely.
-      const exp = setExpiration && expireDate ? expireDate : null
-      const results = await Promise.all(
-        paths.map(async (p) => {
-          const r = await invoke<{ id: string; url: string }>(
-            'create_nextcloud_share',
-            {
-              ncId: accountId,
-              path: p,
-              password: pw,
-              label: shareLabel?.trim() || null,
-              permissions,
-              expireDate: exp,
-            },
-          )
-          return {
-            filename: basename(p),
-            url: r.url,
-            id: r.id,
-            ncId: accountId,
-          } satisfies ShareLink
-        }),
-      )
-      sharePrompt = null
-      onlinks(results)
-      onclose()
-    } catch (e) {
-      error = formatError(e) || 'Failed to create share link(s)'
-    } finally {
-      sharing = false
-    }
+  /** Dialog resolved with freshly-minted share links.  Hand them
+      off to the Compose caller and close the picker. */
+  function onShareResolved(links: ShareLink[]) {
+    shareTarget = null
+    onlinks?.(links)
+    onclose()
   }
 </script>
 
@@ -527,122 +397,19 @@
   </div>
 </div>
 
-<!-- Password prompt for the public share link. Layered on top of
-     the picker's own modal (z-70 vs z-60) so dismissing it returns
-     focus to the picker without unmounting the selection. The
-     "Share without password" path commits with an empty password,
-     which the Rust side translates to omitting the OCS `password`
-     param entirely — keeps the previous "no-password share" flow
-     reachable in one click. -->
-{#if sharePrompt}
-  <div
-    class="fixed inset-0 z-70 flex items-center justify-center bg-black/50"
-    role="dialog"
-    aria-modal="true"
-    tabindex="-1"
-    onmousedown={(e) => { if (e.target === e.currentTarget && !sharing) sharePrompt = null }}
-  >
-    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-[28rem] max-w-full p-5">
-      <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
-      <p class="text-xs text-surface-500 mb-3">
-        {sharePrompt.paths.length === 1
-          ? 'Anyone with the link can open the file.'
-          : `Anyone with each link can open ${sharePrompt.paths.length} files.`}
-        Setting a password gates the recipient behind it; leave it empty
-        to share without one.
-      </p>
-
-      <label class="block text-xs text-surface-500 mb-1" for="share-pw">Password (optional)</label>
-      <!-- svelte-ignore a11y_autofocus -->
-      <input
-        id="share-pw"
-        type="password"
-        class="input w-full text-sm px-2 py-1.5 rounded-md mb-3"
-        placeholder="Leave blank for no password"
-        bind:value={sharePrompt.password}
-        disabled={sharing}
-        autofocus
-        onkeydown={(e) => {
-          if (e.key === 'Enter') { e.preventDefault(); void commitShare() }
-          else if (e.key === 'Escape' && !sharing) { e.preventDefault(); sharePrompt = null }
-        }}
-      />
-
-      <!-- Permissions dropdown — mirrors Nextcloud's own share UI.
-           The bitmask values map to OCS's `permissions` form field.
-           File-only flows (where the picker is used to attach a
-           single document) practically only use 1 / 3; the upload
-           variants ride along for folder shares. -->
-      <label class="block text-xs text-surface-500 mb-1" for="share-perms">Permissions</label>
-      <select
-        id="share-perms"
-        class="select w-full text-sm px-2 py-1.5 rounded-md mb-1"
-        bind:value={sharePrompt.permissions}
-        disabled={sharing}
-      >
-        {#each visiblePermissionOptions(sharePrompt.hasFolders) as opt}
-          <option value={opt.value}>{opt.label}</option>
-        {/each}
-      </select>
-      <p class="text-[11px] text-surface-500 mb-3">
-        {permHint(sharePrompt.permissions)}
-      </p>
-
-      <!-- Expiration date (#324).  Nextcloud's OCS endpoint takes an
-           optional `expireDate=YYYY-MM-DD`; after that date the
-           public link returns a "Link expired" page.  We gate the
-           DateField behind a checkbox so the no-expiry default
-           stays one click away, matching Nextcloud's own UI. -->
-      <label class="flex items-center gap-2 mb-2 text-xs text-surface-700 dark:text-surface-300 cursor-pointer">
-        <input
-          type="checkbox"
-          class="checkbox"
-          bind:checked={sharePrompt.setExpiration}
-          disabled={sharing}
-          onchange={() => {
-            // Seed a sensible default the first time the user opts in,
-            // otherwise reopening the toggle would land on an empty
-            // field that DateField renders as "Pick a date".
-            if (sharePrompt && sharePrompt.setExpiration && !sharePrompt.expireDate) {
-              sharePrompt.expireDate = defaultExpiry()
-            }
-          }}
-        />
-        <span>{m.nc_share_set_expiration_label()}</span>
-      </label>
-      {#if sharePrompt.setExpiration}
-        <div class="mb-3">
-          <DateField
-            bind:value={sharePrompt.expireDate}
-            ariaLabel={m.nc_share_expiration_aria()}
-          />
-          <p class="text-[11px] text-surface-500 mt-1">
-            {m.nc_share_expiration_hint()}
-          </p>
-        </div>
-      {/if}
-
-      {#if error}
-        <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
-      {/if}
-
-      <div class="flex justify-end gap-2">
-        <button
-          class="btn preset-outlined-surface-500 shrink-0"
-          disabled={sharing}
-          onclick={() => (sharePrompt = null)}
-        >Cancel</button>
-        <button
-          class="btn preset-filled-primary-500 shrink-0 whitespace-nowrap"
-          disabled={sharing}
-          onclick={() => void commitShare()}
-        >
-          {#if sharing}Sharing…{:else}Share{/if}
-        </button>
-      </div>
-    </div>
-  </div>
-{/if}
+<!-- Share dialog (password / permissions / expiry).  Sits over the
+     picker's own modal (z-70 vs z-60) so dismissing it returns
+     focus to the picker without unmounting the selection. -->
+<NextcloudShareDialog
+  open={shareTarget !== null}
+  accountId={accountId}
+  paths={shareTarget?.paths ?? []}
+  hasFolders={shareTarget?.hasFolders ?? false}
+  shareLabel={shareLabel}
+  zIndex={70}
+  onresolve={onShareResolved}
+  oncancel={() => (shareTarget = null)}
+/>
 
 <style>
   /* Indeterminate per-file progress head (#160).  Slides a

--- a/ui/src/lib/NextcloudShareDialog.svelte
+++ b/ui/src/lib/NextcloudShareDialog.svelte
@@ -1,0 +1,327 @@
+<script lang="ts" module>
+  /**
+   * NextcloudShareDialog — the password / permissions / expiry
+   * sub-modal used to mint public share links.
+   *
+   * Two callers today, both driving the same OCS endpoint via
+   * `create_nextcloud_share`:
+   *   - **NextcloudFilePicker** — opens from inside Compose's
+   *     "Attach from Nextcloud" flow.  Sits over its parent's
+   *     own modal so it renders at `zIndex: 70`; passes the
+   *     recipient string as `shareLabel` so the Nextcloud
+   *     "Shared with others" list shows who got the link
+   *     (#91).
+   *   - **FilesView** — opens from the sidebar-routed Files
+   *     view's "New mail with link" action.  No outer modal,
+   *     so the default `zIndex: 50` is fine.  No recipient
+   *     list yet (Compose hasn't opened), so no `shareLabel`.
+   *
+   * Both surfaces previously embedded near-identical inline
+   * modals; #324 added an expiry picker to the picker side
+   * and revealed how much duplication had built up.  Pulling
+   * the markup + state + IPC into one component keeps the
+   * two flows from drifting (permission options, copy,
+   * dropdown styling, and now expiry all live in one place).
+   */
+
+  /** A "share as link" result. `id` / `ncId` ride along so the
+   *  caller can drive later share-label updates (#91) or
+   *  share-deletion-on-draft-discard cleanup (#193).  Callers
+   *  that don't need them are free to project the value down
+   *  to `{filename, url}`. */
+  export interface ShareLink {
+    filename: string
+    url: string
+    id: string
+    ncId: string
+  }
+</script>
+
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core'
+  import DateField from './DateField.svelte'
+  import { formatError } from './errors'
+  import { m } from '../paraglide/messages'
+
+  interface Props {
+    /** Whether the dialog is rendered.  The parent owns
+     *  open/close state so it can coordinate with its own
+     *  keyboard handlers (e.g. a wrapping picker's Esc-closes-
+     *  outer-modal behaviour). */
+    open: boolean
+    /** Nextcloud account id to bill the share against. */
+    accountId: string
+    /** Selected paths to mint share links for.  The snapshot is
+     *  taken by the parent at click time so toggling the file
+     *  tree behind the dialog can't change what gets shared. */
+    paths: string[]
+    /** True if any of `paths` points at a folder — drives which
+     *  permission options the dropdown surfaces.  "Upload + edit"
+     *  and "File drop" only make sense for folder shares; file-only
+     *  selections shouldn't see them. */
+    hasFolders: boolean
+    /** Optional human-readable label attached to every share
+     *  (#91) so the Nextcloud "Shared with others" list shows
+     *  who got the link rather than the auto-generated name. */
+    shareLabel?: string
+    /** Stacking depth.  The picker nests this dialog over its
+     *  own modal so it needs `70`; the standalone Files surface
+     *  has no outer modal and uses `50`. */
+    zIndex?: number
+    /** Called with the freshly-minted share links once the OCS
+     *  calls succeed.  The parent decides what to do next
+     *  (insert into draft, hand off to Compose, …) and is also
+     *  responsible for hiding the dialog by clearing `open`. */
+    onresolve: (links: ShareLink[]) => void
+    /** Called when the user dismisses without sharing — Cancel
+     *  button, Esc, or backdrop click. */
+    oncancel: () => void
+  }
+  let {
+    open,
+    accountId,
+    paths,
+    hasFolders,
+    shareLabel,
+    zIndex = 50,
+    onresolve,
+    oncancel,
+  }: Props = $props()
+
+  // Form state.  Reset each time the dialog opens so a previous
+  // run's password / permissions / expiry don't leak into the
+  // next selection.
+  let password = $state('')
+  let permissions = $state(1)
+  let setExpiration = $state(false)
+  let expireDate = $state('')
+  let sharing = $state(false)
+  let error = $state('')
+
+  $effect(() => {
+    if (open) {
+      password = ''
+      permissions = 1
+      setExpiration = false
+      expireDate = ''
+      sharing = false
+      error = ''
+    }
+  })
+
+  /** Common public-link permission combinations Nextcloud's own
+   *  share UI exposes.  The bitfield (1 read, 2 update, 4 create,
+   *  8 delete, 16 share) gets sent to the OCS endpoint verbatim. */
+  const PERMISSION_OPTIONS = [
+    {
+      value: 1,
+      label: 'View only',
+      hint: 'Recipient can read / download.',
+      folderOnly: false,
+    },
+    {
+      value: 3,
+      label: 'View and edit',
+      hint: 'Recipient can edit the file in Nextcloud.',
+      folderOnly: false,
+    },
+    {
+      value: 15,
+      label: 'View, edit, upload, delete',
+      hint: 'Folder share with full read-write — recipient can drop files in and modify existing ones.',
+      folderOnly: true,
+    },
+    {
+      value: 4,
+      label: 'File drop (upload only)',
+      hint: 'Folder share where recipients can upload but not see the contents.',
+      folderOnly: true,
+    },
+  ] as const
+
+  let visiblePerms = $derived(
+    PERMISSION_OPTIONS.filter((o) => !o.folderOnly || hasFolders),
+  )
+  function permHint(value: number): string {
+    return PERMISSION_OPTIONS.find((o) => o.value === value)?.hint ?? ''
+  }
+
+  /** Default expiration suggestion when the user first ticks the
+   *  "Set expiration date" toggle — 7 days out, in the same
+   *  `YYYY-MM-DD` shape DateField round-trips through.  Picked over
+   *  "today" so the recipient has a usable window without further
+   *  clicks; the user can still drill to any date via the calendar
+   *  popover. */
+  function defaultExpiry(): string {
+    const d = new Date()
+    d.setDate(d.getDate() + 7)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+  }
+
+  function basename(path: string): string {
+    return path.split('/').filter(Boolean).pop() ?? path
+  }
+
+  async function commitShare() {
+    if (!open || paths.length === 0) return
+    sharing = true
+    error = ''
+    try {
+      const pw = password.trim() ? password : null
+      // Only send `expireDate` when the user actually opted into
+      // it.  An empty `expireDate=` posted to OCS is parsed as a
+      // bad date and rejects the whole share, so the toggle-off
+      // path must omit the field entirely.
+      const exp = setExpiration && expireDate ? expireDate : null
+      const results = await Promise.all(
+        paths.map(async (p) => {
+          const r = await invoke<{ id: string; url: string }>(
+            'create_nextcloud_share',
+            {
+              ncId: accountId,
+              path: p,
+              password: pw,
+              label: shareLabel?.trim() || null,
+              permissions,
+              expireDate: exp,
+            },
+          )
+          return {
+            filename: basename(p),
+            url: r.url,
+            id: r.id,
+            ncId: accountId,
+          } satisfies ShareLink
+        }),
+      )
+      onresolve(results)
+    } catch (e) {
+      error = formatError(e) || 'Failed to create share link(s)'
+    } finally {
+      sharing = false
+    }
+  }
+</script>
+
+{#if open}
+  <div
+    class="fixed inset-0 flex items-center justify-center bg-black/50"
+    style="z-index: {zIndex}"
+    role="dialog"
+    aria-modal="true"
+    tabindex="-1"
+    onmousedown={(e) => {
+      if (e.target === e.currentTarget && !sharing) oncancel()
+    }}
+  >
+    <div class="bg-surface-50 dark:bg-surface-900 rounded-lg shadow-xl w-[28rem] max-w-full p-5">
+      <h3 class="text-base font-semibold mb-1">Password-protect link?</h3>
+      <p class="text-xs text-surface-500 mb-3">
+        {paths.length === 1
+          ? 'Anyone with the link can open the file.'
+          : `Anyone with each link can open ${paths.length} files.`}
+        Setting a password gates the recipient behind it; leave it empty
+        to share without one.
+      </p>
+
+      <label class="block text-xs text-surface-500 mb-1" for="nc-share-dialog-pw">
+        Password (optional)
+      </label>
+      <!-- svelte-ignore a11y_autofocus -->
+      <input
+        id="nc-share-dialog-pw"
+        type="password"
+        class="input w-full text-sm px-2 py-1.5 rounded-md mb-3"
+        placeholder="Leave blank for no password"
+        bind:value={password}
+        disabled={sharing}
+        autofocus
+        onkeydown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            void commitShare()
+          } else if (e.key === 'Escape' && !sharing) {
+            e.preventDefault()
+            oncancel()
+          }
+        }}
+      />
+
+      <!-- Permissions dropdown — mirrors Nextcloud's own share UI.
+           The bitmask values map to OCS's `permissions` form field.
+           File-only flows (where the picker is used to attach a
+           single document) practically only use 1 / 3; the upload
+           variants ride along for folder shares. -->
+      <label class="block text-xs text-surface-500 mb-1" for="nc-share-dialog-perms">
+        Permissions
+      </label>
+      <select
+        id="nc-share-dialog-perms"
+        class="select w-full text-sm px-2 py-1.5 rounded-md mb-1"
+        bind:value={permissions}
+        disabled={sharing}
+      >
+        {#each visiblePerms as opt (opt.value)}
+          <option value={opt.value}>{opt.label}</option>
+        {/each}
+      </select>
+      <p class="text-[11px] text-surface-500 mb-3">
+        {permHint(permissions)}
+      </p>
+
+      <!-- Expiration date (#324).  Nextcloud's OCS endpoint takes an
+           optional `expireDate=YYYY-MM-DD`; after that date the
+           public link returns a "Link expired" page.  Gated behind
+           a checkbox so the no-expiry default stays one click away,
+           matching Nextcloud's own UI. -->
+      <label class="flex items-center gap-2 mb-2 text-xs text-surface-700 dark:text-surface-300 cursor-pointer">
+        <input
+          type="checkbox"
+          class="checkbox"
+          bind:checked={setExpiration}
+          disabled={sharing}
+          onchange={() => {
+            // Seed a sensible default the first time the user opts
+            // in, otherwise reopening the toggle would land on an
+            // empty field that DateField renders as "Pick a date".
+            if (setExpiration && !expireDate) expireDate = defaultExpiry()
+          }}
+        />
+        <span>{m.nc_share_set_expiration_label()}</span>
+      </label>
+      {#if setExpiration}
+        <div class="mb-3">
+          <DateField
+            bind:value={expireDate}
+            ariaLabel={m.nc_share_expiration_aria()}
+          />
+          <p class="text-[11px] text-surface-500 mt-1">
+            {m.nc_share_expiration_hint()}
+          </p>
+        </div>
+      {/if}
+
+      {#if error}
+        <p class="text-xs text-red-500 mb-3 wrap-break-word">{error}</p>
+      {/if}
+
+      <div class="flex justify-end gap-2">
+        <button
+          class="btn preset-outlined-surface-500 shrink-0"
+          disabled={sharing}
+          onclick={oncancel}
+        >
+          Cancel
+        </button>
+        <button
+          class="btn preset-filled-primary-500 shrink-0 whitespace-nowrap"
+          disabled={sharing}
+          onclick={() => void commitShare()}
+        >
+          {#if sharing}Sharing…{:else}Share{/if}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
## Summary

- Closes #324 — adds an expiration date picker to the Nextcloud share-link flow.
- The share modal in `NextcloudFilePicker` now exposes a "Set expiration date" checkbox; flipping it on reveals the existing `DateField` popover (default: today + 7 days). The opt-in gate keeps the no-expiry default a single click away, matching Nextcloud's own UI.
- The selected `YYYY-MM-DD` flows through the `create_nextcloud_share` Tauri command and onto the OCS `expireDate` form field. Empty / unset values are omitted from the request entirely — Nextcloud rejects an empty `expireDate=` as a malformed date.
- Three new i18n keys (`nc_share_set_expiration_label`, `nc_share_expiration_aria`, `nc_share_expiration_hint`) in both `en.json` and `de.json`.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace` builds
- [x] `cargo test -p unkai-nextcloud` — all 4 existing share-module tests still pass (signature change didn't drop coverage)
- [x] `npm run check` in `ui/` — 0 errors, 0 warnings
- [x] Manual: open Compose → Attach from Nextcloud → tick file → "Share as link" → toggle "Set expiration date" → pick a date → confirm OCS request carries `expireDate=YYYY-MM-DD`
- [x] Manual: same flow with expiration toggle **off** → confirm no `expireDate` is sent and share is open-ended
- [ ] Manual: pick a date in the past → confirm Nextcloud's rejection message surfaces in the modal's error area
