### PR TITLE
#329: forward with original attachments + recover non-ASCII filenames

### DIFF
--- a/crates/unkai-imap/src/attachment_filename.rs
+++ b/crates/unkai-imap/src/attachment_filename.rs
@@ -1,0 +1,416 @@
+//! Robust attachment-filename decoding (#329 follow-up).
+//!
+//! `mail-parser`'s [`attachment_name`][1] handles RFC 2047 encoded
+//! words and properly-tagged RFC 2231 parameters out of the box, but
+//! falls through to `String::from_utf8_lossy` for senders that put
+//! raw 8-bit bytes directly in a `filename=` parameter — and
+//! `from_utf8_lossy` replaces every invalid byte with U+FFFD, the
+//! replacement character (which most fonts render as `?`).  That's
+//! the failure mode behind real-world filenames showing up as
+//! `Preis??nde.pdf` instead of `Preisände.pdf` when the sender's
+//! client is sloppy.
+//!
+//! Two patterns produce *recoverable* U+FFFD here:
+//!
+//! 1. Sender wrote raw Latin-1 / Windows-1252 bytes in the parameter
+//!    (e.g. `filename=Preis\xE4nde.pdf` for `ä = 0xE4`).  Each
+//!    non-ASCII byte is invalid UTF-8 on its own → one U+FFFD per
+//!    affected character.
+//! 2. Sender used RFC 2231 continuation (`filename*0`, `filename*1`,
+//!    …) to split the value *without* the leading charset wrapper
+//!    (`filename*=UTF-8''…`), and the split landed mid-multibyte —
+//!    e.g. UTF-8 `ä = 0xC3 0xA4` split as `0xC3` at the end of one
+//!    continuation and `0xA4` at the start of the next.  mail-parser
+//!    decodes each continuation as UTF-8 individually before
+//!    concatenating, so each half becomes its own U+FFFD: two in a
+//!    row where the multibyte boundary was crossed.
+//!
+//! There's a third pattern we *can't* recover: senders whose own
+//! software replaced the character with U+FFFD before constructing
+//! the MIME header, so the wire bytes already carry the replacement
+//! chars baked into a properly-RFC-2231-encoded value (e.g.
+//! `filename*="UTF-8''Preis%EF%BF%BD%EF%BF%BDnderung.pdf"`).  Once
+//! the source character has been lost upstream, no parsing layer
+//! can guess what it was.  Confirmed in the wild during #329 test;
+//! see `tests::pre_corrupted_ufffd_preserved_faithfully` for the
+//! lock-in behaviour: we surface the U+FFFD chars unchanged, which
+//! keeps the filename truthful (and keeps the on-disk name the user
+//! gets from "Download" matching the one shown in the chip).
+//!
+//! Recovery strategy for the two recoverable patterns:
+//!
+//! - Trust mail-parser's result when it doesn't contain U+FFFD —
+//!   that path is correct for every RFC-compliant encoding plus the
+//!   common case of raw UTF-8 bytes that happen to be valid UTF-8.
+//! - When U+FFFD shows up, re-extract the raw bytes from the
+//!   `Content-Disposition` / `Content-Type` header by indexing into
+//!   `Message::raw_message` via the per-header `offset_start /
+//!   offset_end`, concatenate any RFC 2231 continuations into a
+//!   single byte buffer, then try UTF-8 first (recovers the split-
+//!   multibyte case) and fall back to bytes-as-Latin-1 (recovers
+//!   the raw-Latin-1 case).  The RFC 2231 charset-tagged shapes
+//!   (`filename*=charset''…`, `filename*0*=charset''…`) are mail-
+//!   parser's territory; we don't attempt to re-parse them, so the
+//!   pre-corrupted case above falls through to the U+FFFD-preserving
+//!   final branch.
+//!
+//! Bytes-as-Latin-1 — each byte cast to `char` — maps 1:1 onto
+//! U+0000..=U+00FF.  Latin-1 and Windows-1252 disagree only at
+//! 0x80..0x9F (CP1252 has typography glyphs there; Latin-1 has C1
+//! control codes); none of those bytes appear in real-world German
+//! filenames, so the simpler conversion is sufficient and avoids
+//! pulling in a charset crate.
+//!
+//! [1]: https://docs.rs/mail-parser/0.11.3/mail_parser/trait.MessagePart.html#method.attachment_name
+
+use mail_parser::{Message, MessagePart, MimeHeaders};
+
+/// Decode the attachment filename for a MIME part, recovering from
+/// mail-parser's lossy UTF-8 fallback when the sender put raw 8-bit
+/// bytes in `filename=` / `name=` directly.  Returns `"attachment"`
+/// when the part doesn't carry either parameter — same fallback the
+/// previous in-line `.unwrap_or_else(|| "attachment".to_string())`
+/// produced.
+pub fn decode_attachment_filename(parsed: &Message<'_>, part: &MessagePart<'_>) -> String {
+    if let Some(name) = part.attachment_name() {
+        if !name.contains('\u{FFFD}') {
+            return name.to_string();
+        }
+        if let Some(recovered) = recover_from_raw_headers(parsed, part) {
+            return recovered;
+        }
+        // No recoverable bytes — either the headers carry the
+        // U+FFFD already encoded (sender-side corruption past our
+        // reach) or we couldn't reach the raw header slice.  Return
+        // mail-parser's string as-is rather than fabricating
+        // "attachment"; the user can still recognise most of the
+        // name and the on-disk name from "Download" stays
+        // consistent with what the chip shows.
+        return name.to_string();
+    }
+    "attachment".to_string()
+}
+
+/// Walk the part's headers, locate Content-Disposition or
+/// Content-Type, pull the raw byte slice for each via the offsets
+/// recorded by mail-parser, and re-parse the filename / name
+/// parameter at byte level so non-UTF-8 senders survive.
+fn recover_from_raw_headers(parsed: &Message<'_>, part: &MessagePart<'_>) -> Option<String> {
+    let raw = parsed.raw_message.as_ref();
+    // Content-Disposition's `filename` takes precedence over
+    // Content-Type's `name`, same priority order mail-parser uses
+    // in its own `attachment_name` impl.
+    let candidates: &[(&str, &[u8])] = &[
+        ("Content-Disposition", b"filename"),
+        ("Content-Type", b"name"),
+    ];
+    for (header_name, param_name) in candidates {
+        for header in &part.headers {
+            if !header.name.as_str().eq_ignore_ascii_case(header_name) {
+                continue;
+            }
+            let bytes = raw.get(header.offset_start as usize..header.offset_end as usize)?;
+            if let Some(value) = extract_param_value_bytes(bytes, param_name) {
+                return Some(decode_value_bytes(&value));
+            }
+        }
+    }
+    None
+}
+
+/// Decode a concatenated parameter-value byte buffer.  UTF-8 first —
+/// this rescues the split-multibyte-continuation case, where
+/// concatenating bytes before decoding makes the multibyte sequence
+/// whole again.  Latin-1 (byte → codepoint) as the fallback for
+/// senders that wrote raw 8-bit bytes outright.
+fn decode_value_bytes(bytes: &[u8]) -> String {
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        return s.to_string();
+    }
+    bytes.iter().map(|&b| b as char).collect()
+}
+
+/// Pull the value bytes for `param` out of a raw MIME header.
+///
+/// Handles three real-world shapes:
+///
+/// - `param=value` (unquoted token)
+/// - `param="value"` (quoted-string with `\` escapes)
+/// - `param*0=value0; param*1=value1; …` (RFC 2231 continuation
+///   without the charset wrapper — the *only* RFC 2231 shape that
+///   reaches this path, because mail-parser handles the charset-
+///   tagged `param*=charset''value` and `param*0*=charset''…`
+///   shapes correctly and they wouldn't have produced U+FFFD).
+///
+/// Concatenates continuations in numeric order so a multibyte
+/// character split across the boundary is re-fused before the
+/// caller tries UTF-8 decoding on it.
+fn extract_param_value_bytes(header_bytes: &[u8], param: &[u8]) -> Option<Vec<u8>> {
+    let mut continuations: Vec<(u32, Vec<u8>)> = Vec::new();
+    let mut found_plain: Option<Vec<u8>> = None;
+
+    // Skip past the header's main value (e.g. `attachment` for
+    // Content-Disposition, `application/pdf` for Content-Type) to
+    // the first parameter separator.
+    let mut i = 0;
+    while i < header_bytes.len() && header_bytes[i] != b';' {
+        i += 1;
+    }
+
+    while i < header_bytes.len() {
+        // Skip `;` separators and any whitespace (including folded
+        // CRLF + space that wraps long headers).
+        while i < header_bytes.len()
+            && (header_bytes[i] == b';' || header_bytes[i].is_ascii_whitespace())
+        {
+            i += 1;
+        }
+        if i >= header_bytes.len() {
+            break;
+        }
+
+        // Read the parameter name (token: anything up to whitespace,
+        // `=`, or `;`).
+        let key_start = i;
+        while i < header_bytes.len()
+            && header_bytes[i] != b'='
+            && header_bytes[i] != b';'
+            && !header_bytes[i].is_ascii_whitespace()
+        {
+            i += 1;
+        }
+        let key = &header_bytes[key_start..i];
+
+        // Tolerate whitespace around the `=`.
+        while i < header_bytes.len() && header_bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= header_bytes.len() || header_bytes[i] != b'=' {
+            // Malformed segment — skip to next `;` and continue.
+            while i < header_bytes.len() && header_bytes[i] != b';' {
+                i += 1;
+            }
+            continue;
+        }
+        i += 1; // skip `=`
+        while i < header_bytes.len() && header_bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+
+        // Read the value — quoted-string or token.
+        let mut value: Vec<u8> = Vec::new();
+        if i < header_bytes.len() && header_bytes[i] == b'"' {
+            i += 1;
+            while i < header_bytes.len() && header_bytes[i] != b'"' {
+                if header_bytes[i] == b'\\' && i + 1 < header_bytes.len() {
+                    value.push(header_bytes[i + 1]);
+                    i += 2;
+                } else {
+                    value.push(header_bytes[i]);
+                    i += 1;
+                }
+            }
+            if i < header_bytes.len() {
+                i += 1; // closing `"`
+            }
+        } else {
+            while i < header_bytes.len()
+                && header_bytes[i] != b';'
+                && !header_bytes[i].is_ascii_whitespace()
+            {
+                value.push(header_bytes[i]);
+                i += 1;
+            }
+        }
+
+        // Classify the key against the param we're looking for.
+        // `filename` / `name` plain, or `filename*N` / `name*N`
+        // continuation.  The `*` (charset-tagged single) and `*N*`
+        // (continuation with first-segment charset) shapes are
+        // mail-parser's territory and would not have reached this
+        // recovery path — skip them.
+        if key.eq_ignore_ascii_case(param) {
+            found_plain = Some(value);
+            continue;
+        }
+        if key.len() <= param.len() || !key[..param.len()].eq_ignore_ascii_case(param) {
+            continue;
+        }
+        let suffix = &key[param.len()..];
+        if suffix == b"*" || suffix.last() == Some(&b'*') {
+            continue;
+        }
+        if !suffix.starts_with(b"*") {
+            continue;
+        }
+        if let Ok(idx_str) = std::str::from_utf8(&suffix[1..]) {
+            if let Ok(idx) = idx_str.parse::<u32>() {
+                continuations.push((idx, value));
+            }
+        }
+    }
+
+    if !continuations.is_empty() {
+        continuations.sort_by_key(|(n, _)| *n);
+        let mut joined = Vec::new();
+        for (_, v) in continuations {
+            joined.extend_from_slice(&v);
+        }
+        return Some(joined);
+    }
+    found_plain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mail_parser::MessageParser;
+
+    // 0xE4 is `ä` in Latin-1 / Windows-1252; the same character in
+    // UTF-8 is 0xC3 0xA4.  These tests construct synthetic .eml
+    // bodies with each encoding and confirm the helper recovers
+    // the German `Preisände.pdf` filename in every case.
+
+    fn build_eml(filename_header_line: &[u8]) -> Vec<u8> {
+        let mut eml: Vec<u8> = Vec::new();
+        eml.extend_from_slice(b"From: a@b.example\r\n");
+        eml.extend_from_slice(b"To: c@d.example\r\n");
+        eml.extend_from_slice(b"Subject: t\r\n");
+        eml.extend_from_slice(b"MIME-Version: 1.0\r\n");
+        eml.extend_from_slice(b"Content-Type: multipart/mixed; boundary=BNDR\r\n");
+        eml.extend_from_slice(b"\r\n");
+        eml.extend_from_slice(b"--BNDR\r\n");
+        eml.extend_from_slice(b"Content-Type: text/plain\r\n\r\nhi\r\n");
+        eml.extend_from_slice(b"--BNDR\r\n");
+        eml.extend_from_slice(b"Content-Type: application/pdf\r\n");
+        eml.extend_from_slice(filename_header_line);
+        eml.extend_from_slice(b"\r\n");
+        eml.extend_from_slice(b"Content-Transfer-Encoding: base64\r\n\r\n");
+        eml.extend_from_slice(b"aGVsbG8=\r\n");
+        eml.extend_from_slice(b"--BNDR--\r\n");
+        eml
+    }
+
+    fn decoded_attachment_name(eml: &[u8]) -> String {
+        let msg = MessageParser::default().parse(eml).expect("parse");
+        let part = msg.attachments().next().expect("attachment");
+        decode_attachment_filename(&msg, part)
+    }
+
+    #[test]
+    fn plain_ascii_filename_unchanged() {
+        let eml = build_eml(b"Content-Disposition: attachment; filename=\"plain.pdf\"");
+        assert_eq!(decoded_attachment_name(&eml), "plain.pdf");
+    }
+
+    #[test]
+    fn raw_utf8_bytes_decoded_via_mail_parser() {
+        // `ä` as raw UTF-8 (0xC3 0xA4) is *valid* UTF-8 — mail-parser
+        // hands us the right string directly without our fallback
+        // ever firing.
+        let mut header = b"Content-Disposition: attachment; filename=\"Preis".to_vec();
+        header.extend_from_slice(b"\xC3\xA4");
+        header.extend_from_slice(b"nde.pdf\"");
+        let eml = build_eml(&header);
+        assert_eq!(decoded_attachment_name(&eml), "Preisände.pdf");
+    }
+
+    #[test]
+    fn raw_latin1_bytes_recovered_via_fallback() {
+        // `ä` as raw Latin-1 (single byte 0xE4) is *invalid* UTF-8 —
+        // mail-parser produces "Preis\u{FFFD}nde.pdf", our fallback
+        // re-reads the header bytes and decodes them as Latin-1.
+        let mut header = b"Content-Disposition: attachment; filename=\"Preis".to_vec();
+        header.push(0xE4);
+        header.extend_from_slice(b"nde.pdf\"");
+        let eml = build_eml(&header);
+        assert_eq!(decoded_attachment_name(&eml), "Preisände.pdf");
+    }
+
+    #[test]
+    fn raw_latin1_bytes_unquoted_recovered() {
+        let mut header = b"Content-Disposition: attachment; filename=Preis".to_vec();
+        header.push(0xE4);
+        header.extend_from_slice(b"nde.pdf");
+        let eml = build_eml(&header);
+        assert_eq!(decoded_attachment_name(&eml), "Preisände.pdf");
+    }
+
+    #[test]
+    fn pre_corrupted_ufffd_preserved_faithfully() {
+        // Real-world case (#329 testing): the sender's mail client
+        // replaced `ä` with two U+FFFD chars *before* RFC-2231-
+        // encoding the filename, so the wire bytes already carry
+        // `%EF%BF%BD%EF%BF%BD` inside a properly charset-tagged
+        // value.  mail-parser correctly decodes that to two U+FFFD;
+        // recovery from raw bytes would return the same U+FFFD
+        // because the source character is gone.  We lock the
+        // faithful-pass-through behaviour: surface what came in,
+        // don't guess, don't fabricate, don't drop to "attachment".
+        let header = b"Content-Disposition: attachment;\r\n\
+            \tfilename*=\"UTF-8''Preis%EF%BF%BD%EF%BF%BDnderung.pdf\"";
+        let eml = build_eml(header);
+        let expected = format!("Preis{}{}nderung.pdf", '\u{FFFD}', '\u{FFFD}');
+        assert_eq!(decoded_attachment_name(&eml), expected);
+    }
+
+    #[test]
+    fn rfc2231_split_multibyte_recovered() {
+        // RFC 2231 continuation that splits the UTF-8 bytes of `ä`
+        // (0xC3 0xA4) across two segments without the charset
+        // wrapper.  mail-parser decodes each segment as UTF-8 on
+        // its own, producing two U+FFFD where the split lands; our
+        // fallback concatenates the raw bytes and UTF-8-decodes
+        // the whole buffer to recover the character.
+        let mut header = b"Content-Disposition: attachment; filename*0=\"Preis".to_vec();
+        header.push(0xC3);
+        header.extend_from_slice(b"\"; filename*1=\"");
+        header.push(0xA4);
+        header.extend_from_slice(b"nde.pdf\"");
+        let eml = build_eml(&header);
+        assert_eq!(decoded_attachment_name(&eml), "Preisände.pdf");
+    }
+
+    #[test]
+    fn content_type_name_fallback() {
+        // When only Content-Type carries the filename via the
+        // legacy `name=` parameter and the bytes are raw Latin-1,
+        // the fallback finds them via the second candidate header.
+        let mut eml: Vec<u8> = Vec::new();
+        eml.extend_from_slice(b"From: a@b.example\r\n");
+        eml.extend_from_slice(b"To: c@d.example\r\n");
+        eml.extend_from_slice(b"Subject: t\r\n");
+        eml.extend_from_slice(b"MIME-Version: 1.0\r\n");
+        eml.extend_from_slice(b"Content-Type: multipart/mixed; boundary=BNDR\r\n\r\n");
+        eml.extend_from_slice(b"--BNDR\r\n");
+        eml.extend_from_slice(b"Content-Type: text/plain\r\n\r\nhi\r\n");
+        eml.extend_from_slice(b"--BNDR\r\n");
+        eml.extend_from_slice(b"Content-Type: application/pdf; name=\"Preis");
+        eml.push(0xE4);
+        eml.extend_from_slice(b"nde.pdf\"\r\n");
+        eml.extend_from_slice(b"Content-Disposition: attachment\r\n");
+        eml.extend_from_slice(b"Content-Transfer-Encoding: base64\r\n\r\n");
+        eml.extend_from_slice(b"aGVsbG8=\r\n");
+        eml.extend_from_slice(b"--BNDR--\r\n");
+        assert_eq!(decoded_attachment_name(&eml), "Preisände.pdf");
+    }
+
+    #[test]
+    fn no_filename_returns_attachment_sentinel() {
+        let mut eml: Vec<u8> = Vec::new();
+        eml.extend_from_slice(b"From: a@b.example\r\n");
+        eml.extend_from_slice(b"To: c@d.example\r\n");
+        eml.extend_from_slice(b"Subject: t\r\n");
+        eml.extend_from_slice(b"MIME-Version: 1.0\r\n");
+        eml.extend_from_slice(b"Content-Type: multipart/mixed; boundary=BNDR\r\n\r\n");
+        eml.extend_from_slice(b"--BNDR\r\n");
+        eml.extend_from_slice(b"Content-Type: text/plain\r\n\r\nhi\r\n");
+        eml.extend_from_slice(b"--BNDR\r\n");
+        eml.extend_from_slice(b"Content-Type: application/pdf\r\n");
+        eml.extend_from_slice(b"Content-Disposition: attachment\r\n");
+        eml.extend_from_slice(b"Content-Transfer-Encoding: base64\r\n\r\n");
+        eml.extend_from_slice(b"aGVsbG8=\r\n");
+        eml.extend_from_slice(b"--BNDR--\r\n");
+        assert_eq!(decoded_attachment_name(&eml), "attachment");
+    }
+}

--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -14,6 +14,8 @@ use unkai_core::error::UnkaiError;
 use unkai_core::models::{Email, EmailAttachment, EmailEnvelope, Folder, TrustedCert};
 use unkai_core::tls;
 
+use crate::attachment_filename::decode_attachment_filename;
+
 use crate::mutf7;
 
 /// Parse a raw RFC 5322 message into our `Email` shape.  Same MIME
@@ -91,10 +93,7 @@ pub fn parse_eml_bytes(
         .enumerate()
         .map(|(idx, part)| {
             let part_id = idx as u32;
-            let filename = part
-                .attachment_name()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "attachment".to_string());
+            let filename = decode_attachment_filename(&parsed, part);
             let content_type = part
                 .content_type()
                 .map(|ct| {
@@ -831,10 +830,7 @@ impl ImapClient {
             .enumerate()
             .map(|(idx, part)| {
                 let part_id = idx as u32;
-                let filename = part
-                    .attachment_name()
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "attachment".to_string());
+                let filename = decode_attachment_filename(&parsed, part);
                 // `content_type()` returns a structured ContentType;
                 // rebuild the `type/subtype` string for the UI icon lookup.
                 let content_type = part
@@ -1050,10 +1046,7 @@ impl ImapClient {
                 UnkaiError::Protocol(format!("Message UID {uid} has no part #{part_id}"))
             })?;
 
-        let filename = part
-            .attachment_name()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| "attachment".to_string());
+        let filename = decode_attachment_filename(&parsed, part);
         let content_type = part
             .content_type()
             .map(|ct| {

--- a/crates/unkai-imap/src/lib.rs
+++ b/crates/unkai-imap/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides async IMAP connectivity for fetching,
 //! syncing, and managing mailboxes.
 
+mod attachment_filename;
 mod client;
 mod mutf7;
 

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -92,6 +92,13 @@
   "compose_attachment_warning_body": "Fügen Sie vor dem Senden eine Datei hinzu oder schließen Sie diese Warnung, falls es ein Fehlalarm ist.",
   "compose_attachment_warning_dismiss": "Schließen",
 
+  "compose_forward_attachments_title": "Originalanhänge übernehmen?",
+  "compose_forward_attachments_body_one": "Die weitergeleitete Nachricht enthält 1 Anhang. Soll er in die Weiterleitung übernommen werden?",
+  "compose_forward_attachments_body_many": "Die weitergeleitete Nachricht enthält {n} Anhänge. Sollen sie in die Weiterleitung übernommen werden?",
+  "compose_forward_attachments_include": "Anhänge übernehmen",
+  "compose_forward_attachments_skip": "Ohne Anhänge weiterleiten",
+  "compose_forward_attachments_download_failed": "Einige Anhänge konnten nicht geladen werden: {reason}",
+
   "nc_share_set_expiration_label": "Ablaufdatum festlegen",
   "nc_share_expiration_aria": "Ablaufdatum für den Freigabelink auswählen",
   "nc_share_expiration_hint": "Empfänger können den Link nach diesem Datum nicht mehr öffnen.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -91,6 +91,13 @@
   "compose_attachment_warning_body": "Add a file before sending, or dismiss this warning if it's a false alarm.",
   "compose_attachment_warning_dismiss": "Dismiss",
 
+  "compose_forward_attachments_title": "Include original attachments?",
+  "compose_forward_attachments_body_one": "The forwarded message has 1 attachment. Add it to your forward?",
+  "compose_forward_attachments_body_many": "The forwarded message has {n} attachments. Add them to your forward?",
+  "compose_forward_attachments_include": "Include attachments",
+  "compose_forward_attachments_skip": "Forward without",
+  "compose_forward_attachments_download_failed": "Could not load some attachments: {reason}",
+
   "nc_share_set_expiration_label": "Set expiration date",
   "nc_share_expiration_aria": "Pick expiration date for the share link",
   "nc_share_expiration_hint": "Recipients can't open the link after this date.",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -28,6 +28,7 @@
   import AccountSettings, { type SettingsCategory } from './lib/AccountSettings.svelte'
   import LockScreen from './lib/LockScreen.svelte'
   import Compose, {
+    type Attachment as ComposeAttachment,
     type ComposeInitial,
     type SendFailurePayload,
   } from './lib/Compose.svelte'
@@ -75,6 +76,8 @@
     UI_SCALE_STEP,
   } from './lib/uiScale'
   import { locales } from './paraglide/runtime'
+  import { m } from './paraglide/messages'
+  import { formatError } from './lib/errors'
 
   // ── View state ──────────────────────────────────────────────
   // Which view is currently shown. Starts as 'loading' until we
@@ -261,6 +264,19 @@
      *  cleanup + draft-source expunge that a naive entry-removal
      *  would skip. */
     cancelFn?: () => void
+    /** Resolved with this Compose's external "append attachments"
+     *  function once it has mounted and registered via
+     *  `onaddattachmentsref` (#329).  The forward-with-attachments
+     *  flow downloads bytes in the background after the user picks
+     *  "Include" in the post-open prompt, then `await`s this to
+     *  push them into an already-mounted Compose — survives the
+     *  rare race where the user picks before Compose's mount
+     *  effect has fired. */
+    addAttachmentsReady: Promise<(atts: ComposeAttachment[]) => void>
+    /** Resolver paired with `addAttachmentsReady`. */
+    resolveAddAttachments: (
+      fn: (atts: ComposeAttachment[]) => void,
+    ) => void
     /** Live mirror of the Compose's internal `currentDraftSource`
      *  pointer (#292 follow-up).  Seeded from `initial.draftSource`
      *  and updated via Compose's `ondraftsourcechange` after every
@@ -1039,19 +1055,29 @@
       // have active.
       unlistenComposeFromMail = await listen<{
         kind: 'reply' | 'reply-all' | 'forward'
-        mail: ReplyableMail
+        mail: ForwardableMail
       }>('compose-from-mail', (e) => {
         const { kind, mail } = e.payload
-        let initial: ComposeInitial
-        if (kind === 'reply') initial = buildReplyInitial(mail)
-        else if (kind === 'reply-all') initial = buildReplyAllInitial(mail)
-        else initial = buildForwardInitial(mail)
-        void openComposeInStandaloneWindow({
-          accountId: mail.account_id,
-          initial,
-        }).catch((err) =>
-          console.warn('openComposeInStandaloneWindow from #304 failed', err),
-        )
+        void (async () => {
+          // Forward needs the async builder so the
+          // include-attachments popup (#329) and the
+          // download_email_attachment fan-out can run before the
+          // popped-out Compose window opens.  Reply / reply-all
+          // stay synchronous — their initial doesn't depend on
+          // the original attachments.
+          const initial: ComposeInitial =
+            kind === 'reply'
+              ? buildReplyInitial(mail)
+              : kind === 'reply-all'
+                ? buildReplyAllInitial(mail)
+                : await buildForwardInitialForPopout(mail)
+          void openComposeInStandaloneWindow({
+            accountId: mail.account_id,
+            initial,
+          }).catch((err) =>
+            console.warn('openComposeInStandaloneWindow from #304 failed', err),
+          )
+        })()
       })
       unlistenEditDraftFromMail = await listen<{ mail: DraftMail }>(
         'edit-draft-from-mail',
@@ -1573,6 +1599,18 @@
     }
 
     const id = crypto.randomUUID()
+    // Deferred handle for the attachment-injection path (#329).
+    // Resolved inside Compose's mount $effect — by the time any
+    // caller `await`s this, it's either already settled or will
+    // settle in microseconds when Svelte runs the queued effect.
+    let resolveAddAttachments!: (
+      fn: (atts: ComposeAttachment[]) => void,
+    ) => void
+    const addAttachmentsReady = new Promise<
+      (atts: ComposeAttachment[]) => void
+    >((resolve) => {
+      resolveAddAttachments = resolve
+    })
     composes.push({
       id,
       accountId: options.accountId ?? activeAccountId ?? '',
@@ -1581,6 +1619,8 @@
       currentSubject: initial.subject ?? '',
       currentDraftSource: initial.draftSource ?? null,
       openedAsEditOfOutbox: initial.outboxSource != null,
+      addAttachmentsReady,
+      resolveAddAttachments,
     })
     activeComposeId = id
     return id
@@ -1881,6 +1921,21 @@
     uid: number
   }
 
+  /** Forward (#329) needs everything reply-shaping needs plus the
+   *  original attachment list, so the user can opt to re-attach the
+   *  source message's files to the outgoing forward.  `part_id` is
+   *  the stable index into the original MIME tree the backend uses
+   *  to re-fetch a single attachment's bytes via
+   *  `download_email_attachment` (see `onEditDraft` for the same
+   *  shape, used by the draft-rehydrate flow). */
+  type ForwardableMail = ReplyableMail & {
+    attachments: {
+      filename: string
+      content_type: string
+      part_id: number
+    }[]
+  }
+
   // Pure builders for the reply / reply-all / forward initial
   // (#304).  Extracted so the popped-out-mail event path can reuse
   // the same shaping logic and route the result into a popped-out
@@ -2059,8 +2114,124 @@
     }
   }
 
-  function onForward(mail: OpenMail) {
-    openCompose(buildForwardInitial(mail))
+  /** #329 — when the user forwards a message that carries
+   *  attachments, ask whether to bring them along.  Held as
+   *  `{ count, resolve }` so the async forward flow below can
+   *  `await` the user's choice via a promise; the modal's
+   *  buttons (and the backdrop dismiss) call `resolve` and clear
+   *  this state. */
+  let pendingForwardPrompt = $state<{
+    count: number
+    resolve: (include: boolean) => void
+  } | null>(null)
+
+  function resolveForwardPrompt(include: boolean) {
+    if (!pendingForwardPrompt) return
+    const { resolve } = pendingForwardPrompt
+    pendingForwardPrompt = null
+    resolve(include)
+  }
+
+  /** #329 — show the "include original attachments?" prompt and
+   *  return the user's choice.  Setting `pendingForwardPrompt`
+   *  mounts the modal; the modal's buttons (and backdrop /
+   *  Escape) call `resolveForwardPrompt`, which fulfils this
+   *  promise and clears the state. */
+  function promptIncludeForwardAttachments(count: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      pendingForwardPrompt = { count, resolve }
+    })
+  }
+
+  /** #329 — download every attachment on `mail` in parallel and
+   *  reshape into Compose's `Attachment` form.  Each gets a fresh
+   *  `content_id` so the `/` editor shortcut can still anchor
+   *  cid: links into the body after the bytes arrive — same
+   *  shape `onEditDraft` builds for the draft-edit flow. */
+  function downloadForwardAttachments(
+    mail: ForwardableMail,
+  ): Promise<ComposeAttachment[]> {
+    return Promise.all(
+      mail.attachments.map(async (att) => ({
+        filename: att.filename,
+        content_type: att.content_type,
+        data: await invoke<number[]>('download_email_attachment', {
+          accountId: mail.account_id,
+          folder: mail.folder,
+          uid: mail.uid,
+          partId: att.part_id,
+        }),
+        content_id: crypto.randomUUID().replaceAll('-', ''),
+      })),
+    )
+  }
+
+  /** #329 — main-window forward.  Opens Compose immediately with
+   *  the base initial (no attachments) so the user can already
+   *  start editing the body / addressing the recipient.  If the
+   *  source carries attachments, then prompts on top of the open
+   *  Compose; on "include" the bytes download in the background
+   *  and stream into the open Compose through the
+   *  `addAttachmentsReady` handle Compose registers at mount.
+   *  Dismissing the prompt is "forward without".  A download
+   *  failure surfaces via `alert` and leaves the Compose
+   *  attachment-less — partial-include would silently confuse
+   *  the user about what's actually attached.  If the user
+   *  closes the Compose before the download finishes, the
+   *  injection is dropped silently (lookup misses). */
+  async function onForward(mail: ForwardableMail) {
+    const composeId = openCompose(buildForwardInitial(mail))
+    if (mail.attachments.length === 0) return
+    const include = await promptIncludeForwardAttachments(
+      mail.attachments.length,
+    )
+    if (!include) return
+    try {
+      const downloaded = await downloadForwardAttachments(mail)
+      const entry = composes.find((c) => c.id === composeId)
+      if (!entry) return
+      const addAttachments = await entry.addAttachmentsReady
+      addAttachments(downloaded)
+    } catch (e) {
+      alert(
+        m.compose_forward_attachments_download_failed({
+          reason: formatError(e),
+        }),
+      )
+    }
+  }
+
+  /** #329 — popped-out-window forward (#304).  Compose lives in a
+   *  separate window, so the open-then-inject pattern the
+   *  main-window path uses doesn't apply — we can't reach the
+   *  popout's Compose state from this main-window process
+   *  without a fresh IPC channel, and showing the prompt in the
+   *  main window *after* the popout's Compose has appeared on
+   *  potentially another screen would be easy to miss.  So this
+   *  path keeps the bake-then-open ordering: prompt first
+   *  (the popout-mail trigger came from the main window's
+   *  listener, so focus is here already), download, then open the
+   *  popout's Compose with attachments baked into the initial. */
+  async function buildForwardInitialForPopout(
+    mail: ForwardableMail,
+  ): Promise<ComposeInitial> {
+    const base = buildForwardInitial(mail)
+    if (mail.attachments.length === 0) return base
+    const include = await promptIncludeForwardAttachments(
+      mail.attachments.length,
+    )
+    if (!include) return base
+    try {
+      const attachments = await downloadForwardAttachments(mail)
+      return { ...base, attachments }
+    } catch (e) {
+      alert(
+        m.compose_forward_attachments_download_failed({
+          reason: formatError(e),
+        }),
+      )
+      return base
+    }
   }
 
   // ── "Respond with meeting" flow ────────────────────────────
@@ -2912,10 +3083,70 @@
         onsentenqueued={(rowId) => onComposeSentEnqueued(c, rowId)}
         onsubjectchange={(s) => (c.currentSubject = s)}
         oncancelref={(fn) => (c.cancelFn = fn)}
+        onaddattachmentsref={(fn) => c.resolveAddAttachments(fn)}
         ondraftsourcechange={(src) => (c.currentDraftSource = src)}
         ondraftexpunged={onDraftExpunged}
       />
     {/each}
+  </div>
+{/if}
+
+<!-- Forward-with-attachments confirm modal (#329).  Driven
+     entirely by `pendingForwardPrompt`: setting it opens the
+     prompt; either button (or the backdrop click) resolves the
+     awaited promise inside `buildForwardInitialWithAttachments`
+     with the user's choice and clears the state.  Backdrop /
+     Escape dismiss is treated as "Forward without" — matches
+     the UX choice locked in when this feature shipped.  Sized
+     and styled after the language-restart prompt in
+     AccountSettings so the visual treatment of confirm-style
+     overlays stays consistent across the app. -->
+{#if pendingForwardPrompt}
+  <div
+    class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="forward-attachments-title"
+    tabindex="-1"
+    onclick={(e) => {
+      // Only the backdrop itself counts as "dismiss" — button
+      // clicks inside the card bubble up to this handler too, and
+      // without the target check an "Include attachments" click
+      // would also fire the skip path on its way past.
+      if (e.target === e.currentTarget) resolveForwardPrompt(false)
+    }}
+    onkeydown={(e) => e.key === 'Escape' && resolveForwardPrompt(false)}
+  >
+    <div
+      class="card p-5 max-w-sm w-[90%] bg-surface-100 dark:bg-surface-800 rounded-lg shadow-xl"
+    >
+      <h2 id="forward-attachments-title" class="text-base font-semibold mb-2">
+        {m.compose_forward_attachments_title()}
+      </h2>
+      <p class="text-sm text-surface-600 dark:text-surface-300 mb-4">
+        {pendingForwardPrompt.count === 1
+          ? m.compose_forward_attachments_body_one()
+          : m.compose_forward_attachments_body_many({
+              n: pendingForwardPrompt.count,
+            })}
+      </p>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="btn btn-sm preset-outlined-surface-500"
+          onclick={() => resolveForwardPrompt(false)}
+        >
+          {m.compose_forward_attachments_skip()}
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm preset-filled-primary-500"
+          onclick={() => resolveForwardPrompt(true)}
+        >
+          {m.compose_forward_attachments_include()}
+        </button>
+      </div>
+    </div>
   </div>
 {/if}
 

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -80,7 +80,7 @@
     read_only?: boolean
   }
 
-  interface Attachment {
+  export interface Attachment {
     filename: string
     content_type: string
     data: number[]
@@ -255,6 +255,19 @@
      *  mount; the function reference is stable for the lifetime
      *  of the component. */
     oncancelref?: (cancel: () => void) => void
+    /** One-shot callback handing the parent a function it can call
+     *  to append attachments to this Compose from the outside
+     *  (#329).  Used by the forward-with-attachments flow: the
+     *  parent opens Compose, asks the user whether to bring the
+     *  original message's attachments along, and on "yes"
+     *  downloads the bytes in the background and pushes them in
+     *  through this handle once they're ready.  Fires once on
+     *  mount; the function reference is stable.  Reuses the
+     *  picker's append-and-prewarm path so a parent-pushed
+     *  attachment is indistinguishable from a user-picked one. */
+    onaddattachmentsref?: (
+      addAttachments: (atts: Attachment[]) => void,
+    ) => void
     /** Fires whenever this Compose's tracked Drafts-folder pointer
      *  changes (#292).  Seeded from `initial.draftSource` and
      *  updated after every successful `save_draft` round-trip with
@@ -295,6 +308,7 @@
     onminimize,
     onsubjectchange,
     oncancelref,
+    onaddattachmentsref,
     ondraftsourcechange,
     ondraftexpunged,
   }: Props = $props()
@@ -2196,6 +2210,29 @@
   // a one-shot register is sufficient.
   $effect(() => {
     oncancelref?.(cancel)
+  })
+
+  /** External attachment-append handle (#329).  Same shape the
+   *  picker's `onPickFiles` uses: append to the reactive list, then
+   *  pre-warm thumbs off the critical path so the `/` picker's
+   *  first open lands on fully rendered tiles.  Called by the
+   *  parent once the forward-with-attachments download finishes,
+   *  with a list whose `content_id`s were minted before the bytes
+   *  arrived so the cache key stays stable. */
+  function appendExternalAttachments(atts: Attachment[]) {
+    if (atts.length === 0) return
+    attachments = [...attachments, ...atts]
+    for (const a of atts) {
+      prewarmAttachmentThumb({
+        bytes: a.data,
+        contentType: a.content_type,
+        filename: a.filename,
+        cacheKey: a.content_id,
+      })
+    }
+  }
+  $effect(() => {
+    onaddattachmentsref?.(appendExternalAttachments)
   })
 
   function cancel() {


### PR DESCRIPTION
## Summary

- **Feature**: when forwarding a mail that carries attachments, Compose opens immediately and a confirm popup overlays it asking whether to bring the original attachments along. "Include attachments" downloads the bytes in the background and streams them into the still-open Compose; "Forward without", backdrop click, and Escape all dismiss with no attachments.
- **Bug fix (surfaced during testing)**: non-ASCII attachment filenames that arrive with raw 8-bit bytes (raw Latin-1 / Windows-1252, or RFC 2231 continuations that split a UTF-8 multibyte character across the boundary) no longer collapse to `?` glyphs. A new `attachment_filename` module in `unkai-imap` falls back to raw-header decoding when mail-parser's lossy UTF-8 path fires.

## Closes #329

## What changed

### Forward feature (`63d8504`)
- New `ForwardableMail` type widens the forward payload to carry `account_id`, `folder`, `uid`, and the attachment list.
- New `onaddattachmentsref` prop on `Compose` exposes a stable function the parent can call to inject attachments after mount. Mirrors the existing `oncancelref` ref-callback pattern.
- Each compose entry now holds an `addAttachmentsReady` Promise resolved at Compose mount; the forward flow `await`s it before injecting, so the rare race where the user clicks "Include" before Compose finishes mounting is handled correctly.
- Popped-out-window forward (#304) keeps the old "prompt first, bake-then-open" ordering — reason in [`buildForwardInitialForPopout` comment](ui/src/App.svelte): we can't reach a popout's state from the main window, and a popup fired in the main window after the popout Compose has appeared on an off-screen monitor would be easy to miss.
- 6 new i18n keys (`en.json` + `de.json`) cover the prompt copy and the download-failure error.

### Filename fix (`15b2095`)
- New module [`crates/unkai-imap/src/attachment_filename.rs`](crates/unkai-imap/src/attachment_filename.rs) wraps `MimeHeaders::attachment_name()`.
- Trusts mail-parser's result when it doesn't contain U+FFFD.
- When U+FFFD appears, re-extracts raw header bytes via `Message::raw_message[offset_start..offset_end]`, concatenates RFC 2231 continuations into a single buffer, and tries UTF-8 first (rescues split-multibyte) then bytes-as-Latin-1 (rescues raw 8-bit bytes).
- Wired through the three previous call sites in `client.rs`: `parse_eml_bytes`, `fetch_message_inner`, `download_email_attachment`.
- One pattern is intentionally left as-is: senders whose own software baked U+FFFD into the wire bytes before sending (confirmed in the wild during testing — the percent-encoded RFC 2231 value carried `%EF%BF%BD%EF%BF%BD` literally). The source character is gone before we see it; substituting would diverge the chip name from the on-disk filename when the user clicks Download. Locked in by `pre_corrupted_ufffd_preserved_faithfully`.

## Test plan

- [x] `cargo fmt --check`, `cargo check --workspace`, `cargo test -p unkai-imap --lib` (14 tests including 8 new in `attachment_filename`) all green
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run build` — clean production bundle
- [x] Forward a mail with attachments → popup appears, "Include" attaches them in Compose, "Forward without" skips
- [x] Forward a mail without attachments → no popup, Compose opens immediately
- [x] Backdrop click and Escape on the popup both dismiss as "Forward without"
- [x] Forward from a popped-out mail window → popup appears in main window, popout Compose opens with attachments baked in once user picks
- [x] Send the forward, confirm recipient receives the attachments
- [x] Receive a mail whose filename has raw Latin-1 bytes → chip shows the umlaut correctly (note: filenames where the *sender's* software pre-corrupted the character to U+FFFD will still show `?` — that's expected and the lock-in test documents it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)