### PR TITLE
#334: store thread_id in cache + on-expand backfill + toggle

### DIFF
--- a/crates/unkai-core/src/models.rs
+++ b/crates/unkai-core/src/models.rs
@@ -62,6 +62,16 @@ pub struct AppSettings {
     /// behaviour.  Turn off to fall back to the previous behaviour
     /// where the reading pane goes blank after every delete.
     pub auto_advance_after_remove: bool,
+    /// Group same-conversation messages under a single MailList row
+    /// (#334).  Default on — the conversation badge collapses
+    /// reply chains into one entry with an expand chevron.  Off
+    /// renders every envelope as its own flat row (the pre-#277
+    /// behaviour) for users who prefer chronological scrolling
+    /// over conversation bundling.  The cache still computes
+    /// `thread_id` either way, so toggling back on is a free
+    /// re-render with no IMAP traffic.
+    #[serde(default = "default_true")]
+    pub conversation_view_enabled: bool,
     /// Default calendar for events created in CalendarView and for
     /// inbound RSVPs that the user accepts.  Stored as the app-side
     /// calendar id (`{nc_id}::{path}`) so it's stable across syncs.
@@ -279,6 +289,7 @@ impl Default for AppSettings {
             mail_html_white_background: true,
             auto_load_remote_images: false,
             auto_advance_after_remove: true,
+            conversation_view_enabled: true,
             default_calendar_id: None,
             meeting_reminders_enabled: true,
             calendar_reminders_enabled: true,
@@ -507,6 +518,26 @@ pub struct EmailEnvelope {
     /// branched.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub references_ids: Vec<String>,
+    /// Stable thread identity assigned by the local cache (#334):
+    /// `references_ids[0]` for replies, the envelope's own
+    /// `message_id` for chain roots, or a `solo:<account>:<folder>:<uid>`
+    /// fallback for envelopes that have neither.  Two envelopes share
+    /// `thread_id` iff they belong to the same conversation.  `None`
+    /// for envelopes coming straight off the wire from IMAP/JMAP —
+    /// the cache write-through path stamps it during upsert.  Also
+    /// `None` for cached rows that pre-date the schema migration
+    /// until the warm-up has run; the UI hides the count badge in
+    /// that transient state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    /// Number of cached members of this thread within
+    /// `(account_id, folder)` (#334).  Maintained incrementally by
+    /// the cache on every upsert / remove / move so the MailList
+    /// row can paint the conversation badge from a single column
+    /// read instead of grouping at query time.  `None` mirrors
+    /// `thread_id` (envelope hasn't been assigned a thread yet).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_total_count: Option<u32>,
 }
 
 /// Represents an email message.

--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -1,4 +1,4 @@
-//! IMAP client — connects to a mail server via TLS and provides
+//! IMAP client â€” connects to a mail server via TLS and provides
 //! methods to interact with mailboxes.
 
 use async_imap::Session;
@@ -174,23 +174,23 @@ pub fn parse_eml_bytes(
 /// `async-imap`'s `Session` is generic over its underlying I/O. We
 /// pin the alias to the concrete `Compat<TlsStream<TcpStream>>` so
 /// downstream callers don't have to think about the four layers of
-/// generics — and so the `session: Option<...>` field below has a
+/// generics â€” and so the `session: Option<...>` field below has a
 /// nameable type.
 type ImapSession = Session<Compat<TlsStream<TcpStream>>>;
 
 /// Encode a UTF-8 mailbox name into the IMAP Modified UTF-7 form that
 /// `SELECT` / `EXAMINE` / `STATUS` / `APPEND` etc. expect on the wire.
 /// Pure ASCII names round-trip unchanged so this is a no-op for the
-/// common case (`INBOX`, `Sent`, `Drafts`, …).
+/// common case (`INBOX`, `Sent`, `Drafts`, â€¦).
 ///
-/// **Quoting is the caller's responsibility — but the `async-imap`
+/// **Quoting is the caller's responsibility â€” but the `async-imap`
 /// crate handles it for most commands.**  `select`, `examine`,
 /// `create`, `delete`, `subscribe`, `unsubscribe`, `status`,
 /// `append`, `rename`, `list`, etc. all run their mailbox argument
 /// through `validate_str` internally, which calls the `quote!`
 /// macro and emits `"<name>"` on the wire when needed.  The one
 /// exception is `uid_copy` (and `uid_move`), which passes the
-/// mailbox argument straight through to the wire — names with
+/// mailbox argument straight through to the wire â€” names with
 /// atom-special characters (space, `(`, `)`, `{`, `*`, `%`, `\`,
 /// `"`, controls) get parsed up to the first such char and the
 /// rest becomes syntax junk.  Use [`quoted_mailbox_arg`] at those
@@ -204,7 +204,7 @@ fn to_wire(name: &str) -> String {
 /// form (`"..."`, with `\` and `"` backslash-escaped) when it
 /// contains any RFC 3501 atom-special character.  Pure-ASCII
 /// names without specials round-trip unquoted.  Used **only**
-/// for `uid_copy` / `uid_move` arguments — async-imap doesn't
+/// for `uid_copy` / `uid_move` arguments â€” async-imap doesn't
 /// auto-quote those, and a folder named `"Audi TT"` would
 /// otherwise be parsed by the server as the bare atom `Audi`
 /// with `TT` becoming dangling syntax.
@@ -268,12 +268,12 @@ async fn tls_connect(
 /// trust the server.
 ///
 /// Returns every cert the server presented in handshake order
-/// (leaf first, then intermediates). Trusting the whole chain — not
-/// just the leaf — is the robust thing to do: the server may
+/// (leaf first, then intermediates). Trusting the whole chain â€” not
+/// just the leaf â€” is the robust thing to do: the server may
 /// reorder certs, the active leaf may be reissued under the same
 /// intermediate, and the verifier matches against the trust list
 /// by walking the entire presented chain anyway. Caller is
-/// responsible for never using this for actual mail traffic — we
+/// responsible for never using this for actual mail traffic â€” we
 /// drop the connection immediately after the handshake succeeds.
 pub async fn probe_server_certificate(host: &str, port: u16) -> Result<Vec<Vec<u8>>, UnkaiError> {
     let addr = format!("{host}:{port}");
@@ -318,7 +318,7 @@ pub struct ImapClient {
     session: Option<ImapSession>,
 }
 
-/// Result of a sync fetch — envelopes plus the folder's `UIDVALIDITY`.
+/// Result of a sync fetch â€” envelopes plus the folder's `UIDVALIDITY`.
 ///
 /// Callers store the `uidvalidity` alongside the envelopes. On the next
 /// sync they compare the server's value against the stored one; if it
@@ -334,7 +334,7 @@ pub struct EnvelopeBatch {
 ///
 /// Returned by `fetch_flags`, which exists to refresh the
 /// `\Seen` / `\Flagged` / `\Answered` bits on already-cached
-/// envelopes — the standard envelope-fetch path is incremental and
+/// envelopes â€” the standard envelope-fetch path is incremental and
 /// doesn't re-read flags on UIDs the cache already knows about, so
 /// flag changes another mail client makes (mark-read on a phone,
 /// answer from webmail, etc.) need this catch-up to round-trip.
@@ -351,7 +351,7 @@ impl ImapClient {
     ///
     /// `trusted_certs` is the per-account list of additional roots
     /// (the user's self-signed certs they've explicitly trusted in
-    /// settings). Empty for "trust webpki-roots only" — the
+    /// settings). Empty for "trust webpki-roots only" â€” the
     /// historical behaviour.
     pub async fn connect(
         host: &str,
@@ -366,7 +366,7 @@ impl ImapClient {
         let imap_client = async_imap::Client::new(stream);
 
         let session = imap_client.login(username, password).await.map_err(|e| {
-            // login() returns (error, client) on failure — we only need the error
+            // login() returns (error, client) on failure â€” we only need the error
             UnkaiError::Auth(format!("IMAP login failed: {}", e.0))
         })?;
 
@@ -400,7 +400,7 @@ impl ImapClient {
 
         // Build folder list, then query each folder for its unread count.
         // Mailbox names come over the wire in IMAP Modified UTF-7
-        // (RFC 3501 §5.1.3) — decode them to plain UTF-8 here so the
+        // (RFC 3501 Â§5.1.3) â€” decode them to plain UTF-8 here so the
         // cache and the UI never see the encoded form. We re-encode
         // when sending names back to the server (`STATUS`, `SELECT`,
         // `APPEND`, etc.) via `to_wire`.
@@ -431,15 +431,15 @@ impl ImapClient {
                 Ok(mailbox_status) => {
                     folder.unread_count = mailbox_status.unseen;
                     debug!(
-                        "  Folder: {} — unread: {:?} (attrs: {:?})",
+                        "  Folder: {} â€” unread: {:?} (attrs: {:?})",
                         folder.name, folder.unread_count, folder.attributes
                     );
                 }
                 Err(e) => {
-                    // Some folders (e.g. \Noselect) don't support STATUS — that's fine,
+                    // Some folders (e.g. \Noselect) don't support STATUS â€” that's fine,
                     // we just leave unread_count as None.
                     debug!(
-                        "  Folder: {} — could not get STATUS: {e} (attrs: {:?})",
+                        "  Folder: {} â€” could not get STATUS: {e} (attrs: {:?})",
                         folder.name, folder.attributes
                     );
                 }
@@ -456,8 +456,8 @@ impl ImapClient {
     /// `"Projects"` for a top-level folder, `"INBOX/Projects/2026"`
     /// for a subfolder using the `/` delimiter that most servers
     /// report via LIST). We re-encode to Modified UTF-7 on the wire
-    /// via `to_wire` — the same path every other mailbox-naming
-    /// command uses — so non-ASCII folder names round-trip correctly.
+    /// via `to_wire` â€” the same path every other mailbox-naming
+    /// command uses â€” so non-ASCII folder names round-trip correctly.
     pub async fn create_folder(&mut self, name: &str) -> Result<(), UnkaiError> {
         let session = self
             .session
@@ -474,7 +474,7 @@ impl ImapClient {
     /// Delete a mailbox via IMAP `DELETE`.
     ///
     /// Most servers refuse to delete a folder that still holds
-    /// messages — the error bubbles up to the UI unchanged so the
+    /// messages â€” the error bubbles up to the UI unchanged so the
     /// user sees a real reason ("Mailbox has children" / "Mailbox
     /// is not empty"). Callers that want "delete even if full"
     /// semantics should first move the messages to Trash.
@@ -497,7 +497,7 @@ impl ImapClient {
     /// intact; our local cache needs a parallel update so envelopes
     /// and bodies that were stored under the old name carry over
     /// to the new one. That's handled in the caller (`main.rs`)
-    /// via `Cache::rename_folder` — this method only drives the
+    /// via `Cache::rename_folder` â€” this method only drives the
     /// IMAP side.
     pub async fn rename_folder(&mut self, from: &str, to: &str) -> Result<(), UnkaiError> {
         let session = self
@@ -512,12 +512,12 @@ impl ImapClient {
         Ok(())
     }
 
-    /// Select a folder for reading (uses EXAMINE — read-only, no state changes).
+    /// Select a folder for reading (uses EXAMINE â€” read-only, no state changes).
     ///
     /// In IMAP you must SELECT (or EXAMINE) a folder before you can fetch messages
     /// from it. EXAMINE is like SELECT but opens the mailbox read-only, so marking
     /// messages as seen, etc. won't happen as a side effect. Returns the number
-    /// of messages (`exists`) and the folder's `UIDVALIDITY` — a server-assigned
+    /// of messages (`exists`) and the folder's `UIDVALIDITY` â€” a server-assigned
     /// counter that changes whenever the folder is recreated or its UID space
     /// resets. Callers compare this against a cached copy to detect when their
     /// cached UIDs are no longer valid.
@@ -542,9 +542,9 @@ impl ImapClient {
     ///
     /// `since_uid` toggles the strategy:
     ///
-    /// - `None` → full mode: pull the newest `limit` messages by sequence number.
+    /// - `None` â†’ full mode: pull the newest `limit` messages by sequence number.
     ///   Used on a cold cache or after a UIDVALIDITY reset.
-    /// - `Some(u)` → incremental mode: pull everything with UID `> u` via
+    /// - `Some(u)` â†’ incremental mode: pull everything with UID `> u` via
     ///   `UID FETCH (u+1):*`. Cheap because only genuinely new messages come
     ///   back; the cache already has everything up to `u`.
     ///
@@ -553,7 +553,7 @@ impl ImapClient {
     ///
     /// IMAP messages have two kinds of identifiers:
     /// - **sequence numbers**: 1..N in current session, change as messages are deleted
-    /// - **UIDs**: stable across sessions — this is what we store and return
+    /// - **UIDs**: stable across sessions â€” this is what we store and return
     pub async fn fetch_envelopes(
         &mut self,
         folder: &str,
@@ -575,10 +575,10 @@ impl ImapClient {
 
         // Two FETCH forms depending on mode. `uid_fetch` uses UIDs directly
         // (survives server-side deletions), while `fetch` uses sequence numbers
-        // — the only way to say "newest N" without knowing UIDs in advance.
+        // â€” the only way to say "newest N" without knowing UIDs in advance.
         let fetches: Vec<_> = match since_uid {
             Some(hi) => {
-                // `hi+1:*` — everything strictly newer than the last UID we saw.
+                // `hi+1:*` â€” everything strictly newer than the last UID we saw.
                 // `*` means "the largest UID in the folder", so this always
                 // terminates even when there's nothing new (returns empty).
                 let range = format!("{}:*", hi.saturating_add(1));
@@ -622,7 +622,7 @@ impl ImapClient {
                 let uid = fetch.uid?;
                 let envelope = fetch.envelope()?;
 
-                // Subject — decode the RFC 2047 header if needed. async-imap
+                // Subject â€” decode the RFC 2047 header if needed. async-imap
                 // returns raw bytes; mail-parser's header_to_string handles
                 // the encoded-word decoding for us.
                 let subject = envelope
@@ -631,7 +631,7 @@ impl ImapClient {
                     .map(|s| decode_header(s))
                     .unwrap_or_default();
 
-                // From — take the first address, formatted as "Name <addr>"
+                // From â€” take the first address, formatted as "Name <addr>"
                 let from = envelope
                     .from
                     .as_ref()
@@ -652,8 +652,8 @@ impl ImapClient {
                     })
                     .unwrap_or_else(Utc::now);
 
-                // Flags: \Seen → read, \Flagged → starred,
-                // \Answered → user-or-other-client replied to this
+                // Flags: \Seen â†’ read, \Flagged â†’ starred,
+                // \Answered â†’ user-or-other-client replied to this
                 // message (#255).
                 let mut is_read = false;
                 let mut is_starred = false;
@@ -679,7 +679,7 @@ impl ImapClient {
                     is_starred,
                     is_answered,
                     // The IMAP client doesn't track *how* the user
-                    // replied — that's Unkai-only metadata stamped
+                    // replied â€” that's Unkai-only metadata stamped
                     // by the send path (#255), so leave it None
                     // here; the cache merge preserves whatever's
                     // already on disk.
@@ -692,6 +692,10 @@ impl ImapClient {
                     message_id,
                     in_reply_to,
                     references_ids,
+                    // #334: cache populates these on upsert; off-the-wire
+                    // envelopes don't know their thread identity yet.
+                    thread_id: None,
+                    thread_total_count: None,
                 })
             })
             .collect();
@@ -721,7 +725,7 @@ impl ImapClient {
     /// transfer encodings (base64, quoted-printable), and convert charsets.
     ///
     /// BODY.PEEK[] is used instead of BODY[] so the server does NOT mark the
-    /// message as \Seen — we want marking-as-read to be an explicit action.
+    /// message as \Seen â€” we want marking-as-read to be an explicit action.
     pub async fn fetch_message(
         &mut self,
         folder: &str,
@@ -744,7 +748,7 @@ impl ImapClient {
             .map_err(|e| UnkaiError::Protocol(format!("Failed to read UID FETCH: {e}")))?;
 
         // No fetch row back means the server's expunged this UID
-        // since we cached the envelope — surface `MessageGone` so the
+        // since we cached the envelope â€” surface `MessageGone` so the
         // Tauri layer can evict the dead row + the UI can auto-advance.
         let fetch = fetches.into_iter().next().ok_or(UnkaiError::MessageGone)?;
 
@@ -795,7 +799,7 @@ impl ImapClient {
         //
         // mail-parser returns text with CRLF (\r\n) line endings as required
         // by the MIME RFC. We normalise to LF-only here so the frontend's
-        // `white-space: pre-wrap` renders line breaks correctly — some
+        // `white-space: pre-wrap` renders line breaks correctly â€” some
         // WebKit builds treat a bare \r as a carriage-return (cursor-to-BOL)
         // rather than a newline, collapsing multi-line text onto one line.
         let body_text = (0..parsed.text_body_count())
@@ -821,7 +825,7 @@ impl ImapClient {
         let has_attachments = parsed.attachment_count() > 0;
 
         // Metadata for each attachment. We store only name/type/size
-        // here — the bytes are left on the server and fetched on demand
+        // here â€” the bytes are left on the server and fetched on demand
         // when the user clicks "Download" or "Save to Nextcloud". This
         // keeps the message payload (and its cache row) small even for
         // messages with 20 MB of PDFs.
@@ -850,7 +854,7 @@ impl ImapClient {
                 // RFC 2392 Content-ID, when the part carried one. The
                 // body's `<a href="cid:abc-123">` anchors resolve to
                 // this attachment via case-insensitive equality with
-                // the cid value (no angle brackets — mail-parser
+                // the cid value (no angle brackets â€” mail-parser
                 // strips them already).
                 let content_id = part.content_id().map(|s| s.to_string());
                 EmailAttachment {
@@ -890,7 +894,7 @@ impl ImapClient {
             parsed.attachment_count()
         );
 
-        // RFC 5322 threading headers — same parse as in
+        // RFC 5322 threading headers â€” same parse as in
         // `parse_eml_bytes`.  Mirror that helper inline because
         // the two paths walk slightly different `parsed` shapes.
         let header_first = |name: &str| {
@@ -937,18 +941,18 @@ impl ImapClient {
     /// We re-fetch the whole message body (BODY.PEEK[]) and re-parse it
     /// to extract the attachment at `part_id`. That's simpler than
     /// issuing a targeted BODYSTRUCTURE + BODY[part] pair, which would
-    /// mean teaching the UI about MIME section numbers — and re-fetching
+    /// mean teaching the UI about MIME section numbers â€” and re-fetching
     /// is cheap enough for the "user clicked Download" case. BODY.PEEK[]
     /// keeps the message unread.
     /// Find any iCalendar payload in the message and return its
-    /// raw bytes — regardless of whether mail-parser classified
+    /// raw bytes â€” regardless of whether mail-parser classified
     /// it as an attachment or a body alternative.  Walks
     /// `Message::parts` directly so canonical iMIP messages
     /// (where `text/calendar` lives inside
     /// `multipart/alternative` with no separate `.ics`
     /// download) still surface their calendar payload.
     /// Returns `None` when no calendar-shaped part exists in
-    /// the message — caller treats that as "this isn't an
+    /// the message â€” caller treats that as "this isn't an
     /// invite mail at all".
     pub async fn fetch_calendar_payload(
         &mut self,
@@ -1034,7 +1038,7 @@ impl ImapClient {
         // (matches the listing path's primary indexing) and
         // fall back to the parts-array.  The fallback rescues
         // metadata that was cached during an earlier build
-        // where part_ids referenced the parts-array directly —
+        // where part_ids referenced the parts-array directly â€”
         // without it those legacy entries fail to download
         // and any UI keying off `download_email_attachment`
         // (RSVP card, attachment download button) silently
@@ -1074,7 +1078,7 @@ impl ImapClient {
         ))
     }
 
-    /// Clear the `\Seen` flag on a message — i.e. mark it unread.
+    /// Clear the `\Seen` flag on a message â€” i.e. mark it unread.
     /// Mirror of `mark_as_read`; uses `UID STORE -FLAGS (\Seen)`.
     pub async fn mark_as_unread(&mut self, folder: &str, uid: u32) -> Result<(), UnkaiError> {
         let session = self
@@ -1100,7 +1104,7 @@ impl ImapClient {
 
     /// Mark a message as read by setting the `\Seen` flag on the server.
     ///
-    /// Uses `UID STORE <uid> +FLAGS (\Seen)` — idempotent, so calling it on
+    /// Uses `UID STORE <uid> +FLAGS (\Seen)` â€” idempotent, so calling it on
     /// an already-read message is a no-op. We SELECT (not EXAMINE) here
     /// because EXAMINE opens the folder read-only and rejects STORE.
     pub async fn mark_as_read(&mut self, folder: &str, uid: u32) -> Result<(), UnkaiError> {
@@ -1114,7 +1118,7 @@ impl ImapClient {
             UnkaiError::Protocol(format!("Failed to select folder '{folder}': {e}"))
         })?;
 
-        // uid_store returns a stream of updated flag sets — we don't need them,
+        // uid_store returns a stream of updated flag sets â€” we don't need them,
         // just drain so the command completes.
         let _updates: Vec<_> = session
             .uid_store(uid.to_string(), "+FLAGS (\\Seen)")
@@ -1132,7 +1136,7 @@ impl ImapClient {
     ///
     /// Called after Compose's send path delivers a successful reply
     /// (or reply-all, or "respond with meeting") so the original
-    /// message is marked answered on the server — round-trips to
+    /// message is marked answered on the server â€” round-trips to
     /// other mail clients the user might have open, and gives
     /// Unkai's mail-list a stable signal across cache rebuilds.
     /// Uses `UID STORE <uid> +FLAGS (\Answered)`; idempotent.
@@ -1163,7 +1167,7 @@ impl ImapClient {
     /// snapshot of `\Seen` / `\Flagged` / `\Answered` per UID.
     ///
     /// The standard envelope-fetch path (`fetch_envelopes`) only
-    /// pulls UIDs strictly newer than the cache bookmark — so flag
+    /// pulls UIDs strictly newer than the cache bookmark â€” so flag
     /// changes another client makes (marked-read on a phone,
     /// answered from webmail) never round-trip to Unkai on their
     /// own.  This is the catch-up: cheap (`UID FETCH x,y,z (UID
@@ -1185,7 +1189,7 @@ impl ImapClient {
             .as_mut()
             .ok_or_else(|| UnkaiError::Protocol("Session is closed".into()))?;
 
-        // EXAMINE (read-only) is enough — we're not flipping flags
+        // EXAMINE (read-only) is enough â€” we're not flipping flags
         // here, just observing them, and read-only avoids
         // accidentally clearing the server's `\Recent` flag
         // bookkeeping for the folder.
@@ -1194,7 +1198,7 @@ impl ImapClient {
         })?;
 
         // Comma-separated UID set is the canonical IMAP way to
-        // address a discrete list — no "1:50" range wastefulness if
+        // address a discrete list â€” no "1:50" range wastefulness if
         // the cached UIDs aren't contiguous, and the server folds
         // adjacent ones into ranges in its parser anyway.
         let uid_set = uids
@@ -1249,10 +1253,10 @@ impl ImapClient {
     /// Used by the "save sent mail to Sent folder" path: SMTP delivers
     /// the message to recipients, then we APPEND a copy here so the
     /// user can see what they sent. `flags` is the literal IMAP flag
-    /// list (e.g. `&["\\Seen"]` — pre-marked read because the user
+    /// list (e.g. `&["\\Seen"]` â€” pre-marked read because the user
     /// just wrote it themselves).
     ///
-    /// `raw` must already be properly CRLF-terminated RFC 822 bytes —
+    /// `raw` must already be properly CRLF-terminated RFC 822 bytes â€”
     /// `lettre::Message::formatted()` produces exactly that.
     pub async fn append_message(
         &mut self,
@@ -1267,7 +1271,7 @@ impl ImapClient {
 
         // async-imap 0.10's `append` takes the flag list as a single
         // pre-formatted parenthesised IMAP atom. We pass `\Seen` so
-        // the appended copy doesn't add to the unread badge — the
+        // the appended copy doesn't add to the unread badge â€” the
         // user wrote it themselves and has already "read" it.
         let flag_atom = if flags.is_empty() {
             None
@@ -1302,7 +1306,7 @@ impl ImapClient {
     /// `Message-ID` works as a stable handle because lettre stamps
     /// every outgoing message with a UUID-anchored `<uuid@host>` value
     /// (see `build_outgoing_message`), so the search criterion is
-    /// effectively unique. Returns the highest matching UID — on the
+    /// effectively unique. Returns the highest matching UID â€” on the
     /// unlikely event of a collision the most recent server-assigned
     /// UID is the one we just wrote.
     ///
@@ -1320,7 +1324,7 @@ impl ImapClient {
             .as_mut()
             .ok_or_else(|| UnkaiError::Protocol("Session is closed".into()))?;
 
-        // IMAP quoted strings only need to escape `\` and `"` — the
+        // IMAP quoted strings only need to escape `\` and `"` â€” the
         // Message-ID's `<uuid@host>` shape contains neither, but
         // escape defensively anyway in case a future caller passes
         // a less well-behaved value through.
@@ -1340,13 +1344,13 @@ impl ImapClient {
     ///
     /// Why not `UID MOVE` (RFC 6851)? MOVE is cleaner but requires the
     /// server to advertise the `MOVE` capability, which still isn't
-    /// universal in 2026 — the COPY+EXPUNGE fallback works on every
+    /// universal in 2026 â€” the COPY+EXPUNGE fallback works on every
     /// IMAP4rev1 server. We pay for one extra round-trip vs MOVE but
     /// never surprise the user with a "your server doesn't support
     /// that" error on an Archive/Delete button press.
     ///
     /// Used by the Archive and (future) Trash flows in MailView. The
-    /// destination folder must already exist — callers locate it via
+    /// destination folder must already exist â€” callers locate it via
     /// `pick_archive_folder` / `pick_trash_folder` before calling.
     pub async fn move_message(
         &mut self,
@@ -1402,12 +1406,12 @@ impl ImapClient {
     /// but does the UID COPY and UID STORE with a comma-joined UID
     /// set so the server processes the lot in one round-trip, and
     /// EXPUNGEs once at the end.  Single SELECT, single COPY,
-    /// single STORE, single EXPUNGE — N×3 round-trips collapse to
+    /// single STORE, single EXPUNGE â€” NÃ—3 round-trips collapse to
     /// 4, and there's no chance of racing per-message connection
     /// state across rapid sequential calls.
     ///
     /// Used by the multi-select drag-and-drop and right-click move
-    /// flows in MailList where N can easily be 5–50 messages and a
+    /// flows in MailList where N can easily be 5â€“50 messages and a
     /// per-message connect/login/logout dance was both slow and,
     /// on some servers, dropping the last move outright due to
     /// rate-limiting / connection-recycling weirdness.
@@ -1430,7 +1434,7 @@ impl ImapClient {
         })?;
 
         // IMAP allows comma-separated UID sets in UID COPY / UID
-        // STORE — one round-trip moves the whole batch.
+        // STORE â€” one round-trip moves the whole batch.
         let uid_set: String = uids
             .iter()
             .map(u32::to_string)
@@ -1495,7 +1499,7 @@ impl ImapClient {
         );
 
         // Probe the UID first. If this comes back empty, the UID we
-        // were handed isn't in this folder at all — the envelope
+        // were handed isn't in this folder at all â€” the envelope
         // cache is out of sync with the server, or (far more likely
         // in practice) the backend is driving the wrong folder for
         // the message the user is looking at. Surfacing *which* of
@@ -1521,7 +1525,7 @@ impl ImapClient {
         }
 
         // STORE the `\Deleted` flag and keep the returned FETCH
-        // responses — if the set is empty the server accepted the
+        // responses â€” if the set is empty the server accepted the
         // STORE but didn't actually modify anything, which almost
         // always means the SELECT landed on a read-only view or the
         // server suppresses the FETCH echo for \Deleted (rare). We
@@ -1538,7 +1542,7 @@ impl ImapClient {
         if updates.is_empty() {
             tracing::warn!(
                 "delete_message: UID STORE (\\Deleted) on UID {uid} in '{folder}' \
-                 returned no FETCH updates even though the UID probe found the message — \
+                 returned no FETCH updates even though the UID probe found the message â€” \
                  proceeding to EXPUNGE anyway, the flag may have been set silently"
             );
         } else {
@@ -1548,7 +1552,7 @@ impl ImapClient {
             );
         }
 
-        // Prefer `UID EXPUNGE` (RFC 4315 / UIDPLUS) — it only expunges
+        // Prefer `UID EXPUNGE` (RFC 4315 / UIDPLUS) â€” it only expunges
         // the specific UID we just marked, leaving any other
         // `\Deleted`-flagged messages other clients might be juggling
         // in the same mailbox untouched. Most servers advertise
@@ -1559,7 +1563,7 @@ impl ImapClient {
         // The inner helper consumes the returned stream fully before
         // returning, which is what lets us fall back to a second
         // mutable borrow of `session` on the outer error branch
-        // without tripping the borrow checker — if we kept the
+        // without tripping the borrow checker â€” if we kept the
         // Stream around we'd be holding a mutable borrow into the
         // Err arm.
         let uid_set = uid.to_string();
@@ -1585,7 +1589,7 @@ impl ImapClient {
             Err(e) => {
                 // UIDPLUS not supported (or the server rejected the
                 // command for another reason). Fall back to plain
-                // EXPUNGE — we only flagged one UID in this session
+                // EXPUNGE â€” we only flagged one UID in this session
                 // so the broader command is still targeted enough.
                 tracing::warn!("delete_message: UID EXPUNGE failed ({e}), falling back to EXPUNGE");
                 let expunged: Vec<_> = session
@@ -1605,7 +1609,7 @@ impl ImapClient {
 
         if expunged_count == 0 {
             return Err(UnkaiError::Protocol(format!(
-                "EXPUNGE in '{folder}' removed 0 messages after flagging UID {uid} — \
+                "EXPUNGE in '{folder}' removed 0 messages after flagging UID {uid} â€” \
                  the \\Deleted flag didn't stick on this server"
             )));
         }
@@ -1645,7 +1649,7 @@ impl ImapClient {
     /// Used when the FTS5 cache misses (e.g. the user is looking for an
     /// old message that was never opened on this machine).
     ///
-    /// IMAP SEARCH is server-implementation-dependent and can be slow —
+    /// IMAP SEARCH is server-implementation-dependent and can be slow â€”
     /// this is the "last resort" path. The frontend calls it only after
     /// the local cache search returns fewer results than expected, or on
     /// explicit user action ("search server too").
@@ -1679,7 +1683,7 @@ impl ImapClient {
         uids.sort_unstable_by(|a, b| b.cmp(a));
         uids.truncate(limit as usize);
 
-        // Build a UID set like `42,17,9` — async-imap accepts this form.
+        // Build a UID set like `42,17,9` â€” async-imap accepts this form.
         let set = uids
             .iter()
             .map(|u| u.to_string())
@@ -1752,12 +1756,19 @@ impl ImapClient {
                     message_id: thread_msg_id,
                     in_reply_to: thread_in_reply_to,
                     references_ids: thread_refs,
+                    // #334: cache populates these on upsert; off-the-wire
+                    // envelopes don't know their thread identity yet.
+                    thread_id: None,
+                    thread_total_count: None,
                 })
             })
             .collect();
         envelopes.sort_unstable_by_key(|e| std::cmp::Reverse(e.date));
 
-        info!("SEARCH '{folder}' '{criterion}' → {} hits", envelopes.len());
+        info!(
+            "SEARCH '{folder}' '{criterion}' â†’ {} hits",
+            envelopes.len()
+        );
         Ok(envelopes)
     }
 
@@ -1789,7 +1800,7 @@ impl ImapClient {
 
         // AND the user's query with `UID 1:<before_uid-1>` so the
         // server returns only matches strictly older than the
-        // anchor — saves us a client-side filter pass.
+        // anchor â€” saves us a client-side filter pass.
         let combined = format!("UID 1:{} {}", before_uid - 1, criterion);
         debug!("UID SEARCH (older) in '{folder}': {combined}");
         let mut uids: Vec<u32> = session
@@ -1873,6 +1884,10 @@ impl ImapClient {
                     message_id: thread_msg_id,
                     in_reply_to: thread_in_reply_to,
                     references_ids: thread_refs,
+                    // #334: cache populates these on upsert; off-the-wire
+                    // envelopes don't know their thread identity yet.
+                    thread_id: None,
+                    thread_total_count: None,
                 })
             })
             .collect();
@@ -1891,7 +1906,7 @@ impl ImapClient {
     ///
     /// Returns the freshly-fetched envelopes; the caller is
     /// responsible for writing them through to the cache. An empty
-    /// return means there's nothing older — frontend can stop
+    /// return means there's nothing older â€” frontend can stop
     /// asking.
     ///
     /// Two round trips (SEARCH then FETCH) on purpose: a single
@@ -1937,7 +1952,7 @@ impl ImapClient {
             });
         }
 
-        // Top `limit` by descending UID — those are the newest
+        // Top `limit` by descending UID â€” those are the newest
         // among "older than before_uid".
         uids.sort_unstable_by(|a, b| b.cmp(a));
         uids.truncate(limit as usize);
@@ -2014,6 +2029,10 @@ impl ImapClient {
                     message_id: thread_msg_id,
                     in_reply_to: thread_in_reply_to,
                     references_ids: thread_refs,
+                    // #334: cache populates these on upsert; off-the-wire
+                    // envelopes don't know their thread identity yet.
+                    thread_id: None,
+                    thread_total_count: None,
                 })
             })
             .collect();
@@ -2031,7 +2050,7 @@ impl ImapClient {
 
     /// Log out from the IMAP server and close the connection cleanly.
     ///
-    /// Always call this when you're done — it sends the LOGOUT command
+    /// Always call this when you're done â€” it sends the LOGOUT command
     /// so the server knows we're leaving properly.
     pub async fn logout(mut self) -> Result<(), UnkaiError> {
         if let Some(mut session) = self.session.take() {
@@ -2045,7 +2064,7 @@ impl ImapClient {
     }
 }
 
-// ── Helpers ────────────────────────────────────────────────────
+// â”€â”€ Helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 /// Decode a possibly RFC 2047-encoded header value (e.g. `=?UTF-8?B?...?=`).
 fn decode_header(bytes: &[u8]) -> String {
@@ -2065,7 +2084,7 @@ fn decode_header(bytes: &[u8]) -> String {
 /// (case-insensitive), we drop the name and emit just the address.
 /// Some senders / mail servers populate the personal-name component
 /// with the email itself, which would produce malformed RFC 5322
-/// like `alex@example.com <alex@example.com>` — the unquoted `@` in
+/// like `alex@example.com <alex@example.com>` â€” the unquoted `@` in
 /// the phrase makes the result unparseable, and a plain reply would
 /// fail with "Invalid 'to' address".  Collapsing the redundant name
 /// also cleans up the mail-list display.
@@ -2114,8 +2133,8 @@ fn format_address(addr: &async_imap::imap_proto::types::Address<'_>) -> String {
 /// Pull RFC 5322 threading headers off a `Fetch` response (#277).
 ///
 /// Returns `(message_id, in_reply_to, references)` where each
-/// Message-ID has its angle brackets stripped — `<abc@h>` →
-/// `abc@h` — so cache lookups don't have to be bracket-aware.
+/// Message-ID has its angle brackets stripped â€” `<abc@h>` â†’
+/// `abc@h` â€” so cache lookups don't have to be bracket-aware.
 ///
 /// `Message-ID` and `In-Reply-To` come from the IMAP `ENVELOPE`
 /// response (cheap, already in the FETCH).  `References` is *not*
@@ -2142,7 +2161,7 @@ fn extract_threading_headers(
     (message_id, in_reply_to, references)
 }
 
-/// `<abc@host>` → `Some("abc@host")`.  Tolerates surrounding
+/// `<abc@host>` â†’ `Some("abc@host")`.  Tolerates surrounding
 /// whitespace and a value that's already bare (no brackets).
 /// Empty / whitespace-only inputs return `None` so the caller can
 /// store a clean `NULL` instead of an empty string.
@@ -2165,7 +2184,7 @@ fn strip_msgid_brackets(s: &str) -> Option<String> {
 /// Parse the body of a `BODY[HEADER.FIELDS (REFERENCES)]` response
 /// into the ordered Message-ID list from the `References:` header.
 /// The body is one or more lines starting with `References:`, with
-/// continuation lines (RFC 5322 §2.2.3) folded by leading
+/// continuation lines (RFC 5322 Â§2.2.3) folded by leading
 /// whitespace.  We unfold by joining all non-empty lines that
 /// follow `References:` until a blank line.  Each resulting token
 /// matching `<...>` becomes one entry, brackets stripped.
@@ -2185,7 +2204,7 @@ fn parse_references_header(raw: &str) -> Vec<String> {
             joined.push(' ');
             joined.push_str(line);
         } else if in_refs {
-            // Reached the next header or a blank line — done.
+            // Reached the next header or a blank line â€” done.
             break;
         }
     }
@@ -2227,7 +2246,7 @@ mod tests {
 
     #[test]
     fn to_wire_is_bare_mutf7_no_quoting() {
-        // `to_wire` must NOT add IMAP quoting — async-imap's
+        // `to_wire` must NOT add IMAP quoting â€” async-imap's
         // `validate_str` quotes for SELECT / EXAMINE / CREATE
         // / etc. internally, so quoting here would result in
         // double-quoting on the wire.  Pure-ASCII names pass
@@ -2237,7 +2256,7 @@ mod tests {
         assert_eq!(to_wire("Sent"), "Sent");
         assert_eq!(to_wire("Audi TT"), "Audi TT"); // no quoting at this layer
         assert_eq!(to_wire("INBOX/Projects"), "INBOX/Projects");
-        let unicode = to_wire("Bücher");
+        let unicode = to_wire("BÃ¼cher");
         assert!(unicode.is_ascii());
     }
 

--- a/crates/unkai-jmap/src/client.rs
+++ b/crates/unkai-jmap/src/client.rs
@@ -362,6 +362,9 @@ impl JmapClient {
                     message_id: None,
                     in_reply_to: None,
                     references_ids: Vec::new(),
+                    // #334: cache populates these on upsert.
+                    thread_id: None,
+                    thread_total_count: None,
                 }
             })
             .collect();

--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -1,4 +1,4 @@
-//! Local mail cache backed by SQLite.
+﻿//! Local mail cache backed by SQLite.
 //!
 //! # What lives here
 //!
@@ -16,7 +16,7 @@
 //!
 //! The UI loads from the cache first (instant, offline-safe) and then
 //! kicks off a network refresh which write-throughs back to the cache.
-//! The Tauri layer owns this dance — there are separate `get_cached_*`
+//! The Tauri layer owns this dance â€” there are separate `get_cached_*`
 //! commands for the cache path and `fetch_*` commands for the network
 //! path. Keeping them distinct makes the strategy explicit in the UI
 //! and lets future views (search, notifications) pick whichever they
@@ -76,7 +76,7 @@ pub enum CacheError {
     /// authenticated yet.  Surface this from any IPC that touches
     /// cached data so the UI can hold off until the lock screen
     /// completes the unlock.
-    #[error("cache is locked — authenticate to unlock")]
+    #[error("cache is locked â€” authenticate to unlock")]
     Locked,
 }
 
@@ -98,7 +98,7 @@ pub struct SyncState {
     pub last_synced_at: Option<DateTime<Utc>>,
 }
 
-/// Handle to the local mail cache. Cheap to clone — under the hood it's
+/// Handle to the local mail cache. Cheap to clone â€” under the hood it's
 /// an `Arc` around a connection pool.
 ///
 /// The pool is `Option`-wrapped so the cache can exist in a
@@ -144,7 +144,7 @@ impl Cache {
                 hex.len()
             ))),
             None => {
-                // No keychain entry yet — first-run; mint a key and
+                // No keychain entry yet â€” first-run; mint a key and
                 // open normally.  `get_or_create_master_key`
                 // handles the empty-keychain case for us.
                 if envelope.wraps.is_empty() {
@@ -171,7 +171,7 @@ impl Cache {
     /// Used by the default opener above and by future multi-profile
     /// support. The key must be a 64-char lowercase hex string.
     ///
-    /// Handles the pre-encryption → encryption upgrade: if a legacy
+    /// Handles the pre-encryption â†’ encryption upgrade: if a legacy
     /// unencrypted `cache.db` is found on disk, opening it with a key
     /// will fail at the first decrypt; we detect that, wipe the file,
     /// and recreate from scratch. The user loses their cache but
@@ -184,7 +184,7 @@ impl Cache {
                 warn!(
                     "Existing cache at {} could not be unlocked (likely an \
                      unencrypted cache from a pre-encryption build). Wiping \
-                     and recreating — mail will re-sync on next launch.",
+                     and recreating â€” mail will re-sync on next launch.",
                     path.display()
                 );
                 wipe_cache_files(path)?;
@@ -215,7 +215,7 @@ impl Cache {
         })
     }
 
-    /// True when the pool isn't open yet — every data method
+    /// True when the pool isn't open yet â€” every data method
     /// returns `Locked` until `unlock_with_master_key` runs.
     pub fn is_locked(&self) -> bool {
         self.pool.read().map(|g| g.is_none()).unwrap_or(true)
@@ -224,13 +224,13 @@ impl Cache {
     /// Open the pool for a previously-locked Cache.  Called from
     /// the unlock-flow IPCs once the user has authenticated and
     /// the master key has been recovered from a wrap.
-    /// Idempotent — a second call with the same key is a no-op.
+    /// Idempotent â€” a second call with the same key is a no-op.
     pub fn unlock_with_master_key(&self, key_hex: String) -> Result<(), CacheError> {
         if !self.is_locked() {
             return Ok(());
         }
         // No wipe-on-wrong-key fallback here.  At unlock time a
-        // SQLCipher key mismatch means authentication failed —
+        // SQLCipher key mismatch means authentication failed â€”
         // silently wiping the DB would destroy the user's mail and
         // accounts.  Surface the error so the unlock IPC can
         // re-prompt instead.  (The legacy-DB wipe lives in
@@ -239,7 +239,7 @@ impl Cache {
         let pool = pool::open_pool(&self.path, key_hex.clone())?;
         let mut conn = pool.get()?;
         schema::run_migrations(&mut conn)?;
-        // Same stale-tombstone sweep as `open_with_key` — see
+        // Same stale-tombstone sweep as `open_with_key` â€” see
         // there for the why.  Done while we still hold the pooled
         // conn so the cleanup runs before any data IPC can.
         if let Err(e) = conn.execute(
@@ -276,7 +276,7 @@ impl Cache {
     /// by the "wipe on failed authentication" policy: when the
     /// user exhausts their unlock attempts we drop the file so
     /// the next launch starts clean.  The Cache stays locked
-    /// (pool is `None` either way) — the caller is responsible
+    /// (pool is `None` either way) â€” the caller is responsible
     /// for clearing the keychain envelope's wraps if it wants a
     /// completely fresh setup on next launch.
     pub fn wipe_on_disk(&self) -> Result<(), CacheError> {
@@ -286,7 +286,7 @@ impl Cache {
     /// Borrow a pooled connection or return `Locked`.  Every
     /// data-touching method funnels through here so locked
     /// state propagates uniformly.  `pub(crate)` so sibling
-    /// modules (`account_store`, …) can reuse it instead of
+    /// modules (`account_store`, â€¦) can reuse it instead of
     /// duplicating the lock-and-checkout dance.
     pub(crate) fn conn(&self) -> Result<PooledConnection<SqliteConnectionManager>, CacheError> {
         let guard = self.pool.read().expect("Cache pool RwLock poisoned");
@@ -295,7 +295,7 @@ impl Cache {
     }
 
     /// Open an in-memory cache for tests. Each call gets its own
-    /// fresh DB — see `pool::open_memory_pool` for the URI trick
+    /// fresh DB â€” see `pool::open_memory_pool` for the URI trick
     /// that makes that work. Useful for any sibling module
     /// (e.g. `account_store`) that needs a Cache to run unit tests
     /// against without touching the user's real config dir or the
@@ -322,7 +322,7 @@ impl Cache {
     /// whose owning account no longer exists and `load_account`
     /// would fail on every click.
     ///
-    /// Returns the count of orphan account ids that were pruned —
+    /// Returns the count of orphan account ids that were pruned â€”
     /// zero on a clean cache, any other number is worth a log line.
     pub fn prune_orphan_accounts(&self, active_ids: &[String]) -> Result<usize, CacheError> {
         let conn = self.conn()?;
@@ -361,7 +361,7 @@ impl Cache {
         Ok(orphans.len())
     }
 
-    /// Clears the cache for a specific account — called when an account
+    /// Clears the cache for a specific account â€” called when an account
     /// is removed, or when `UIDVALIDITY` changes and we need to start fresh.
     pub fn wipe_account(&self, account_id: &str) -> Result<(), CacheError> {
         let conn = self.conn()?;
@@ -383,7 +383,7 @@ impl Cache {
     /// across a rename, so updating the `folder` column on `messages`,
     /// `folder_sync_state`, and `folders` is enough to keep every
     /// envelope / body / unread-count bookmark pointing at the right
-    /// mailbox — without re-fetching a single byte.
+    /// mailbox â€” without re-fetching a single byte.
     pub fn rename_folder(
         &self,
         account_id: &str,
@@ -410,7 +410,7 @@ impl Cache {
         Ok(())
     }
 
-    /// Clear all cached rows for a single folder — used when the server's
+    /// Clear all cached rows for a single folder â€” used when the server's
     /// `UIDVALIDITY` for that folder has changed, meaning every UID we had
     /// cached now refers to a different message (or none at all).
     ///
@@ -430,7 +430,7 @@ impl Cache {
         Ok(())
     }
 
-    // ── Folders ─────────────────────────────────────────────────
+    // â”€â”€ Folders â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Replace the cached folder list for an account.
     ///
@@ -468,12 +468,12 @@ impl Cache {
 
     /// Read the cached folder list for an account.
     ///
-    /// Returns folders in the order they were inserted — i.e. the
+    /// Returns folders in the order they were inserted â€” i.e. the
     /// server's native order, which is what the user expects (INBOX
     /// first, then the server's own ordering). `upsert_folders`
     /// wipes-and-reinserts in a single transaction, so SQLite's
     /// monotonically-assigned `rowid` matches the input iteration
-    /// order exactly. Sorting by `name` instead — as we used to —
+    /// order exactly. Sorting by `name` instead â€” as we used to â€”
     /// alphabetised by ASCII code, which puts all-caps `INBOX`
     /// behind names like `Drafts` and made the sidebar look
     /// scrambled compared to every other mail client.
@@ -503,11 +503,11 @@ impl Cache {
         Ok(out)
     }
 
-    // ── Envelopes ───────────────────────────────────────────────
+    // â”€â”€ Envelopes â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Upsert a batch of envelopes, tagging each with the given `account_id`.
     ///
-    /// `EmailEnvelope` doesn't carry an account id — the frontend never
+    /// `EmailEnvelope` doesn't carry an account id â€” the frontend never
     /// needs it, and the Tauri command always knows which account it
     /// connected to. We take the id once here instead of widening the
     /// shared struct.
@@ -516,6 +516,63 @@ impl Cache {
     /// refreshes its flags (e.g. user marked-as-read on another device).
     /// Runs inside a transaction: either the whole batch lands or none
     /// of it does.
+    /// One-shot warm-up: fill in `thread_id` for any rows in this
+    /// folder that pre-date the v32 migration or were inserted by a
+    /// path that didn't compute it (#334).  Cheap to run on every
+    /// read â€” when every row already has a `thread_id`, the UPDATE
+    /// matches zero rows.
+    ///
+    /// Computes the same canonical key shape as `compute_thread_id`
+    /// directly in SQL via COALESCE.  Folder-scoped so a big folder
+    /// doesn't tax other folders' read paths.
+    pub fn assign_pending_thread_ids(
+        &self,
+        account_id: &str,
+        folder: &str,
+    ) -> Result<usize, CacheError> {
+        let conn = self.conn()?;
+        let updated = conn.execute(
+            "UPDATE messages
+             SET thread_id = COALESCE(
+                 json_extract(references_ids, '$[0]'),
+                 message_id,
+                 'solo:' || account_id || ':' || folder || ':' || uid
+             )
+             WHERE account_id = ?1 AND folder = ?2 AND thread_id IS NULL",
+            params![account_id, folder],
+        )?;
+        if updated > 0 {
+            tracing::info!(
+                "Warmed up thread_id for {updated} envelope(s) in '{account_id}'/'{folder}' (#334)"
+            );
+        }
+        Ok(updated)
+    }
+
+    /// Canonical thread identity for the local cache (#334).
+    /// Two envelopes share a thread iff they produce the same key:
+    ///
+    ///   1. `references_ids[0]` â€” the chain root, when this is a reply.
+    ///   2. `message_id` â€” for top-of-thread originals (future replies
+    ///      will carry this value as their first References entry, so
+    ///      siblings still resolve correctly).
+    ///   3. `solo:<account>:<folder>:<uid>` â€” synthetic fallback for
+    ///      envelopes that have neither (e.g. pre-parser cached rows
+    ///      that didn't capture the headers).
+    ///
+    /// Kept in lock-step with the frontend's old `threadKeyOf` shape
+    /// so subjects already bucketed in the UI roll forward to the
+    /// same group once they pick up a stored `thread_id`.
+    fn compute_thread_id(account_id: &str, env: &EmailEnvelope) -> String {
+        if let Some(first) = env.references_ids.first() {
+            return first.clone();
+        }
+        if let Some(mid) = &env.message_id {
+            return mid.clone();
+        }
+        format!("solo:{}:{}:{}", account_id, env.folder, env.uid)
+    }
+
     pub fn upsert_envelopes_for_account(
         &self,
         account_id: &str,
@@ -529,7 +586,7 @@ impl Cache {
         let now = Utc::now().timestamp();
         {
             // Note (#255): `replied_kind` is intentionally NOT in
-            // the UPDATE clause — IMAP envelope re-fetches don't
+            // the UPDATE clause â€” IMAP envelope re-fetches don't
             // know which kind of reply happened, so leave whatever
             // we stamped from the send path in place.  `is_answered`
             // *is* refreshed because the IMAP `\Answered` flag is
@@ -538,15 +595,15 @@ impl Cache {
             // `references_ids` is serialised to JSON before the
             // bind so SQLite stores a single TEXT cell (the same
             // shape we use for `attendees_json` etc.).  Empty
-            // vector → `NULL` so the indexed column stays sparse
+            // vector â†’ `NULL` so the indexed column stays sparse
             // for messages that aren't in any thread.
             let mut stmt = tx.prepare(
                 "INSERT INTO messages
                    (account_id, folder, uid, from_addr, subject, internal_date,
                     is_read, is_starred, is_answered, cached_at,
-                    message_id, in_reply_to, references_ids)
+                    message_id, in_reply_to, references_ids, thread_id)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                         ?11, ?12, ?13)
+                         ?11, ?12, ?13, ?14)
                  ON CONFLICT (account_id, folder, uid) DO UPDATE SET
                    from_addr     = excluded.from_addr,
                    subject       = excluded.subject,
@@ -560,7 +617,12 @@ impl Cache {
                    -- wipe data we successfully extracted earlier.
                    message_id    = COALESCE(excluded.message_id, messages.message_id),
                    in_reply_to   = COALESCE(excluded.in_reply_to, messages.in_reply_to),
-                   references_ids = COALESCE(excluded.references_ids, messages.references_ids)",
+                   references_ids = COALESCE(excluded.references_ids, messages.references_ids),
+                   -- #334: `thread_id` is computed from the headers above,
+                   -- so a re-fetch that brought new threading info updates
+                   -- the row; otherwise we preserve whatever the previous
+                   -- write (or the warm-up pass) assigned.
+                   thread_id     = COALESCE(excluded.thread_id, messages.thread_id)",
             )?;
             for env in envelopes {
                 let refs_json: Option<String> = if env.references_ids.is_empty() {
@@ -568,6 +630,7 @@ impl Cache {
                 } else {
                     serde_json::to_string(&env.references_ids).ok()
                 };
+                let thread_id = Self::compute_thread_id(account_id, env);
                 stmt.execute(params![
                     account_id,
                     env.folder,
@@ -582,6 +645,7 @@ impl Cache {
                     env.message_id,
                     env.in_reply_to,
                     refs_json,
+                    thread_id,
                 ])?;
             }
         }
@@ -603,14 +667,30 @@ impl Cache {
         folder: &str,
         limit: u32,
     ) -> Result<Vec<EmailEnvelope>, CacheError> {
+        // #334: warm up any pre-migration rows so the read below
+        // returns populated thread_id / count fields.  Single
+        // UPDATE, no-op when every row is already warm.
+        let _ = self.assign_pending_thread_ids(account_id, folder);
+
         let conn = self.conn()?;
+        // Correlated subquery for `thread_total_count` rather than a
+        // CTE because we want each row's count computed against the
+        // *whole folder*, not just the returned window â€” a thread
+        // whose root is in the newest 50 may have replies older than
+        // the window, and the badge needs to report the true total.
         let mut stmt = conn.prepare(
-            "SELECT uid, folder, from_addr, subject, internal_date,
-                    is_read, is_starred, is_answered, replied_kind,
-                    message_id, in_reply_to, references_ids
-             FROM messages
-             WHERE account_id = ?1 AND folder = ?2 AND pending_action IS NULL
-             ORDER BY internal_date DESC
+            "SELECT m.uid, m.folder, m.from_addr, m.subject, m.internal_date,
+                    m.is_read, m.is_starred, m.is_answered, m.replied_kind,
+                    m.message_id, m.in_reply_to, m.references_ids,
+                    m.thread_id,
+                    (SELECT COUNT(*) FROM messages m2
+                     WHERE m2.account_id = ?1
+                       AND m2.folder = ?2
+                       AND m2.thread_id = m.thread_id
+                       AND m2.pending_action IS NULL) AS thread_total_count
+             FROM messages m
+             WHERE m.account_id = ?1 AND m.folder = ?2 AND m.pending_action IS NULL
+             ORDER BY m.internal_date DESC
              LIMIT ?3",
         )?;
         let rows = stmt.query_map(params![account_id, folder, limit as i64], |r| {
@@ -621,6 +701,8 @@ impl Cache {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or_default();
+            let thread_id: Option<String> = r.get(12)?;
+            let thread_total_count: Option<i64> = r.get(13)?;
             Ok(EmailEnvelope {
                 uid: r.get::<_, i64>(0)? as u32,
                 folder: r.get(1)?,
@@ -635,6 +717,8 @@ impl Cache {
                 message_id: r.get(9)?,
                 in_reply_to: r.get(10)?,
                 references_ids,
+                thread_id,
+                thread_total_count: thread_total_count.map(|n| n as u32),
             })
         })?;
 
@@ -645,9 +729,81 @@ impl Cache {
         Ok(out)
     }
 
+    /// Return every cached envelope belonging to a single conversation
+    /// (#334).  Folder-scoped because that's the scope the MailList
+    /// row lives in, and matches the scope used by the badge count.
+    /// Used by the on-expand backfill: the user clicks the chevron on
+    /// a thread head and we want every member the local DB knows
+    /// about, not just whichever happened to be in the newest-
+    /// `PAGE_SIZE` window.  Skips `pending_action` tombstones so a
+    /// just-moved message doesn't reappear in the source thread.
+    ///
+    /// `thread_total_count` is populated via the same correlated
+    /// subquery the broader read paths use — i.e. it agrees with
+    /// what `get_envelopes` would have returned for any member that
+    /// also happens to be in the newest window.  Sorted newest-first.
+    pub fn get_envelopes_by_thread(
+        &self,
+        account_id: &str,
+        folder: &str,
+        thread_id: &str,
+    ) -> Result<Vec<EmailEnvelope>, CacheError> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT m.uid, m.folder, m.from_addr, m.subject, m.internal_date,
+                    m.is_read, m.is_starred, m.is_answered, m.replied_kind,
+                    m.message_id, m.in_reply_to, m.references_ids,
+                    m.thread_id,
+                    (SELECT COUNT(*) FROM messages m2
+                     WHERE m2.account_id = ?1
+                       AND m2.folder = ?2
+                       AND m2.thread_id = m.thread_id
+                       AND m2.pending_action IS NULL) AS thread_total_count
+             FROM messages m
+             WHERE m.account_id = ?1
+               AND m.folder = ?2
+               AND m.thread_id = ?3
+               AND m.pending_action IS NULL
+             ORDER BY m.internal_date DESC",
+        )?;
+        let rows = stmt.query_map(params![account_id, folder, thread_id], |r| {
+            let ts: i64 = r.get(4)?;
+            let date = Utc.timestamp_opt(ts, 0).single().unwrap_or_else(Utc::now);
+            let refs_json: Option<String> = r.get(11)?;
+            let references_ids: Vec<String> = refs_json
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok())
+                .unwrap_or_default();
+            let thread_id: Option<String> = r.get(12)?;
+            let thread_total_count: Option<i64> = r.get(13)?;
+            Ok(EmailEnvelope {
+                uid: r.get::<_, i64>(0)? as u32,
+                folder: r.get(1)?,
+                from: r.get(2)?,
+                subject: r.get(3)?,
+                date,
+                is_read: r.get::<_, i64>(5)? != 0,
+                is_starred: r.get::<_, i64>(6)? != 0,
+                is_answered: r.get::<_, i64>(7)? != 0,
+                replied_kind: r.get(8)?,
+                account_id: account_id.to_string(),
+                message_id: r.get(9)?,
+                in_reply_to: r.get(10)?,
+                references_ids,
+                thread_id,
+                thread_total_count: thread_total_count.map(|n| n as u32),
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
     /// Return the newest `limit` envelopes in `folder` whose body has
     /// **not** yet been fetched (no row in `message_bodies`).  Used by
-    /// the launch-time prerender (#178) to warm the message cache —
+    /// the launch-time prerender (#178) to warm the message cache â€”
     /// the user clicks an inbox row and the reading pane paints
     /// instantly because the body is already on disk, instead of
     /// waiting for an IMAP round-trip.
@@ -688,14 +844,44 @@ impl Cache {
         folder: &str,
         limit: u32,
     ) -> Result<Vec<EmailEnvelope>, CacheError> {
+        // #334: warm up every account's copy of this folder before
+        // reading.  Cheap â€” one no-op UPDATE per warm folder.
+        if let Ok(mut conn) = self.conn() {
+            let tx = conn.transaction().ok();
+            if let Some(tx) = tx {
+                let _ = tx.execute(
+                    "UPDATE messages
+                     SET thread_id = COALESCE(
+                         json_extract(references_ids, '$[0]'),
+                         message_id,
+                         'solo:' || account_id || ':' || folder || ':' || uid
+                     )
+                     WHERE folder = ?1 AND thread_id IS NULL",
+                    params![folder],
+                );
+                let _ = tx.commit();
+            }
+        }
+
         let conn = self.conn()?;
+        // Subquery scopes the count by `(account_id, folder, thread_id)`
+        // because a thread_id can collide across accounts (two unrelated
+        // users may end up with the same `<msg-id@host>` if a sender
+        // delivers to both inboxes) â€” counting across accounts would
+        // wrongly merge those.
         let mut stmt = conn.prepare(
-            "SELECT account_id, uid, folder, from_addr, subject, internal_date,
-                    is_read, is_starred, is_answered, replied_kind,
-                    message_id, in_reply_to, references_ids
-             FROM messages
-             WHERE folder = ?1 AND pending_action IS NULL
-             ORDER BY internal_date DESC
+            "SELECT m.account_id, m.uid, m.folder, m.from_addr, m.subject, m.internal_date,
+                    m.is_read, m.is_starred, m.is_answered, m.replied_kind,
+                    m.message_id, m.in_reply_to, m.references_ids,
+                    m.thread_id,
+                    (SELECT COUNT(*) FROM messages m2
+                     WHERE m2.account_id = m.account_id
+                       AND m2.folder = m.folder
+                       AND m2.thread_id = m.thread_id
+                       AND m2.pending_action IS NULL) AS thread_total_count
+             FROM messages m
+             WHERE m.folder = ?1 AND m.pending_action IS NULL
+             ORDER BY m.internal_date DESC
              LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![folder, limit as i64], |r| {
@@ -706,6 +892,8 @@ impl Cache {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or_default();
+            let thread_id: Option<String> = r.get(13)?;
+            let thread_total_count: Option<i64> = r.get(14)?;
             Ok(EmailEnvelope {
                 account_id: r.get(0)?,
                 uid: r.get::<_, i64>(1)? as u32,
@@ -720,6 +908,8 @@ impl Cache {
                 message_id: r.get(10)?,
                 in_reply_to: r.get(11)?,
                 references_ids,
+                thread_id,
+                thread_total_count: thread_total_count.map(|n| n as u32),
             })
         })?;
 
@@ -734,7 +924,7 @@ impl Cache {
     /// `(account_id, folder)` pairs, newest-first. Powers the global
     /// "All Sent" / "All Drafts" views, where each account stores
     /// outgoing mail in a differently-named folder (`Sent`, `Sent
-    /// Items`, `Gesendete Elemente`, `[Gmail]/Sent Mail`, …) so the
+    /// Items`, `Gesendete Elemente`, `[Gmail]/Sent Mail`, â€¦) so the
     /// single-folder-name query used by `get_unified_envelopes` can't
     /// match them all at once.
     ///
@@ -749,9 +939,9 @@ impl Cache {
             return Ok(Vec::new());
         }
         let conn = self.conn()?;
-        // Build `(account_id = ?N AND folder = ?N+1) OR …` so each
+        // Build `(account_id = ?N AND folder = ?N+1) OR â€¦` so each
         // account's resolved special-use folder contributes only the
-        // rows that actually live in it. Parameterised — no string
+        // rows that actually live in it. Parameterised â€” no string
         // interpolation of folder names into the SQL.
         let mut where_clause = String::new();
         for i in 0..pairs.len() {
@@ -763,13 +953,21 @@ impl Cache {
             where_clause.push_str(&format!("(account_id = ?{a} AND folder = ?{b})"));
         }
         let limit_param = 2 * pairs.len() + 1;
+        // #334: thread_total_count is folder-and-account-scoped, same
+        // shape as the single-account read.
         let sql = format!(
-            "SELECT account_id, uid, folder, from_addr, subject, internal_date,
-                    is_read, is_starred, is_answered, replied_kind,
-                    message_id, in_reply_to, references_ids
-             FROM messages
-             WHERE ({where_clause}) AND pending_action IS NULL
-             ORDER BY internal_date DESC
+            "SELECT m.account_id, m.uid, m.folder, m.from_addr, m.subject, m.internal_date,
+                    m.is_read, m.is_starred, m.is_answered, m.replied_kind,
+                    m.message_id, m.in_reply_to, m.references_ids,
+                    m.thread_id,
+                    (SELECT COUNT(*) FROM messages m2
+                     WHERE m2.account_id = m.account_id
+                       AND m2.folder = m.folder
+                       AND m2.thread_id = m.thread_id
+                       AND m2.pending_action IS NULL) AS thread_total_count
+             FROM messages m
+             WHERE ({where_clause}) AND m.pending_action IS NULL
+             ORDER BY m.internal_date DESC
              LIMIT ?{limit_param}"
         );
         let mut params_vec: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(2 * pairs.len() + 1);
@@ -789,6 +987,8 @@ impl Cache {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or_default();
+            let thread_id: Option<String> = r.get(13)?;
+            let thread_total_count: Option<i64> = r.get(14)?;
             Ok(EmailEnvelope {
                 account_id: r.get(0)?,
                 uid: r.get::<_, i64>(1)? as u32,
@@ -803,6 +1003,8 @@ impl Cache {
                 message_id: r.get(10)?,
                 in_reply_to: r.get(11)?,
                 references_ids,
+                thread_id,
+                thread_total_count: thread_total_count.map(|n| n as u32),
             })
         })?;
 
@@ -821,7 +1023,7 @@ impl Cache {
     /// cache immediately so the UI reflects the change without waiting
     /// for the network round-trip to the IMAP server. If the row isn't
     /// cached yet (message was never listed), the message-table UPDATE
-    /// is a no-op and we don't decrement the folder count — there's
+    /// is a no-op and we don't decrement the folder count â€” there's
     /// nothing to subtract from.
     ///
     /// Wrapped in a transaction so the message flip and the folder
@@ -869,7 +1071,7 @@ impl Cache {
         Ok(())
     }
 
-    /// Return every cached envelope UID for a folder — used by the
+    /// Return every cached envelope UID for a folder â€” used by the
     /// reconciler that diffs the cache against the server's live UID
     /// set after each incremental fetch and drops rows whose UIDs no
     /// longer exist on the server.
@@ -892,7 +1094,7 @@ impl Cache {
     }
 
     /// Newest `limit` cached envelope UIDs for a folder, sorted by
-    /// `internal_date DESC` — the same ordering the mail list
+    /// `internal_date DESC` â€” the same ordering the mail list
     /// renders.  Used by the flag-refresh path (#255 follow-up) to
     /// catch up on cross-client `\Seen` / `\Flagged` / `\Answered`
     /// changes on the visible window without re-pulling the whole
@@ -922,7 +1124,7 @@ impl Cache {
 
     /// Mark a cached envelope as having an in-flight optimistic
     /// action so envelope-list queries hide it instantly (#174).
-    /// `action` is a free-form string — `"delete"` for delete /
+    /// `action` is a free-form string â€” `"delete"` for delete /
     /// move-to-trash, `"move:<dest>"` for explicit folder moves.
     /// Cleared on IMAP failure via `clear_message_pending`; on
     /// IMAP success the existing `remove_envelope` / source-folder
@@ -948,7 +1150,7 @@ impl Cache {
     /// row when the target UID isn't cached yet (#292 follow-up).
     ///
     /// The minimize-save path APPENDs to IMAP without writing the
-    /// new envelope into the cache — `save_draft` only invokes
+    /// new envelope into the cache â€” `save_draft` only invokes
     /// `remove_envelope` on the replaced source, never `upsert` on
     /// the freshly-APPENDed copy.  A subsequent send that targets
     /// the minimize-saved UID hits a tombstone-via-UPDATE that
@@ -963,12 +1165,12 @@ impl Cache {
     /// pending flag.  `get_envelopes` filters out any row with
     /// `pending_action IS NOT NULL`, so the placeholder is
     /// invisible.  When `poll_folder`'s upsert later writes the
-    /// real envelope, the `ON CONFLICT … DO UPDATE` clause
+    /// real envelope, the `ON CONFLICT â€¦ DO UPDATE` clause
     /// deliberately *doesn't* touch `pending_action`, so the
     /// tombstone survives the merge.  On IMAP success the row
     /// gets dropped entirely via `remove_envelope`; on IMAP
     /// failure `clear_message_pending` un-tombstones, which
-    /// briefly exposes the placeholder's empty fields — accepted
+    /// briefly exposes the placeholder's empty fields â€” accepted
     /// as a rare edge case since the next poll fills them in.
     pub fn upsert_message_pending(
         &self,
@@ -986,7 +1188,7 @@ impl Cache {
         if updated > 0 {
             return Ok(());
         }
-        // Row missing — insert a placeholder.  `INSERT OR IGNORE`
+        // Row missing â€” insert a placeholder.  `INSERT OR IGNORE`
         // covers the race where a concurrent poll inserts the
         // real row between our UPDATE-found-nothing and this
         // INSERT; in that case we'd need a second UPDATE to flip
@@ -1008,7 +1210,7 @@ impl Cache {
         Ok(())
     }
 
-    /// Reverse of `mark_message_pending` — called when the IMAP
+    /// Reverse of `mark_message_pending` â€” called when the IMAP
     /// action errors so the row reappears in the next list pull
     /// without the user having to restart anything.
     pub fn clear_message_pending(
@@ -1030,7 +1232,7 @@ impl Cache {
     /// app startup (after `unlock_with_master_key` opens the pool)
     /// so a row left tombstoned by a crashed run doesn't stay
     /// permanently invisible.  At launch nothing is genuinely in
-    /// flight — the IMAP requests live in the previous process —
+    /// flight â€” the IMAP requests live in the previous process â€”
     /// so any surviving pending flag is by definition stale.
     /// Returns the number of rows reset.
     pub fn clear_all_pending_actions(&self) -> Result<usize, CacheError> {
@@ -1046,7 +1248,7 @@ impl Cache {
     /// Remove a single cached envelope + body after the message has been
     /// expunged / moved on the server. The incremental envelope fetch
     /// only pulls UIDs `> highest_seen`, so without an explicit delete
-    /// here the cache accumulates ghost rows for every expunged UID —
+    /// here the cache accumulates ghost rows for every expunged UID â€”
     /// and MailList keeps showing them, handing the user stale UIDs
     /// that the server has since reassigned or reclaimed.
     ///
@@ -1054,7 +1256,7 @@ impl Cache {
     /// `unread_count` is also decremented so the sidebar badge tracks
     /// the row disappearing. Same clamp-at-zero guard as
     /// `mark_envelope_read`. Returns `true` iff a row was actually
-    /// removed — callers can tell the difference between "cleaned up
+    /// removed â€” callers can tell the difference between "cleaned up
     /// a real stale row" and "no row existed in the first place".
     pub fn remove_envelope(
         &self,
@@ -1137,14 +1339,14 @@ impl Cache {
     /// flags for a batch of envelope rows against fresh server-side
     /// values (#255 follow-up).
     ///
-    /// The standard envelope-fetch path is incremental — it never
+    /// The standard envelope-fetch path is incremental â€” it never
     /// re-reads flags on UIDs older than the bookmark.  Without
     /// this catch-up, marks made from another mail client (read on
     /// a phone, answered from webmail, starred elsewhere) never
     /// round-trip into the local cache, and Unkai's mail list
     /// drifts out of sync with reality.
     ///
-    /// `replied_kind` is intentionally not touched — it's
+    /// `replied_kind` is intentionally not touched â€” it's
     /// Unkai-only metadata about *how* the user replied via
     /// Compose, and the IMAP `\Answered` bit doesn't carry the
     /// kind, so leave whatever the send path stamped earlier.
@@ -1153,7 +1355,7 @@ impl Cache {
     /// same transaction.
     ///
     /// Each tuple is `(uid, is_read, is_starred, is_answered)`.
-    /// UIDs that don't exist in the cache are silently skipped —
+    /// UIDs that don't exist in the cache are silently skipped â€”
     /// they got expunged between fetch and reconcile, and the
     /// envelope-fetch path will sweep them out on its own
     /// reconcile pass.
@@ -1174,7 +1376,7 @@ impl Cache {
         for (uid, is_read, is_starred, is_answered) in snapshots {
             // Fetch current flags so we know whether to bump the
             // folder's unread badge.  `query_row` returns
-            // `QueryReturnedNoRows` when the UID isn't cached —
+            // `QueryReturnedNoRows` when the UID isn't cached â€”
             // skip those.
             let prior: Option<(bool, bool, bool)> = tx
                 .query_row(
@@ -1213,8 +1415,8 @@ impl Cache {
             changed += 1;
 
             // Bump the unread accumulator: if the flag flipped
-            // unread → read, the folder count drops by one; if it
-            // flipped read → unread, it goes up by one.
+            // unread â†’ read, the folder count drops by one; if it
+            // flipped read â†’ unread, it goes up by one.
             if was_read != *is_read {
                 unread_delta += if *is_read { -1 } else { 1 };
             }
@@ -1242,7 +1444,7 @@ impl Cache {
     /// Called from the Compose send path after a successful
     /// reply / reply-all / meeting reply.  Idempotent: re-running
     /// with the same kind is a no-op; re-running with a different
-    /// kind overwrites — useful only in unusual flows where the
+    /// kind overwrites â€” useful only in unusual flows where the
     /// user replies, then later "responds with meeting" on the
     /// same source thread.
     pub fn mark_envelope_replied(
@@ -1288,7 +1490,7 @@ impl Cache {
 
     /// Total unread messages across all accounts' INBOX folders.
     ///
-    /// Feeds the tray tooltip ("Unkai Mail — 3 unread") and any
+    /// Feeds the tray tooltip ("Unkai Mail â€” 3 unread") and any
     /// aggregate badge UI. We scope to INBOX only because other folders
     /// (Archive, Trash) aren't typically surfaced as "unread" to the
     /// user even when they technically have `is_read = 0` rows.
@@ -1333,11 +1535,11 @@ impl Cache {
         Ok(out)
     }
 
-    // ── Message bodies ──────────────────────────────────────────
+    // â”€â”€ Message bodies â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     /// Upsert a cached message body alongside its envelope.
     ///
-    /// Takes an `Email` since that's the shape the IMAP client returns — we
+    /// Takes an `Email` since that's the shape the IMAP client returns â€” we
     /// split it into an envelope row (via `upsert_envelopes_for_account`)
     /// and a body row here, in a single transaction so partial rows never
     /// survive a failed write.
@@ -1346,7 +1548,7 @@ impl Cache {
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
 
-        // Envelope row — mirrors upsert_envelopes_for_account but inside
+        // Envelope row â€” mirrors upsert_envelopes_for_account but inside
         // the same transaction as the body so the two can't drift.
         tx.execute(
             "INSERT INTO messages
@@ -1364,7 +1566,7 @@ impl Cache {
                 email.account_id,
                 email.folder,
                 // `id` from IMAP is formatted as "folder:uid" in the
-                // fetch path — we don't rely on it here, the UID is
+                // fetch path â€” we don't rely on it here, the UID is
                 // re-parsed by the caller.
                 uid_from_email_id(&email.id) as i64,
                 email.from,
@@ -1376,13 +1578,13 @@ impl Cache {
             ],
         )?;
 
-        // Addresses are stored as JSON arrays — see the v1 → v2 migration
+        // Addresses are stored as JSON arrays â€” see the v1 â†’ v2 migration
         // note. `unwrap_or_else` fallbacks are defensive; serde_json on a
         // Vec<String> can only fail if allocation fails.
         let to_json = serde_json::to_string(&email.to).unwrap_or_else(|_| "[]".into());
         let cc_json = serde_json::to_string(&email.cc).unwrap_or_else(|_| "[]".into());
-        // Attachment metadata as JSON — one record per attachment,
-        // with the stable `part_id` the IMAP re-fetch uses. See v5 → v6.
+        // Attachment metadata as JSON â€” one record per attachment,
+        // with the stable `part_id` the IMAP re-fetch uses. See v5 â†’ v6.
         let attachments_json =
             serde_json::to_string(&email.attachments).unwrap_or_else(|_| "[]".into());
 
@@ -1488,7 +1690,7 @@ impl Cache {
         Ok(row)
     }
 
-    // ── Sync state ──────────────────────────────────────────────
+    // â”€â”€ Sync state â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
     pub fn get_sync_state(
         &self,
@@ -1543,18 +1745,18 @@ impl Cache {
         Ok(())
     }
 
-    // ── Attachment-thumbnail cache (#157) ──────────────────────
+    // â”€â”€ Attachment-thumbnail cache (#157) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     //
     // MailView's chip strip used to re-fetch every image / video
     // attachment per open and re-extract its thumbnail.  These
-    // helpers persist a tiny JPEG (≤256 px on the long edge)
+    // helpers persist a tiny JPEG (â‰¤256 px on the long edge)
     // generated by the frontend so subsequent opens render
     // straight from the cache without an IPC, blob copy, or
     // GStreamer pipeline.
 
     /// Insert / replace a stored thumbnail for one attachment.
     /// `bytes` is whatever encoded image format the frontend
-    /// produced — we treat it opaquely and hand it back to
+    /// produced â€” we treat it opaquely and hand it back to
     /// callers verbatim.
     pub fn put_attachment_preview(
         &self,
@@ -1576,7 +1778,7 @@ impl Cache {
     }
 
     /// Load every stored thumbnail for one message in a single
-    /// query — MailView batches them all into the in-memory
+    /// query â€” MailView batches them all into the in-memory
     /// thumb cache when the email mounts.
     pub fn get_attachment_previews_for_message(
         &self,
@@ -1604,9 +1806,9 @@ impl Cache {
         Ok(out)
     }
 
-    // ── Outbox (#276) ────────────────────────────────────────────
+    // â”€â”€ Outbox (#276) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
     //
-    // Local-only "send queue" — every send routes through this
+    // Local-only "send queue" â€” every send routes through this
     // table first, the SMTP send runs in a spawned drain task.
     // Rows that drain successfully are removed within the same
     // tick (sub-second on a healthy network); rows that fail
@@ -1636,7 +1838,7 @@ impl Cache {
     /// won the claim and should proceed, `false` when another
     /// drain holds the row.  The TTL means that even if a drain
     /// task panics or the process dies mid-send the row isn't
-    /// permanently stuck — the next sweep past the TTL boundary
+    /// permanently stuck â€” the next sweep past the TTL boundary
     /// reclaims it.
     pub fn claim_outbox_for_drain(&self, id: i64, claim_ttl_secs: i64) -> Result<bool, CacheError> {
         let conn = self.conn()?;
@@ -1719,7 +1921,7 @@ impl Cache {
         Ok(out)
     }
 
-    /// Fetch one queued row by id — used by the drain task (when
+    /// Fetch one queued row by id â€” used by the drain task (when
     /// the caller knows the row it just enqueued) and by the
     /// `edit_outbox_entry` Tauri command.
     pub fn get_outbox(&self, id: i64) -> Result<Option<OutboxRow>, CacheError> {
@@ -1741,7 +1943,7 @@ impl Cache {
 
     /// Bookkeeping after a drain attempt failed: bump the count,
     /// stamp the last attempt time, store the human-readable
-    /// error.  Doesn't delete — the row stays for the next sweep.
+    /// error.  Doesn't delete â€” the row stays for the next sweep.
     pub fn record_outbox_failure(&self, id: i64, error: &str) -> Result<(), CacheError> {
         let conn = self.conn()?;
         let now = Utc::now().timestamp();
@@ -1789,7 +1991,7 @@ impl Cache {
 
     /// Queued-row counts grouped by account (#290).  Drives the
     /// per-account decision of "render the synthetic Outbox folder
-    /// in this sidebar?" — the previous global count caused the
+    /// in this sidebar?" â€” the previous global count caused the
     /// folder to leak into every account's sidebar whenever any
     /// account had a pending send.  Accounts with zero queued
     /// rows are omitted so the caller can `?? 0` without an
@@ -1817,7 +2019,7 @@ impl Cache {
 }
 
 /// Row shape inserted into `outbox_messages` by
-/// `Cache::enqueue_outbox`.  Mirrors the columns of the table —
+/// `Cache::enqueue_outbox`.  Mirrors the columns of the table â€”
 /// kept as a separate struct so callers don't have to hand-build
 /// a `params![]` tuple at every enqueue site.
 #[derive(Debug, Clone)]
@@ -1880,7 +2082,7 @@ pub struct AttachmentPreview {
 
 /// Parse the IMAP UID out of an `Email.id` produced by the IMAP client.
 ///
-/// `unkai_imap` formats ids as `"{folder}:{uid}"` — folder names can
+/// `unkai_imap` formats ids as `"{folder}:{uid}"` â€” folder names can
 /// themselves contain `:` (rare but legal), so we split on the *last*
 /// colon. A malformed id yields 0 with a warn log; this can only happen
 /// if the upstream id format changes, in which case the cache row will
@@ -1922,7 +2124,7 @@ fn is_wrong_key_error(err: &CacheError) -> bool {
 /// effective on rotational drives.  On SSDs with wear-levelling
 /// the new write may land on a different physical block,
 /// leaving the old ciphertext recoverable until the controller
-/// reclaims that block — there's no way to force a true secure
+/// reclaims that block â€” there's no way to force a true secure
 /// erase from userspace, so this is best-effort.
 fn wipe_cache_files(path: &Path) -> Result<(), CacheError> {
     for suffix in ["", "-wal", "-shm"] {
@@ -1938,7 +2140,7 @@ fn wipe_cache_files(path: &Path) -> Result<(), CacheError> {
                 // Don't refuse the wipe just because the
                 // overwrite step couldn't open the file
                 // (read-only filesystem, locked by another
-                // process, …) — unlinking the file is still
+                // process, â€¦) â€” unlinking the file is still
                 // strictly better than leaving it.
                 tracing::warn!("secure overwrite of {} failed: {e}", p.display());
             }
@@ -1981,7 +2183,7 @@ fn secure_overwrite(path: &Path) -> Result<(), CacheError> {
     Ok(())
 }
 
-// ── Tests ───────────────────────────────────────────────────────
+// â”€â”€ Tests â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
 #[cfg(test)]
 mod tests {
@@ -2171,7 +2373,7 @@ mod tests {
             skip_sent_copy: false,
         };
         let a = cache.enqueue_outbox(&mk("acc-a", "first")).unwrap();
-        // Sleep one second so the queued_at timestamps differ —
+        // Sleep one second so the queued_at timestamps differ â€”
         // SQLite's strftime resolution is per-second.
         std::thread::sleep(std::time::Duration::from_secs(1));
         let b = cache.enqueue_outbox(&mk("acc-b", "second")).unwrap();
@@ -2243,7 +2445,7 @@ mod tests {
 
     /// Regression test for #63: `ORDER BY name` would put `Drafts`
     /// ahead of `INBOX` (uppercase 'I' (0x49) sorts before lowercase
-    /// 'r' (0x72), but only against same-case neighbours — once mixed
+    /// 'r' (0x72), but only against same-case neighbours â€” once mixed
     /// with mixed-case names ASCII order shuffles things). Insertion
     /// order from `upsert_folders` should be preserved verbatim.
     #[test]
@@ -2311,11 +2513,11 @@ mod tests {
 
         cache.wipe_folder("acc", "INBOX").unwrap();
 
-        // INBOX is gone…
+        // INBOX is goneâ€¦
         assert!(cache.get_envelopes("acc", "INBOX", 5).unwrap().is_empty());
         assert!(cache.get_message("acc", "INBOX", 1).unwrap().is_none());
         assert!(cache.get_sync_state("acc", "INBOX").unwrap().is_none());
-        // …but Sent is untouched.
+        // â€¦but Sent is untouched.
         assert_eq!(cache.get_envelopes("acc", "Sent", 5).unwrap().len(), 1);
         assert!(cache.get_message("acc", "Sent", 2).unwrap().is_some());
     }

--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -2205,6 +2205,8 @@ mod tests {
             message_id: None,
             in_reply_to: None,
             references_ids: Vec::new(),
+            thread_id: None,
+            thread_total_count: None,
         }
     }
 

--- a/crates/unkai-store/src/cache/schema.rs
+++ b/crates/unkai-store/src/cache/schema.rs
@@ -1046,6 +1046,44 @@ const MIGRATIONS: &[&str] = &[
     CREATE INDEX IF NOT EXISTS idx_messages_message_id
         ON messages (message_id);
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v31 → v32: stored threading index (#334).
+    //
+    // The frontend used to do all the grouping work at render time
+    // off `message_id` / `references_ids[0]`, and tried to bring in
+    // missing thread members via an IMAP UID SEARCH at every poll.
+    // Result: the conversation-count badge under-reported until the
+    // user scrolled, and even after backfill the count would flicker
+    // because cache reads and IMAP backfill landed at different times.
+    //
+    // New shape:
+    //   - Every cached envelope carries a stable `thread_id` (the
+    //     canonical thread key — `references_ids[0]` for replies, or
+    //     the envelope's own `message_id` for the chain root, with a
+    //     `solo:` fallback for envelopes that have neither).
+    //   - `thread_total_count` is the number of cached members of
+    //     that thread *within this folder*; maintained incrementally
+    //     on upsert / remove / move so reads never have to aggregate.
+    //
+    // Both columns are nullable for the upgrade path — existing rows
+    // start as NULL and get populated by a one-shot warm-up the
+    // first time a folder is read after migration (see
+    // `Cache::assign_pending_thread_ids`).  The frontend hides the
+    // conversation badge while warm-up is in progress so the user
+    // never sees a temporarily-wrong count.
+    r#"
+    ALTER TABLE messages
+        ADD COLUMN thread_id TEXT;
+    ALTER TABLE messages
+        ADD COLUMN thread_total_count INTEGER;
+
+    -- Grouping by thread is the hot path for the MailList view;
+    -- without this index, every fetch would scan the whole folder
+    -- to count members.  Composite with `(account_id, folder)`
+    -- because the count is folder-scoped.
+    CREATE INDEX IF NOT EXISTS idx_messages_thread
+        ON messages (account_id, folder, thread_id);
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6012,6 +6012,9 @@ async fn fetch_envelopes_inner(
     // the sync bookmark; we return the newest `limit` from the cache
     // rather than just the delta, because the UI expects a full list
     // regardless of whether this was an incremental or full sync.
+    // The cache read populates `thread_id` and `thread_total_count`
+    // per row (#334) so the UI's conversation badge paints with the
+    // right number on first frame.
     cache
         .get_envelopes(account_id, folder, limit)
         .map_err(Into::into)
@@ -8579,6 +8582,9 @@ fn get_cached_envelopes(
     limit: u32,
     cache: State<'_, Cache>,
 ) -> Result<Vec<EmailEnvelope>, UnkaiError> {
+    // #334: `get_envelopes` now warms up `thread_id` and computes
+    // `thread_total_count` per row in a single read; no separate
+    // backfill query needed.
     cache
         .get_envelopes(&account_id, &folder, limit)
         .map_err(Into::into)
@@ -8595,6 +8601,25 @@ fn get_unified_cached_envelopes(
 ) -> Result<Vec<EmailEnvelope>, UnkaiError> {
     cache
         .get_unified_envelopes(&folder, limit)
+        .map_err(Into::into)
+}
+
+/// Fetch every cached envelope belonging to a single conversation
+/// in `(account_id, folder)` (#334).  Used by the MailList expand
+/// path: when the user clicks a thread head's chevron we want to
+/// reveal every member the local cache knows about, not just those
+/// that happened to be in the newest-`PAGE_SIZE` window.  Lean
+/// folder-scoped lookup keyed off the stored `thread_id` — no IMAP,
+/// no IPC echoes, just the index hit.
+#[tauri::command]
+fn get_envelopes_by_thread(
+    account_id: String,
+    folder: String,
+    thread_id: String,
+    cache: State<'_, Cache>,
+) -> Result<Vec<EmailEnvelope>, UnkaiError> {
+    cache
+        .get_envelopes_by_thread(&account_id, &folder, &thread_id)
         .map_err(Into::into)
 }
 
@@ -12131,6 +12156,7 @@ fn main() {
             move_messages,
             get_cached_envelopes,
             get_unified_cached_envelopes,
+            get_envelopes_by_thread,
             get_cached_message,
             get_cached_folders,
             test_jmap_connection,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -16,6 +16,9 @@
   "settings_general_file_assoc_hint": "Unkai ist beim Betriebssystem als möglicher Handler registriert. Setzen Sie Unkai in den OS-Einstellungen als Standardprogramm, damit doppelt angeklickte Kalender­einladungen und E-Mail-Dateien hier geöffnet werden.",
   "settings_general_file_assoc_button": "OS-Einstellungen öffnen",
 
+  "settings_mail_conversation_view_label": "Nachrichten nach Konversation gruppieren",
+  "settings_mail_conversation_view_hint": "Antworten desselben Threads werden in einer Zeile mit Aufklapp-Pfeil zusammengefasst. Ausschalten zeigt jede Nachricht als eigene Zeile in zeitlicher Reihenfolge.",
+
   "account_setup_welcome_title": "Willkommen bei Unkai Mail",
   "account_setup_welcome_subtitle": "Lassen Sie uns Ihr E-Mail-Konto einrichten",
   "account_setup_close_label": "Einrichtungsassistenten schließen",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -16,6 +16,9 @@
   "settings_general_file_assoc_hint": "Unkai is registered with your operating system as a possible handler. Mark it as the default in your OS settings to have double-clicked calendar invites and email files open here.",
   "settings_general_file_assoc_button": "Open OS settings",
 
+  "settings_mail_conversation_view_label": "Group messages by conversation",
+  "settings_mail_conversation_view_hint": "Bundle replies in the same thread under a single row with an expand chevron. Turn off to see every message as its own row in date order.",
+
   "account_setup_welcome_title": "Welcome to Unkai Mail",
   "account_setup_welcome_subtitle": "Let's set up your email account",
   "account_setup_close_label": "Close setup wizard",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -601,6 +601,10 @@
     mail_html_white_background: boolean
     auto_load_remote_images: boolean
     auto_advance_after_remove: boolean
+    /** #334 — when off, the MailList renders every envelope as
+     *  its own flat row instead of bundling conversations under a
+     *  single head with an expand chevron.  Default on. */
+    conversation_view_enabled?: boolean
     /** #203: gates reminders for events that carry a meeting URL. */
     meeting_reminders_enabled: boolean
     /** #203: gates reminders for events without a meeting URL. */
@@ -3002,6 +3006,7 @@
               unified={unifiedMode}
               selectedUid={selectedUid}
               refreshToken={refreshToken}
+              conversationView={appPrefs?.conversation_view_enabled ?? true}
               onselect={selectMessage}
               bind:envelopes={mailListEnvelopes}
               bind:refreshing={mailListRefreshing}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -207,6 +207,10 @@
     mail_html_white_background: boolean
     auto_load_remote_images: boolean
     auto_advance_after_remove: boolean
+    /** #334 — when off, the MailList renders every envelope as
+     *  its own row instead of bundling reply chains under one
+     *  conversation head with an expand chevron.  Default on. */
+    conversation_view_enabled: boolean
     /** #165 master toggle for the URLhaus link checker.
      *  Off → no pills, no click interception, refresh worker
      *  sleeps.  On (default) → links in rendered email show
@@ -281,6 +285,7 @@
     mail_html_white_background: true,
     auto_load_remote_images: false,
     auto_advance_after_remove: true,
+    conversation_view_enabled: true,
     link_check_enabled: true,
     default_calendar_id: null,
     meeting_reminders_enabled: true,
@@ -1596,6 +1601,25 @@
             onchange={() => scheduleSave()}
           />
           <span>Show desktop notifications for new mail</span>
+        </div>
+
+        <!-- #334 — group replies into a single conversation row in
+             the MailList.  When off, every envelope renders as its
+             own row (the pre-#277 flat-list behaviour).  The cache
+             still tracks thread_id either way so flipping back on
+             is an immediate re-render with no IMAP traffic. -->
+        <div class="flex items-start gap-3">
+          <Toggle
+            bind:checked={appSettings.conversation_view_enabled}
+            label={m.settings_mail_conversation_view_label()}
+            onchange={() => scheduleSave()}
+          />
+          <div>
+            <span>{m.settings_mail_conversation_view_label()}</span>
+            <p class="text-xs text-surface-400 mt-0.5">
+              {m.settings_mail_conversation_view_hint()}
+            </p>
+          </div>
         </div>
 
         <!-- Auto-load remote images (#197).  Off by default —

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -48,6 +48,22 @@
     message_id?: string | null
     in_reply_to?: string | null
     references_ids?: string[]
+    /** Local cache thread identity (#334).  Stable per
+     *  conversation, computed by the cache on upsert from
+     *  `references_ids[0]` / `message_id` / a `solo:` fallback.
+     *  `null` for envelopes that haven't been warmed up yet
+     *  (e.g. just-arrived rows on a JMAP path that doesn't fill
+     *  threading headers) — the UI hides the conversation badge
+     *  in that transient state. */
+    thread_id?: string | null
+    /** Number of cached members of this thread in
+     *  `(account_id, folder)` (#334).  Read off a per-row SQL
+     *  subquery so it stays correct even when the visible window
+     *  doesn't contain every member.  Combined with the
+     *  `references_ids.length` lower bound at render time so a
+     *  thread whose root is in cache but whose newer replies
+     *  aren't doesn't under-report. */
+    thread_total_count?: number | null
   }
 
   /** Slim account row used to render the account label on each row in
@@ -108,6 +124,13 @@
      *  always sees the latest map without one-shot fire-and-forget
      *  semantics. */
     threadMembersByEnv?: Map<string, EmailEnvelope[]>
+    /** Render conversation grouping (#334).  Default `true` — reply
+     *  chains collapse under one row with an expand chevron.  Set
+     *  `false` to fall back to the pre-#277 flat list where every
+     *  envelope renders as its own row in date order.  Mirrors the
+     *  user's `conversation_view_enabled` app preference; the
+     *  parent passes the current value through. */
+    conversationView?: boolean
   }
   let {
     accounts = [],
@@ -121,6 +144,7 @@
     onmessagemoved,
     refreshing = $bindable(false),
     threadMembersByEnv = $bindable(new Map<string, EmailEnvelope[]>()),
+    conversationView = true,
   }: Props = $props()
 
   // ── Conversation-view grouping (#277) ───────────────────────
@@ -143,7 +167,17 @@
   //      gets its own bucket → behaves like the old flat list.
   let expandedThreads = $state<Set<string>>(new Set())
 
+  /** Pick the conversation key for grouping (#334).  The cache now
+   *  stamps a stable `thread_id` on every envelope during upsert —
+   *  that's the authoritative grouping key.  We keep the header-
+   *  derived fallback for envelopes that haven't gone through the
+   *  warm-up pass yet (a JMAP-fetched row, or a brand-new envelope
+   *  just received from the IMAP path that hasn't been read back
+   *  out of the cache).  Eventually the cache stamps every row and
+   *  the fallback path is dead, but the fallback keeps the UI
+   *  resilient against any race / migration corner case. */
   function threadKeyOf(env: EmailEnvelope): string {
+    if (env.thread_id) return env.thread_id
     if (env.references_ids && env.references_ids.length > 0) {
       return env.references_ids[0]
     }
@@ -188,13 +222,54 @@
     return /^(re|fwd?|aw|wg|sv)\s*(\[\d+\])?\s*:/i.test(subject || '')
   }
 
+  /** Thread keys we've already pulled the full membership for from
+   *  the cache (#334).  Reset on folder change.  Used to skip the
+   *  per-expand IPC round-trip on a thread the user has already
+   *  expanded once. */
+  let expandBackfilled = $state<Set<string>>(new Set())
+
+  /** On-expand: pull every cached member of this thread into
+   *  `envelopes` so the visible list matches the badge count.
+   *  Cache-only (no IMAP) — fast, no network, no surprises.  Solo
+   *  threads (`__solo:` keys) have no other members to find, so we
+   *  skip the call.  Single-account only for now — unified mode
+   *  spans multiple `(account_id, folder)` pairs and would need a
+   *  shaped backfill that's not worth wiring until someone asks. */
+  async function backfillThreadOnExpand(threadKey: string): Promise<void> {
+    if (unified) return
+    if (threadKey.startsWith('__solo:')) return
+    if (expandBackfilled.has(threadKey)) return
+    const idAtCall = accountId
+    const folderAtCall = folder
+    try {
+      const members = await invoke<EmailEnvelope[]>('get_envelopes_by_thread', {
+        accountId: idAtCall,
+        folder: folderAtCall,
+        threadId: threadKey,
+      })
+      // Stale-response guard — same shape as `load()`.
+      if (!isStillCurrent(idAtCall, folderAtCall, false)) return
+      // Mark first so a second expand on the same thread (collapse
+      // + re-expand) doesn't re-issue the round-trip.
+      const next = new Set(expandBackfilled)
+      next.add(threadKey)
+      expandBackfilled = next
+      if (members.length === 0) return
+      envelopes = mergeEnvelopes(envelopes, members)
+    } catch (e) {
+      console.warn('get_envelopes_by_thread failed:', e)
+    }
+  }
+
   function toggleThread(key: string) {
     // Re-assign so Svelte 5 picks up the mutation — Set
     // mutations alone don't trigger reactivity.
     const next = new Set(expandedThreads)
-    if (next.has(key)) next.delete(key)
-    else next.add(key)
+    const expanding = !next.has(key)
+    if (expanding) next.add(key)
+    else next.delete(key)
     expandedThreads = next
+    if (expanding) void backfillThreadOnExpand(key)
   }
 
   /** One row to actually paint.  Heads carry `siblingCount`
@@ -222,6 +297,29 @@
 
   const threadView = $derived.by(():
     | { rows: RenderRow[]; threadMembersByEnv: Map<string, EmailEnvelope[]> } => {
+    // #334: Conversation grouping can be disabled by the user.  In
+    // flat mode we emit one row per envelope and skip every
+    // bucket / JWZ / orphan-merge pass.  Synthetic per-envelope
+    // threadKey so the rest of the UI (selection, drag, archive-
+    // affected-envelopes lookup) still has a stable handle to key
+    // off; nothing groups by it because the keys are all distinct.
+    if (!conversationView) {
+      const rows: RenderRow[] = envelopes.map((env) => ({
+        env,
+        siblingCount: 0,
+        isSibling: false,
+        isLastSibling: false,
+        threadKey: `__solo:${env.account_id}:${env.uid}`,
+      }))
+      // Each envelope is its own one-member "bucket" so consumers
+      // that read `threadMembersByEnv` (Archive's sweep-the-thread
+      // path) just see the single envelope and do nothing extra.
+      const single = new Map<string, EmailEnvelope[]>()
+      for (const env of envelopes) {
+        single.set(envKey(env), [env])
+      }
+      return { rows, threadMembersByEnv: single }
+    }
     // Bucket envelopes by thread key, preserving the bucket
     // order in which the *first* member appears (envelopes are
     // already date-sorted newest-first).
@@ -366,9 +464,31 @@
       if (!group) continue
       const head = group[0]
       const siblings = group.slice(1)
+      // #334: pick the authoritative member count for the badge.
+      //  1. `thread_total_count` from the cache — what the local DB
+      //     actually contains for this thread within this folder.
+      //     This is the truth source: moves and deletes update it
+      //     because the SQL aggregate is folder-scoped and skips
+      //     `pending_action` tombstones.
+      //  2. The visible group size — never under-report what's on
+      //     screen (cold-cache races aside, this stays ≤ cachedTotal).
+      //
+      // We deliberately do NOT use the References-chain depth as a
+      // lower bound: while it correctly reflects what *once existed*
+      // in the conversation, it can't see deletions/moves, so it
+      // over-reports for threads whose older members were
+      // archived or trashed (the badge would say "4" when only 2
+      // are actually in this folder).
+      let cachedTotal = 0
+      for (const m of group) {
+        if (typeof m.thread_total_count === 'number' && m.thread_total_count > cachedTotal) {
+          cachedTotal = m.thread_total_count
+        }
+      }
+      const totalCount = Math.max(group.length, cachedTotal)
       out.push({
         env: head,
-        siblingCount: siblings.length,
+        siblingCount: totalCount - 1,
         isSibling: false,
         isLastSibling: false,
         threadKey: key,
@@ -921,6 +1041,15 @@
     if (key !== lastFolderKey) {
       envelopes = []
       lastFolderKey = key
+      // #334: on-expand backfill is folder-scoped — start the new
+      // folder with a fresh "haven't pulled the rest of any thread
+      // yet" slate.
+      expandBackfilled = new Set()
+      // #334: suppress the conversation badge until the eager
+      // prefetch for this folder has settled.  Without this the
+      // badge briefly shows the cache-as-of-now count, then jumps
+      // as the prefetch lands more thread members.
+      prefetchSettled = false
     }
     loadingOlder = false
     olderExhausted = false
@@ -1031,13 +1160,27 @@
     }
   }
 
-  /** Compute the smallest UID per account in the currently-rendered
-   *  envelope list — the anchor for the next "load older" round.
-   *  Returned as a Map<accountId, smallestUid> for the unified mode,
-   *  or as a single number for single-account mode. */
+  /** The "main pagination window" — the newest PAGE_SIZE envelopes
+   *  by date, excluding any thread-member extras the cache merged
+   *  in beyond that window (#334).  We can't anchor `loadOlder` on
+   *  the absolute-smallest UID across `envelopes` because thread
+   *  extras may have older UIDs than the newest-PAGE_SIZE main
+   *  window — using them as the cursor would cause `loadOlder` to
+   *  skip the intervening UIDs.  Sort then slice gives us the
+   *  same set the UI considers "the current page". */
+  function paginationWindow(): EmailEnvelope[] {
+    if (envelopes.length <= PAGE_SIZE) return envelopes
+    const sorted = [...envelopes].sort((a, b) => b.date.localeCompare(a.date))
+    return sorted.slice(0, PAGE_SIZE)
+  }
+
+  /** Compute the smallest UID per account in the main pagination
+   *  window — the anchor for the next "load older" round.  Returned
+   *  as a Map<accountId, smallestUid> for the unified mode, or as a
+   *  single number for single-account mode. */
   function smallestUidPerAccount(): Map<string, number> {
     const out = new Map<string, number>()
-    for (const e of envelopes) {
+    for (const e of paginationWindow()) {
       const prev = out.get(e.account_id)
       if (prev === undefined || e.uid < prev) {
         out.set(e.account_id, e.uid)
@@ -1086,7 +1229,11 @@
           limit: PAGE_SIZE,
         })
       } else {
-        const smallest = envelopes.reduce<number | null>(
+        // Smallest UID in the main pagination window — thread-member
+        // extras (#334) may have older UIDs but they aren't part of
+        // the visible page sequence, so anchoring on them would cause
+        // the next round to skip over real messages.
+        const smallest = paginationWindow().reduce<number | null>(
           (acc, e) => (acc === null || e.uid < acc ? e.uid : acc),
           null,
         )
@@ -1165,14 +1312,36 @@
    *  folder; subsequent pages still come via the scroll-based
    *  trigger. */
   let prefetchedFor = $state<string | null>(null)
+  /** Has the initial eager prefetch for the current folder *settled*
+   *  (returned, regardless of outcome)?  #334: while it's in flight,
+   *  the conversation-count badge can still be growing — a thread
+   *  whose older members are about to arrive will report a too-low
+   *  count from the cache.  We suppress the badge during this brief
+   *  window so the user never sees a "2 → 4" jump; once the
+   *  prefetch lands and the cache has the right shape, the badge
+   *  pops in at the correct number. */
+  let prefetchSettled = $state<boolean>(false)
   $effect(() => {
     const key = `${unified ? '__all__' : accountId}::${folder}`
     if (prefetchedFor === key) return
     if (loading || loadingOlder) return
     if (envelopes.length === 0) return
-    if (olderExhausted) return
+    if (olderExhausted) {
+      // No older page to fetch — nothing to wait for; badge is as
+      // stable as it'll ever get.
+      prefetchedFor = key
+      prefetchSettled = true
+      return
+    }
     prefetchedFor = key
-    void loadOlder()
+    prefetchSettled = false
+    void loadOlder().finally(() => {
+      // Re-check the key in case the user changed folders before
+      // the round-trip landed; in that case `lastFolderKey` has
+      // moved on and our settle signal would be stale.
+      const liveKey = `${unified ? '__all__' : accountId}::${folder}`
+      if (liveKey === key) prefetchSettled = true
+    })
   })
 
   // ── Answered-indicator (#255) ───────────────────────────────
@@ -1530,9 +1699,9 @@
                      trails to the right via `ml-auto`.  Only renders
                      if at least one piece has content; otherwise the
                      row stays compact. -->
-                {#if row.siblingCount > 0 || (unified && env.account_id)}
+                {#if (row.siblingCount > 0 && prefetchSettled) || (unified && env.account_id)}
                   <div class="flex items-center gap-2 mt-1 text-[11px] text-surface-500 min-w-0">
-                    {#if row.siblingCount > 0}
+                    {#if row.siblingCount > 0 && prefetchSettled}
                       <!-- Modern pill badge: rounded-full, soft
                            primary tint, primary-coloured count, and
                            an inline SVG chevron that rotates 180° on


### PR DESCRIPTION
## Summary

- Conversation counts are now stored on each envelope (`thread_id` + folder-scoped SQL aggregate) instead of recomputed from the visible window on every render, so the MailList badge paints correctly on first frame and stays stable across folder switches, deletes, and moves.
- On-expand backfill: clicking the chevron now pulls every cached member of that thread into the visible list, so expand always matches the badge.
- New **Settings → E-Mail → "Group messages by conversation"** toggle (default on) — off falls back to the pre-#277 flat row-per-envelope list; the cache keeps stamping `thread_id` either way, so toggling back on is a free re-render.

## Changes

**Schema (v32):**
- New `messages.thread_id` and `thread_total_count` columns + `idx_messages_thread` index.

**Backend:**
- `Cache::compute_thread_id` (references_ids[0] → message_id → `solo:` fallback) stamped on every upsert.
- `Cache::assign_pending_thread_ids` warm-up runs at the head of every cache read so pre-migration rows pick up a `thread_id` without a separate migration pass.
- `get_envelopes` / unified read paths return `thread_id` + a correlated `COUNT(*)` subquery scoped by `(account_id, folder, thread_id)` with `pending_action IS NULL` so optimistic moves/deletes update the count immediately.
- New `get_envelopes_by_thread` Tauri command for the on-expand backfill.

**Frontend:**
- `threadView` groups by stored `thread_id` (header fallback kept as a safety net for fresh-off-the-wire envelopes); badge = `max(group.length, cached thread_total_count)`. No more references_ids heuristic — it over-reported after deletes/moves.
- New `expandBackfilled` state + `backfillThreadOnExpand` round-trip; first expand fetches, subsequent toggles reuse loaded members.
- Eager-prefetch settle gate (`prefetchSettled`) hides the conversation badge until the initial loadOlder round returns, so the user never sees the cache-as-of-now count flash before the prefetch lands more members.

**Settings:**
- New `conversation_view_enabled` field on `AppSettings` (Rust + TS), default true. Toggle UI sits in Settings → E-Mail above "Auto-load remote images". Live — flipping it re-renders MailList immediately. EN + DE paraglide strings added.

**Removed:**
- `Cache::get_envelopes_with_thread_members`, `Cache::get_thread_members`, `IMAP::fetch_thread_members`, `get_thread_members_cached` Tauri command, frontend cache-backfill effect, all `[#334]` diagnostic logs.

## Test plan

- [x] Open Sent cold (after migration). Test thread shows the correct count on first frame without a 2→4 jump.
- [x] Switch between folders rapidly. Counts stay stable, never flicker to a wrong value.
- [x] Expand a thread head whose older members aren't in the newest 50. Every member listed in the badge actually appears.
- [x] Move or archive one message of a multi-member thread. Source folder's badge drops by one on the next read; destination's grows.
- [x] Settings → E-Mail → toggle "Group messages by conversation" off. MailList re-renders as a flat list, no chevrons. Toggle back on — conversation rows return immediately.
- [x] Settings → E-Mail → toggle off, restart the app. Setting persists.
- [ ] DE locale: Settings strings render in German.

Closes #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)