### PR TITLE
Add GitHub issue templates (closes #349)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,142 @@
+name: Bug report
+description: Report something that isn't working in Unkai Mail.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. The more detail you give, the faster we can reproduce and fix the problem.
+
+        **Before submitting:** please search the [existing issues](https://github.com/firn-labs/unkai-mail/issues?q=is%3Aissue) to make sure this hasn't already been reported.
+
+        If you believe this is a **security vulnerability**, please do not file a public issue — use the [private security advisory form](https://github.com/firn-labs/unkai-mail/security/advisories/new) instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I have searched the existing issues and this bug has not already been reported.
+          required: true
+        - label: I am running the latest available version of Unkai Mail (or have noted the version below).
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps the team can follow to reproduce the bug on a fresh install.
+      placeholder: |
+        1. Open Unkai Mail
+        2. Go to '...'
+        3. Click on '...'
+        4. See the error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include exact error messages if any.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: e.g. Windows 11 23H2, macOS 14.4, Ubuntu 24.04
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: Unkai Mail version
+      description: Shown in the app's About panel, or in the installer filename (e.g. unkai-mail_0.3.1_x64-setup.exe).
+      placeholder: e.g. 0.3.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the app does this bug affect?
+      options:
+        - Mail (IMAP / SMTP / JMAP)
+        - Encryption / PGP
+        - Nextcloud integration (Talk / Files / OCS)
+        - Contacts (CardDAV)
+        - Calendar (CalDAV)
+        - Account setup / authentication
+        - UI / rendering
+        - Settings
+        - Installer / startup / crash
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: account-setup
+    attributes:
+      label: Account / server setup (if relevant)
+      description: |
+        If the bug involves a specific provider or server, describe the setup at a high level.
+        **Do not paste passwords, app tokens, or full email addresses.** Provider name and protocol are enough.
+      placeholder: |
+        - Provider: Nextcloud (self-hosted, version 28.0.4)
+        - Protocols in use: IMAP + SMTP via STARTTLS
+        - Account type: standard password / OAuth / app password
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or screen recording
+      description: |
+        Attach any relevant logs, screenshots, or short screen recordings. Drag-and-drop files into this field to upload them.
+        **Please redact email addresses, message contents, and any other personal data before uploading.**
+      placeholder: Paste log output here, or drop files into this field.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help — when the bug started, workarounds you tried, related issues, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/firn-labs/unkai-mail/security/advisories/new
+    about: Please report security issues privately via GitHub Security Advisories rather than opening a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,78 @@
+name: Feature request
+description: Suggest a new feature or improvement for Unkai Mail.
+title: "[Feature]: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. The more concrete the use case, the easier it is to scope and prioritise.
+
+        **Before submitting:** please search the [existing issues](https://github.com/firn-labs/unkai-mail/issues?q=is%3Aissue) to check whether this idea has already been raised.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I have searched the existing issues and this feature has not already been requested.
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A one- or two-sentence description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you trying to do today, and why is the current behaviour insufficient?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How do you imagine this working? UI sketches, sample workflows, or rough API ideas are all welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered, and why you'd rather see the proposed solution.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the app does this feature touch?
+      options:
+        - Mail (IMAP / SMTP / JMAP)
+        - Encryption / PGP
+        - Nextcloud integration (Talk / Files / OCS)
+        - Contacts (CardDAV)
+        - Calendar (CalDAV)
+        - Account setup / authentication
+        - UI / UX
+        - Settings
+        - Build / CI / packaging
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mock-ups, links to similar features elsewhere, related issues, RFC references, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,58 @@
+name: Question / Support
+description: Ask a question about using Unkai Mail or get help with setup.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for usage questions, configuration help, or "is this supposed to work this way?" enquiries.
+
+        **Before submitting:** please check the [README](https://github.com/firn-labs/unkai-mail/blob/main/README.md) and search [existing issues](https://github.com/firn-labs/unkai-mail/issues?q=is%3Aissue) — your question may already have been answered.
+
+        If you're hitting an error or something that looks broken, please use the **Bug report** template instead.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight checks
+      options:
+        - label: I have checked the README and searched existing issues for an answer.
+          required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What are you trying to do?
+      description: Describe the goal you're working toward — that often lets us suggest a better path than the one you're asking about.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Not applicable / general question
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: Unkai Mail version
+      description: If relevant. Shown in the app's About panel, or in the installer filename.
+      placeholder: e.g. 0.3.1
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Adds structured YAML issue forms for bug reports, feature requests, and questions under `.github/ISSUE_TEMPLATE/`.
- Disables blank issues via `config.yml` so reporters must pick a template.
- Redirects security reports to the private GitHub Security Advisory form rather than letting them be filed publicly.

Closes #349.

## What's in each template
- **bug_report.yml** — required fields for repro steps, expected vs actual, OS, Unkai version, and an affected-area dropdown (Mail / Encryption / Nextcloud / Contacts / Calendar / Auth / UI / Settings / Installer / Other). Optional account-setup and logs/screenshots fields with a redaction reminder.
- **feature_request.yml** — required summary, motivation, proposed solution; optional alternatives; affected-area dropdown.
- **question.yml** — lightweight support template that points reporters at the bug template if they're actually hitting an error.
- **config.yml** — `blank_issues_enabled: false`, plus a contact link to `…/security/advisories/new` for vulnerability reports.

## Test plan
- [ ] After merge, open https://github.com/firn-labs/unkai-mail/issues/new/choose and confirm the three templates render correctly with all fields.
- [ ] Confirm the "Report a security vulnerability" link is visible on the chooser page and routes to the private advisory form.
- [ ] Confirm filing a blank issue is no longer possible.
- [ ] File a test bug report end-to-end to verify required-field validation kicks in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)