### PR TITLE
#341: PGP reply/forward — decrypt-before-quote, auto-encrypt on reply, recipient-key warning

### DIFF
--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -363,6 +363,86 @@ fn apply_pgp_envelope(
     }
 }
 
+/// #341 follow-up to #57 — pull the bytes of a single attachment out
+/// of a PGP/MIME encrypted message, decrypting through the supplied
+/// bridge so the part_id indexes into the *decrypted inner MIME tree*
+/// rather than the encrypted outer envelope.
+///
+/// Counterpart to `IMAPClient::fetch_attachment` for the encrypted
+/// case.  The receive path parses the decrypted plaintext and stamps
+/// `EmailAttachment.part_id` as a sequential index into the *inner*
+/// tree (the real user attachments), but `fetch_attachment` re-parses
+/// the raw IMAP bytes — which are still the `multipart/encrypted`
+/// outer envelope — and walks those with the inner index.  For a
+/// real attachment at inner `part_id = 0` that lookup returns the
+/// outer envelope's `application/pgp-encrypted` "Version: 1" header
+/// instead of the actual file bytes.  This function bridges the gap
+/// by decrypting first and walking the inner tree with the same
+/// `attachments()` / `parts` fallback `fetch_attachment` uses.
+///
+/// Returns `Ok(None)` if `raw` isn't a PGP/MIME envelope at all so
+/// the caller can fall back to the plaintext path.  Returns
+/// `Err(Protocol)` when the inner tree doesn't carry the requested
+/// `part_id` — typically a sign the caller is mixing inner / outer
+/// indices and should be routed through `fetch_attachment` instead.
+pub fn extract_decrypted_attachment(
+    raw: &[u8],
+    bridge: &dyn CryptoBridge,
+    part_id: u32,
+) -> Result<Option<(EmailAttachment, Vec<u8>)>, UnkaiError> {
+    let envelope = match detect_pgp_mime_envelope(raw)? {
+        Some(e) => e,
+        None => return Ok(None),
+    };
+    let ciphertext_armor = match envelope {
+        PgpMimeEnvelope::Encrypted { ciphertext_armor } => ciphertext_armor,
+        // `multipart/signed` carries its parts in cleartext already,
+        // so an attachment fetch against a signed-only envelope is
+        // the regular IMAP path — tell the caller to fall back.
+        PgpMimeEnvelope::Signed => return Ok(None),
+    };
+    let payload = bridge.decrypt(&ciphertext_armor)?;
+    let parsed = MessageParser::default()
+        .parse(payload.plaintext.as_slice())
+        .ok_or_else(|| UnkaiError::Protocol("Failed to parse decrypted message".into()))?;
+
+    // Same primary-then-fallback lookup `fetch_attachment` uses so
+    // a part_id assigned during the listing parse always resolves
+    // to the same byte slice during fetch — wherever the index was
+    // first stamped from.
+    let part = parsed
+        .attachment(part_id)
+        .or_else(|| parsed.parts.get(part_id as usize))
+        .ok_or_else(|| {
+            UnkaiError::Protocol(format!("Decrypted inner MIME tree has no part #{part_id}"))
+        })?;
+
+    let filename = decode_attachment_filename(&parsed, part);
+    let content_type = part
+        .content_type()
+        .map(|ct| {
+            let ctype = ct.ctype();
+            match ct.subtype() {
+                Some(sub) => format!("{ctype}/{sub}"),
+                None => ctype.to_string(),
+            }
+        })
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let data = part.contents().to_vec();
+    let size = Some(data.len() as u64);
+    let content_id = part.content_id().map(|s| s.to_string());
+    Ok(Some((
+        EmailAttachment {
+            filename,
+            content_type,
+            size,
+            part_id,
+            content_id,
+        },
+        data,
+    )))
+}
+
 /// `async-imap`'s `Session` is generic over its underlying I/O. We
 /// pin the alias to the concrete `Compat<TlsStream<TcpStream>>` so
 /// downstream callers don't have to think about the four layers of

--- a/crates/unkai-imap/src/lib.rs
+++ b/crates/unkai-imap/src/lib.rs
@@ -8,6 +8,6 @@ mod client;
 mod mutf7;
 
 pub use client::{
-    EnvelopeBatch, FlagSnapshot, ImapClient, parse_eml_bytes, parse_eml_bytes_with_crypto,
-    probe_server_certificate,
+    EnvelopeBatch, FlagSnapshot, ImapClient, extract_decrypted_attachment, parse_eml_bytes,
+    parse_eml_bytes_with_crypto, probe_server_certificate,
 };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6911,6 +6911,52 @@ async fn download_email_attachment(
     Ok(data)
 }
 
+/// Counterpart to `download_email_attachment` for PGP/MIME messages
+/// (#341 follow-up to #57).  The plain command walks the *outer*
+/// `multipart/encrypted` envelope with whatever `part_id` it gets,
+/// which for a decrypted message would return the `Version: 1`
+/// header part instead of the real attachment bytes — `EmailAttachment.part_id`
+/// on a decrypted message indexes the *inner* tree.  This command
+/// pulls the raw IMAP bytes, decrypts through the bridge built from
+/// the account's stored key + the freshly-prompted passphrase, walks
+/// the inner tree with the same primary-then-fallback `attachments()`
+/// / `parts` lookup the plaintext path uses, and returns those bytes.
+///
+/// IMAP only — JMAP encrypted attachment download needs the same
+/// `Blob/get` plumbing as the JMAP body-decrypt fallback (#341).
+#[tauri::command]
+async fn download_decrypted_attachment(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    part_id: u32,
+    pgp_passphrase: String,
+    cache: State<'_, Cache>,
+) -> Result<Vec<u8>, UnkaiError> {
+    let account = load_account(&cache, &account_id)?;
+    if uses_jmap(&account) {
+        return Err(UnkaiError::Protocol(
+            "JMAP encrypted attachment download needs Blob/get plumbing — \
+             switch the account to IMAP to download decrypted attachments"
+                .into(),
+        ));
+    }
+    let bridge = TauriCryptoBridge::for_account(&account_id, &pgp_passphrase, (*cache).clone())?;
+    let mut client = connect_imap(&account).await?;
+    let raw = client.fetch_raw_message(&folder, uid).await?;
+    let _ = client.logout().await;
+    match unkai_imap::extract_decrypted_attachment(&raw, &bridge, part_id)? {
+        Some((_meta, data)) => Ok(data),
+        // Not a PGP/MIME envelope — the caller should be on
+        // `download_email_attachment` for this message.  Surfacing
+        // as a typed error rather than silently falling through
+        // keeps the UI's encryption-aware routing honest.
+        None => Err(UnkaiError::Protocol(
+            "Message is not PGP-encrypted; use download_email_attachment".into(),
+        )),
+    }
+}
+
 // ── Attachment preview cache (#157) ──────────────────────────
 //
 // Persists frontend-generated thumbnails alongside the cached
@@ -12892,6 +12938,7 @@ fn main() {
             fetch_older_unified_envelopes,
             fetch_message,
             download_email_attachment,
+            download_decrypted_attachment,
             put_attachment_preview,
             get_attachment_previews,
             download_calendar_from_message,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -292,6 +292,7 @@
   "encryption_import_submit": "Importieren",
   "encryption_import_cancel": "Abbrechen",
 
+  "mail_view_attachment_decrypt_required": "Bitte geben Sie Ihre Passphrase erneut über die Schaltfläche Entschlüsseln unten ein, um diesen Anhang zu öffnen.",
   "mail_view_cannot_decrypt_banner": "Diese Nachricht ist verschlüsselt. Der Server liefert die Rohbytes nicht aus, daher kann sie hier nicht entschlüsselt werden – öffne sie über IMAP oder einen Desktop-PGP-Client.",
   "mail_view_chip_decrypted": "Entschlüsselt",
   "mail_view_chip_encrypted": "Verschlüsselt",

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -102,6 +102,18 @@
   "compose_forward_attachments_skip": "Ohne Anhänge weiterleiten",
   "compose_forward_attachments_download_failed": "Einige Anhänge konnten nicht geladen werden: {reason}",
 
+  "compose_pgp_recipient_no_key_title": "Kein PGP-Schlüssel für einige Empfänger",
+  "compose_pgp_recipient_no_key_body": "Für folgende Adressen liegt kein öffentlicher Schlüssel vor: {addresses}. Der verschlüsselte Versand schlägt fehl, bis ein Schlüssel importiert oder die Adresse entfernt wird.",
+
+  "mail_decrypt_for_reply_title": "Zum Antworten entschlüsseln",
+  "mail_decrypt_for_reply_body": "Geben Sie Ihre PGP-Passphrase ein, um die Nachricht von {sender} zu entschlüsseln, damit Ihre Antwort den Originaltext zitieren kann.",
+  "mail_decrypt_for_forward_title": "Zum Weiterleiten entschlüsseln",
+  "mail_decrypt_for_forward_body": "Geben Sie Ihre PGP-Passphrase ein, um die Nachricht von {sender} zu entschlüsseln, damit die Weiterleitung den Originaltext enthält.",
+  "mail_decrypt_passphrase_label": "PGP-Passphrase",
+  "mail_decrypt_cancel_button": "Abbrechen",
+  "mail_decrypt_submit_button": "Entschlüsseln",
+  "mail_decrypt_busy_button": "Entschlüsseln …",
+
   "nc_share_set_expiration_label": "Ablaufdatum festlegen",
   "nc_share_expiration_aria": "Ablaufdatum für den Freigabelink auswählen",
   "nc_share_expiration_hint": "Empfänger können den Link nach diesem Datum nicht mehr öffnen.",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -292,6 +292,7 @@
   "encryption_import_cancel": "Cancel",
 
   "mail_view_cannot_decrypt_banner": "This message is encrypted. The server didn't expose the raw bytes so it can't be decrypted here — open it via IMAP or a desktop PGP client.",
+  "mail_view_attachment_decrypt_required": "Please re-enter your passphrase via the Decrypt button below to open this attachment.",
   "mail_view_chip_decrypted": "Decrypted",
   "mail_view_chip_encrypted": "Encrypted",
   "mail_view_chip_signed_valid": "Signed by {fp}",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -101,6 +101,18 @@
   "compose_forward_attachments_skip": "Forward without",
   "compose_forward_attachments_download_failed": "Could not load some attachments: {reason}",
 
+  "compose_pgp_recipient_no_key_title": "No PGP key for some recipients",
+  "compose_pgp_recipient_no_key_body": "We don't have a public key on file for: {addresses}. The encrypted send will fail until you import a key or remove these recipients.",
+
+  "mail_decrypt_for_reply_title": "Decrypt to reply",
+  "mail_decrypt_for_reply_body": "Enter your PGP passphrase to decrypt the message from {sender} so your reply can quote the original content.",
+  "mail_decrypt_for_forward_title": "Decrypt to forward",
+  "mail_decrypt_for_forward_body": "Enter your PGP passphrase to decrypt the message from {sender} so the forward carries the original content.",
+  "mail_decrypt_passphrase_label": "PGP passphrase",
+  "mail_decrypt_cancel_button": "Cancel",
+  "mail_decrypt_submit_button": "Decrypt",
+  "mail_decrypt_busy_button": "Decrypting…",
+
   "nc_share_set_expiration_label": "Set expiration date",
   "nc_share_expiration_aria": "Pick expiration date for the share link",
   "nc_share_expiration_hint": "Recipients can't open the link after this date.",

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1063,6 +1063,14 @@
       }>('compose-from-mail', (e) => {
         const { kind, mail } = e.payload
         void (async () => {
+          // #341 — same decrypt-before-quoting hook as the
+          // in-window onReply / onReplyAll / onForward path, so a
+          // popped-out reply / forward against an encrypted source
+          // doesn't open a blank quoted block either.  Returns
+          // null if the user cancels the prompt; we abort the
+          // popout open entirely in that case.
+          const ready = await ensureDecryptedForReply(mail, kind)
+          if (!ready) return
           // Forward needs the async builder so the
           // include-attachments popup (#329) and the
           // download_email_attachment fan-out can run before the
@@ -1071,12 +1079,12 @@
           // the original attachments.
           const initial: ComposeInitial =
             kind === 'reply'
-              ? buildReplyInitial(mail)
+              ? buildReplyInitial(ready)
               : kind === 'reply-all'
-                ? buildReplyAllInitial(mail)
-                : await buildForwardInitialForPopout(mail)
+                ? buildReplyAllInitial(ready)
+                : await buildForwardInitialForPopout(ready)
           void openComposeInStandaloneWindow({
-            accountId: mail.account_id,
+            accountId: ready.account_id,
             initial,
           }).catch((err) =>
             console.warn('openComposeInStandaloneWindow from #304 failed', err),
@@ -1911,6 +1919,13 @@
     message_id?: string | null
     in_reply_to?: string | null
     references_ids?: string[]
+    /** Kebab-case protection tag from the receive path (#57).  Used
+     *  by the Reply / Forward path (#341) to detect that the source
+     *  message is encrypted: if so, the quoted-history builder needs
+     *  to decrypt the body first (or the new draft would carry an
+     *  empty "On <date> X wrote:" block), and Reply pre-enables the
+     *  Encryption tab toggle so the thread stays encrypted. */
+    protection?: string | null
   }
 
   /** Reply / reply-all / "respond with meeting" need to know
@@ -1946,11 +1961,42 @@
   // Compose window instead of the in-window modal — without the
   // shared helpers, the popout path would silently drift away
   // from the main-window flow on every future tweak.
+  /** #341 — does this message carry a PGP-encrypted payload?  Both
+   *  the encrypt-only and the signed-and-encrypted variants from
+   *  the receive path qualify.  The third `"encrypted-cannot-decrypt"`
+   *  state from the JMAP-no-raw-blob fallback is intentionally
+   *  excluded — we can't decrypt those locally so the Reply/Forward
+   *  flow can't carry a quoted body anyway. */
+  function wasEncrypted(mail: OpenMail): boolean {
+    const p = mail.protection
+    return p === 'encrypted' || p === 'signed-and-encrypted'
+  }
+
+  /** #341 — does the cached body actually need a decrypt round-trip?
+   *  Only true when the message was encrypted *and* neither plain
+   *  text nor HTML body is sitting in the local cache.  When the
+   *  user has already clicked Decrypt in MailView, the cache row
+   *  carries the plaintext and we can build the quoted-history
+   *  block straight from it without re-prompting. */
+  function needsDecryptForReply(mail: OpenMail): boolean {
+    if (!wasEncrypted(mail)) return false
+    const hasText = (mail.body_text ?? '').trim().length > 0
+    const hasHtml = (mail.body_html ?? '').trim().length > 0
+    return !hasText && !hasHtml
+  }
+
   function buildReplyInitial(mail: ReplyableMail): ComposeInitial {
     return {
       to: mail.from,
       subject: replySubject(mail.subject),
       body: quoteBody(mail.from, mail.date, mail.body_text, mail.body_html),
+      // #341 — Reply to an encrypted thread keeps the thread
+      // encrypted by default.  The Compose layer reads this and
+      // pre-flips the Encryption-tab toggle on; the user can still
+      // click it back off if they want to send plaintext.  Forward
+      // does *not* pre-enable encryption: the user is changing
+      // recipients and the new target may not have a key.
+      encryptByDefault: wasEncrypted(mail),
       repliedTo: {
         accountId: mail.account_id,
         folder: mail.folder,
@@ -1975,6 +2021,8 @@
       cc: others.join(', '),
       subject: replySubject(mail.subject),
       body: quoteBody(mail.from, mail.date, mail.body_text, mail.body_html),
+      // #341 — same rationale as buildReplyInitial.
+      encryptByDefault: wasEncrypted(mail),
       repliedTo: {
         accountId: mail.account_id,
         folder: mail.folder,
@@ -1986,12 +2034,127 @@
     }
   }
 
+  /** #341 — promise-based passphrase prompt for Reply / Forward on
+   *  an encrypted message that hasn't been decrypted yet.  Held as
+   *  `{ kind, fromName, resolve, error?, busy }` so the async
+   *  reply/forward flow below can `await` the user's input via a
+   *  promise; the modal's buttons (and the backdrop dismiss) call
+   *  `resolveDecryptPrompt` and clear this state.  `error` and
+   *  `busy` are flipped by the wrapper that calls `decrypt_message`
+   *  so a wrong passphrase keeps the modal up with a visible
+   *  message instead of forcing the user to re-click Reply. */
+  type DecryptPromptKind = 'reply' | 'reply-all' | 'forward'
+  let pendingDecryptPrompt = $state<{
+    kind: DecryptPromptKind
+    fromName: string
+    resolve: (passphrase: string | null) => void
+    error: string
+    busy: boolean
+    /** Bound to the password input — kept on the prompt object
+     *  rather than as a top-level `$state` so reopening the modal
+     *  for a different message can't carry over a value the user
+     *  typed for the previous one. */
+    value: string
+  } | null>(null)
+
+  function resolveDecryptPrompt(passphrase: string | null) {
+    if (!pendingDecryptPrompt) return
+    if (pendingDecryptPrompt.busy) return
+    // Snapshot the resolver before clearing so the closure isn't
+    // racing the state mutation; the busy guard above means we
+    // never race the in-flight decrypt_message call.
+    const { resolve } = pendingDecryptPrompt
+    pendingDecryptPrompt = null
+    resolve(passphrase)
+  }
+
+  /** #341 — if the source message is encrypted but not yet decrypted,
+   *  prompt the user for their passphrase, run `decrypt_message`,
+   *  and return a copy of the mail with the plaintext body fields
+   *  filled in.  On wrong passphrase the modal stays up with an
+   *  inline error (the user re-tries inside the same prompt).  On
+   *  cancel returns `null` so the caller can abort the Reply /
+   *  Forward open instead of pushing an empty quoted-history into
+   *  Compose.  Pass-through when the mail is plaintext or the
+   *  cached body is already populated. */
+  async function ensureDecryptedForReply<T extends ReplyableMail>(
+    mail: T,
+    kind: DecryptPromptKind,
+  ): Promise<T | null> {
+    if (!needsDecryptForReply(mail)) return mail
+    let lastError = ''
+    while (true) {
+      const passphrase = await new Promise<string | null>((resolve) => {
+        pendingDecryptPrompt = {
+          kind,
+          fromName: mail.from,
+          resolve,
+          error: lastError,
+          busy: false,
+          value: '',
+        }
+      })
+      if (passphrase == null) {
+        // User dismissed — clear the modal (the resolver clears
+        // `pendingDecryptPrompt` itself only when called via
+        // `resolveDecryptPrompt`; resolving directly through the
+        // closure above doesn't touch the state object).
+        pendingDecryptPrompt = null
+        return null
+      }
+      // Flip the same modal into a busy frame so the user sees
+      // immediate feedback while the IMAP fetch + rpgp decrypt run.
+      pendingDecryptPrompt = {
+        kind,
+        fromName: mail.from,
+        resolve: () => {},
+        error: '',
+        busy: true,
+        value: passphrase,
+      }
+      try {
+        const decrypted = await invoke<{
+          body_text: string | null
+          body_html: string | null
+        }>('decrypt_message', {
+          accountId: mail.account_id,
+          folder: mail.folder,
+          uid: mail.uid,
+          pgpPassphrase: passphrase,
+        })
+        pendingDecryptPrompt = null
+        return {
+          ...mail,
+          body_text: decrypted.body_text,
+          body_html: decrypted.body_html,
+        }
+      } catch (e) {
+        // Strip the `Crypto: ` variant prefix from UnkaiError (same
+        // idiom MailView's runDecrypt uses) so the message reads as
+        // a clean sentence rather than a typed-enum dump.  Loop
+        // around — the next iteration re-mounts the prompt with
+        // `error` populated so the user can retry without losing
+        // their place.
+        const raw = formatError(e) || 'Decrypt failed'
+        lastError = raw.replace(/^Crypto:\s*/i, '')
+      }
+    }
+  }
+
   function onReply(mail: ReplyableMail) {
-    openCompose(buildReplyInitial(mail))
+    void (async () => {
+      const ready = await ensureDecryptedForReply(mail, 'reply')
+      if (!ready) return
+      openCompose(buildReplyInitial(ready))
+    })()
   }
 
   function onReplyAll(mail: ReplyableMail) {
-    openCompose(buildReplyAllInitial(mail))
+    void (async () => {
+      const ready = await ensureDecryptedForReply(mail, 'reply-all')
+      if (!ready) return
+      openCompose(buildReplyAllInitial(ready))
+    })()
   }
 
   /** Does the given folder name look like the account's Drafts folder?
@@ -2184,14 +2347,21 @@
    *  closes the Compose before the download finishes, the
    *  injection is dropped silently (lookup misses). */
   async function onForward(mail: ForwardableMail) {
-    const composeId = openCompose(buildForwardInitial(mail))
-    if (mail.attachments.length === 0) return
+    // #341 — decrypt the source body before we build the forward
+    // initial so the quoted block actually carries the original
+    // content.  Without this, forwarding an unopened encrypted
+    // message would put a "Forwarded message" header on top of an
+    // empty body block.
+    const ready = await ensureDecryptedForReply(mail, 'forward')
+    if (!ready) return
+    const composeId = openCompose(buildForwardInitial(ready))
+    if (ready.attachments.length === 0) return
     const include = await promptIncludeForwardAttachments(
-      mail.attachments.length,
+      ready.attachments.length,
     )
     if (!include) return
     try {
-      const downloaded = await downloadForwardAttachments(mail)
+      const downloaded = await downloadForwardAttachments(ready)
       const entry = composes.find((c) => c.id === composeId)
       if (!entry) return
       const addAttachments = await entry.addAttachmentsReady
@@ -3151,6 +3321,102 @@
           {m.compose_forward_attachments_include()}
         </button>
       </div>
+    </div>
+  </div>
+{/if}
+
+<!-- #341 — decrypt-passphrase prompt for Reply / Forward on a still-
+     encrypted message.  Driven entirely by `pendingDecryptPrompt`:
+     setting it opens the modal; submit / cancel / backdrop /
+     Escape call `resolveDecryptPrompt`, which fulfils the awaited
+     promise inside `ensureDecryptedForReply` so the reply / forward
+     pipeline can continue (or abort cleanly on cancel).  The busy
+     flag locks every dismiss path while `decrypt_message` is in
+     flight so a backdrop click can't tear down the modal halfway
+     through the IPC. -->
+{#if pendingDecryptPrompt}
+  <div
+    class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="decrypt-prompt-title"
+    tabindex="-1"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) resolveDecryptPrompt(null)
+    }}
+    onkeydown={(e) => e.key === 'Escape' && resolveDecryptPrompt(null)}
+  >
+    <div
+      class="card p-5 max-w-sm w-[90%] bg-surface-100 dark:bg-surface-800 rounded-lg shadow-xl"
+    >
+      <h2 id="decrypt-prompt-title" class="text-base font-semibold mb-2">
+        {pendingDecryptPrompt.kind === 'forward'
+          ? m.mail_decrypt_for_forward_title()
+          : m.mail_decrypt_for_reply_title()}
+      </h2>
+      <p class="text-sm text-surface-600 dark:text-surface-300 mb-3">
+        {pendingDecryptPrompt.kind === 'forward'
+          ? m.mail_decrypt_for_forward_body({
+              sender: pendingDecryptPrompt.fromName,
+            })
+          : m.mail_decrypt_for_reply_body({
+              sender: pendingDecryptPrompt.fromName,
+            })}
+      </p>
+      <form
+        onsubmit={(e) => {
+          e.preventDefault()
+          if (!pendingDecryptPrompt || pendingDecryptPrompt.busy) return
+          resolveDecryptPrompt(pendingDecryptPrompt.value)
+        }}
+      >
+        <label
+          for="decrypt-prompt-passphrase"
+          class="block text-xs text-surface-500 mb-1"
+        >
+          {m.mail_decrypt_passphrase_label()}
+        </label>
+        <input
+          id="decrypt-prompt-passphrase"
+          type="password"
+          class="input w-full px-3 py-2 text-sm rounded-md mb-2"
+          bind:value={pendingDecryptPrompt.value}
+          disabled={pendingDecryptPrompt.busy}
+          autocomplete="off"
+          {@attach (node: HTMLInputElement) => {
+            // Pull focus the moment the modal mounts so the user
+            // can start typing without an extra click.  Skipped
+            // when the input is disabled (busy frame during the
+            // in-flight decrypt) — focusing a disabled input
+            // would be a no-op and trip the a11y linter.
+            if (!pendingDecryptPrompt?.busy) {
+              queueMicrotask(() => node.focus())
+            }
+          }}
+        />
+        {#if pendingDecryptPrompt.error}
+          <p class="text-xs text-red-500 mb-3">{pendingDecryptPrompt.error}</p>
+        {/if}
+        <div class="flex justify-end gap-2 mt-2">
+          <button
+            type="button"
+            class="btn btn-sm preset-outlined-surface-500"
+            disabled={pendingDecryptPrompt.busy}
+            onclick={() => resolveDecryptPrompt(null)}
+          >
+            {m.mail_decrypt_cancel_button()}
+          </button>
+          <button
+            type="submit"
+            class="btn btn-sm preset-filled-primary-500"
+            disabled={pendingDecryptPrompt.busy || !pendingDecryptPrompt.value}
+          >
+            {pendingDecryptPrompt.busy
+              ? m.mail_decrypt_busy_button()
+              : m.mail_decrypt_submit_button()}
+          </button>
+        </div>
+      </form>
     </div>
   </div>
 {/if}

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1074,20 +1074,38 @@
           // #341 — the popped-out mail window owns its own decrypt
           // prompt (so the modal appears next to the popout the user
           // was looking at instead of stealing focus to the main
-          // window).  By the time this event arrives, the mail is
-          // either already-decrypted (popout did the work) or never
-          // needed decryption — `ensureDecryptedForReply` is still
-          // called as a safety net for an old / unmodified popout,
-          // but `needsDecryptForReply` will short-circuit for the
-          // happy path so no prompt fires here.
-          const ready = await ensureDecryptedForReply(mail, kind)
-          if (!ready) return
-          // Carry the popout-side passphrase through to the forward
-          // attachment fetch so the bytes come from the *inner*
-          // decrypted MIME tree.  Falls back to whatever
-          // `ensureDecryptedForReply` collected if (somehow) the
-          // popout sent an encrypted mail without a passphrase.
-          const attachmentPassphrase = pgpPassphrase ?? ready.passphrase
+          // window).  When the popout sends a passphrase along, we
+          // *skip* this main-window listener's own prompt entirely —
+          // the popout has already decrypted the mail (body + the
+          // inner-tree attachments are already overlaid on the
+          // payload) and validated the user's key, so a second
+          // prompt here would be a double prompt for the same
+          // operation.  Without this bypass, the forward-needs-
+          // attachment-key check inside `ensureDecryptedForReply`
+          // re-fires on every popout-originated forward of an
+          // encrypted message and confuses the UI: a popout prompt
+          // that does nothing because its resolver isn't the same
+          // one the main window awaits, then a main-window prompt
+          // the user has to fill in again.
+          //
+          // When `pgpPassphrase` is null/undefined either the source
+          // was plaintext (no key needed) or the popout's body cache
+          // was already populated and the kind isn't 'forward' — in
+          // both cases `ensureDecryptedForReply` would short-circuit
+          // to a no-op anyway, but we call it for the safety-net
+          // case of an old popout build that doesn't emit the
+          // `pgpPassphrase` field.
+          let composeReady: ForwardableMail
+          let attachmentPassphrase: string | null
+          if (pgpPassphrase) {
+            composeReady = mail
+            attachmentPassphrase = pgpPassphrase
+          } else {
+            const ready = await ensureDecryptedForReply(mail, kind)
+            if (!ready) return
+            composeReady = ready.mail
+            attachmentPassphrase = ready.passphrase
+          }
           // Forward needs the async builder so the
           // include-attachments popup (#329) and the
           // download_email_attachment fan-out can run before the
@@ -1096,15 +1114,15 @@
           // the original attachments.
           const initial: ComposeInitial =
             kind === 'reply'
-              ? buildReplyInitial(ready.mail)
+              ? buildReplyInitial(composeReady)
               : kind === 'reply-all'
-                ? buildReplyAllInitial(ready.mail)
+                ? buildReplyAllInitial(composeReady)
                 : await buildForwardInitialForPopout(
-                    ready.mail,
+                    composeReady,
                     attachmentPassphrase,
                   )
           void openComposeInStandaloneWindow({
-            accountId: ready.mail.account_id,
+            accountId: composeReady.account_id,
             initial,
           }).catch((err) =>
             console.warn('openComposeInStandaloneWindow from #304 failed', err),
@@ -2187,9 +2205,27 @@
         value: passphrase,
       }
       try {
+        // Pull `attachments` back too — `decrypt_message` returns the
+        // full `Email`, and the attachments list on a freshly-
+        // decrypted message indexes the *inner* MIME tree (the real
+        // files), whereas the cached envelope the user clicked
+        // Forward on still lists the *outer* `multipart/encrypted`
+        // parts (`application/pgp-encrypted` "Version: 1" + the
+        // armored octet-stream).  Without overlaying this, the
+        // forward fan-out would call `download_decrypted_attachment`
+        // with the *outer* part_ids and ship the wrong bytes (or
+        // error out) — exactly the symptom that re-surfaced after
+        // the prior fix.
         const decrypted = await invoke<{
           body_text: string | null
           body_html: string | null
+          attachments: {
+            filename: string
+            content_type: string
+            size: number | null
+            part_id: number
+            content_id?: string | null
+          }[]
         }>('decrypt_message', {
           accountId: mail.account_id,
           folder: mail.folder,
@@ -2202,7 +2238,8 @@
             ...mail,
             body_text: decrypted.body_text,
             body_html: decrypted.body_html,
-          },
+            attachments: decrypted.attachments,
+          } as T,
           passphrase,
         }
       } catch (e) {

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1068,8 +1068,16 @@
          *  Absent when the source was plaintext or the popout's
          *  cache already had a decrypted body. */
         pgpPassphrase?: string | null
+        /** #341 — answer to the popout-local "include original
+         *  attachments?" prompt.  `true` / `false` when the popout
+         *  asked (forward with attachments); `null` when no question
+         *  was needed (reply / no attachments) or the popout is an
+         *  old build without the field.  Lets this listener skip
+         *  re-prompting in the main window for popout-driven
+         *  forwards. */
+        includeAttachments?: boolean | null
       }>('compose-from-mail', (e) => {
-        const { kind, mail, pgpPassphrase } = e.payload
+        const { kind, mail, pgpPassphrase, includeAttachments } = e.payload
         void (async () => {
           // #341 — the popped-out mail window owns its own decrypt
           // prompt (so the modal appears next to the popout the user
@@ -1120,6 +1128,7 @@
                 : await buildForwardInitialForPopout(
                     composeReady,
                     attachmentPassphrase,
+                    includeAttachments ?? null,
                   )
           void openComposeInStandaloneWindow({
             accountId: composeReady.account_id,
@@ -2543,12 +2552,19 @@
   async function buildForwardInitialForPopout(
     mail: ForwardableMail,
     passphrase: string | null,
+    includeAttachmentsDecision: boolean | null,
   ): Promise<ComposeInitial> {
     const base = buildForwardInitial(mail)
     if (mail.attachments.length === 0) return base
-    const include = await promptIncludeForwardAttachments(
-      mail.attachments.length,
-    )
+    // #341 — when the popout already asked the include / skip
+    // question locally (so the modal stayed next to the popped-out
+    // mail), trust that answer instead of mounting a second prompt
+    // in the main window.  `null` means the popout couldn't decide
+    // (old build that doesn't emit the field) — fall back to the
+    // main-window prompt as a safety net.
+    const include =
+      includeAttachmentsDecision ??
+      (await promptIncludeForwardAttachments(mail.attachments.length))
     if (!include) return base
     try {
       const attachments = await downloadForwardAttachments(mail, passphrase)

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1060,17 +1060,34 @@
       unlistenComposeFromMail = await listen<{
         kind: 'reply' | 'reply-all' | 'forward'
         mail: ForwardableMail
+        /** #341 — passphrase the popout collected when its local
+         *  decrypt prompt ran.  Carries through so this main-window
+         *  listener can decrypt forward attachments without
+         *  re-prompting the user (the prompt already happened
+         *  inside the popout where the user clicked Reply / Forward).
+         *  Absent when the source was plaintext or the popout's
+         *  cache already had a decrypted body. */
+        pgpPassphrase?: string | null
       }>('compose-from-mail', (e) => {
-        const { kind, mail } = e.payload
+        const { kind, mail, pgpPassphrase } = e.payload
         void (async () => {
-          // #341 — same decrypt-before-quoting hook as the
-          // in-window onReply / onReplyAll / onForward path, so a
-          // popped-out reply / forward against an encrypted source
-          // doesn't open a blank quoted block either.  Returns
-          // null if the user cancels the prompt; we abort the
-          // popout open entirely in that case.
+          // #341 — the popped-out mail window owns its own decrypt
+          // prompt (so the modal appears next to the popout the user
+          // was looking at instead of stealing focus to the main
+          // window).  By the time this event arrives, the mail is
+          // either already-decrypted (popout did the work) or never
+          // needed decryption — `ensureDecryptedForReply` is still
+          // called as a safety net for an old / unmodified popout,
+          // but `needsDecryptForReply` will short-circuit for the
+          // happy path so no prompt fires here.
           const ready = await ensureDecryptedForReply(mail, kind)
           if (!ready) return
+          // Carry the popout-side passphrase through to the forward
+          // attachment fetch so the bytes come from the *inner*
+          // decrypted MIME tree.  Falls back to whatever
+          // `ensureDecryptedForReply` collected if (somehow) the
+          // popout sent an encrypted mail without a passphrase.
+          const attachmentPassphrase = pgpPassphrase ?? ready.passphrase
           // Forward needs the async builder so the
           // include-attachments popup (#329) and the
           // download_email_attachment fan-out can run before the
@@ -1079,12 +1096,15 @@
           // the original attachments.
           const initial: ComposeInitial =
             kind === 'reply'
-              ? buildReplyInitial(ready)
+              ? buildReplyInitial(ready.mail)
               : kind === 'reply-all'
-                ? buildReplyAllInitial(ready)
-                : await buildForwardInitialForPopout(ready)
+                ? buildReplyAllInitial(ready.mail)
+                : await buildForwardInitialForPopout(
+                    ready.mail,
+                    attachmentPassphrase,
+                  )
           void openComposeInStandaloneWindow({
-            accountId: ready.account_id,
+            accountId: ready.mail.account_id,
             initial,
           }).catch((err) =>
             console.warn('openComposeInStandaloneWindow from #304 failed', err),
@@ -2068,20 +2088,38 @@
     resolve(passphrase)
   }
 
+  /** Result of `ensureDecryptedForReply`.  `mail` carries the
+   *  (possibly newly-decrypted) source; `passphrase` carries the
+   *  passphrase the user supplied at the prompt — held just long
+   *  enough for the caller to run a follow-up decrypt operation
+   *  (e.g. forward-with-attachments needs to decrypt each
+   *  attachment with the same key, #341).  `null` when no decrypt
+   *  was needed (plaintext source / already-decrypted cache hit).
+   *  The caller MUST NOT persist the passphrase anywhere — its
+   *  lifetime is bounded by the current Reply / Forward operation
+   *  per #57's "never persist passphrases" posture. */
+  type DecryptedForReply<T> = {
+    mail: T
+    passphrase: string | null
+  }
+
   /** #341 — if the source message is encrypted but not yet decrypted,
    *  prompt the user for their passphrase, run `decrypt_message`,
    *  and return a copy of the mail with the plaintext body fields
-   *  filled in.  On wrong passphrase the modal stays up with an
-   *  inline error (the user re-tries inside the same prompt).  On
-   *  cancel returns `null` so the caller can abort the Reply /
-   *  Forward open instead of pushing an empty quoted-history into
-   *  Compose.  Pass-through when the mail is plaintext or the
+   *  filled in *plus* the passphrase the user supplied (so the
+   *  forward path can use it to decrypt each attachment's bytes
+   *  through `download_decrypted_attachment`).  On wrong passphrase
+   *  the modal stays up with an inline error (the user re-tries
+   *  inside the same prompt).  On cancel returns `null` so the
+   *  caller can abort the Reply / Forward open instead of pushing
+   *  an empty quoted-history into Compose.  Pass-through (no
+   *  prompt, `passphrase: null`) when the mail is plaintext or the
    *  cached body is already populated. */
   async function ensureDecryptedForReply<T extends ReplyableMail>(
     mail: T,
     kind: DecryptPromptKind,
-  ): Promise<T | null> {
-    if (!needsDecryptForReply(mail)) return mail
+  ): Promise<DecryptedForReply<T> | null> {
+    if (!needsDecryptForReply(mail)) return { mail, passphrase: null }
     let lastError = ''
     while (true) {
       const passphrase = await new Promise<string | null>((resolve) => {
@@ -2124,9 +2162,12 @@
         })
         pendingDecryptPrompt = null
         return {
-          ...mail,
-          body_text: decrypted.body_text,
-          body_html: decrypted.body_html,
+          mail: {
+            ...mail,
+            body_text: decrypted.body_text,
+            body_html: decrypted.body_html,
+          },
+          passphrase,
         }
       } catch (e) {
         // Strip the `Crypto: ` variant prefix from UnkaiError (same
@@ -2145,7 +2186,7 @@
     void (async () => {
       const ready = await ensureDecryptedForReply(mail, 'reply')
       if (!ready) return
-      openCompose(buildReplyInitial(ready))
+      openCompose(buildReplyInitial(ready.mail))
     })()
   }
 
@@ -2153,7 +2194,7 @@
     void (async () => {
       const ready = await ensureDecryptedForReply(mail, 'reply-all')
       if (!ready) return
-      openCompose(buildReplyAllInitial(ready))
+      openCompose(buildReplyAllInitial(ready.mail))
     })()
   }
 
@@ -2314,20 +2355,41 @@
    *  reshape into Compose's `Attachment` form.  Each gets a fresh
    *  `content_id` so the `/` editor shortcut can still anchor
    *  cid: links into the body after the bytes arrive — same
-   *  shape `onEditDraft` builds for the draft-edit flow. */
+   *  shape `onEditDraft` builds for the draft-edit flow.
+   *
+   *  #341 — when `passphrase` is supplied (forward-from-encrypted
+   *  flow) the bytes come from `download_decrypted_attachment`
+   *  instead.  That command decrypts the raw IMAP bytes server-side
+   *  and walks the *inner* MIME tree, so `att.part_id` (which on a
+   *  decrypted message indexes the inner tree, not the outer
+   *  `multipart/encrypted` envelope) resolves to the actual file
+   *  bytes rather than the `application/pgp-encrypted` "Version: 1"
+   *  header part the plain command would return. */
   function downloadForwardAttachments(
     mail: ForwardableMail,
+    passphrase: string | null,
   ): Promise<ComposeAttachment[]> {
     return Promise.all(
       mail.attachments.map(async (att) => ({
         filename: att.filename,
         content_type: att.content_type,
-        data: await invoke<number[]>('download_email_attachment', {
-          accountId: mail.account_id,
-          folder: mail.folder,
-          uid: mail.uid,
-          partId: att.part_id,
-        }),
+        data: await invoke<number[]>(
+          passphrase ? 'download_decrypted_attachment' : 'download_email_attachment',
+          passphrase
+            ? {
+                accountId: mail.account_id,
+                folder: mail.folder,
+                uid: mail.uid,
+                partId: att.part_id,
+                pgpPassphrase: passphrase,
+              }
+            : {
+                accountId: mail.account_id,
+                folder: mail.folder,
+                uid: mail.uid,
+                partId: att.part_id,
+              },
+        ),
         content_id: crypto.randomUUID().replaceAll('-', ''),
       })),
     )
@@ -2351,17 +2413,24 @@
     // initial so the quoted block actually carries the original
     // content.  Without this, forwarding an unopened encrypted
     // message would put a "Forwarded message" header on top of an
-    // empty body block.
+    // empty body block.  The passphrase the user supplied at the
+    // prompt rides through to `downloadForwardAttachments` so each
+    // attachment's bytes also come from the decrypted inner tree —
+    // otherwise we'd ship the outer envelope's `application/pgp-encrypted`
+    // "Version: 1" header instead of the file.
     const ready = await ensureDecryptedForReply(mail, 'forward')
     if (!ready) return
-    const composeId = openCompose(buildForwardInitial(ready))
-    if (ready.attachments.length === 0) return
+    const composeId = openCompose(buildForwardInitial(ready.mail))
+    if (ready.mail.attachments.length === 0) return
     const include = await promptIncludeForwardAttachments(
-      ready.attachments.length,
+      ready.mail.attachments.length,
     )
     if (!include) return
     try {
-      const downloaded = await downloadForwardAttachments(ready)
+      const downloaded = await downloadForwardAttachments(
+        ready.mail,
+        ready.passphrase,
+      )
       const entry = composes.find((c) => c.id === composeId)
       if (!entry) return
       const addAttachments = await entry.addAttachmentsReady
@@ -2388,6 +2457,7 @@
    *  popout's Compose with attachments baked into the initial. */
   async function buildForwardInitialForPopout(
     mail: ForwardableMail,
+    passphrase: string | null,
   ): Promise<ComposeInitial> {
     const base = buildForwardInitial(mail)
     if (mail.attachments.length === 0) return base
@@ -2396,7 +2466,7 @@
     )
     if (!include) return base
     try {
-      const attachments = await downloadForwardAttachments(mail)
+      const attachments = await downloadForwardAttachments(mail, passphrase)
       return { ...base, attachments }
     } catch (e) {
       alert(

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -2005,6 +2005,23 @@
     return !hasText && !hasHtml
   }
 
+  /** #341 — does the Forward path need to *collect* a passphrase
+   *  regardless of whether the body is already in the cache?  Yes
+   *  when the source was encrypted and carries at least one
+   *  attachment — `download_decrypted_attachment` is the only path
+   *  that walks the *inner* MIME tree to extract real bytes; the
+   *  plain `download_email_attachment` returns the outer envelope's
+   *  `application/pgp-encrypted` "Version: 1" header for the same
+   *  inner part_id.  Decoupled from `needsDecryptForReply` because
+   *  this can be true when the cached body short-circuits the
+   *  body-decrypt prompt (user opened the message before clicking
+   *  Forward) but attachments still need the key. */
+  function needsPassphraseForForwardAttachments(
+    mail: ForwardableMail,
+  ): boolean {
+    return wasEncrypted(mail) && mail.attachments.length > 0
+  }
+
   function buildReplyInitial(mail: ReplyableMail): ComposeInitial {
     return {
       to: mail.from,
@@ -2103,23 +2120,42 @@
     passphrase: string | null
   }
 
-  /** #341 — if the source message is encrypted but not yet decrypted,
-   *  prompt the user for their passphrase, run `decrypt_message`,
-   *  and return a copy of the mail with the plaintext body fields
-   *  filled in *plus* the passphrase the user supplied (so the
-   *  forward path can use it to decrypt each attachment's bytes
-   *  through `download_decrypted_attachment`).  On wrong passphrase
-   *  the modal stays up with an inline error (the user re-tries
-   *  inside the same prompt).  On cancel returns `null` so the
-   *  caller can abort the Reply / Forward open instead of pushing
-   *  an empty quoted-history into Compose.  Pass-through (no
-   *  prompt, `passphrase: null`) when the mail is plaintext or the
-   *  cached body is already populated. */
+  /** #341 — collect (and validate) the passphrase needed for a
+   *  Reply / Forward of an encrypted source.  Two trigger conditions:
+   *  the cached body is empty (so we must decrypt to populate the
+   *  quoted-history block), or the Forward path needs the key to
+   *  decrypt attachment bytes through `download_decrypted_attachment`.
+   *
+   *  On wrong passphrase the modal stays up with an inline error
+   *  (the user re-tries inside the same prompt).  On cancel returns
+   *  `null` so the caller can abort the Reply / Forward open instead
+   *  of pushing an empty quoted-history into Compose.  Pass-through
+   *  (no prompt, `passphrase: null`) when neither trigger fires.
+   *
+   *  We always validate the passphrase by actually running
+   *  `decrypt_message` even when the body is already cached: this
+   *  is the only way to know the typed passphrase is correct before
+   *  the user wades into Compose and fails at attachment-fetch
+   *  time.  The re-decrypt is cheap and the body it produces is
+   *  identical to what's already cached, so the second `.body_text`
+   *  / `.body_html` overlay is a no-op for the caller. */
   async function ensureDecryptedForReply<T extends ReplyableMail>(
     mail: T,
     kind: DecryptPromptKind,
   ): Promise<DecryptedForReply<T> | null> {
-    if (!needsDecryptForReply(mail)) return { mail, passphrase: null }
+    const bodyNeedsDecrypt = needsDecryptForReply(mail)
+    // The forward-attachment check is gated on `kind === 'forward'`
+    // because Reply / Reply All never carry the source attachments
+    // through to the outgoing draft; the passphrase would just sit
+    // unused.  Cast is safe because only the `onForward` callers
+    // ever pass a `ForwardableMail` in, and `attachments` is the
+    // only field this check inspects.
+    const forwardNeedsAttachmentKey =
+      kind === 'forward' &&
+      needsPassphraseForForwardAttachments(mail as unknown as ForwardableMail)
+    if (!bodyNeedsDecrypt && !forwardNeedsAttachmentKey) {
+      return { mail, passphrase: null }
+    }
     let lastError = ''
     while (true) {
       const passphrase = await new Promise<string | null>((resolve) => {
@@ -2357,25 +2393,37 @@
    *  cid: links into the body after the bytes arrive — same
    *  shape `onEditDraft` builds for the draft-edit flow.
    *
-   *  #341 — when `passphrase` is supplied (forward-from-encrypted
-   *  flow) the bytes come from `download_decrypted_attachment`
-   *  instead.  That command decrypts the raw IMAP bytes server-side
-   *  and walks the *inner* MIME tree, so `att.part_id` (which on a
-   *  decrypted message indexes the inner tree, not the outer
-   *  `multipart/encrypted` envelope) resolves to the actual file
-   *  bytes rather than the `application/pgp-encrypted` "Version: 1"
-   *  header part the plain command would return. */
+   *  #341 — for a forward of an encrypted source, route through
+   *  `download_decrypted_attachment` so the bytes come from the
+   *  *inner* MIME tree (the real Excel / PDF / image).  The
+   *  plain `download_email_attachment` would walk the outer
+   *  `multipart/encrypted` envelope with the inner part_id and
+   *  return the `application/pgp-encrypted` "Version: 1" header
+   *  for part_id 0 — that's the bug behind the user reports of
+   *  "forwarded a 4 MB attachment, recipient got 9 bytes."  The
+   *  dispatch is keyed on `mail.protection` rather than just
+   *  "did the caller supply a passphrase?" so a missing-passphrase
+   *  case throws a typed error here (caught by `onForward`)
+   *  instead of silently regressing to the buggy path. */
   function downloadForwardAttachments(
     mail: ForwardableMail,
     passphrase: string | null,
   ): Promise<ComposeAttachment[]> {
+    const useDecrypted = wasEncrypted(mail)
+    if (useDecrypted && !passphrase) {
+      return Promise.reject(
+        new Error(
+          'Cannot forward encrypted attachments without the user passphrase',
+        ),
+      )
+    }
     return Promise.all(
       mail.attachments.map(async (att) => ({
         filename: att.filename,
         content_type: att.content_type,
         data: await invoke<number[]>(
-          passphrase ? 'download_decrypted_attachment' : 'download_email_attachment',
-          passphrase
+          useDecrypted ? 'download_decrypted_attachment' : 'download_email_attachment',
+          useDecrypted
             ? {
                 accountId: mail.account_id,
                 folder: mail.folder,

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -179,6 +179,17 @@
      *  the signature from the original send; without this we'd
      *  stack a second one and the user would see two. */
     skipSignatureInsert?: boolean
+    /** Pre-enable the PGP encrypt + sign toggle on mount (#341).
+     *  Set by App.svelte's Reply path when the user is responding
+     *  to an encrypted message — the assumption is the thread
+     *  stays encrypted, so saving the manual toggle click is a
+     *  meaningful ergonomic win.  Forward is *not* auto-encrypted
+     *  because the user is changing recipients and the new target
+     *  may not have a key — they should opt in instead.  When
+     *  true Compose also opens with the Encryption ribbon tab
+     *  active so the passphrase input is the first thing the
+     *  user sees. */
+    encryptByDefault?: boolean
   }
 
   /** Payload handed back to the parent when a background send
@@ -993,10 +1004,14 @@
   // End-to-end encryption toggle (#57).  When true, the send IPC
   // sets `encryption_mode = "pgp"` and `signing_enabled = true` on
   // the OutgoingEmail payload and prompts the user for their PGP
-  // passphrase — pre-send modal below.  The toggle defaults off so
-  // the historical plaintext send path is untouched for accounts
-  // that haven't imported a key.
-  let encryptEnabled = $state(false)
+  // passphrase — pre-send modal below.  Defaults off so plaintext
+  // sends from accounts without a key are untouched; the
+  // `encryptByDefault` flag on `initial` (#341 — Reply to an
+  // encrypted message) pre-flips it so the user doesn't have to
+  // click the Encryption tab toggle on every reply in a secured
+  // thread.
+  // svelte-ignore state_referenced_locally
+  let encryptEnabled = $state(initial?.encryptByDefault === true)
   // Inline passphrase entry shown when the user clicks Send with
   // encryption on.  Cleared on submit and on cancel so a freshly-
   // opened Compose never inherits a stale passphrase.
@@ -1006,6 +1021,116 @@
    *  passphrase prompt block (rendered just above the Send
    *  button). */
   let awaitingPassphrase = $state(false)
+
+  // #341 — when the parent pre-enabled encryption (reply to an
+  // encrypted message), pull the passphrase input into focus once
+  // the ribbon's Encryption tab has mounted it.  `untrack` on the
+  // prop read so the effect runs once on first paint rather than
+  // re-triggering whenever the parent's `initial` object identity
+  // changes (e.g. recovery from a background-send failure that
+  // reopens Compose pre-filled).  The DOM lookup is by id rather
+  // than `bind:this` because the input lives inside a snippet that
+  // mounts behind the editor's tab strip — the binding wouldn't
+  // resolve until the snippet body actually rendered, which is
+  // exactly what `requestAnimationFrame` waits out.
+  $effect(() => {
+    if (!untrack(() => initial?.encryptByDefault)) return
+    const raf = requestAnimationFrame(() => {
+      const el = document.getElementById('pgp-passphrase-input')
+      if (el instanceof HTMLInputElement) {
+        el.focus()
+      }
+    })
+    return () => cancelAnimationFrame(raf)
+  })
+
+  // ── Per-recipient key status (#341) ─────────────────────────────
+  // When encryption is on, look up each To/Cc/Bcc address against
+  // the cached `pgp_public_keys` table so a missing key surfaces
+  // *before* the user finishes writing the body — saves them from
+  // typing a long reply only to hit "no key for X" at Send.  The
+  // map keys are the bare lower-cased addresses; values are
+  // 'has-key' / 'no-key' / 'checking'.  Cleared the moment the
+  // user disables encryption again so a stale "no key" warning
+  // doesn't linger on a plaintext draft.
+  type RecipientKeyState = 'checking' | 'has-key' | 'no-key'
+  let recipientKeyStatus = $state<Map<string, RecipientKeyState>>(new Map())
+
+  /** Deduped lower-cased bare addresses currently in any of the
+   *  recipient fields.  Recomputes on every keystroke; the lookup
+   *  effect below debounces the actual IPC calls so the user
+   *  doesn't pay a roundtrip per character. */
+  const encryptionRecipients = $derived.by<string[]>(() => {
+    if (!encryptEnabled) return []
+    const seen = new Set<string>()
+    for (const piece of [...splitAddrs(to), ...splitAddrs(cc), ...splitAddrs(bcc)]) {
+      const bare = bareAddr(piece).toLowerCase()
+      if (bare && bare.includes('@')) seen.add(bare)
+    }
+    return [...seen]
+  })
+
+  $effect(() => {
+    if (!encryptEnabled) {
+      recipientKeyStatus = new Map()
+      return
+    }
+    const targets = encryptionRecipients
+    if (targets.length === 0) {
+      recipientKeyStatus = new Map()
+      return
+    }
+    // Debounce — 400ms after the last typed character feels like
+    // "user has paused typing" without the warning chip lagging
+    // far behind the To line.  `aborted` guards the post-await
+    // writes so a torn-down effect (recipient field edited mid-
+    // lookup) doesn't paint stale results.
+    let aborted = false
+    const handle = setTimeout(() => {
+      void (async () => {
+        const seeded = new Map<string, RecipientKeyState>()
+        for (const addr of targets) {
+          const prior = recipientKeyStatus.get(addr)
+          if (prior === 'has-key' || prior === 'no-key') {
+            seeded.set(addr, prior)
+          } else {
+            seeded.set(addr, 'checking')
+          }
+        }
+        if (aborted) return
+        recipientKeyStatus = seeded
+        for (const addr of targets) {
+          if (aborted) return
+          if (seeded.get(addr) !== 'checking') continue
+          try {
+            const rows = await invoke<unknown[]>('pgp_get_keys_for_email', {
+              email: addr,
+            })
+            if (aborted) return
+            const hit = Array.isArray(rows) && rows.length > 0
+            recipientKeyStatus = new Map(recipientKeyStatus).set(
+              addr,
+              hit ? 'has-key' : 'no-key',
+            )
+          } catch (e) {
+            if (aborted) return
+            console.warn('pgp_get_keys_for_email failed for', addr, e)
+            recipientKeyStatus = new Map(recipientKeyStatus).set(addr, 'no-key')
+          }
+        }
+      })()
+    }, 400)
+    return () => {
+      aborted = true
+      clearTimeout(handle)
+    }
+  })
+
+  /** Addresses currently flagged as having no cached PGP key.
+   *  Drives the warning banner rendered above the Send button. */
+  const recipientsWithoutKey = $derived<string[]>(
+    encryptionRecipients.filter((a) => recipientKeyStatus.get(a) === 'no-key'),
+  )
   // `initialError` seeds the banner when Compose is re-opened
   // after a background send failure (#156).  Cleared by the next
   // `send()` validation pass — the user retrying is the implicit
@@ -2544,8 +2669,33 @@
             }))}
           actionsTrailing={sendActions}
           extraTabs={composeExtraTabs}
+          defaultActiveTab={initial?.encryptByDefault ? 'encryption' : undefined}
         />
       </div>
+
+      <!-- #341 — no-cached-PGP-key warning.  Surfaces *before* the
+           user finishes the body so they don't type a long reply
+           only to hit "no key for X" at Send.  Listing each
+           affected address by name (rather than a generic count)
+           keeps the chip diagnostic when a multi-recipient reply
+           has only one missing key.  Hidden whenever every
+           recipient has a key, or encryption is off. -->
+      {#if encryptEnabled && recipientsWithoutKey.length > 0}
+        <div
+          class="flex items-start gap-3 px-3 py-2 rounded-md border border-warning-500/40 bg-warning-500/10 text-sm text-warning-700 dark:text-warning-300"
+          role="alert"
+        >
+          <span class="shrink-0 mt-0.5"><Icon name="warning" size={16} /></span>
+          <div class="flex-1 min-w-0">
+            <p class="font-medium">{m.compose_pgp_recipient_no_key_title()}</p>
+            <p class="text-xs mt-0.5">
+              {m.compose_pgp_recipient_no_key_body({
+                addresses: recipientsWithoutKey.join(', '),
+              })}
+            </p>
+          </div>
+        </div>
+      {/if}
 
       <!-- #250 — gentle "you mentioned an attachment but didn't
            attach a file" warning.  Hides itself the moment any

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -202,6 +202,18 @@
   let decrypting = $state(false)
   let decryptError = $state('')
 
+  /** #341 — passphrase held for the duration of the current
+   *  message view, so attachment opens / downloads / prints /
+   *  save-to-Nextcloud can re-decrypt the encrypted inner MIME
+   *  tree without prompting per click.  Set on successful body
+   *  decrypt (carried over from `decryptPassphrase` before the
+   *  input is wiped); cleared whenever the open message changes
+   *  via `load()` so the passphrase never outlives the mail it
+   *  unlocked.  Separate from `decryptPassphrase` so the DOM
+   *  input still gets wiped (no plaintext-in-input footprint)
+   *  while attachments stay usable for the same message session. */
+  let sessionPassphrase = $state('')
+
   async function runDecrypt() {
     if (!email || !decryptPassphrase || decrypting) {
       return
@@ -221,6 +233,11 @@
         pgpPassphrase: decryptPassphrase,
       })
       email = decrypted
+      // #341 — stash the passphrase so attachment fetches for this
+      // same message session can use `download_decrypted_attachment`
+      // without re-prompting.  Done BEFORE wiping the input so the
+      // session value carries through.
+      sessionPassphrase = decryptPassphrase
       // Clear the passphrase the moment the IPC resolves so it
       // never lingers on the heap or in a DOM input that the
       // user could leave open.
@@ -236,6 +253,68 @@
     } finally {
       decrypting = false
     }
+  }
+
+  /** #341 — does the open message need the decrypt-aware attachment
+   *  fetch path?  True when the receive layer tagged it as PGP-
+   *  encrypted (either flavour); false for plaintext and
+   *  signed-only mail.  `encrypted-cannot-decrypt` (JMAP fallback)
+   *  also returns false because we can't decrypt locally anyway —
+   *  the UI surfaces a different banner for that case. */
+  function emailNeedsDecryptedAttachmentFetch(em: Email | null): boolean {
+    const p = em?.protection
+    return p === 'encrypted' || p === 'signed-and-encrypted'
+  }
+
+  /** Sentinel error string — thrown by `fetchAttachmentBytes` when
+   *  the message is encrypted but we don't have a session passphrase
+   *  in hand.  Caught by the per-action wrappers below so the
+   *  surfaced error reads as a clear UX hint ("re-enter passphrase")
+   *  rather than a raw IPC error. */
+  const DECRYPT_REQUIRED_MARKER = '__unkai_decrypt_required__'
+
+  /** #341 — encryption-aware single source of truth for "give me the
+   *  decoded bytes of attachment X on the open message".  Routes to
+   *  `download_decrypted_attachment` (with the session passphrase)
+   *  when the message is encrypted, and to the plain
+   *  `download_email_attachment` otherwise.  Throws the
+   *  `DECRYPT_REQUIRED_MARKER` sentinel when an encrypted message
+   *  has no session passphrase available (e.g. the user opened it
+   *  from cache without re-running the Decrypt flow) so each call
+   *  site can surface a consistent "please re-decrypt first" hint
+   *  without each one having to reproduce the conditional. */
+  async function fetchAttachmentBytes(att: EmailAttachment): Promise<number[]> {
+    if (!email || uid == null) {
+      throw new Error('No message open')
+    }
+    if (emailNeedsDecryptedAttachmentFetch(email)) {
+      if (!sessionPassphrase) {
+        throw new Error(DECRYPT_REQUIRED_MARKER)
+      }
+      return await invoke<number[]>('download_decrypted_attachment', {
+        accountId: email.account_id,
+        folder: email.folder,
+        uid,
+        partId: att.part_id,
+        pgpPassphrase: sessionPassphrase,
+      })
+    }
+    return await invoke<number[]>('download_email_attachment', {
+      accountId: email.account_id,
+      folder: email.folder,
+      uid,
+      partId: att.part_id,
+    })
+  }
+
+  /** Convert the sentinel from `fetchAttachmentBytes` into the UI's
+   *  inline-error string.  Other errors fall through with the normal
+   *  `formatError` treatment. */
+  function formatAttachmentFetchError(e: unknown, fallback: string): string {
+    if (e instanceof Error && e.message === DECRYPT_REQUIRED_MARKER) {
+      return m.mail_view_attachment_decrypt_required()
+    }
+    return formatError(e) || fallback
   }
 
   /** Pre-fetch persisted thumbnails for one message and seed
@@ -395,6 +474,11 @@
     decryptPassphrase = ''
     decryptError = ''
     decrypting = false
+    // #341 — drop the session passphrase too.  Held only for the
+    // currently-open message so attachment fetches can decrypt
+    // without re-prompting; opening a different message starts a
+    // fresh session.
+    sessionPassphrase = ''
 
     // Cache first — lets the reading pane paint instantly when the user
     // re-opens a previously read message (the common case).
@@ -1510,21 +1594,15 @@
    *  Download — Save-to-disk stays available in the dropdown. */
   async function attachmentClicked(att: EmailAttachment) {
     if (!email || uid == null) return
-    const acc = email.account_id
-    const fld = email.folder
-    const u = uid
     setBusy(att.part_id, true)
     try {
-      await openAttachment(att, () =>
-        invoke<number[]>('download_email_attachment', {
-          accountId: acc,
-          folder: fld,
-          uid: u,
-          partId: att.part_id,
-        }),
-      )
+      // #341 — route through `fetchAttachmentBytes` so encrypted
+      // messages pull bytes from the decrypted inner MIME tree
+      // rather than the outer envelope's `application/pgp-encrypted`
+      // "Version: 1" header part.
+      await openAttachment(att, () => fetchAttachmentBytes(att))
     } catch (e) {
-      error = formatError(e) || 'Failed to open attachment'
+      error = formatAttachmentFetchError(e, 'Failed to open attachment')
     } finally {
       setBusy(att.part_id, false)
     }
@@ -1610,15 +1688,10 @@
 
     setBusy(att.part_id, true)
     try {
-      const bytes = await invoke<number[]>('download_email_attachment', {
-        accountId: email.account_id,
-        folder: email.folder,
-        uid,
-        partId: att.part_id,
-      })
+      const bytes = await fetchAttachmentBytes(att)
       await invoke('save_bytes_to_path', { path: chosenPath, data: bytes })
     } catch (e) {
-      error = formatError(e) || 'Failed to download attachment'
+      error = formatAttachmentFetchError(e, 'Failed to download attachment')
     } finally {
       setBusy(att.part_id, false)
     }
@@ -1643,18 +1716,13 @@
     if (!email || uid == null) return
     setBusy(att.part_id, true)
     try {
-      const bytes = await invoke<number[]>('download_email_attachment', {
-        accountId: email.account_id,
-        folder: email.folder,
-        uid,
-        partId: att.part_id,
-      })
+      const bytes = await fetchAttachmentBytes(att)
       await invoke('print_attachment', {
         fileName: att.filename,
         bytes,
       })
     } catch (e) {
-      error = formatError(e) || 'Failed to print attachment'
+      error = formatAttachmentFetchError(e, 'Failed to print attachment')
     } finally {
       setBusy(att.part_id, false)
     }
@@ -1704,12 +1772,7 @@
       // like `{account}-{folder}-{uid}` and parseInt'ing it gives NaN,
       // which serializes to null and fails Tauri's u32 validation.
       if (uid == null) return
-      const bytes = await invoke<number[]>('download_email_attachment', {
-        accountId: email.account_id,
-        folder: email.folder,
-        uid,
-        partId: att.part_id,
-      })
+      const bytes = await fetchAttachmentBytes(att)
       // Join the folder path with the filename, avoiding double slashes
       // when folderPath is just '/'.
       const base = folderPath.endsWith('/') ? folderPath : `${folderPath}/`
@@ -1721,7 +1784,7 @@
         contentType: att.content_type || null,
       })
     } catch (e) {
-      error = formatError(e) || 'Failed to save to Nextcloud'
+      error = formatAttachmentFetchError(e, 'Failed to save to Nextcloud')
     } finally {
       setBusy(att.part_id, false)
     }
@@ -2101,13 +2164,7 @@
                   }}
                   bytesProvider={tooLarge
                     ? undefined
-                    : () =>
-                        invoke<number[]>('download_email_attachment', {
-                          accountId: email!.account_id,
-                          folder: email!.folder,
-                          uid: uid!,
-                          partId: att.part_id,
-                        })}
+                    : () => fetchAttachmentBytes(att)}
                   class="w-9 h-9"
                 />
               {/if}

--- a/ui/src/lib/RichTextEditor.svelte
+++ b/ui/src/lib/RichTextEditor.svelte
@@ -142,6 +142,12 @@
      *  tab strip when the tab is active.  Empty / omitted → no
      *  extra tabs. */
     extraTabs?: ExtraTab[]
+    /** Initial active tab — built-in `'format' | 'insert' | 'layout'`
+     *  or one of the `extraTabs[].id` values the embedder contributed.
+     *  Used by Compose's auto-encrypt-on-reply flow (#341) so the
+     *  passphrase input is the first thing the user sees rather than
+     *  hidden behind a tab switch.  Defaults to `'format'`. */
+    defaultActiveTab?: string
   }
 
   /** Embedder-provided tab spec.  Mirrors the ribbon tabs the
@@ -211,6 +217,7 @@
     actionsTrailing,
     actionsTrailingCompact = false,
     extraTabs = [],
+    defaultActiveTab,
   }: Props = $props()
 
   // \u2500\u2500 Inline `@` and `/` picker state \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -1421,7 +1428,8 @@
   // beyond the built-in three come from the embedder's
   // `extraTabs` prop (Compose contributes "attach").
   type BuiltinTab = 'format' | 'insert' | 'layout'
-  let activeTab = $state<BuiltinTab | string>('format')
+  // svelte-ignore state_referenced_locally
+  let activeTab = $state<BuiltinTab | string>(defaultActiveTab ?? 'format')
 
   let showEmojiPicker = $state(false)
 

--- a/ui/src/lib/StandaloneMail.svelte
+++ b/ui/src/lib/StandaloneMail.svelte
@@ -116,6 +116,32 @@
   }
   let pendingDecryptPrompt = $state<PendingPrompt | null>(null)
 
+  // #341 — same window-locality rule for the "include original
+  // attachments?" prompt (#329).  Previously this fired from the
+  // main window's `buildForwardInitialForPopout`, so the user
+  // clicked Forward in the popout, answered a passphrase prompt
+  // here, then had to switch monitors to find the include-or-not
+  // modal in the main window.  Owning it locally too means a
+  // popped-out forward never bounces focus until the resulting
+  // Compose actually opens.
+  let pendingIncludeAttachmentsPrompt = $state<{
+    count: number
+    resolve: (include: boolean) => void
+  } | null>(null)
+
+  function resolveIncludeAttachmentsPrompt(include: boolean) {
+    if (!pendingIncludeAttachmentsPrompt) return
+    const { resolve } = pendingIncludeAttachmentsPrompt
+    pendingIncludeAttachmentsPrompt = null
+    resolve(include)
+  }
+
+  function promptIncludeAttachments(count: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      pendingIncludeAttachmentsPrompt = { count, resolve }
+    })
+  }
+
   function resolveDecryptPrompt(passphrase: string | null) {
     if (!pendingDecryptPrompt) return
     if (pendingDecryptPrompt.busy) return
@@ -255,10 +281,28 @@
     try {
       const ready = await ensureDecryptedLocal(mail, kind)
       if (!ready) return
+      // #341 — for a forward that carries attachments, ask the
+      // include/skip question *here* so the modal sits next to the
+      // popout the user just clicked Forward on.  Default
+      // ("Forward without" on backdrop / Escape dismiss) matches
+      // the in-window flow.  Reply / Reply All never propagate the
+      // source attachments, so we skip the prompt for those kinds.
+      // `null` for `includeAttachments` is the "no question
+      // needed" signal so the main window can route accordingly
+      // without re-prompting.
+      let includeAttachments: boolean | null = null
+      if (kind === 'forward') {
+        const narrow = ready.mail as DecryptableMail
+        const count = narrow.attachments?.length ?? 0
+        if (count > 0) {
+          includeAttachments = await promptIncludeAttachments(count)
+        }
+      }
       await emit('compose-from-mail', {
         kind,
         mail: ready.mail,
         pgpPassphrase: ready.passphrase,
+        includeAttachments,
       })
     } catch (e) {
       console.warn(`compose-from-mail (${kind}) emit failed`, e)
@@ -316,6 +360,55 @@
     onmailto={onMailto}
   />
 </div>
+
+<!-- #341 — popout-local "include original attachments?" prompt.
+     Same shape App.svelte's `pendingForwardPrompt` modal uses, just
+     instantiated here so a popout-originated Forward keeps the
+     follow-up question in the popout window too. -->
+{#if pendingIncludeAttachmentsPrompt}
+  <div
+    class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="forward-attachments-title-popout"
+    tabindex="-1"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) resolveIncludeAttachmentsPrompt(false)
+    }}
+    onkeydown={(e) => e.key === 'Escape' && resolveIncludeAttachmentsPrompt(false)}
+  >
+    <div
+      class="card p-5 max-w-sm w-[90%] bg-surface-100 dark:bg-surface-800 rounded-lg shadow-xl"
+    >
+      <h2 id="forward-attachments-title-popout" class="text-base font-semibold mb-2">
+        {m.compose_forward_attachments_title()}
+      </h2>
+      <p class="text-sm text-surface-600 dark:text-surface-300 mb-4">
+        {pendingIncludeAttachmentsPrompt.count === 1
+          ? m.compose_forward_attachments_body_one()
+          : m.compose_forward_attachments_body_many({
+              n: pendingIncludeAttachmentsPrompt.count,
+            })}
+      </p>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          class="btn btn-sm preset-outlined-surface-500"
+          onclick={() => resolveIncludeAttachmentsPrompt(false)}
+        >
+          {m.compose_forward_attachments_skip()}
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm preset-filled-primary-500"
+          onclick={() => resolveIncludeAttachmentsPrompt(true)}
+        >
+          {m.compose_forward_attachments_include()}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <!-- #341 — popout-local decrypt prompt.  Same shape App.svelte
      mounts at the main-window level, just instantiated here so it

--- a/ui/src/lib/StandaloneMail.svelte
+++ b/ui/src/lib/StandaloneMail.svelte
@@ -202,9 +202,26 @@
         value: passphrase,
       }
       try {
+        // Pull `attachments` back too — `decrypt_message` returns
+        // the full `Email`, and the freshly-decrypted attachments
+        // list indexes the *inner* MIME tree (real files), while
+        // the cached envelope the user clicked Forward on still
+        // lists the *outer* `multipart/encrypted` parts (a
+        // `Version: 1` header part + the armored octet-stream).
+        // Overlaying both bodies AND the attachments here means
+        // the main-window listener can route the forward fan-out
+        // through `download_decrypted_attachment` with valid
+        // inner-tree part_ids.
         const decrypted = await invoke<{
           body_text: string | null
           body_html: string | null
+          attachments: {
+            filename: string
+            content_type: string
+            size: number | null
+            part_id: number
+            content_id?: string | null
+          }[]
         }>('decrypt_message', {
           accountId: narrow.account_id,
           folder: narrow.folder,
@@ -217,6 +234,7 @@
             ...(mail as object),
             body_text: decrypted.body_text,
             body_html: decrypted.body_html,
+            attachments: decrypted.attachments,
           } as EmailPayload,
           passphrase,
         }

--- a/ui/src/lib/StandaloneMail.svelte
+++ b/ui/src/lib/StandaloneMail.svelte
@@ -22,13 +22,31 @@
   import { getCurrentWindow } from '@tauri-apps/api/window'
   import MailView from './MailView.svelte'
   import { applyTheme, installSystemModeListener, type ThemeMode } from './theme'
+  import { formatError } from './errors'
+  import { m } from '../paraglide/messages'
 
   // We never inspect the email shape inside the standalone window —
   // it's just a payload we forward to the main window via Tauri
   // events.  The main window's listener treats it as the existing
   // `Email` type (defined inside MailView).  Using `unknown` here
-  // avoids a cross-component type-export dance.
+  // avoids a cross-component type-export dance; the decrypt path
+  // below narrows the few fields it needs via an internal alias.
   type EmailPayload = unknown
+
+  /** #341 — subset of MailView's `Email` we actually inspect inside
+   *  `emitCompose` to decide whether the popout needs to prompt for
+   *  a passphrase before forwarding the payload on.  Narrowed via
+   *  an `as` cast at the boundary so the rest of this file stays
+   *  on the opaque `EmailPayload` type. */
+  type DecryptableMail = {
+    account_id: string
+    folder: string
+    uid: number
+    from: string
+    body_text: string | null
+    body_html?: string | null
+    protection?: string | null
+  }
 
   let {
     accountId,
@@ -70,16 +88,132 @@
     }
   })
 
+  // #341 — Reply / Forward on an encrypted-but-not-yet-decrypted
+  // message needs the user's PGP passphrase so we can decrypt the
+  // body (for the quoted-history block) and any attachments (for
+  // the forward fan-out).  Owning the prompt locally — rather than
+  // letting the main-window listener prompt — keeps the modal next
+  // to the popped-out mail the user just clicked Reply on, instead
+  // of stealing focus over to a main window the user may have
+  // pushed to a different monitor.  After collecting the passphrase
+  // we decrypt locally via `decrypt_message` and emit
+  // `compose-from-mail` with the already-decrypted payload + the
+  // passphrase, so the main window can hand it through to the
+  // forward-attachment fetch without re-prompting.
+  type ComposeKind = 'reply' | 'reply-all' | 'forward'
+  type PendingPrompt = {
+    kind: ComposeKind
+    fromName: string
+    resolve: (passphrase: string | null) => void
+    error: string
+    busy: boolean
+    value: string
+  }
+  let pendingDecryptPrompt = $state<PendingPrompt | null>(null)
+
+  function resolveDecryptPrompt(passphrase: string | null) {
+    if (!pendingDecryptPrompt) return
+    if (pendingDecryptPrompt.busy) return
+    const { resolve } = pendingDecryptPrompt
+    pendingDecryptPrompt = null
+    resolve(passphrase)
+  }
+
+  /** Does this mail need the popout-side decrypt step?  Same logic
+   *  as App.svelte's `needsDecryptForReply` — encrypted protection
+   *  tag *and* an empty cached body.  When the user clicked Decrypt
+   *  inside the popout's reading pane already, the cache row
+   *  carries the plaintext and this short-circuits to false. */
+  function needsDecrypt(mail: DecryptableMail): boolean {
+    const p = mail.protection
+    if (p !== 'encrypted' && p !== 'signed-and-encrypted') return false
+    const text = (mail.body_text ?? '').trim()
+    const html = (mail.body_html ?? '').trim()
+    return text.length === 0 && html.length === 0
+  }
+
+  /** Prompt for the passphrase (looping on wrong input), call
+   *  `decrypt_message`, return `{ mail, passphrase }` with the
+   *  plaintext bodies overlaid.  Returns `null` if the user
+   *  cancels — caller aborts the emit so no compose-from-mail
+   *  event reaches the main window.  Pass-through (no prompt,
+   *  passphrase null) when the mail doesn't need decryption. */
+  async function ensureDecryptedLocal(
+    mail: EmailPayload,
+    kind: ComposeKind,
+  ): Promise<{ mail: EmailPayload; passphrase: string | null } | null> {
+    // Narrow once at the boundary so the rest of this function can
+    // touch decrypt-relevant fields directly without further casts.
+    // The cast is safe in practice because every caller path threads
+    // a MailView `Email & { uid }` here; the narrower type lists the
+    // subset we actually read.
+    const narrow = mail as DecryptableMail
+    if (!needsDecrypt(narrow)) return { mail, passphrase: null }
+    let lastError = ''
+    while (true) {
+      const passphrase = await new Promise<string | null>((resolve) => {
+        pendingDecryptPrompt = {
+          kind,
+          fromName: narrow.from,
+          resolve,
+          error: lastError,
+          busy: false,
+          value: '',
+        }
+      })
+      if (passphrase == null) {
+        pendingDecryptPrompt = null
+        return null
+      }
+      pendingDecryptPrompt = {
+        kind,
+        fromName: narrow.from,
+        resolve: () => {},
+        error: '',
+        busy: true,
+        value: passphrase,
+      }
+      try {
+        const decrypted = await invoke<{
+          body_text: string | null
+          body_html: string | null
+        }>('decrypt_message', {
+          accountId: narrow.account_id,
+          folder: narrow.folder,
+          uid: narrow.uid,
+          pgpPassphrase: passphrase,
+        })
+        pendingDecryptPrompt = null
+        return {
+          mail: {
+            ...(mail as object),
+            body_text: decrypted.body_text,
+            body_html: decrypted.body_html,
+          } as EmailPayload,
+          passphrase,
+        }
+      } catch (e) {
+        const raw = formatError(e) || 'Decrypt failed'
+        lastError = raw.replace(/^Crypto:\s*/i, '')
+      }
+    }
+  }
+
   // Compose actions: emit a Tauri event the main window listens for.
   // The event payload mirrors the `Email` shape Compose's reply /
   // forward init expects, so the main window can splat it straight
   // into `openCompose`.  We don't focus the main window here — the
   // user just clicked a button in *this* window, so they know it
   // popped a Compose somewhere; jumping focus would be jarring.
-  type ComposeKind = 'reply' | 'reply-all' | 'forward'
   async function emitCompose(kind: ComposeKind, mail: EmailPayload) {
     try {
-      await emit('compose-from-mail', { kind, mail })
+      const ready = await ensureDecryptedLocal(mail, kind)
+      if (!ready) return
+      await emit('compose-from-mail', {
+        kind,
+        mail: ready.mail,
+        pgpPassphrase: ready.passphrase,
+      })
     } catch (e) {
       console.warn(`compose-from-mail (${kind}) emit failed`, e)
     }
@@ -136,3 +270,89 @@
     onmailto={onMailto}
   />
 </div>
+
+<!-- #341 — popout-local decrypt prompt.  Same shape App.svelte
+     mounts at the main-window level, just instantiated here so it
+     appears on the same screen as the popped-out mail the user
+     just clicked Reply / Forward on. -->
+{#if pendingDecryptPrompt}
+  <div
+    class="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="decrypt-prompt-title"
+    tabindex="-1"
+    onclick={(e) => {
+      if (e.target === e.currentTarget) resolveDecryptPrompt(null)
+    }}
+    onkeydown={(e) => e.key === 'Escape' && resolveDecryptPrompt(null)}
+  >
+    <div
+      class="card p-5 max-w-sm w-[90%] bg-surface-100 dark:bg-surface-800 rounded-lg shadow-xl"
+    >
+      <h2 id="decrypt-prompt-title" class="text-base font-semibold mb-2">
+        {pendingDecryptPrompt.kind === 'forward'
+          ? m.mail_decrypt_for_forward_title()
+          : m.mail_decrypt_for_reply_title()}
+      </h2>
+      <p class="text-sm text-surface-600 dark:text-surface-300 mb-3">
+        {pendingDecryptPrompt.kind === 'forward'
+          ? m.mail_decrypt_for_forward_body({
+              sender: pendingDecryptPrompt.fromName,
+            })
+          : m.mail_decrypt_for_reply_body({
+              sender: pendingDecryptPrompt.fromName,
+            })}
+      </p>
+      <form
+        onsubmit={(e) => {
+          e.preventDefault()
+          if (!pendingDecryptPrompt || pendingDecryptPrompt.busy) return
+          resolveDecryptPrompt(pendingDecryptPrompt.value)
+        }}
+      >
+        <label
+          for="decrypt-prompt-passphrase-popout"
+          class="block text-xs text-surface-500 mb-1"
+        >
+          {m.mail_decrypt_passphrase_label()}
+        </label>
+        <input
+          id="decrypt-prompt-passphrase-popout"
+          type="password"
+          class="input w-full px-3 py-2 text-sm rounded-md mb-2"
+          bind:value={pendingDecryptPrompt.value}
+          disabled={pendingDecryptPrompt.busy}
+          autocomplete="off"
+          {@attach (node: HTMLInputElement) => {
+            if (!pendingDecryptPrompt?.busy) {
+              queueMicrotask(() => node.focus())
+            }
+          }}
+        />
+        {#if pendingDecryptPrompt.error}
+          <p class="text-xs text-red-500 mb-3">{pendingDecryptPrompt.error}</p>
+        {/if}
+        <div class="flex justify-end gap-2 mt-2">
+          <button
+            type="button"
+            class="btn btn-sm preset-outlined-surface-500"
+            disabled={pendingDecryptPrompt.busy}
+            onclick={() => resolveDecryptPrompt(null)}
+          >
+            {m.mail_decrypt_cancel_button()}
+          </button>
+          <button
+            type="submit"
+            class="btn btn-sm preset-filled-primary-500"
+            disabled={pendingDecryptPrompt.busy || !pendingDecryptPrompt.value}
+          >
+            {pendingDecryptPrompt.busy
+              ? m.mail_decrypt_busy_button()
+              : m.mail_decrypt_submit_button()}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+{/if}

--- a/ui/src/lib/StandaloneMail.svelte
+++ b/ui/src/lib/StandaloneMail.svelte
@@ -37,7 +37,11 @@
    *  `emitCompose` to decide whether the popout needs to prompt for
    *  a passphrase before forwarding the payload on.  Narrowed via
    *  an `as` cast at the boundary so the rest of this file stays
-   *  on the opaque `EmailPayload` type. */
+   *  on the opaque `EmailPayload` type.  `attachments` is included
+   *  because Forward of an encrypted message with attachments needs
+   *  the passphrase even if the body is already in the cache —
+   *  attachment bytes only come out of the inner MIME tree via
+   *  `download_decrypted_attachment`. */
   type DecryptableMail = {
     account_id: string
     folder: string
@@ -46,6 +50,7 @@
     body_text: string | null
     body_html?: string | null
     protection?: string | null
+    attachments?: { part_id: number }[]
   }
 
   let {
@@ -119,17 +124,40 @@
     resolve(passphrase)
   }
 
+  /** Was the source PGP-encrypted by the receive path?  Both
+   *  encrypt-only and the signed-and-encrypted variants qualify. */
+  function wasEncrypted(mail: DecryptableMail): boolean {
+    const p = mail.protection
+    return p === 'encrypted' || p === 'signed-and-encrypted'
+  }
+
   /** Does this mail need the popout-side decrypt step?  Same logic
    *  as App.svelte's `needsDecryptForReply` — encrypted protection
    *  tag *and* an empty cached body.  When the user clicked Decrypt
    *  inside the popout's reading pane already, the cache row
    *  carries the plaintext and this short-circuits to false. */
-  function needsDecrypt(mail: DecryptableMail): boolean {
-    const p = mail.protection
-    if (p !== 'encrypted' && p !== 'signed-and-encrypted') return false
+  function needsBodyDecrypt(mail: DecryptableMail): boolean {
+    if (!wasEncrypted(mail)) return false
     const text = (mail.body_text ?? '').trim()
     const html = (mail.body_html ?? '').trim()
     return text.length === 0 && html.length === 0
+  }
+
+  /** Does the popout-local prompt need to fire for this Reply /
+   *  Forward?  Two triggers, matched to App.svelte:
+   *    - Body needs decrypting (cached body is empty).
+   *    - Forward of an encrypted message with attachments — the
+   *      passphrase rides through to `downloadForwardAttachments`
+   *      so the bytes come from the inner MIME tree instead of the
+   *      outer `multipart/encrypted` envelope.  Without this, a
+   *      forward triggered after the user clicked Decrypt in the
+   *      popout would still ship "Version: 1" header bytes. */
+  function needsPromptForKind(mail: DecryptableMail, kind: ComposeKind): boolean {
+    if (needsBodyDecrypt(mail)) return true
+    if (kind === 'forward' && wasEncrypted(mail)) {
+      return (mail.attachments?.length ?? 0) > 0
+    }
+    return false
   }
 
   /** Prompt for the passphrase (looping on wrong input), call
@@ -148,7 +176,7 @@
     // a MailView `Email & { uid }` here; the narrower type lists the
     // subset we actually read.
     const narrow = mail as DecryptableMail
-    if (!needsDecrypt(narrow)) return { mail, passphrase: null }
+    if (!needsPromptForKind(narrow, kind)) return { mail, passphrase: null }
     let lastError = ''
     while (true) {
       const passphrase = await new Promise<string | null>((resolve) => {


### PR DESCRIPTION
Closes the Reply / Forward chunk of #341 (deferred from #57's PGP rollout).

## Summary

- **Decrypt before quoting.** Reply / Reply All / Forward on an encrypted message whose cached body is empty now opens a modal passphrase prompt, runs `decrypt_message`, and builds the quoted-history block off the plaintext. Cancel aborts the open; wrong passphrase keeps the modal up with an inline error. Pass-through when the user already decrypted the message in the reading pane (the cached body is non-empty).
- **Auto-encrypt on Reply.** `ComposeInitial.encryptByDefault` is set when the source carried `protection == encrypted` / `signed-and-encrypted`; Compose pre-flips the Encryption-tab toggle on and asks the editor to mount with the Encryption ribbon tab active so the passphrase input is the first thing the user sees. Forward is intentionally *not* auto-encrypted (changing recipients).
- **Recipient-key pre-validation.** When encryption is on, Compose debounces (400ms) all To/Cc/Bcc bare addresses through `pgp_get_keys_for_email` and surfaces a warning chip naming each recipient without a cached key — saves the user from typing a long reply only to hit "no key for X" at Send.

## Files

- [App.svelte](ui/src/App.svelte): `ensureDecryptedForReply` helper + `pendingDecryptPrompt` modal, threaded through `onReply` / `onReplyAll` / `onForward` and the popped-out `compose-from-mail` listener. New `protection?` field on `OpenMail`.
- [Compose.svelte](ui/src/lib/Compose.svelte): `ComposeInitial.encryptByDefault`, encrypt-on-mount, focus-passphrase-input effect, recipient-key check effect + warning banner.
- [RichTextEditor.svelte](ui/src/lib/RichTextEditor.svelte): new `defaultActiveTab` prop so Compose can seed the ribbon's active tab on mount.
- [en.json](ui/messages/en.json) / [de.json](ui/messages/de.json): paraglide strings for the new prompt + warning.

## Out of scope (still open in #341)

- JMAP `Blob/get` + decrypt plumbing
- `multipart/signed` sign-only
- BCC + PGP per-recipient envelopes
- Subkey selection for signing
- "Remember passphrase for session" opt-in
- Outbox encrypted-retry UX
- Cache armored ciphertext locally

These need their own PRs; this one stays focused on the Reply / Forward slice.

## Test plan

- [x] Reply to an encrypted-but-not-yet-decrypted message → passphrase prompt opens, decrypt succeeds → Compose opens with quoted history populated and the Encryption tab toggle on.
- [x] Wrong passphrase on the prompt → inline error, prompt stays up, retry succeeds.
- [x] Cancel the prompt → no Compose modal opens.
- [x] Reply to an encrypted message that was already decrypted in the reading pane → no prompt, opens immediately with the quoted body.
- [x] Reply to a plaintext message → no prompt, encryption toggle stays off (no regression).
- [x] Forward an encrypted message → prompt opens, encryption toggle stays **off** in Compose.
- [x] Forward an encrypted message with attachments → both the include-attachments prompt and the decrypt prompt run in the right order.
- [x] Popped-out reply (`compose-from-mail` event) on an encrypted message → same flow as the in-window path.
- [x] In Compose with encryption on, type an unknown recipient → warning chip appears within 400ms naming the address. Add a known recipient → only the unknown one stays in the chip.
- [x] Toggle encryption off → warning chip disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)