### PR TITLE
#341: opt-in Remember passphrase for session cache

### DIFF
--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -288,7 +288,7 @@
   "encryption_paste_label": "Armierten privaten OpenPGP-Schlüssel einfügen",
   "encryption_passphrase_label": "Passphrase",
   "encryption_passphrase_placeholder": "Wird benötigt, um den Schlüssel zu entsperren",
-  "encryption_passphrase_hint": "Die Passphrase wird einmal zur Validierung verwendet und dann verworfen. Compose fragt sie bei jeder verschlüsselten Sendung erneut ab.",
+  "encryption_passphrase_hint": "Die Passphrase wird einmal zur Validierung verwendet und dann verworfen. Compose fragt sie beim Senden verschlüsselter Nachrichten ab — es sei denn, die Option „Passphrase für diese Sitzung merken“ unter Sicherheit ist aktiv.",
   "encryption_import_submit": "Importieren",
   "encryption_import_cancel": "Abbrechen",
 
@@ -304,5 +304,13 @@
   "contact_form_label_pgp_keys": "OpenPGP-Schlüssel",
   "contact_form_placeholder_pgp_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----",
   "contact_form_button_add_pgp_key": "Schlüssel hinzufügen",
-  "contact_form_hint_pgp_keys": "Füge einen ASCII-armierten öffentlichen OpenPGP-Schlüssel ein. Wird über die vCard des Kontakts synchronisiert und lokal zwischengespeichert, damit Compose verschlüsselt an diese Adresse senden kann."
+  "contact_form_hint_pgp_keys": "Füge einen ASCII-armierten öffentlichen OpenPGP-Schlüssel ein. Wird über die vCard des Kontakts synchronisiert und lokal zwischengespeichert, damit Compose verschlüsselt an diese Adresse senden kann.",
+
+  "security_pgp_section_title": "PGP-Passphrase",
+  "security_pgp_remember_toggle_label": "Passphrase für diese Sitzung merken",
+  "security_pgp_remember_toggle_hint_off": "Aus — Compose und Entschlüsseln fragen Ihre PGP-Passphrase jedes Mal neu ab.",
+  "security_pgp_remember_toggle_hint_on_empty": "An — sobald Sie eine verschlüsselte Nachricht entschlüsseln oder senden, bleibt Ihre Passphrase im Speicher, bis Sie Unkai Mail schließen.",
+  "security_pgp_remember_toggle_hint_on_cached_one": "Für ein Konto in dieser Sitzung zwischengespeichert. Nur im Speicher — nicht auf der Festplatte, nicht in herausgelösten Fenstern.",
+  "security_pgp_remember_toggle_hint_on_cached_many": "Für {count} Konten in dieser Sitzung zwischengespeichert. Nur im Speicher — nicht auf der Festplatte, nicht in herausgelösten Fenstern.",
+  "security_pgp_forget_button": "Gespeicherte Passphrasen verwerfen"
 }

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -287,7 +287,7 @@
   "encryption_paste_label": "Paste armored OpenPGP private key",
   "encryption_passphrase_label": "Passphrase",
   "encryption_passphrase_placeholder": "Required to unlock the key",
-  "encryption_passphrase_hint": "The passphrase is used once to verify the key parses, then dropped. Compose will prompt for it again on every encrypted send.",
+  "encryption_passphrase_hint": "The passphrase is used once to verify the key parses, then dropped. Compose asks for it when you send encrypted mail — unless you've enabled \"Remember passphrase for this session\" under Security.",
   "encryption_import_submit": "Import",
   "encryption_import_cancel": "Cancel",
 
@@ -303,5 +303,13 @@
   "contact_form_label_pgp_keys": "OpenPGP keys",
   "contact_form_placeholder_pgp_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----",
   "contact_form_button_add_pgp_key": "Add a key",
-  "contact_form_hint_pgp_keys": "Paste an ASCII-armored OpenPGP public key. Round-trips through the contact's vCard and is also cached locally so Compose can encrypt to this address."
+  "contact_form_hint_pgp_keys": "Paste an ASCII-armored OpenPGP public key. Round-trips through the contact's vCard and is also cached locally so Compose can encrypt to this address.",
+
+  "security_pgp_section_title": "PGP passphrase",
+  "security_pgp_remember_toggle_label": "Remember passphrase for this session",
+  "security_pgp_remember_toggle_hint_off": "Off — Compose and Decrypt ask for your PGP passphrase every time.",
+  "security_pgp_remember_toggle_hint_on_empty": "On — once you decrypt or send an encrypted message, your passphrase stays in memory until you close Unkai Mail.",
+  "security_pgp_remember_toggle_hint_on_cached_one": "Cached for one account in this session. Stored in memory only — never written to disk, never shared with popped-out windows.",
+  "security_pgp_remember_toggle_hint_on_cached_many": "Cached for {count} accounts in this session. Stored in memory only — never written to disk, never shared with popped-out windows.",
+  "security_pgp_forget_button": "Forget cached passphrases"
 }

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -55,6 +55,11 @@
     type MeetingInvite,
   } from './lib/inviteHtml'
   import { parseMailtoUrl } from './lib/mailtoUrl'
+  import {
+    cachePassphrase,
+    forgetPassphrase,
+    readCachedPassphrase,
+  } from './lib/sessionPassphraseStore.svelte'
   import SearchBar, {
     type SearchScope,
     type SearchFilters,
@@ -2183,7 +2188,52 @@
     if (!bodyNeedsDecrypt && !forwardNeedsAttachmentKey) {
       return { mail, passphrase: null }
     }
+    // #341 — when the user has opted into "Remember passphrase
+    // for this session" *and* a previous decrypt/send on this
+    // account already populated the cache, skip the modal
+    // entirely on the first attempt and try the cached value
+    // against `decrypt_message`.  If it succeeds the Reply /
+    // Forward continues straight into Compose with no extra
+    // click; if it fails we evict the now-stale entry and fall
+    // through to the manual prompt loop below (with the error
+    // shown above the input so the user knows why).  Cache
+    // returns null for opt-out users, so this whole block is a
+    // no-op for them.
     let lastError = ''
+    const cachedPassphrase = readCachedPassphrase(mail.account_id)
+    if (cachedPassphrase) {
+      try {
+        const decrypted = await invoke<{
+          body_text: string | null
+          body_html: string | null
+          attachments: {
+            filename: string
+            content_type: string
+            size: number | null
+            part_id: number
+            content_id?: string | null
+          }[]
+        }>('decrypt_message', {
+          accountId: mail.account_id,
+          folder: mail.folder,
+          uid: mail.uid,
+          pgpPassphrase: cachedPassphrase,
+        })
+        return {
+          mail: {
+            ...mail,
+            body_text: decrypted.body_text,
+            body_html: decrypted.body_html,
+            attachments: decrypted.attachments,
+          } as T,
+          passphrase: cachedPassphrase,
+        }
+      } catch (e) {
+        forgetPassphrase(mail.account_id)
+        const raw = formatError(e) || 'Decrypt failed'
+        lastError = raw.replace(/^Crypto:\s*/i, '')
+      }
+    }
     while (true) {
       const passphrase = await new Promise<string | null>((resolve) => {
         pendingDecryptPrompt = {
@@ -2242,6 +2292,11 @@
           pgpPassphrase: passphrase,
         })
         pendingDecryptPrompt = null
+        // #341 — passphrase just verifiably unlocked the key,
+        // so feed the session cache before handing it back to
+        // the Reply / Forward caller.  No-op for users who
+        // haven't opted in via Security.
+        cachePassphrase(mail.account_id, passphrase)
         return {
           mail: {
             ...mail,

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -42,6 +42,11 @@
   import CreateTalkRoomModal, { type TalkRoom } from './CreateTalkRoomModal.svelte'
   import EventEditor, { type SavedEvent } from './EventEditor.svelte'
   import { openComposeInStandaloneWindow } from './standaloneComposeWindow'
+  import {
+    cachePassphrase,
+    forgetPassphrase,
+    readCachedPassphrase,
+  } from './sessionPassphraseStore.svelte'
 
   /** Slim Nextcloud account row — same shape `TalkView` / `Sidebar` use.
       We only need the id to pass to the Talk + Calendar commands. */
@@ -1014,13 +1019,39 @@
   let encryptEnabled = $state(initial?.encryptByDefault === true)
   // Inline passphrase entry shown when the user clicks Send with
   // encryption on.  Cleared on submit and on cancel so a freshly-
-  // opened Compose never inherits a stale passphrase.
-  let pgpPassphrase = $state('')
+  // opened Compose never inherits a stale passphrase — *unless*
+  // the user has opted into Security → "Remember passphrase for
+  // this session" (#341), in which case `readCachedPassphrase`
+  // returns the cached value for the active sending account and
+  // we skip the re-prompt entirely.
+  // svelte-ignore state_referenced_locally
+  let pgpPassphrase = $state(readCachedPassphrase(accountId) ?? '')
   /** `true` once the user has clicked Send with encryption on but
    *  before they've supplied the passphrase.  Drives the inline
    *  passphrase prompt block (rendered just above the Send
    *  button). */
   let awaitingPassphrase = $state(false)
+
+  // #341 — when encryption is on and the user hasn't typed
+  // anything yet, pull the cached session passphrase for the
+  // current sending account (returns null when the user hasn't
+  // opted in, or hasn't decrypted/sent yet this session).  Re-
+  // runs when the user flips the encryption toggle on or
+  // switches the From dropdown — both legitimately changing
+  // which cache slot we should consult.  `pgpPassphrase` is
+  // read under `untrack` so deliberately clearing the input
+  // doesn't trip the effect into immediately re-populating
+  // from cache; only the explicit triggers above kick a re-
+  // fill, and the truthy short-circuit prevents clobbering a
+  // value the user has actually typed.
+  $effect(() => {
+    if (!encryptEnabled) return
+    if (untrack(() => pgpPassphrase)) return
+    const cached = readCachedPassphrase(fromAccountId)
+    if (cached) {
+      pgpPassphrase = cached
+    }
+  })
 
   // #341 — when the parent pre-enabled encryption (reply to an
   // encrypted message), pull the passphrase input into focus once
@@ -2156,6 +2187,14 @@
         // IPC resolves so it doesn't linger across re-renders.
         pgpPassphrase: encryptEnabled ? pgpPassphrase : null,
       })
+      // #341 — feed the cross-Compose session cache from the
+      // passphrase that just verifiably unlocked the active key.
+      // Done before the local wipe so the value is still in
+      // scope; the cache helper short-circuits when the user
+      // hasn't opted in.
+      if (encryptEnabled && pgpPassphrase) {
+        cachePassphrase(snap.fromAccountId, pgpPassphrase)
+      }
       // Wipe the in-memory passphrase before yielding back to the
       // outer flow so a successful send doesn't leave it sitting
       // on the heap for the rest of Compose's lifetime.
@@ -2169,6 +2208,18 @@
     } catch (e: any) {
       const msg = formatError(e) || 'Failed to send'
       console.warn('send_email failed', e)
+      // #341 — a `Crypto:`-prefixed UnkaiError means the
+      // passphrase didn't unlock the active key.  If we'd
+      // sourced it from the session cache the cached value is
+      // now stale, so evict it before the user retries — they
+      // need to type the right one anyway, and leaving the
+      // wrong one cached would have every subsequent encrypt
+      // fail with the same error.  Non-crypto errors (SMTP
+      // down, network glitch, etc.) are unrelated to the
+      // passphrase, so the cache is left alone there.
+      if (encryptEnabled && /^Crypto:/i.test(msg)) {
+        forgetPassphrase(snap.fromAccountId)
+      }
       // #304: in a popped-out Compose the modal is still on screen
       // (we await this pipeline inline before closing).  Rethrow
       // so `send()` can surface the error inline and keep the

--- a/ui/src/lib/EncryptionSettings.svelte
+++ b/ui/src/lib/EncryptionSettings.svelte
@@ -25,6 +25,7 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core'
   import { m } from '../paraglide/messages'
+  import { forgetPassphrase } from './sessionPassphraseStore.svelte'
 
   /** Status payload returned by `pgp_get_account_key_status`. */
   interface PgpKeyStatus {
@@ -136,6 +137,12 @@
     errorMessage = null
     try {
       await invoke<void>('pgp_remove_private_key', { accountId: account.id })
+      // #341 — without a key there's nothing to unlock, so any
+      // cached session passphrase for this account is now
+      // meaningless.  Drop it so a fresh import (possibly with
+      // a different passphrase) doesn't silently inherit the
+      // wrong cached value.
+      forgetPassphrase(account.id)
       await refreshStatus(account.id)
       oncrypto_changed?.()
     } catch (e) {

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -34,6 +34,11 @@
     isSenderTrusted,
   } from './trustedSenders'
   import { parseMailtoUrl } from './mailtoUrl'
+  import {
+    cachePassphrase,
+    forgetPassphrase,
+    readCachedPassphrase,
+  } from './sessionPassphraseStore.svelte'
 
   interface EmailAttachment {
     filename: string
@@ -238,6 +243,13 @@
       // without re-prompting.  Done BEFORE wiping the input so the
       // session value carries through.
       sessionPassphrase = decryptPassphrase
+      // #341 — also feed the cross-message session cache so the
+      // next encrypted mail the user opens (and any encrypted
+      // send from Compose) can skip the prompt.  A no-op when
+      // the user hasn't opted into Security → "Remember
+      // passphrase for this session", so the strict-prompt
+      // default is preserved for everyone else.
+      cachePassphrase(email.account_id, decryptPassphrase)
       // Clear the passphrase the moment the IPC resolves so it
       // never lingers on the heap or in a DOM input that the
       // user could leave open.
@@ -250,6 +262,12 @@
       // the IPC channel, so debugging info isn't lost.
       const raw = formatError(e) || 'Decrypt failed'
       decryptError = raw.replace(/^Crypto:\s*/i, '')
+      // #341 — evict the session cache the moment a decrypt fails:
+      // if the cached value was the one that just got rejected,
+      // leaving it in place would silently break the user's next
+      // attachment open / Compose send.  Cheap to re-cache on the
+      // next successful decrypt.
+      if (email) forgetPassphrase(email.account_id)
     } finally {
       decrypting = false
     }
@@ -470,15 +488,20 @@
     whiteBackgroundOverride = null
     // #57 — clear any in-flight decrypt state from the previous
     // message; a passphrase the user typed for `mail A` must not
-    // ride along to `mail B`.
-    decryptPassphrase = ''
+    // ride along to `mail B`.  #341 — *unless* the user opted
+    // into "Remember passphrase for this session" in Security,
+    // in which case `readCachedPassphrase` returns the cached
+    // value for this account and we pre-populate both the
+    // visible Decrypt input (so the click submits without
+    // re-typing) and the session passphrase (so attachment
+    // fetches work even before the user clicks Decrypt).  When
+    // the user hasn't opted in the helper returns null and the
+    // behaviour collapses back to the strict per-message reset.
+    const cached = readCachedPassphrase(id) ?? ''
+    decryptPassphrase = cached
     decryptError = ''
     decrypting = false
-    // #341 — drop the session passphrase too.  Held only for the
-    // currently-open message so attachment fetches can decrypt
-    // without re-prompting; opening a different message starts a
-    // fresh session.
-    sessionPassphrase = ''
+    sessionPassphrase = cached
 
     // Cache first — lets the reading pane paint instantly when the user
     // re-opens a previously read message (the common case).

--- a/ui/src/lib/SecuritySettings.svelte
+++ b/ui/src/lib/SecuritySettings.svelte
@@ -26,6 +26,13 @@
     isWebAuthnAvailable,
   } from './webauthnPrf'
   import Toggle from './Toggle.svelte'
+  import { m } from '../paraglide/messages'
+  import {
+    cachedPassphraseCount,
+    forgetAllPassphrases,
+    isSessionPassphraseEnabled,
+    setSessionPassphraseEnabled,
+  } from './sessionPassphraseStore.svelte'
 
   interface FidoCredential {
     kind: 'fido_prf' | 'passphrase'
@@ -605,4 +612,52 @@
       {/if}
     </div>
   {/if}
+
+  <!-- PGP passphrase session cache (#341).  Independent of the
+       FIDO unlock block above — this controls whether your
+       OpenPGP key passphrase is re-prompted on every encrypted
+       send/decrypt or remembered for the rest of the running
+       app session.  Off by default; the toggle persists in
+       localStorage but the cached passphrases themselves live
+       only in JS memory and die with the window. -->
+  <div class="rounded-md border border-surface-200 dark:border-surface-700 p-4 space-y-3">
+    <div class="flex items-start gap-3">
+      <Toggle
+        checked={isSessionPassphraseEnabled()}
+        onchange={(v) => setSessionPassphraseEnabled(v)}
+        label={m.security_pgp_remember_toggle_label()}
+        class="mt-0.5"
+      />
+      <div class="flex-1">
+        <h3 class="font-medium leading-tight">
+          {m.security_pgp_section_title()}
+        </h3>
+        <p class="text-xs text-surface-500 mt-1 max-w-xl leading-snug">
+          {#if !isSessionPassphraseEnabled()}
+            {m.security_pgp_remember_toggle_hint_off()}
+          {:else if cachedPassphraseCount() === 0}
+            {m.security_pgp_remember_toggle_hint_on_empty()}
+          {:else if cachedPassphraseCount() === 1}
+            {m.security_pgp_remember_toggle_hint_on_cached_one()}
+          {:else}
+            {m.security_pgp_remember_toggle_hint_on_cached_many({
+              count: cachedPassphraseCount(),
+            })}
+          {/if}
+        </p>
+      </div>
+    </div>
+    {#if isSessionPassphraseEnabled()}
+      <div class="ml-12">
+        <button
+          type="button"
+          class="btn btn-sm preset-outlined-surface-500"
+          disabled={cachedPassphraseCount() === 0}
+          onclick={forgetAllPassphrases}
+        >
+          {m.security_pgp_forget_button()}
+        </button>
+      </div>
+    {/if}
+  </div>
 </section>

--- a/ui/src/lib/StandaloneMail.svelte
+++ b/ui/src/lib/StandaloneMail.svelte
@@ -24,6 +24,11 @@
   import { applyTheme, installSystemModeListener, type ThemeMode } from './theme'
   import { formatError } from './errors'
   import { m } from '../paraglide/messages'
+  import {
+    cachePassphrase,
+    forgetPassphrase,
+    readCachedPassphrase,
+  } from './sessionPassphraseStore.svelte'
 
   // We never inspect the email shape inside the standalone window —
   // it's just a payload we forward to the main window via Tauri
@@ -203,7 +208,49 @@
     // subset we actually read.
     const narrow = mail as DecryptableMail
     if (!needsPromptForKind(narrow, kind)) return { mail, passphrase: null }
+    // #341 — popout windows have their own JS context, so the
+    // module-level session cache here is independent of the main
+    // window's.  The opt-in flag lives in localStorage and *is*
+    // shared, so as soon as the user has decrypted or sent
+    // anything inside this popout the cache picks up for the
+    // rest of its lifetime.  Try a cache hit before mounting the
+    // prompt; on failure evict and fall through to the manual
+    // entry loop with the error already pinned above the input.
     let lastError = ''
+    const cachedPassphrase = readCachedPassphrase(narrow.account_id)
+    if (cachedPassphrase) {
+      try {
+        const decrypted = await invoke<{
+          body_text: string | null
+          body_html: string | null
+          attachments: {
+            filename: string
+            content_type: string
+            size: number | null
+            part_id: number
+            content_id?: string | null
+          }[]
+        }>('decrypt_message', {
+          accountId: narrow.account_id,
+          folder: narrow.folder,
+          uid: narrow.uid,
+          pgpPassphrase: cachedPassphrase,
+        })
+        return {
+          mail: {
+            ...(mail as object),
+            body_text: decrypted.body_text,
+            body_html: decrypted.body_html,
+            attachments: decrypted.attachments,
+          } as EmailPayload,
+          passphrase: cachedPassphrase,
+        }
+      } catch (e) {
+        forgetPassphrase(narrow.account_id)
+        const raw = formatError(e) || 'Decrypt failed'
+        lastError = raw.replace(/^Crypto:\s*/i, '')
+      }
+    }
     while (true) {
       const passphrase = await new Promise<string | null>((resolve) => {
         pendingDecryptPrompt = {
@@ -255,6 +302,10 @@
           pgpPassphrase: passphrase,
         })
         pendingDecryptPrompt = null
+        // #341 — passphrase just unlocked the active key in
+        // this popout; seed the popout's own session cache so
+        // a follow-up Forward / Reply skips the prompt.
+        cachePassphrase(narrow.account_id, passphrase)
         return {
           mail: {
             ...(mail as object),

--- a/ui/src/lib/sessionPassphraseStore.svelte.ts
+++ b/ui/src/lib/sessionPassphraseStore.svelte.ts
@@ -1,0 +1,142 @@
+/**
+ * sessionPassphraseStore — opt-in in-memory cache of PGP
+ * passphrases for the lifetime of the running app session (#341).
+ *
+ * Default behaviour matches the #57 v1 design decision: every
+ * decrypt or encrypted-send re-prompts for the passphrase, the
+ * input is wiped the moment the IPC resolves, no plaintext
+ * passphrase outlives the surface that captured it.  This
+ * module *opts the user out* of that re-prompting when they
+ * flip the Security setting on: the passphrase that
+ * successfully unlocked a key is kept in this module's
+ * heap-resident Map (keyed by account id) until the toggle is
+ * flipped off, the user clicks "Forget cached passphrases",
+ * or the app window closes.
+ *
+ * Why a module store and not a Tauri-side cache?  The user
+ * picked the smallest-scope option for this sub-item of #341,
+ * and the existing per-message `sessionPassphrase` $state in
+ * MailView is the hook this extends.  A backend
+ * `RwLock<UnlockedKey>` would survive popout windows for free
+ * (separate JS contexts share one Rust process), but it forces
+ * a refactor through every PGP Tauri command.  This module
+ * stops at the same surface the v1 hook already covered: the
+ * main window's Compose / MailView / in-window decrypt prompt.
+ * Popped-out windows (StandaloneMail) keep re-prompting — a
+ * deliberate v1 limitation worth a follow-up if popout-heavy
+ * workflows surface real friction.
+ *
+ * Storage rules:
+ *  - The cache itself never touches disk.  A full app close
+ *    wipes the JS heap, which is the strongest guarantee a
+ *    pure-frontend cache can offer.
+ *  - Only the *enable flag* persists, via localStorage, so the
+ *    setting survives restart even though the cache doesn't.
+ *  - Flipping the toggle OFF wipes every cached entry, not just
+ *    new captures — the user has signalled they want
+ *    re-prompting back.
+ */
+
+const LOCAL_STORAGE_KEY = 'unkai.rememberSessionPassphrase'
+
+function readEnabledFromStorage(): boolean {
+  try {
+    return localStorage.getItem(LOCAL_STORAGE_KEY) === '1'
+  } catch {
+    // Some webview modes don't expose localStorage; treat that
+    // as "not enabled" so we fall back to the strict re-prompt
+    // behaviour rather than silently caching against the user's
+    // expectations.
+    return false
+  }
+}
+
+function writeEnabledToStorage(v: boolean): void {
+  try {
+    localStorage.setItem(LOCAL_STORAGE_KEY, v ? '1' : '0')
+  } catch {
+    /* webview may not expose localStorage */
+  }
+}
+
+// Heap-only `accountId -> passphrase`.  Plain Map: cache reads
+// are not reactive (the consumer's IPC payload doesn't need to
+// re-run when the cache changes), only the meta-fields below
+// are.
+const cache = new Map<string, string>()
+
+// Reactive mirror of localStorage so a Settings toggle bound to
+// `isEnabled()` updates in step with `setEnabled(...)`.
+let enabled = $state(readEnabledFromStorage())
+
+// Reactive size mirror so the Settings UI can render a "N
+// accounts currently cached" affordance and grey out the
+// Forget button when nothing's cached.  We can't subscribe
+// directly to a Map, so every mutator updates this field
+// alongside the underlying Map.
+let cachedCount = $state(0)
+
+/** Whether the session-passphrase cache is currently opt-in.
+ *  Reactive — Svelte components reading this inside an effect
+ *  or template re-render when the toggle flips. */
+export function isSessionPassphraseEnabled(): boolean {
+  return enabled
+}
+
+/** Flip the opt-in.  Persists to localStorage so the choice
+ *  survives restart.  Turning the toggle *off* always wipes
+ *  any currently-cached entries — caching them was conditional
+ *  on the user wanting the feature, so consent withdrawal
+ *  evicts them immediately. */
+export function setSessionPassphraseEnabled(v: boolean): void {
+  enabled = v
+  writeEnabledToStorage(v)
+  if (!v) {
+    cache.clear()
+    cachedCount = 0
+  }
+}
+
+/** Stash a passphrase for an account.  No-ops when the user
+ *  hasn't opted in, so callers can fire this unconditionally
+ *  after every successful decrypt / encrypt without gating
+ *  themselves on the setting. */
+export function cachePassphrase(accountId: string, passphrase: string): void {
+  if (!enabled || !accountId || !passphrase) return
+  cache.set(accountId, passphrase)
+  cachedCount = cache.size
+}
+
+/** Returns the cached passphrase for an account, or `null`.
+ *  Also returns `null` whenever caching is disabled — callers
+ *  can treat a null result the same way regardless of why. */
+export function readCachedPassphrase(accountId: string): string | null {
+  if (!enabled || !accountId) return null
+  return cache.get(accountId) ?? null
+}
+
+/** Drop one account's cached passphrase.  Used when an
+ *  IPC rejects the cached value (passphrase changed underneath
+ *  us, or key was rotated) so the next attempt re-prompts the
+ *  user instead of silently failing in a loop. */
+export function forgetPassphrase(accountId: string): void {
+  if (cache.delete(accountId)) {
+    cachedCount = cache.size
+  }
+}
+
+/** Nuke everything.  Bound to the Settings "Forget cached
+ *  passphrases" button and reused when the user removes their
+ *  PGP key entirely. */
+export function forgetAllPassphrases(): void {
+  if (cache.size === 0) return
+  cache.clear()
+  cachedCount = 0
+}
+
+/** How many distinct accounts currently have a cached
+ *  passphrase.  Reactive — drives the Settings UI's "N cached"
+ *  copy and Forget-button enabled state. */
+export function cachedPassphraseCount(): number {
+  return cachedCount
+}


### PR DESCRIPTION
## Summary

Closes one sub-item of #341: the **"Remember passphrase for session"** opt-in.

Adds a toggle under **Settings → Security** that, when on, keeps the PGP passphrase in JS memory for the lifetime of the running window — so once you've decrypted or sent an encrypted message, Compose pre-fills, MailView's Decrypt button submits on one click, and Reply / Forward on encrypted threads skips the modal entirely. Off by default; behaviour for everyone who doesn't flip the toggle is byte-identical to before.

## Design

- **Module-level Svelte store** (`ui/src/lib/sessionPassphraseStore.svelte.ts`) keyed by `accountId`. Cache stays in the JS heap; closing the window wipes it. The toggle itself lives in `localStorage` so the opt-in survives restart even though the cache never does.
- **One cache per WebviewWindow** — deliberate. The main window and any popped-out mail window have independent caches; closing one window doesn't drain the other. The opt-in flag is shared (localStorage is per-origin). A future follow-up could move this to a Tauri-side `RwLock` for cross-window sharing — the issue body's `tokio::sync::RwLock<Option<UnlockedKey>>` sketch — but that's a bigger refactor through every PGP command and not justified by current friction.
- **Eviction is conservative** — only on `Crypto:`-prefixed errors (wrong passphrase) and on private-key removal. SMTP / network errors leave the cache alone so a transient outage doesn't force a re-type on retry.

## Surfaces wired

| Surface | Read cache | Write cache | Evict |
|---|---|---|---|
| MailView body decrypt | `load()` pre-fills both `sessionPassphrase` (attachments) and `decryptPassphrase` (input) | After `decrypt_message` succeeds | After `decrypt_message` fails |
| Compose | On mount + `$effect` on encryption-on / From-change (with `untrack` so clearing the input stays cleared) | After successful send with encryption on | On `Crypto:`-prefixed send error |
| App.svelte Reply / Forward prompt | Silent first attempt before the modal mounts | After manual prompt succeeds | After silent attempt fails |
| StandaloneMail popout prompt | Same pattern (own cache instance) | Same | Same |
| EncryptionSettings | — | — | On `pgp_remove_private_key` |

## Localisation

New keys in `en.json` + `de.json` (paraglide `_one` / `_many` split rather than ICU `plural`, matching the existing `account_setup_cert_fingerprint_many_plural` convention). Also softens the existing `encryption_passphrase_hint` since it previously promised always-re-prompt.

## Out of scope (still open under #341)

JMAP Blob/get plumbing, multipart/signed sign-only, BCC + PGP per-recipient, Outbox encrypted-retry UX, armored-ciphertext local cache. Each gets its own branch off main per the tracker rule.

## Test plan

- [ ] Toggle **Settings → Security → Remember passphrase for this session** on. Hint text flips between off / on-empty / on-1 / on-N as you decrypt across accounts.
- [ ] Open an encrypted message → click Decrypt → typed passphrase succeeds. Open a *second* encrypted message on the same account → Decrypt input is pre-filled, click submits without retyping. Open an attachment without clicking Decrypt first → it opens (encrypted-attachment fetch picks up the pre-populated `sessionPassphrase`).
- [ ] Reply / Forward an encrypted message → modal does NOT appear when a cached passphrase exists; Compose opens with the quoted history and (for Reply) encryption pre-enabled.
- [ ] Compose a new encrypted mail → passphrase field is pre-filled; clearing it manually stays cleared (the `untrack` guard).
- [ ] Type a wrong passphrase in Compose's Encryption tab → Send fails with a Crypto error → next Compose Send opens with an empty passphrase field (evicted) and prompts you again.
- [ ] **Forget cached passphrases** button wipes the count back to 0 immediately; subsequent decrypt re-prompts.
- [ ] Toggle the setting OFF → cache is wiped immediately; every subsequent decrypt / send prompts as before.
- [ ] Remove the PGP key under per-account Encryption settings → cache entry for that account drops (verify by re-importing a different key and confirming no auto-fill).
- [ ] Pop a mail out into a standalone window → first decrypt prompts; subsequent Reply / Forward in that same popout skips the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
