### PR TITLE
#341: background-decrypt encrypted mail during sync

### DIFF
--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -859,7 +859,7 @@ impl ImapClient {
                     .uid_fetch(
                         range,
                         "(UID FLAGS INTERNALDATE ENVELOPE \
-                         BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
+                         BODY.PEEK[HEADER.FIELDS (REFERENCES CONTENT-TYPE)])",
                     )
                     .await
                     .map_err(|e| UnkaiError::Protocol(format!("UID FETCH failed: {e}")))?
@@ -876,7 +876,7 @@ impl ImapClient {
                     .fetch(
                         &range,
                         "(UID FLAGS INTERNALDATE ENVELOPE \
-                         BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
+                         BODY.PEEK[HEADER.FIELDS (REFERENCES CONTENT-TYPE)])",
                     )
                     .await
                     .map_err(|e| UnkaiError::Protocol(format!("FETCH failed: {e}")))?
@@ -940,6 +940,12 @@ impl ImapClient {
                 }
 
                 let (message_id, in_reply_to, references_ids) = extract_threading_headers(fetch);
+                // #341 background-decrypt: detect a PGP/MIME envelope
+                // from the Content-Type header we pulled in the same
+                // FETCH — lets the mail-list lock chip appear the
+                // moment new mail arrives, instead of waiting for the
+                // user to open the message once.
+                let protection = extract_envelope_protection(fetch);
 
                 Some(EmailEnvelope {
                     uid,
@@ -968,13 +974,7 @@ impl ImapClient {
                     // envelopes don't know their thread identity yet.
                     thread_id: None,
                     thread_total_count: None,
-                    // Set on full-body fetch — IMAP envelope-only paths
-                    // don't see the message body, so they can't tell
-                    // whether it's PGP/MIME yet.  The cache LEFT-JOIN
-                    // in `get_envelopes` lifts the value out of
-                    // `message_bodies` once the message has been
-                    // opened at least once.
-                    protection: None,
+                    protection,
                 })
             })
             .collect();
@@ -2030,7 +2030,7 @@ impl ImapClient {
             .uid_fetch(
                 set,
                 "(UID FLAGS INTERNALDATE ENVELOPE \
-                 BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
+                 BODY.PEEK[HEADER.FIELDS (REFERENCES CONTENT-TYPE)])",
             )
             .await
             .map_err(|e| UnkaiError::Protocol(format!("UID FETCH after SEARCH failed: {e}")))?
@@ -2077,6 +2077,7 @@ impl ImapClient {
 
                 let (thread_msg_id, thread_in_reply_to, thread_refs) =
                     extract_threading_headers(fetch);
+                let protection = extract_envelope_protection(fetch);
 
                 Some(EmailEnvelope {
                     uid,
@@ -2096,13 +2097,7 @@ impl ImapClient {
                     // envelopes don't know their thread identity yet.
                     thread_id: None,
                     thread_total_count: None,
-                    // Set on full-body fetch — IMAP envelope-only paths
-                    // don't see the message body, so they can't tell
-                    // whether it's PGP/MIME yet.  The cache LEFT-JOIN
-                    // in `get_envelopes` lifts the value out of
-                    // `message_bodies` once the message has been
-                    // opened at least once.
-                    protection: None,
+                    protection,
                 })
             })
             .collect();
@@ -2166,7 +2161,7 @@ impl ImapClient {
             .uid_fetch(
                 set,
                 "(UID FLAGS INTERNALDATE ENVELOPE \
-                 BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
+                 BODY.PEEK[HEADER.FIELDS (REFERENCES CONTENT-TYPE)])",
             )
             .await
             .map_err(|e| UnkaiError::Protocol(format!("UID FETCH (older search) failed: {e}")))?
@@ -2210,6 +2205,7 @@ impl ImapClient {
                 }
                 let (thread_msg_id, thread_in_reply_to, thread_refs) =
                     extract_threading_headers(fetch);
+                let protection = extract_envelope_protection(fetch);
                 Some(EmailEnvelope {
                     uid,
                     folder: folder.to_string(),
@@ -2228,13 +2224,7 @@ impl ImapClient {
                     // envelopes don't know their thread identity yet.
                     thread_id: None,
                     thread_total_count: None,
-                    // Set on full-body fetch — IMAP envelope-only paths
-                    // don't see the message body, so they can't tell
-                    // whether it's PGP/MIME yet.  The cache LEFT-JOIN
-                    // in `get_envelopes` lifts the value out of
-                    // `message_bodies` once the message has been
-                    // opened at least once.
-                    protection: None,
+                    protection,
                 })
             })
             .collect();
@@ -2314,7 +2304,7 @@ impl ImapClient {
             .uid_fetch(
                 set,
                 "(UID FLAGS INTERNALDATE ENVELOPE \
-                 BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
+                 BODY.PEEK[HEADER.FIELDS (REFERENCES CONTENT-TYPE)])",
             )
             .await
             .map_err(|e| UnkaiError::Protocol(format!("UID FETCH (older) failed: {e}")))?
@@ -2361,6 +2351,7 @@ impl ImapClient {
 
                 let (thread_msg_id, thread_in_reply_to, thread_refs) =
                     extract_threading_headers(fetch);
+                let protection = extract_envelope_protection(fetch);
 
                 Some(EmailEnvelope {
                     uid,
@@ -2380,13 +2371,7 @@ impl ImapClient {
                     // envelopes don't know their thread identity yet.
                     thread_id: None,
                     thread_total_count: None,
-                    // Set on full-body fetch — IMAP envelope-only paths
-                    // don't see the message body, so they can't tell
-                    // whether it's PGP/MIME yet.  The cache LEFT-JOIN
-                    // in `get_envelopes` lifts the value out of
-                    // `message_bodies` once the message has been
-                    // opened at least once.
-                    protection: None,
+                    protection,
                 })
             })
             .collect();
@@ -2513,6 +2498,57 @@ fn extract_threading_headers(
         .map(parse_references_header)
         .unwrap_or_default();
     (message_id, in_reply_to, references)
+}
+
+/// #341 background-decrypt: peek at the BODY.PEEK[HEADER.FIELDS ...]
+/// payload to classify a message's PGP/MIME envelope (encrypted /
+/// signed / plaintext) without having to fetch the body.
+///
+/// Returns `Some("encrypted")` for `multipart/encrypted; protocol="application/pgp-encrypted"`,
+/// `Some("signed")` for `multipart/signed; protocol="application/pgp-signature"`,
+/// and `None` for anything else — including plain mail and messages
+/// whose top-level Content-Type isn't a PGP/MIME wrapper.
+///
+/// The mail-list lock chip is keyed off this value via the cache's
+/// `messages.protection` column, so the moment a new encrypted
+/// message lands the UI can render the chip without first opening
+/// the message.  The body-side `message_bodies.protection` stays
+/// authoritative once we've decrypted (it can carry the post-decrypt
+/// `"signed-and-encrypted"` label this header-only check can't), and
+/// envelope reads `COALESCE(b.protection, m.protection)` to prefer
+/// it.
+///
+/// Relies on the FETCH call site requesting `CONTENT-TYPE` in the
+/// header-fields list — callers that don't pass it will only see
+/// `None` here regardless of the message shape.  The PGP/MIME
+/// detection rules mirror [`detect_pgp_mime_envelope`] so a message
+/// classified as encrypted at envelope-fetch time stays classified
+/// the same way once its full body lands and the body parser runs.
+fn extract_envelope_protection(fetch: &async_imap::types::Fetch) -> Option<String> {
+    let raw = fetch.header()?;
+    // mail-parser handles RFC 5322 continuation lines + RFC 2045
+    // Content-Type parameter parsing for us — including quoted /
+    // unquoted protocol values, mixed-case header names, and
+    // RFC 2231-encoded attributes — without re-implementing the
+    // unfolding rules here.
+    let parsed = MessageParser::default().parse(raw)?;
+    let ct = parsed.content_type()?;
+    if !ct.ctype().eq_ignore_ascii_case("multipart") {
+        return None;
+    }
+    let subtype = ct.subtype()?;
+    let protocol = ct.attribute("protocol").unwrap_or("");
+    if subtype.eq_ignore_ascii_case("encrypted")
+        && protocol.eq_ignore_ascii_case("application/pgp-encrypted")
+    {
+        Some("encrypted".to_string())
+    } else if subtype.eq_ignore_ascii_case("signed")
+        && protocol.eq_ignore_ascii_case("application/pgp-signature")
+    {
+        Some("signed".to_string())
+    } else {
+        None
+    }
 }
 
 /// `<abc@host>` → `Some("abc@host")`.  Tolerates surrounding

--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -603,9 +603,9 @@ impl Cache {
                 "INSERT INTO messages
                    (account_id, folder, uid, from_addr, subject, internal_date,
                     is_read, is_starred, is_answered, cached_at,
-                    message_id, in_reply_to, references_ids, thread_id)
+                    message_id, in_reply_to, references_ids, thread_id, protection)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                         ?11, ?12, ?13, ?14)
+                         ?11, ?12, ?13, ?14, ?15)
                  ON CONFLICT (account_id, folder, uid) DO UPDATE SET
                    from_addr     = excluded.from_addr,
                    subject       = excluded.subject,
@@ -624,7 +624,12 @@ impl Cache {
                    -- so a re-fetch that brought new threading info updates
                    -- the row; otherwise we preserve whatever the previous
                    -- write (or the warm-up pass) assigned.
-                   thread_id     = COALESCE(excluded.thread_id, messages.thread_id)",
+                   thread_id     = COALESCE(excluded.thread_id, messages.thread_id),
+                   -- #341 background-decrypt: COALESCE preserves a
+                   -- post-decrypt label (\"signed-and-encrypted\") that a
+                   -- later envelope re-fetch — which can only see the
+                   -- top-level Content-Type — couldn't reproduce.
+                   protection    = COALESCE(excluded.protection, messages.protection)",
             )?;
             for env in envelopes {
                 let refs_json: Option<String> = if env.references_ids.is_empty() {
@@ -648,6 +653,7 @@ impl Cache {
                     env.in_reply_to,
                     refs_json,
                     thread_id,
+                    env.protection,
                 ])?;
             }
         }
@@ -680,6 +686,13 @@ impl Cache {
         // *whole folder*, not just the returned window — a thread
         // whose root is in the newest 50 may have replies older than
         // the window, and the badge needs to report the true total.
+        // #341 background-decrypt: COALESCE so the envelope-level
+        // protection (stamped at IMAP envelope-fetch time from the
+        // Content-Type header) shows up immediately on new mail, while
+        // the body-level protection — authoritative once we've decrypted,
+        // since it can carry "signed-and-encrypted" which the envelope
+        // path can't tell from headers alone — wins whenever the body
+        // row exists.
         let mut stmt = conn.prepare(
             "SELECT m.uid, m.folder, m.from_addr, m.subject, m.internal_date,
                     m.is_read, m.is_starred, m.is_answered, m.replied_kind,
@@ -690,7 +703,7 @@ impl Cache {
                        AND m2.folder = ?2
                        AND m2.thread_id = m.thread_id
                        AND m2.pending_action IS NULL) AS thread_total_count,
-                    b.protection
+                    COALESCE(b.protection, m.protection)
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE m.account_id = ?1 AND m.folder = ?2 AND m.pending_action IS NULL
@@ -765,7 +778,7 @@ impl Cache {
                        AND m2.folder = ?2
                        AND m2.thread_id = m.thread_id
                        AND m2.pending_action IS NULL) AS thread_total_count,
-                    b.protection
+                    COALESCE(b.protection, m.protection)
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE m.account_id = ?1
@@ -889,7 +902,7 @@ impl Cache {
                        AND m2.folder = m.folder
                        AND m2.thread_id = m.thread_id
                        AND m2.pending_action IS NULL) AS thread_total_count,
-                    b.protection
+                    COALESCE(b.protection, m.protection)
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE m.folder = ?1 AND m.pending_action IS NULL
@@ -979,7 +992,7 @@ impl Cache {
                        AND m2.folder = m.folder
                        AND m2.thread_id = m.thread_id
                        AND m2.pending_action IS NULL) AS thread_total_count,
-                    b.protection
+                    COALESCE(b.protection, m.protection)
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE ({where_clause}) AND m.pending_action IS NULL

--- a/crates/unkai-store/src/cache/schema.rs
+++ b/crates/unkai-store/src/cache/schema.rs
@@ -1139,6 +1139,23 @@ const MIGRATIONS: &[&str] = &[
     CREATE INDEX pgp_public_keys_by_email
         ON pgp_public_keys (email);
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // Background-decrypt during sync (#341 follow-up to PR #355).
+    //
+    // `messages.protection` lets the envelope-fetch path stamp the
+    // encryption / signature status of a message *without* waiting
+    // for the body to be fetched and parsed — so the mail-list lock
+    // chip appears the moment new mail arrives, not only after the
+    // user opens the message once.  The body-side
+    // `message_bodies.protection` stays authoritative once we've
+    // decrypted (it carries the post-decrypt label
+    // `"signed-and-encrypted"`); envelope reads `COALESCE` to the
+    // body's value when both are present.  Legacy rows stay `NULL`
+    // and continue to behave exactly as before the migration.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE messages ADD COLUMN protection TEXT;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6655,6 +6655,43 @@ async fn poll_folder(
         }
     };
 
+    // #341 background-decrypt: for accounts that opted into
+    // "Unlock automatically" (keychain holds a passphrase),
+    // proactively decrypt any newly-arrived PGP/MIME messages
+    // *during sync* so the plaintext lands in `message_bodies`
+    // before the user clicks the row.  This is what powers
+    // body previews / snippets and search hits on encrypted
+    // threads — without it the user has to open every encrypted
+    // message manually for the cache to pick up the plaintext
+    // (the auto-decrypt-on-open path shipped in PR #355 only
+    // fires from MailView's mount).
+    //
+    // Scope: new mail only.  `prior_highest` filters to UIDs
+    // strictly newer than the last sync bookmark — exactly the
+    // same definition `new_envelopes` uses for the new-mail
+    // badge.  A UIDVALIDITY rotation collapses `prior_highest`
+    // semantics (every UID is "new" under the rotated space),
+    // so we skip background decrypt in that branch.  Backfill
+    // of existing encrypted messages on first opt-in is a
+    // follow-up — the existing on-open auto-decrypt path
+    // covers it per message.
+    let background_decrypted: Vec<Email> =
+        if uidvalidity_rotated || !credentials::has_pgp_passphrase(account_id).unwrap_or(false) {
+            Vec::new()
+        } else {
+            let new_encrypted: Vec<&EmailEnvelope> = batch
+                .envelopes
+                .iter()
+                .filter(|e| prior_highest.is_some_and(|p| e.uid > p))
+                .filter(|e| e.protection.as_deref() == Some("encrypted"))
+                .collect();
+            if new_encrypted.is_empty() {
+                Vec::new()
+            } else {
+                background_decrypt_new(&mut client, account_id, folder, &new_encrypted, cache).await
+            }
+        };
+
     let _ = client.logout().await;
 
     if !server_uids.is_empty() || uidvalidity_rotated {
@@ -6685,6 +6722,27 @@ async fn poll_folder(
 
     if let Err(e) = cache.upsert_envelopes_for_account(account_id, &batch.envelopes) {
         tracing::warn!("cache.upsert_envelopes failed: {e}");
+    }
+
+    // #341 background-decrypt: write the just-decrypted bodies
+    // through *after* the envelope upsert so the body row's
+    // ON-CONFLICT-DO-UPDATE doesn't fight whatever the envelope
+    // upsert just wrote.  Per-row failure is logged but doesn't
+    // unwind the poll — the user can still open the message
+    // manually and the existing on-open path will fill the cache.
+    if !background_decrypted.is_empty() {
+        tracing::info!(
+            "background-decrypted {} encrypted message(s) for '{account_id}'/'{folder}'",
+            background_decrypted.len()
+        );
+        for email in &background_decrypted {
+            if let Err(e) = cache.upsert_message(email) {
+                tracing::warn!(
+                    "background-decrypt cache.upsert_message ({}) failed: {e}",
+                    email.id
+                );
+            }
+        }
     }
 
     let new_envelopes: Vec<EmailEnvelope> = if uidvalidity_rotated {
@@ -6817,6 +6875,93 @@ async fn fetch_message_inner(
     }
 
     Ok(email)
+}
+
+/// #341 background-decrypt: walk the just-detected new
+/// PGP/MIME-encrypted envelopes and produce one decrypted [`Email`]
+/// per UID we could successfully unlock.
+///
+/// Shares the live IMAP `client` with the surrounding `poll_folder`
+/// (folder already SELECTed, body fetches go down the same TCP
+/// session) so the only extra IMAP cost is `n` × `UID FETCH
+/// BODY.PEEK[]` for the encrypted UIDs.  Build the
+/// [`TauriCryptoBridge`] once per call: rpgp's `SignedSecretKey`
+/// owns the unlocked private material and we don't want to pay the
+/// keychain + parse cost per message.
+///
+/// Failure surfaces are deliberately split:
+///   - Passphrase resolution or bridge construction failure (the
+///     keychain entry is corrupt, or the stored private key won't
+///     parse with that passphrase) — one warning, skip every UID.
+///     Re-trying per message would just repeat the same failure.
+///   - Per-UID fetch or decrypt failure — one warning per UID, keep
+///     going.  A single recipient-mismatched or corrupted ciphertext
+///     shouldn't block the rest of the batch.
+///
+/// The returned [`Email`]s carry the `is_read` / `is_starred` flags
+/// from their matching envelope row so the subsequent
+/// `cache.upsert_message` write doesn't reset them — same overlay
+/// `decrypt_message` does on its on-demand path.
+async fn background_decrypt_new(
+    client: &mut ImapClient,
+    account_id: &str,
+    folder: &str,
+    new_encrypted: &[&EmailEnvelope],
+    cache: &Cache,
+) -> Vec<Email> {
+    let passphrase = match resolve_pgp_passphrase(account_id, "") {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                "background-decrypt: keychain passphrase resolve for '{account_id}' failed: {e}"
+            );
+            return Vec::new();
+        }
+    };
+    let bridge = match TauriCryptoBridge::for_account(account_id, &passphrase, (*cache).clone()) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(
+                "background-decrypt: bridge build for '{account_id}' failed (keychain \
+                 passphrase + stored key mismatch?): {e}"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut out = Vec::with_capacity(new_encrypted.len());
+    for env in new_encrypted {
+        let uid = env.uid;
+        let raw = match client.fetch_raw_message(folder, uid).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(
+                    "background-decrypt: fetch_raw_message UID {uid} in \
+                     '{account_id}'/'{folder}' failed: {e}"
+                );
+                continue;
+            }
+        };
+        let id = format!("{folder}:{uid}");
+        match unkai_imap::parse_eml_bytes_with_crypto(&raw, &id, account_id, folder, Some(&bridge))
+        {
+            Ok(mut email) => {
+                // Overlay IMAP flags from the matching envelope so the
+                // cache write below doesn't reset them — same overlay
+                // `decrypt_message` does on the user-clicked path.
+                email.is_read = env.is_read;
+                email.is_starred = env.is_starred;
+                out.push(email);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "background-decrypt: parse-with-crypto UID {uid} in \
+                     '{account_id}'/'{folder}' failed: {e}"
+                );
+            }
+        }
+    }
+    out
 }
 
 /// Pick the passphrase that should unlock this account's PGP key


### PR DESCRIPTION
## Summary

Follow-up to PR #355 (Unlock automatically). For accounts that opted into the per-account "Unlock automatically" toggle, this extends `poll_folder` to decrypt newly-arrived PGP/MIME messages during the sync poll itself — so plaintext lands in the `message_bodies` cache without waiting for the user to click into each encrypted message.

Wins this unlocks:
- **Full-text search hits decrypted bodies.** The FTS5 index is fed by triggers on `message_bodies` writes, so a background-decrypt automatically grows search coverage to encrypted threads.
- **Instant on-open render for encrypted mail.** The user clicks an encrypted row in the mail list and the cache already has plaintext — no IMAP fetch, no decrypt round-trip.
- **Mail-list lock chip appears the moment new encrypted mail arrives** (side benefit, applies to **all** accounts — not just opted-in ones — because envelope-level protection detection ships universally).

## Design

### Detection — Content-Type header instead of BODYSTRUCTURE

Extended the existing envelope-fetch `BODY.PEEK[HEADER.FIELDS (REFERENCES)]` to `(REFERENCES CONTENT-TYPE)`. mail-parser already handles the RFC 2045 quirks (continuation lines, quoted protocol params, mixed-case), and `multipart/encrypted; protocol="application/pgp-encrypted"` detection only needs the top-level Content-Type. Lighter than a separate `UID FETCH BODYSTRUCTURE` round trip (which would ship the entire MIME tree just to peek at the wrapper), and stays consistent with the existing header-fields pattern.

The new `extract_envelope_protection(fetch)` helper mirrors `detect_pgp_mime_envelope`'s classification rules so a message that lights up the lock chip at envelope-fetch time stays classified the same way once its full body is fetched and the body parser runs.

### Cache — new `messages.protection` column

Migration v3 → v4 adds `messages.protection TEXT`. `upsert_envelopes_for_account` writes it via `COALESCE(excluded.protection, messages.protection)` so a later envelope re-fetch (which can only see the top-level Content-Type) can't blow away a post-decrypt label that the body row carries.

Envelope reads — `get_envelopes` / `get_envelopes_by_thread` / `get_unified_envelopes` / `get_unified_envelopes_by_pairs` — now select `COALESCE(b.protection, m.protection)` so the body's authoritative value (e.g. `"signed-and-encrypted"`, which the envelope path can't infer from headers alone) wins whenever the body row exists.

### Background decrypt — inside `poll_folder`, gated on opt-in

After the existing `fetch_envelopes` / `list_all_uids` / `fetch_flags` block and before `client.logout()`:

- Gate on `credentials::has_pgp_passphrase(account_id)` — if no keychain entry, skip entirely. Same gate `try_auto_decrypt_message` uses.
- Filter `batch.envelopes` to UIDs strictly newer than `prior_highest` (the sync bookmark) AND `protection == Some("encrypted")` — same definition `new_envelopes` uses for the new-mail badge.
- Build one `TauriCryptoBridge` via `resolve_pgp_passphrase(account_id, "")` (the empty-string sentinel → keychain fallback path from PR #355). rpgp's `SignedSecretKey` owns the unlocked material; building once amortises the keychain + parse cost across the batch.
- For each UID: `client.fetch_raw_message` + `unkai_imap::parse_eml_bytes_with_crypto` (with the bridge) + overlay flags from the matching envelope. Per-UID failure logs a warning and continues; bridge-build failure short-circuits to skip the whole batch.
- After the existing envelope upsert, `cache.upsert_message` writes each decrypted body through. The FTS5 triggers pick it up automatically.

UIDVALIDITY rotation skips background-decrypt by design — `prior_highest` semantics collapse under a rotated UID space, and the existing `new_envelopes` logic already empties out in that branch.

## Scope cuts

- **Backfill of existing encrypted messages on first opt-in** is deferred. Background-decrypt only fires for UIDs strictly newer than the prior sync bookmark. The auto-decrypt-on-open path (#355) covers existing messages per-message when the user opens them. A follow-up could trigger a one-time backfill sweep on first opt-in.
- **JMAP path unchanged.** Background-decrypt only fires in the IMAP branch — JMAP still stamps `protection = "encrypted-cannot-decrypt"` per the existing JMAP-Blob/get deferral.

## Test plan

- [x] `cargo check --workspace` — green
- [x] `cargo fmt --check` — green
- [x] `cargo test -p unkai-store --lib` — 69 tests pass (incl. existing envelope upsert + thread + search coverage)
- [x] `cargo test -p unkai-imap --lib` — 19 tests pass (incl. PGP/MIME parse paths)
- [x] Manual: enable Unlock automatically on a PGP account, receive a new encrypted message, verify lock chip appears in mail list immediately and clicking the row shows decrypted plaintext without an IMAP fetch
- [x] Manual: search query that matches encrypted-message body returns the message after sync
- [x] Manual: disable Unlock automatically and verify new encrypted mail still shows the lock chip in the mail list (envelope-level detection) but stays encrypted until clicked
- [ ] Manual: confirm UIDVALIDITY rotation path doesn't crash or background-decrypt under the rotated UID space

🤖 Generated with [Claude Code](https://claude.com/claude-code)