### PR TITLE
#341: cache encrypted ciphertext locally so Decrypt runs offline

### DIFF
--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -1731,6 +1731,73 @@ impl Cache {
         Ok(row)
     }
 
+    // ── Encrypted ciphertext cache (#341) ───────────────────────
+    //
+    // Before this cache, every Decrypt click and every encrypted
+    // attachment download issued a fresh `UID FETCH BODY.PEEK[]`
+    // round-trip to IMAP — measurable latency on slow networks and
+    // a hard fail offline.  Storing the raw `.eml` bytes alongside
+    // the (decrypted) body lets the next decrypt for the same UID
+    // run entirely from local storage.
+
+    /// Cache the raw RFC 5322 bytes of an encrypted message so
+    /// later decrypts / attachment downloads for the same UID can
+    /// skip IMAP.
+    ///
+    /// UPSERT — creates a `message_bodies` row stamped with just
+    /// this column when one doesn't already exist (background-
+    /// decrypt during sync runs *before* the user has ever opened
+    /// the message, so the row may not be there yet), or patches
+    /// the column in place when it does.  The envelope row in
+    /// `messages` must already exist — the FK keeps us honest, and
+    /// every caller has already gone through envelope-fetch first.
+    pub fn put_encrypted_raw_eml(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+        raw: &[u8],
+    ) -> Result<(), CacheError> {
+        let conn = self.conn()?;
+        let now = Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO message_bodies
+                 (account_id, folder, uid, cached_at, encrypted_raw_eml)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT (account_id, folder, uid) DO UPDATE SET
+                 encrypted_raw_eml = excluded.encrypted_raw_eml",
+            params![account_id, folder, uid as i64, now, raw],
+        )?;
+        Ok(())
+    }
+
+    /// Load the cached raw `.eml` bytes for an encrypted message,
+    /// if any.  See [`Cache::put_encrypted_raw_eml`] for the write
+    /// side.
+    ///
+    /// `Ok(None)` covers: never-cached UIDs, plaintext messages
+    /// (we don't cache those), and pre-#341 rows.  Callers treat
+    /// any of those as a cache miss and fall through to IMAP.
+    pub fn get_encrypted_raw_eml(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+    ) -> Result<Option<Vec<u8>>, CacheError> {
+        let conn = self.conn()?;
+        let row = conn
+            .query_row(
+                "SELECT encrypted_raw_eml
+                   FROM message_bodies
+                  WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+                params![account_id, folder, uid as i64],
+                |r| r.get::<_, Option<Vec<u8>>>(0),
+            )
+            .optional()?
+            .flatten();
+        Ok(row)
+    }
+
     // ── Sync state ──────────────────────────────────────────────
 
     pub fn get_sync_state(

--- a/crates/unkai-store/src/cache/schema.rs
+++ b/crates/unkai-store/src/cache/schema.rs
@@ -1156,6 +1156,30 @@ const MIGRATIONS: &[&str] = &[
     r#"
     ALTER TABLE messages ADD COLUMN protection TEXT;
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v34 → v35: cache armored ciphertext locally (#341).
+    //
+    // `encrypted_raw_eml` stores the raw RFC 5322 bytes of an
+    // encrypted message so subsequent decrypts (manual Decrypt
+    // click, attachment download, auto-decrypt on re-open) can
+    // run without going back to IMAP for `BODY.PEEK[]`.  Before
+    // this column every decrypt was a fresh fetch — measurable
+    // latency on slow networks and a hard fail when offline.
+    //
+    // `BLOB` not `TEXT` because the wire format is binary: even
+    // when the inner OpenPGP packet is ASCII-armoured the
+    // surrounding MIME envelope can carry non-UTF-8 bytes from
+    // older transfer encodings, and SQLite TEXT enforces UTF-8.
+    //
+    // `NULL` means "not cached" — covers plaintext messages
+    // (column irrelevant), envelope-only rows the user hasn't
+    // opened yet, and rows that pre-date this migration.  All
+    // three roll forward unchanged: the decrypt path falls back
+    // to the IMAP fetch the same way it did before.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE message_bodies ADD COLUMN encrypted_raw_eml BLOB;
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6951,6 +6951,26 @@ async fn background_decrypt_new(
                 // `decrypt_message` does on the user-clicked path.
                 email.is_read = env.is_read;
                 email.is_starred = env.is_starred;
+                // #341 ciphertext cache — stash the raw bytes so a
+                // later user-driven Decrypt click / encrypted
+                // attachment download for this UID skips the IMAP
+                // round-trip.  Best-effort: a failed put just
+                // leaves the on-demand path to fetch fresh on its
+                // first run.  Guarded on the post-decrypt
+                // `protection` label so we don't store bytes for
+                // anything the parser didn't actually treat as a
+                // PGP/MIME envelope.
+                if matches!(
+                    email.protection.as_deref(),
+                    Some("encrypted" | "signed-and-encrypted")
+                ) {
+                    if let Err(e) = cache.put_encrypted_raw_eml(account_id, folder, uid, &raw) {
+                        tracing::debug!(
+                            "background-decrypt: put_encrypted_raw_eml UID {uid} \
+                             in '{account_id}'/'{folder}' failed: {e}"
+                        );
+                    }
+                }
                 out.push(email);
             }
             Err(e) => {
@@ -6994,19 +7014,27 @@ fn resolve_pgp_passphrase(account_id: &str, supplied: &str) -> Result<String, Un
 /// Decrypt an encrypted message on demand (#57).
 ///
 /// Called by MailView when the user clicks "Decrypt" on a message
-/// the receive path marked `protection = "encrypted"`.  Re-fetches
-/// the raw bytes from IMAP (no cache shortcut yet — we never
-/// persisted the armored ciphertext), composes a
-/// `TauriCryptoBridge` from the freshly-prompted passphrase, and
-/// runs the bytes through `parse_eml_bytes_with_crypto` so
-/// decryption + re-parse happen in one place.
+/// the receive path marked `protection = "encrypted"`.  Composes a
+/// `TauriCryptoBridge` from the freshly-prompted (or keychain-
+/// resolved) passphrase and runs the raw `.eml` bytes through
+/// `parse_eml_bytes_with_crypto` so decryption + re-parse happen
+/// in one place.
 ///
-/// IMAP flags (Seen / Flagged) ride along by re-fetching the
-/// envelope via `fetch_message` first and overlaying them onto the
-/// decrypted body — keeps the read state honest for the cache
-/// write that follows.  JMAP isn't wired into this path yet; that's
-/// the same banner-fallback case the JMAP receive path already
-/// surfaces.
+/// **Bytes source order (#341 ciphertext cache):**
+///   1. `Cache::get_encrypted_raw_eml` — populated by any previous
+///      decrypt / attachment fetch / background-decrypt for this
+///      UID.  Hit = full decrypt without an IMAP round-trip
+///      (works offline).
+///   2. Cache miss → IMAP `UID FETCH BODY.PEEK[]`, and on success
+///      stash the bytes for next time.
+///
+/// IMAP flags (Seen / Flagged) come from a parallel envelope fetch
+/// on the IMAP path; on the cache-hit path we pull them from the
+/// envelope row already in the cache (which the user just saw in
+/// MailView, so it's at least as fresh as the displayed list).
+///
+/// JMAP isn't wired into this path yet; that's the same banner-
+/// fallback case the JMAP receive path already surfaces.
 #[tauri::command]
 async fn decrypt_message(
     account_id: String,
@@ -7032,6 +7060,50 @@ async fn decrypt_message(
     let resolved = resolve_pgp_passphrase(&account_id, &pgp_passphrase)?;
     let bridge = TauriCryptoBridge::for_account(&account_id, &resolved, (*cache).clone())?;
 
+    let id = format!("{folder}:{uid}");
+
+    // #341 ciphertext cache — try the local copy first.  A
+    // successful path returns without ever opening an IMAP
+    // connection, so this is also the path the offline UX walks.
+    // Any failure (corrupt cache row, key rotated, etc.) falls
+    // through to the IMAP refetch below rather than surfacing as a
+    // permanent decrypt error — a stale cache entry mustn't brick
+    // the user's ability to read their mail.
+    if let Ok(Some(raw)) = cache.get_encrypted_raw_eml(&account_id, &folder, uid) {
+        match unkai_imap::parse_eml_bytes_with_crypto(
+            &raw,
+            &id,
+            &account_id,
+            &folder,
+            Some(&bridge),
+        ) {
+            Ok(mut decrypted) => {
+                // Pull is_read / is_starred from the cached
+                // envelope so we don't reset them via
+                // `parse_eml_bytes_with_crypto`'s defaults.  The
+                // envelope cache is refreshed by the next poll
+                // tick — for the user clicking Decrypt right now
+                // it's as fresh as the MailList row they just
+                // clicked from.
+                if let Ok(Some(env)) = cache.get_message(&account_id, &folder, uid) {
+                    decrypted.is_read = env.is_read;
+                    decrypted.is_starred = env.is_starred;
+                }
+                if let Err(e) = cache.upsert_message(&decrypted) {
+                    tracing::warn!("cache.upsert_message after offline decrypt failed: {e}");
+                }
+                return Ok(decrypted);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "decrypt_message: cached ciphertext for \
+                     {account_id}/{folder}/{uid} failed to decrypt ({e}); \
+                     refetching from IMAP"
+                );
+            }
+        }
+    }
+
     let mut client = connect_imap(&account).await?;
     // Get IMAP flags + envelope from one fetch, then the raw bytes
     // from a second on the same session so we can hand the bytes to
@@ -7041,7 +7113,6 @@ async fn decrypt_message(
     let raw = client.fetch_raw_message(&folder, uid).await?;
     let _ = client.logout().await;
 
-    let id = format!("{folder}:{uid}");
     let mut decrypted =
         unkai_imap::parse_eml_bytes_with_crypto(&raw, &id, &account_id, &folder, Some(&bridge))?;
     // Overlay IMAP flags so the cache write below doesn't reset
@@ -7052,6 +7123,21 @@ async fn decrypt_message(
 
     if let Err(e) = cache.upsert_message(&decrypted) {
         tracing::warn!("cache.upsert_message after decrypt failed: {e}");
+    }
+    // Only cache the raw bytes when the parser actually unlocked a
+    // PGP/MIME envelope — caching plaintext bytes would just bloat
+    // the DB without ever paying off, since the cache-hit path is
+    // only exercised by `decrypt_message` / encrypted-attachment
+    // downloads.  The parser stamps `protection` to one of the
+    // encryption labels exactly when a PGP/MIME envelope was
+    // detected and processed.
+    if matches!(
+        decrypted.protection.as_deref(),
+        Some("encrypted" | "signed-and-encrypted")
+    ) {
+        if let Err(e) = cache.put_encrypted_raw_eml(&account_id, &folder, uid, &raw) {
+            tracing::warn!("cache.put_encrypted_raw_eml after decrypt failed: {e}");
+        }
     }
     Ok(decrypted)
 }
@@ -7167,11 +7253,46 @@ async fn download_decrypted_attachment(
     // `resolve_pgp_passphrase`).
     let resolved = resolve_pgp_passphrase(&account_id, &pgp_passphrase)?;
     let bridge = TauriCryptoBridge::for_account(&account_id, &resolved, (*cache).clone())?;
+
+    // #341 ciphertext cache — try the local copy first so a second
+    // attachment open / Forward of the same encrypted message
+    // doesn't pay the IMAP cost again.  On cache miss (or a
+    // decrypt-from-cache failure) fall through to IMAP and
+    // populate the cache from the fresh bytes.
+    if let Ok(Some(raw)) = cache.get_encrypted_raw_eml(&account_id, &folder, uid) {
+        match unkai_imap::extract_decrypted_attachment(&raw, &bridge, part_id) {
+            Ok(Some((_meta, data))) => return Ok(data),
+            // Cached bytes aren't a PGP/MIME envelope after all —
+            // same typed error as the IMAP path so the UI's
+            // encryption-aware routing stays consistent.
+            Ok(None) => {
+                return Err(UnkaiError::Protocol(
+                    "Message is not PGP-encrypted; use download_email_attachment".into(),
+                ));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "download_decrypted_attachment: cached ciphertext for \
+                     {account_id}/{folder}/{uid} failed ({e}); refetching from IMAP"
+                );
+            }
+        }
+    }
+
     let mut client = connect_imap(&account).await?;
     let raw = client.fetch_raw_message(&folder, uid).await?;
     let _ = client.logout().await;
     match unkai_imap::extract_decrypted_attachment(&raw, &bridge, part_id)? {
-        Some((_meta, data)) => Ok(data),
+        Some((_meta, data)) => {
+            // Best-effort cache write — a failure here just means
+            // the next attachment download pays the IMAP cost
+            // again.  Logged at debug because the user's request
+            // succeeded.
+            if let Err(e) = cache.put_encrypted_raw_eml(&account_id, &folder, uid, &raw) {
+                tracing::debug!("put_encrypted_raw_eml after attachment fetch failed: {e}");
+            }
+            Ok(data)
+        }
         // Not a PGP/MIME envelope — the caller should be on
         // `download_email_attachment` for this message.  Surfacing
         // as a typed error rather than silently falling through


### PR DESCRIPTION
## Summary

- Adds an `encrypted_raw_eml BLOB` column on `message_bodies` (migration v34 → v35) and two cache helpers (`put_encrypted_raw_eml` / `get_encrypted_raw_eml`)
- Wires the three decrypt code paths to populate the cache on success and read from it before falling back to IMAP — so a second Decrypt / attachment download / Forward of the same message runs without an IMAP round-trip (and works offline)
- Background-decrypt during sync now pre-populates the cache, so the first user-driven decrypt for new mail already lands cached

Picks up another open sub-item from #341. Branches off `main` post-#356.

## Behaviour matrix

| Surface | Before | After |
| --- | --- | --- |
| Manual Decrypt button | Fetches envelope + `BODY.PEEK[]` every click | Cache hit = zero IMAP calls (offline-capable); cache miss = old path + stash |
| `try_auto_decrypt_message` on MailView load | Same two IMAP fetches | Same — auto-decrypt is the one place the cache gets populated for free |
| Encrypted attachment download / Forward | Re-fetches `BODY.PEEK[]` per click | Cache hit = zero IMAP calls; cache miss = old path + stash |
| Background-decrypt during sync (#356) | Decrypts in-memory, discards raw bytes | Stashes raw bytes so the *first* user click is already a cache hit |

## Failure handling

- Cache read returning `Err` or a blob the parser can't decrypt → warn, fall through to IMAP, repopulate from fresh bytes. A stale or corrupt cache entry can never permanently brick decryption.
- Cache write failure → warn (debug for the attachment path since the user's request still succeeded), continue. Worst case the next decrypt pays the IMAP cost again.
- Only PGP/MIME envelopes get cached (`protection` in `{encrypted, signed-and-encrypted}` after parse). Plaintext clicks don't bloat the DB.

## Schema migration

```sql
ALTER TABLE message_bodies ADD COLUMN encrypted_raw_eml BLOB;
```

NULL means "not cached" — covers plaintext, envelope-only rows, and pre-#341 rows. All roll forward unchanged: the decrypt path falls back to IMAP exactly as before.

BLOB rather than TEXT because the raw `.eml` MIME envelope can carry non-UTF-8 transfer encodings even when the inner OpenPGP packet is ASCII-armoured.

## Test plan

- [x] `cargo check --workspace` clean (verified locally)
- [x] `cargo fmt --check` clean (verified locally)
- [x] Fresh DB migrates v0 → v35 without error on launch
- [x] Existing DB at v34 migrates to v35 on next launch, existing rows untouched
- [x] Open an encrypted message, click Decrypt → succeeds, opens normally
- [ ] Open same message a second time, click Decrypt with the machine offline (e.g. disable network) → still decrypts
- [ ] Download an encrypted attachment, then disable network and re-download → still works
- [ ] Forward an encrypted message → attachment grab still works after the message has been decrypted at least once
- [ ] With "Unlock automatically" on and a new encrypted message arriving via sync, immediately go offline and open the message → decrypts from cache
- [ ] Open a *plaintext* message — `encrypted_raw_eml` stays NULL (verify via `sqlite3` if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)