### PR TITLE
#341: JMAP Blob/get + decrypt plumbing

### DIFF
--- a/crates/unkai-jmap/src/client.rs
+++ b/crates/unkai-jmap/src/client.rs
@@ -490,23 +490,28 @@ impl JmapClient {
         let is_starred = email.keywords.contains_key("$flagged");
         let has_attachments = email.has_attachment;
 
-        // PGP/MIME detection on JMAP (#57): the server has already
-        // parsed the message into `bodyValues`, so we can't get at
-        // the raw `multipart/encrypted` MIME structure cheaply.
-        // Instead we sniff for the OpenPGP armor headers in the
-        // body text — if the server returned the application/
+        // PGP/MIME detection on JMAP (#57, #341): the server has
+        // already parsed the message into `bodyValues`, so we can't
+        // get at the raw `multipart/encrypted` MIME structure
+        // cheaply.  Instead we sniff for the OpenPGP armor headers
+        // in the body text — if the server returned the application/
         // octet-stream content as a body part (which Fastmail and
         // others do), the value starts with `-----BEGIN PGP MESSAGE-----`.
         //
-        // When we recognise that signature, we mark the message as
-        // encrypted-cannot-decrypt: the MailView banner kicks in
-        // and tells the user to open the message via the IMAP path
-        // (or a desktop client) for decryption.  Properly decrypting
-        // server-side requires an extra `Blob/get` round-trip and
-        // running the recovered raw bytes through
-        // `unkai_imap::parse_eml_bytes_with_crypto`; that's a real
-        // follow-up tracked under #57 once we've validated the
-        // banner UX with real users.
+        // When we recognise the signature, stamp `protection =
+        // "encrypted"` to mirror the IMAP receive path.  MailView's
+        // Decrypt button will fire `decrypt_message`, which now
+        // pulls the raw RFC 5322 bytes via `fetch_raw_message`
+        // (JMAP `Blob/get` via the session's download URL) and
+        // runs them through `unkai_imap::parse_eml_bytes_with_crypto`
+        // — the actual MIME envelope re-stamps `protection` to
+        // `encrypted` / `signed-and-encrypted` at decrypt time, so
+        // the coarse sniff here is just the "show a Decrypt
+        // affordance" trigger.  The deprecated
+        // `encrypted-cannot-decrypt` marker is no longer produced
+        // by the receive path; CryptoChips.svelte still handles
+        // it defensively for any external entry point that might
+        // legitimately emit it.
         let looks_pgp_encrypted = body_text
             .as_deref()
             .map(|s| s.trim_start().starts_with("-----BEGIN PGP MESSAGE-----"))
@@ -518,20 +523,16 @@ impl JmapClient {
 
         let (protection, body_text, body_html) = if looks_pgp_encrypted {
             tracing::info!(
-                "JMAP: message '{}' appears to be PGP-encrypted; flagging for banner",
+                "JMAP: message '{}' appears to be PGP-encrypted; \
+                 stamping `encrypted` so MailView shows the Decrypt button",
                 email.id
             );
-            // Replace the body with a deterministic marker the UI
-            // can match on — keeps the cache row meaningful even
-            // for users who never enable encryption.
-            (
-                Some("encrypted-cannot-decrypt".to_string()),
-                Some(
-                    "(encrypted message — open via IMAP or a PGP-capable client to decrypt)"
-                        .to_string(),
-                ),
-                None,
-            )
+            // Null the body so the user sees the Decrypt affordance
+            // instead of the armored ciphertext.  Same shape as the
+            // IMAP receive path, which leaves `body_text` /
+            // `body_html` as `None` for `multipart/encrypted` until
+            // `decrypt_message` unlocks the inner MIME tree.
+            (Some("encrypted".to_string()), None, None)
         } else {
             (None, body_text, body_html)
         };
@@ -570,6 +571,123 @@ impl JmapClient {
             signature_status: None,
             signer_fingerprint: None,
         })
+    }
+
+    /// Fetch the raw RFC 5322 bytes for a single message (#341).
+    ///
+    /// JMAP equivalent of `ImapClient::fetch_raw_message` — used by
+    /// the encrypted-message decrypt flow at the Tauri layer: it
+    /// builds a `CryptoBridge` from the user's freshly-prompted (or
+    /// keychain-resolved) passphrase and feeds the bytes here to
+    /// `unkai_imap::parse_eml_bytes_with_crypto` so the decryption +
+    /// re-parse happens in one place.
+    ///
+    /// Two HTTP round-trips:
+    ///   1. `Email/get` with `properties: ["id", "blobId"]` to find
+    ///      the blob ID for this synthetic UID.  JMAP keeps the
+    ///      RFC 5322 source addressable separately from the parsed
+    ///      `Email` object — the `blobId` is the handle.
+    ///   2. `GET` against the session's `downloadUrl` template, with
+    ///      `{accountId}` / `{blobId}` substituted, to pull the
+    ///      armored MIME envelope.
+    ///
+    /// The download returns the same wire-format bytes a SMTP
+    /// deposit produced — so the decrypt-aware parser sees the
+    /// real `multipart/encrypted; protocol="application/pgp-encrypted"`
+    /// envelope rather than the JMAP-server's already-flattened
+    /// `bodyValues` view, which is the whole point of going through
+    /// `Blob/get`.
+    pub async fn fetch_raw_message(&self, folder: &str, uid: u32) -> Result<Vec<u8>, UnkaiError> {
+        let jmap_id = self.resolve_jmap_id(folder, uid).await?;
+
+        let resp = self
+            .call(vec![MethodCall {
+                name: "Email/get".into(),
+                args: json!({
+                    "accountId": self.account_id,
+                    "ids": [jmap_id.clone()],
+                    "properties": ["id", "blobId"],
+                }),
+                call_id: "blob0".into(),
+            }])
+            .await?;
+
+        let args = Self::find_response(&resp.method_responses, "blob0")?;
+        let result: GetResult<JmapEmail> = serde_json::from_value(args.clone())
+            .map_err(|e| UnkaiError::Protocol(format!("Failed to parse Email/get: {e}")))?;
+
+        // Same `MessageGone` semantics as `fetch_message`: a missing
+        // row means the message was expunged between the synthetic-
+        // UID resolve and this call.
+        let email = result
+            .list
+            .into_iter()
+            .next()
+            .ok_or(UnkaiError::MessageGone)?;
+        let blob_id = email.blob_id.ok_or_else(|| {
+            UnkaiError::Protocol(format!(
+                "JMAP email '{jmap_id}' has no blobId — server didn't expose raw download"
+            ))
+        })?;
+
+        self.download_blob(&blob_id, "message.eml", "message/rfc822")
+            .await
+    }
+
+    /// Download a blob by ID via the session's `downloadUrl` template
+    /// (RFC 8620 §6.2).  Substitutes `{accountId}`, `{blobId}`,
+    /// `{name}`, `{type}` per the spec and pulls the bytes with the
+    /// same Basic Auth the API calls use.
+    ///
+    /// `name` and `content_type` are advisory — most servers ignore
+    /// them on the download side and serve the stored blob verbatim.
+    /// They're included so the request matches the spec exactly and
+    /// servers that log them get useful context.
+    async fn download_blob(
+        &self,
+        blob_id: &str,
+        name: &str,
+        content_type: &str,
+    ) -> Result<Vec<u8>, UnkaiError> {
+        let url = self
+            .session
+            .download_url
+            .replace("{accountId}", &self.account_id)
+            .replace("{blobId}", blob_id)
+            .replace("{name}", name)
+            .replace("{type}", content_type);
+        let url = self.resolve_url(&url)?;
+        ensure_https(&url)?;
+
+        let resp = self
+            .http
+            .get(&url)
+            .basic_auth(&self.username, Some(&self.password))
+            .send()
+            .await
+            .map_err(|e| UnkaiError::Network(format!("JMAP blob download failed: {e}")))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            // The server's view of the message no longer contains
+            // this blob — treat as `MessageGone` so the Tauri layer
+            // can evict the dead row, same as the API path.
+            return Err(UnkaiError::MessageGone);
+        }
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(UnkaiError::Protocol(format!(
+                "JMAP blob download returned HTTP {status}: {body}"
+            )));
+        }
+
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| UnkaiError::Protocol(format!("Failed to read JMAP blob bytes: {e}")))?;
+        info!("JMAP: downloaded blob '{blob_id}' ({} bytes)", bytes.len());
+        Ok(bytes.to_vec())
     }
 
     /// Clear the `$seen` keyword on a message — i.e. mark it unread.

--- a/crates/unkai-jmap/tests/mock_server.rs
+++ b/crates/unkai-jmap/tests/mock_server.rs
@@ -6,7 +6,7 @@
 
 use axum::{
     Json, Router,
-    extract::State as AxState,
+    extract::{Path, State as AxState},
     http::{HeaderMap, StatusCode},
     routing::{get, post},
 };
@@ -122,8 +122,8 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                 "Email/query",
                 {
                     "accountId": "acc1",
-                    "ids": ["email-001", "email-002"],
-                    "total": 2,
+                    "ids": ["email-001", "email-002", "email-pgp"],
+                    "total": 3,
                     "position": 0,
                 },
                 call_id
@@ -139,34 +139,118 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                 let has_body =
                     properties.contains(&"bodyValues") || _args.get("fetchAllBodyValues").is_some();
 
-                if has_body {
-                    // Full message fetch.
+                // `fetch_raw_message` only asks for ["id", "blobId"]
+                // — that's the JMAP shape for "give me the handle to
+                // the raw RFC 5322 bytes so I can `Blob/get` them".
+                // Return the blobId for whichever specific id was
+                // requested, so the test can drive the encrypted vs
+                // plaintext distinction by id.
+                let only_blob = properties.contains(&"id")
+                    && properties.contains(&"blobId")
+                    && properties.len() == 2;
+
+                let requested_ids = _args
+                    .get("ids")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(str::to_string))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+
+                if only_blob {
+                    let id = requested_ids
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "email-001".to_string());
+                    let blob_id = match id.as_str() {
+                        "email-002" => "blob-charlie",
+                        "email-pgp" => "blob-pgp",
+                        _ => "blob-alice",
+                    };
                     json!([
                         "Email/get",
                         {
                             "accountId": "acc1",
                             "state": "state1",
                             "list": [{
-                                "id": "email-001",
-                                "from": [{ "name": "Alice", "email": "alice@example.com" }],
-                                "to": [{ "email": "bob@example.com" }],
-                                "cc": [],
-                                "subject": "Hello from JMAP!",
-                                "receivedAt": "2025-01-15T10:30:00Z",
-                                "keywords": { "$seen": true },
-                                "hasAttachment": false,
-                                "mailboxIds": { "mbox-inbox": true },
-                                "bodyValues": {
-                                    "1": { "value": "Hi Bob,\n\nThis is a JMAP test message.\n\nBest,\nAlice", "isEncodingProblem": false, "isTruncated": false },
-                                },
-                                "textBody": [{ "partId": "1", "type": "text/plain" }],
-                                "htmlBody": [],
-                                "attachments": [],
+                                "id": id,
+                                "blobId": blob_id,
                             }],
                             "notFound": [],
                         },
                         call_id
                     ])
+                } else if has_body {
+                    // Full message fetch.  The encrypted test seeds
+                    // a separate id ("email-pgp") with armored
+                    // ciphertext as the text-body part — mirrors
+                    // what Fastmail returns for `multipart/encrypted`
+                    // under `fetchAllBodyValues=true`.
+                    let id = requested_ids
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "email-001".to_string());
+                    if id == "email-pgp" {
+                        json!([
+                            "Email/get",
+                            {
+                                "accountId": "acc1",
+                                "state": "state1",
+                                "list": [{
+                                    "id": "email-pgp",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "to": [{ "email": "bob@example.com" }],
+                                    "cc": [],
+                                    "subject": "Encrypted JMAP message",
+                                    "receivedAt": "2025-01-15T10:30:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": false,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                    "bodyValues": {
+                                        "1": {
+                                            "value": "-----BEGIN PGP MESSAGE-----\n\nwV4D...\n-----END PGP MESSAGE-----\n",
+                                            "isEncodingProblem": false,
+                                            "isTruncated": false,
+                                        },
+                                    },
+                                    "textBody": [{ "partId": "1", "type": "text/plain" }],
+                                    "htmlBody": [],
+                                    "attachments": [],
+                                }],
+                                "notFound": [],
+                            },
+                            call_id
+                        ])
+                    } else {
+                        json!([
+                            "Email/get",
+                            {
+                                "accountId": "acc1",
+                                "state": "state1",
+                                "list": [{
+                                    "id": "email-001",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "to": [{ "email": "bob@example.com" }],
+                                    "cc": [],
+                                    "subject": "Hello from JMAP!",
+                                    "receivedAt": "2025-01-15T10:30:00Z",
+                                    "keywords": { "$seen": true },
+                                    "hasAttachment": false,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                    "bodyValues": {
+                                        "1": { "value": "Hi Bob,\n\nThis is a JMAP test message.\n\nBest,\nAlice", "isEncodingProblem": false, "isTruncated": false },
+                                    },
+                                    "textBody": [{ "partId": "1", "type": "text/plain" }],
+                                    "htmlBody": [],
+                                    "attachments": [],
+                                }],
+                                "notFound": [],
+                            },
+                            call_id
+                        ])
+                    }
                 } else {
                     // Envelope fetch.
                     json!([
@@ -191,6 +275,15 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                                     "receivedAt": "2025-01-14T09:00:00Z",
                                     "keywords": {},
                                     "hasAttachment": true,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                },
+                                {
+                                    "id": "email-pgp",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "subject": "Encrypted JMAP message",
+                                    "receivedAt": "2025-01-13T08:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": false,
                                     "mailboxIds": { "mbox-inbox": true },
                                 },
                             ],
@@ -255,6 +348,38 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
     }))
 }
 
+/// `GET /download/{blobId}` — serve a stored RFC 5322 envelope per
+/// blob id.  The encrypted-message test relies on `blob-pgp`
+/// returning a well-formed PGP/MIME envelope (so the bridge-aware
+/// parser detects it correctly when the test wires this up
+/// end-to-end via the Tauri layer); the plaintext blobs are also
+/// served so a future round-trip test can verify them.
+async fn download_handler(
+    Path(blob_id): Path<String>,
+    headers: HeaderMap,
+) -> Result<Vec<u8>, StatusCode> {
+    let auth = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !auth.starts_with("Basic ") {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let bytes: &[u8] = match blob_id.as_str() {
+        "blob-alice" => b"From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Hello from JMAP!\r\n\r\nHi Bob,\r\n\r\nThis is a JMAP test message.\r\n",
+        "blob-charlie" => b"From: charlie@example.com\r\nTo: bob@example.com\r\nSubject: JMAP rocks\r\n\r\nHey.\r\n",
+        // `multipart/encrypted` envelope shape per RFC 3156 §4 —
+        // matches what `detect_pgp_mime_envelope` looks for.  The
+        // ciphertext is a placeholder (real OpenPGP decryption is
+        // covered in unit tests in the unkai-imap crate).
+        "blob-pgp" => b"MIME-Version: 1.0\r\nFrom: alice@example.com\r\nTo: bob@example.com\r\nSubject: Encrypted JMAP message\r\nContent-Type: multipart/encrypted; protocol=\"application/pgp-encrypted\"; boundary=\"PGP\"\r\n\r\n--PGP\r\nContent-Type: application/pgp-encrypted\r\n\r\nVersion: 1\r\n\r\n--PGP\r\nContent-Type: application/octet-stream\r\n\r\n-----BEGIN PGP MESSAGE-----\r\n\r\nwV4D...\r\n-----END PGP MESSAGE-----\r\n--PGP--\r\n",
+        _ => return Err(StatusCode::NOT_FOUND),
+    };
+
+    Ok(bytes.to_vec())
+}
+
 // ── Test helpers ────��──────────────────────────────────────────
 
 /// Start the mock JMAP server and return (base_url, port).
@@ -268,6 +393,7 @@ async fn start_mock() -> (String, u16) {
     let app = Router::new()
         .route("/.well-known/jmap", get(well_known))
         .route("/api", post(api_handler))
+        .route("/download/{blob_id}", get(download_handler))
         .with_state(state);
 
     tokio::spawn(async move {
@@ -339,7 +465,7 @@ async fn test_fetch_envelopes() {
         .await
         .expect("fetch_envelopes should succeed");
 
-    assert_eq!(envelopes.len(), 2);
+    assert_eq!(envelopes.len(), 3);
 
     // First email (Alice)
     assert_eq!(envelopes[0].subject, "Hello from JMAP!");
@@ -349,6 +475,14 @@ async fn test_fetch_envelopes() {
     // Second email (Charlie)
     assert_eq!(envelopes[1].subject, "JMAP rocks");
     assert!(!envelopes[1].is_read); // no $seen keyword
+
+    // Third — the encrypted-message fixture; the envelope itself
+    // doesn't carry encryption metadata (JMAP needs a body fetch
+    // to sniff for the armor headers), so the chip only lights up
+    // after `fetch_message` runs.  Verified separately in
+    // `test_fetch_message_pgp_stamps_encrypted`.
+    assert_eq!(envelopes[2].subject, "Encrypted JMAP message");
+    assert!(envelopes[2].protection.is_none());
 }
 
 #[tokio::test]
@@ -437,4 +571,59 @@ async fn test_connection_test() {
         .expect("test should succeed");
     assert!(result.contains("JMAP login succeeded"));
     assert!(result.contains("Test User"));
+}
+
+// ── #341 — JMAP Blob/get + decrypt plumbing ────────────────────
+
+/// `fetch_message` on a PGP/MIME-encrypted JMAP message stamps
+/// `protection = "encrypted"` (mirrors the IMAP receive path) and
+/// nulls the body so MailView shows the Decrypt button instead of
+/// the armored ciphertext.  Pre-#341 the same fixture stamped
+/// `encrypted-cannot-decrypt`, which the UI rendered as a "switch
+/// to IMAP" banner — now JMAP can unlock locally so the banner
+/// path is no longer exercised here.
+#[tokio::test]
+async fn test_fetch_message_pgp_stamps_encrypted() {
+    let client = connect_mock().await;
+
+    let envelopes = client.fetch_envelopes("Inbox", 50, None).await.unwrap();
+    let pgp_env = envelopes
+        .iter()
+        .find(|e| e.subject == "Encrypted JMAP message")
+        .expect("seeded encrypted envelope missing");
+
+    let email = client
+        .fetch_message("Inbox", pgp_env.uid, "test-account")
+        .await
+        .expect("fetch_message should succeed for the encrypted fixture");
+
+    assert_eq!(email.protection.as_deref(), Some("encrypted"));
+    assert_eq!(email.body_text, None);
+    assert_eq!(email.body_html, None);
+}
+
+/// `fetch_raw_message` round-trips through `Email/get` (for the
+/// blob id) and the session `downloadUrl` template, returning the
+/// stored RFC 5322 envelope verbatim.  This is the bytes source
+/// `decrypt_message` hands to `parse_eml_bytes_with_crypto` on
+/// JMAP accounts.
+#[tokio::test]
+async fn test_fetch_raw_message_returns_blob_bytes() {
+    let client = connect_mock().await;
+
+    let envelopes = client.fetch_envelopes("Inbox", 50, None).await.unwrap();
+    let pgp_env = envelopes
+        .iter()
+        .find(|e| e.subject == "Encrypted JMAP message")
+        .expect("seeded encrypted envelope missing");
+
+    let raw = client
+        .fetch_raw_message("Inbox", pgp_env.uid)
+        .await
+        .expect("fetch_raw_message should succeed");
+
+    let text = std::str::from_utf8(&raw).expect("blob is utf-8 in this fixture");
+    assert!(text.contains("multipart/encrypted"));
+    assert!(text.contains("application/pgp-encrypted"));
+    assert!(text.contains("-----BEGIN PGP MESSAGE-----"));
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7023,18 +7023,17 @@ fn resolve_pgp_passphrase(account_id: &str, supplied: &str) -> Result<String, Un
 /// **Bytes source order (#341 ciphertext cache):**
 ///   1. `Cache::get_encrypted_raw_eml` — populated by any previous
 ///      decrypt / attachment fetch / background-decrypt for this
-///      UID.  Hit = full decrypt without an IMAP round-trip
+///      UID.  Hit = full decrypt without an IMAP / JMAP round-trip
 ///      (works offline).
-///   2. Cache miss → IMAP `UID FETCH BODY.PEEK[]`, and on success
-///      stash the bytes for next time.
+///   2. Cache miss → fetch from the server: IMAP `UID FETCH
+///      BODY.PEEK[]` on IMAP accounts, JMAP `Blob/get` via the
+///      session's download URL (#341) on JMAP accounts.  On
+///      success stash the bytes for next time.
 ///
-/// IMAP flags (Seen / Flagged) come from a parallel envelope fetch
-/// on the IMAP path; on the cache-hit path we pull them from the
+/// Flags (Seen / Flagged) come from a parallel envelope fetch on
+/// the server path; on the cache-hit path we pull them from the
 /// envelope row already in the cache (which the user just saw in
 /// MailView, so it's at least as fresh as the displayed list).
-///
-/// JMAP isn't wired into this path yet; that's the same banner-
-/// fallback case the JMAP receive path already surfaces.
 #[tauri::command]
 async fn decrypt_message(
     account_id: String,
@@ -7044,13 +7043,6 @@ async fn decrypt_message(
     cache: State<'_, Cache>,
 ) -> Result<Email, UnkaiError> {
     let account = load_account(&cache, &account_id)?;
-    if uses_jmap(&account) {
-        return Err(UnkaiError::Protocol(
-            "JMAP encrypted-message decryption needs Blob/get plumbing — \
-             switch the account to IMAP to decrypt locally"
-                .into(),
-        ));
-    }
 
     // #341 — empty passphrase means "use the keychain entry stored
     // by the per-account Unlock-automatically opt-in."  When neither
@@ -7104,20 +7096,30 @@ async fn decrypt_message(
         }
     }
 
-    let mut client = connect_imap(&account).await?;
-    // Get IMAP flags + envelope from one fetch, then the raw bytes
-    // from a second on the same session so we can hand the bytes to
-    // the bridge-aware parser without losing the IMAP-level read /
-    // flagged state.
-    let envelope_email = client.fetch_message(&folder, uid, &account_id).await?;
-    let raw = client.fetch_raw_message(&folder, uid).await?;
-    let _ = client.logout().await;
+    // Get envelope (Seen / Flagged) + raw bytes from the server.
+    // IMAP reuses one session for both calls; JMAP issues two HTTP
+    // round-trips (Email/get for blobId + the download URL) but is
+    // stateless so no logout is needed.  We need the envelope flags
+    // so the post-decrypt cache write below doesn't reset
+    // is_read / is_starred via the bridge-aware parser's defaults.
+    let (envelope_email, raw) = if uses_jmap(&account) {
+        let client = connect_jmap(&account).await?;
+        let env = client.fetch_message(&folder, uid, &account_id).await?;
+        let raw = client.fetch_raw_message(&folder, uid).await?;
+        (env, raw)
+    } else {
+        let mut client = connect_imap(&account).await?;
+        let env = client.fetch_message(&folder, uid, &account_id).await?;
+        let raw = client.fetch_raw_message(&folder, uid).await?;
+        let _ = client.logout().await;
+        (env, raw)
+    };
 
     let mut decrypted =
         unkai_imap::parse_eml_bytes_with_crypto(&raw, &id, &account_id, &folder, Some(&bridge))?;
-    // Overlay IMAP flags so the cache write below doesn't reset
-    // them — `parse_eml_bytes_with_crypto` defaults to is_read=true
-    // when it has no IMAP context.
+    // Overlay server-side flags so the cache write below doesn't
+    // reset them — `parse_eml_bytes_with_crypto` defaults to
+    // is_read=true when it has no IMAP / JMAP context.
     decrypted.is_read = envelope_email.is_read;
     decrypted.is_starred = envelope_email.is_starred;
 
@@ -7224,13 +7226,16 @@ async fn download_email_attachment(
 /// which for a decrypted message would return the `Version: 1`
 /// header part instead of the real attachment bytes — `EmailAttachment.part_id`
 /// on a decrypted message indexes the *inner* tree.  This command
-/// pulls the raw IMAP bytes, decrypts through the bridge built from
-/// the account's stored key + the freshly-prompted passphrase, walks
-/// the inner tree with the same primary-then-fallback `attachments()`
-/// / `parts` lookup the plaintext path uses, and returns those bytes.
+/// pulls the raw IMAP / JMAP bytes, decrypts through the bridge
+/// built from the account's stored key + the freshly-prompted
+/// passphrase, walks the inner tree with the same primary-then-
+/// fallback `attachments()` / `parts` lookup the plaintext path
+/// uses, and returns those bytes.
 ///
-/// IMAP only — JMAP encrypted attachment download needs the same
-/// `Blob/get` plumbing as the JMAP body-decrypt fallback (#341).
+/// IMAP and JMAP both go through the same
+/// `extract_decrypted_attachment` helper; the only difference is
+/// where the raw `.eml` comes from — IMAP `UID FETCH BODY.PEEK[]`
+/// vs. JMAP `Blob/get` via the session's download URL (#341).
 #[tauri::command]
 async fn download_decrypted_attachment(
     account_id: String,
@@ -7241,13 +7246,6 @@ async fn download_decrypted_attachment(
     cache: State<'_, Cache>,
 ) -> Result<Vec<u8>, UnkaiError> {
     let account = load_account(&cache, &account_id)?;
-    if uses_jmap(&account) {
-        return Err(UnkaiError::Protocol(
-            "JMAP encrypted attachment download needs Blob/get plumbing — \
-             switch the account to IMAP to download decrypted attachments"
-                .into(),
-        ));
-    }
     // #341 — empty passphrase falls back to the keychain entry from
     // the per-account Unlock-automatically opt-in (see
     // `resolve_pgp_passphrase`).
@@ -7256,14 +7254,14 @@ async fn download_decrypted_attachment(
 
     // #341 ciphertext cache — try the local copy first so a second
     // attachment open / Forward of the same encrypted message
-    // doesn't pay the IMAP cost again.  On cache miss (or a
-    // decrypt-from-cache failure) fall through to IMAP and
+    // doesn't pay the server cost again.  On cache miss (or a
+    // decrypt-from-cache failure) fall through to the network and
     // populate the cache from the fresh bytes.
     if let Ok(Some(raw)) = cache.get_encrypted_raw_eml(&account_id, &folder, uid) {
         match unkai_imap::extract_decrypted_attachment(&raw, &bridge, part_id) {
             Ok(Some((_meta, data))) => return Ok(data),
             // Cached bytes aren't a PGP/MIME envelope after all —
-            // same typed error as the IMAP path so the UI's
+            // same typed error as the live-fetch path so the UI's
             // encryption-aware routing stays consistent.
             Ok(None) => {
                 return Err(UnkaiError::Protocol(
@@ -7273,19 +7271,25 @@ async fn download_decrypted_attachment(
             Err(e) => {
                 tracing::warn!(
                     "download_decrypted_attachment: cached ciphertext for \
-                     {account_id}/{folder}/{uid} failed ({e}); refetching from IMAP"
+                     {account_id}/{folder}/{uid} failed ({e}); refetching from server"
                 );
             }
         }
     }
 
-    let mut client = connect_imap(&account).await?;
-    let raw = client.fetch_raw_message(&folder, uid).await?;
-    let _ = client.logout().await;
+    let raw = if uses_jmap(&account) {
+        let client = connect_jmap(&account).await?;
+        client.fetch_raw_message(&folder, uid).await?
+    } else {
+        let mut client = connect_imap(&account).await?;
+        let raw = client.fetch_raw_message(&folder, uid).await?;
+        let _ = client.logout().await;
+        raw
+    };
     match unkai_imap::extract_decrypted_attachment(&raw, &bridge, part_id)? {
         Some((_meta, data)) => {
             // Best-effort cache write — a failure here just means
-            // the next attachment download pays the IMAP cost
+            // the next attachment download pays the network cost
             // again.  Logged at debug because the user's request
             // succeeded.
             if let Err(e) = cache.put_encrypted_raw_eml(&account_id, &folder, uid, &raw) {


### PR DESCRIPTION
## Summary

Next sub-item from the #341 tracking issue: wire JMAP accounts into the existing PGP decrypt path so encrypted mail unlocks locally instead of routing the user to IMAP.

- New `JmapClient::fetch_raw_message` — `Email/get` for the message's `blobId`, then `GET` against the session's `downloadUrl` template (RFC 8620 §6.2) to pull the raw RFC 5322 envelope. Bytes go straight through `unkai_imap::parse_eml_bytes_with_crypto` — same parser, same chip semantics, same ciphertext cache stash on success.
- JMAP receive path stamps `protection = "encrypted"` (matching IMAP) and nulls the body, so MailView renders the Decrypt button instead of the `encrypted-cannot-decrypt` banner. The deprecated marker is no longer emitted by the receive path; `CryptoChips.svelte` keeps it as a defensive fallback.
- `decrypt_message` and `download_decrypted_attachment` lose their `uses_jmap` gate; both pick the right raw-fetch transport (IMAP `UID FETCH BODY.PEEK[]` vs. JMAP `Blob/get`).
- Ciphertext cache (#357) and auto-decrypt-on-open (#355) now work for JMAP accounts too — both go through `decrypt_message`, which now handles JMAP.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p unkai-jmap --tests` — 11/11 pass (two new tests: `test_fetch_message_pgp_stamps_encrypted`, `test_fetch_raw_message_returns_blob_bytes`)
- [x] `cargo test -p unkai-imap --tests` — 19/19 pass (no regression)
- [ ] Manual: add a JMAP account (Fastmail), receive a PGP/MIME message, click Decrypt — should unlock locally without the "switch to IMAP" banner
- [ ] Manual: with Unlock automatically on, open an encrypted JMAP message — should auto-decrypt
- [ ] Manual: download an encrypted attachment on a JMAP-fetched message — should decrypt + save

🤖 Generated with [Claude Code](https://claude.com/claude-code)