### PR TITLE
#338: S/MIME + PGP JMAP receive sniff (Chunk 5)

### DIFF
--- a/crates/unkai-jmap/src/client.rs
+++ b/crates/unkai-jmap/src/client.rs
@@ -490,51 +490,56 @@ impl JmapClient {
         let is_starred = email.keywords.contains_key("$flagged");
         let has_attachments = email.has_attachment;
 
-        // PGP/MIME detection on JMAP (#57, #341): the server has
-        // already parsed the message into `bodyValues`, so we can't
-        // get at the raw `multipart/encrypted` MIME structure
-        // cheaply.  Instead we sniff for the OpenPGP armor headers
-        // in the body text — if the server returned the application/
-        // octet-stream content as a body part (which Fastmail and
-        // others do), the value starts with `-----BEGIN PGP MESSAGE-----`.
+        // Crypto detection on JMAP (#57 PGP, #341, #338 S/MIME): the
+        // server has already parsed the message into `bodyValues`, so we
+        // can't see the raw `multipart/encrypted` / `application/pkcs7-mime`
+        // envelope cheaply.  `detect_jmap_crypto` sniffs the flattened
+        // body armor + per-part content types instead (see its docs for
+        // the per-stack signals it keys on).
         //
-        // When we recognise the signature, stamp `protection =
-        // "encrypted"` to mirror the IMAP receive path.  MailView's
-        // Decrypt button will fire `decrypt_message`, which now
-        // pulls the raw RFC 5322 bytes via `fetch_raw_message`
-        // (JMAP `Blob/get` via the session's download URL) and
-        // runs them through `unkai_imap::parse_eml_bytes_with_crypto`
-        // — the actual MIME envelope re-stamps `protection` to
-        // `encrypted` / `signed-and-encrypted` at decrypt time, so
-        // the coarse sniff here is just the "show a Decrypt
-        // affordance" trigger.  The deprecated
-        // `encrypted-cannot-decrypt` marker is no longer produced
-        // by the receive path; CryptoChips.svelte still handles
+        // The coarse stamp here is just the "show a Decrypt affordance"
+        // (encrypted) / "show a signed chip" (signed) trigger.  When the
+        // user decrypts, `decrypt_message` pulls the raw RFC 5322 bytes
+        // via `fetch_raw_message` (JMAP `Blob/get` via the session's
+        // download URL) and runs them through
+        // `unkai_imap::parse_eml_bytes_with_crypto`, whose parameter-aware
+        // `detect_pgp_mime_envelope` / `detect_smime_envelope` re-stamp
+        // `protection` precisely (`encrypted` / `signed-and-encrypted`).
+        // The deprecated `encrypted-cannot-decrypt` marker is no longer
+        // produced by the receive path; CryptoChips.svelte still handles
         // it defensively for any external entry point that might
         // legitimately emit it.
-        let looks_pgp_encrypted = body_text
-            .as_deref()
-            .map(|s| s.trim_start().starts_with("-----BEGIN PGP MESSAGE-----"))
-            .unwrap_or(false)
-            || body_html
-                .as_deref()
-                .map(|s| s.contains("-----BEGIN PGP MESSAGE-----"))
-                .unwrap_or(false);
+        let crypto_kind = detect_jmap_crypto(&email, body_text.as_deref(), body_html.as_deref());
 
-        let (protection, body_text, body_html) = if looks_pgp_encrypted {
-            tracing::info!(
-                "JMAP: message '{}' appears to be PGP-encrypted; \
-                 stamping `encrypted` so MailView shows the Decrypt button",
-                email.id
-            );
-            // Null the body so the user sees the Decrypt affordance
-            // instead of the armored ciphertext.  Same shape as the
-            // IMAP receive path, which leaves `body_text` /
-            // `body_html` as `None` for `multipart/encrypted` until
-            // `decrypt_message` unlocks the inner MIME tree.
-            (Some("encrypted".to_string()), None, None)
-        } else {
-            (None, body_text, body_html)
+        let (protection, body_text, body_html) = match crypto_kind {
+            Some(JmapCryptoKind::Encrypted) => {
+                tracing::info!(
+                    "JMAP: message '{}' looks encrypted (PGP armor or S/MIME \
+                     pkcs7-mime); stamping `encrypted` so MailView shows the \
+                     Decrypt button",
+                    email.id
+                );
+                // Null the body so the user sees the Decrypt affordance
+                // instead of the raw ciphertext.  Same shape as the IMAP
+                // receive path, which leaves `body_text` / `body_html` as
+                // `None` for an encrypted envelope until `decrypt_message`
+                // unlocks the inner MIME tree.
+                (Some("encrypted".to_string()), None, None)
+            }
+            Some(JmapCryptoKind::Signed) => {
+                tracing::info!(
+                    "JMAP: message '{}' is a detached multipart/signed (PGP or \
+                     S/MIME); stamping `signed`",
+                    email.id
+                );
+                // Clear-signed: the body is already readable, so keep it and
+                // just tag the chip.  Mirrors the IMAP receive path's
+                // `Signed` arms for both stacks (detection-only; OpenPGP /
+                // CMS signature verification is deferred on the same
+                // canonical-bytes blocker).
+                (Some("signed".to_string()), body_text, body_html)
+            }
+            None => (None, body_text, body_html),
         };
 
         info!("JMAP: fetched message '{}'", email.id);
@@ -1157,6 +1162,94 @@ impl JmapClient {
 }
 
 // ── Free-standing helpers ──────────────────────────────────────
+
+/// What a coarse JMAP crypto sniff found in a fetched message (#57 PGP,
+/// #338 S/MIME).
+///
+/// The JMAP server flattens the MIME tree before we see it, so this only
+/// distinguishes "needs decryption" from "clear-signed" — it deliberately
+/// does *not* name the stack (PGP vs S/MIME) or the precise label.  Both
+/// are re-derived at decrypt time from the raw bytes (via
+/// `fetch_raw_message` and `parse_eml_bytes_with_crypto`), which run the
+/// parameter-aware `detect_pgp_mime_envelope` / `detect_smime_envelope`.
+enum JmapCryptoKind {
+    /// PGP `multipart/encrypted` armor or S/MIME `enveloped-data`.  Null
+    /// the body so MailView shows the Decrypt button.
+    Encrypted,
+    /// A detached `multipart/signed` message (either stack).  The body is
+    /// already readable, so keep it and just tag the chip.
+    Signed,
+}
+
+/// Coarse crypto sniff for the JMAP receive path (#57, #341, #338).
+///
+/// Unlike the IMAP path — which runs the real
+/// `detect_pgp_mime_envelope` / `detect_smime_envelope` over the raw MIME
+/// bytes — JMAP hands us an already-parsed message: flattened body values
+/// plus per-part content types, with all Content-Type *parameters*
+/// stripped (RFC 8621 §4.1.4).  So we can't read `protocol=` or
+/// `smime-type=`; the sniff keys only on what survives:
+///
+/// - PGP `multipart/encrypted`: the server exposes the inner
+///   `application/octet-stream` armor as body text starting with
+///   `-----BEGIN PGP MESSAGE-----` ⇒ [`JmapCryptoKind::Encrypted`];
+/// - S/MIME `enveloped-data`: a binary `application/pkcs7-mime` (or legacy
+///   `x-pkcs7-mime`) part ⇒ [`JmapCryptoKind::Encrypted`];
+/// - detached `multipart/signed` (either stack): a sibling
+///   `application/pgp-signature` or `application/pkcs7-signature` (or
+///   `x-`) part ⇒ [`JmapCryptoKind::Signed`].
+///
+/// This only drives the affordance; the precise `protection` label
+/// (`encrypted` / `signed-and-encrypted`) is re-stamped at decrypt time.
+/// The legacy `x-pkcs7-*` spellings are accepted to match the IMAP
+/// detector.  The two stacks are mutually exclusive at the top level, and
+/// encrypted signals are checked before signed, so a single message only
+/// ever resolves to one kind.
+fn detect_jmap_crypto(
+    email: &JmapEmail,
+    body_text: Option<&str>,
+    body_html: Option<&str>,
+) -> Option<JmapCryptoKind> {
+    let has_media_type = |needles: &[&str]| {
+        email
+            .attachments
+            .iter()
+            .chain(email.text_body.iter())
+            .chain(email.html_body.iter())
+            .filter_map(|part| part.content_type.as_deref())
+            .any(|ct| {
+                // JMAP normalises `type` to lowercase and drops params, but
+                // be defensive: split off any stray params and compare
+                // case-insensitively.
+                let bare = ct.split(';').next().unwrap_or(ct).trim();
+                needles.iter().any(|n| bare.eq_ignore_ascii_case(n))
+            })
+    };
+
+    // ── Encrypted ──
+    // PGP `multipart/encrypted`: the inner octet-stream armor surfaces as
+    // body text (leading marker on text, anywhere in HTML).
+    let pgp_encrypted = body_text
+        .map(|s| s.trim_start().starts_with("-----BEGIN PGP MESSAGE-----"))
+        .unwrap_or(false)
+        || body_html
+            .map(|s| s.contains("-----BEGIN PGP MESSAGE-----"))
+            .unwrap_or(false);
+    if pgp_encrypted || has_media_type(&["application/pkcs7-mime", "application/x-pkcs7-mime"]) {
+        return Some(JmapCryptoKind::Encrypted);
+    }
+
+    // ── Signed (detached, either stack) ──
+    if has_media_type(&[
+        "application/pgp-signature",
+        "application/pkcs7-signature",
+        "application/x-pkcs7-signature",
+    ]) {
+        return Some(JmapCryptoKind::Signed);
+    }
+
+    None
+}
 
 /// Build a full hierarchical folder name by walking up parent_id links.
 ///

--- a/crates/unkai-jmap/tests/mock_server.rs
+++ b/crates/unkai-jmap/tests/mock_server.rs
@@ -122,8 +122,8 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                 "Email/query",
                 {
                     "accountId": "acc1",
-                    "ids": ["email-001", "email-002", "email-pgp"],
-                    "total": 3,
+                    "ids": ["email-001", "email-002", "email-pgp", "email-smime-enc", "email-smime-sig", "email-pgp-sig"],
+                    "total": 6,
                     "position": 0,
                 },
                 call_id
@@ -167,6 +167,8 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                     let blob_id = match id.as_str() {
                         "email-002" => "blob-charlie",
                         "email-pgp" => "blob-pgp",
+                        "email-smime-enc" => "blob-smime-enc",
+                        "email-smime-sig" => "blob-smime-sig",
                         _ => "blob-alice",
                     };
                     json!([
@@ -186,7 +188,7 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                     // Full message fetch.  The encrypted test seeds
                     // a separate id ("email-pgp") with armored
                     // ciphertext as the text-body part — mirrors
-                    // what Fastmail returns for `multipart/encrypted`
+                    // what some servers return for `multipart/encrypted`
                     // under `fetchAllBodyValues=true`.
                     let id = requested_ids
                         .first()
@@ -218,6 +220,116 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                                     "textBody": [{ "partId": "1", "type": "text/plain" }],
                                     "htmlBody": [],
                                     "attachments": [],
+                                }],
+                                "notFound": [],
+                            },
+                            call_id
+                        ])
+                    } else if id == "email-smime-enc" {
+                        // S/MIME enveloped-data (#338): the encrypted CMS
+                        // blob arrives as a binary `application/pkcs7-mime`
+                        // attachment — there's no text body, so the sniff
+                        // keys on the part's content type, not body text.
+                        json!([
+                            "Email/get",
+                            {
+                                "accountId": "acc1",
+                                "state": "state1",
+                                "list": [{
+                                    "id": "email-smime-enc",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "to": [{ "email": "bob@example.com" }],
+                                    "cc": [],
+                                    "subject": "S/MIME encrypted JMAP message",
+                                    "receivedAt": "2025-01-12T07:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": true,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                    "bodyValues": {},
+                                    "textBody": [],
+                                    "htmlBody": [],
+                                    "attachments": [{
+                                        "partId": "1",
+                                        "blobId": "blob-smime-enc",
+                                        "name": "smime.p7m",
+                                        "type": "application/pkcs7-mime",
+                                        "size": 1234,
+                                    }],
+                                }],
+                                "notFound": [],
+                            },
+                            call_id
+                        ])
+                    } else if id == "email-smime-sig" {
+                        // S/MIME detached `multipart/signed` (#338): the
+                        // server surfaces the clear-signed text as the body
+                        // and the `.p7s` signature as a sibling
+                        // `application/pkcs7-signature` attachment.
+                        json!([
+                            "Email/get",
+                            {
+                                "accountId": "acc1",
+                                "state": "state1",
+                                "list": [{
+                                    "id": "email-smime-sig",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "to": [{ "email": "bob@example.com" }],
+                                    "cc": [],
+                                    "subject": "S/MIME signed JMAP message",
+                                    "receivedAt": "2025-01-11T06:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": true,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                    "bodyValues": {
+                                        "1": { "value": "This message is signed.\n", "isEncodingProblem": false, "isTruncated": false },
+                                    },
+                                    "textBody": [{ "partId": "1", "type": "text/plain" }],
+                                    "htmlBody": [],
+                                    "attachments": [{
+                                        "partId": "2",
+                                        "blobId": "blob-smime-sig",
+                                        "name": "smime.p7s",
+                                        "type": "application/pkcs7-signature",
+                                        "size": 567,
+                                    }],
+                                }],
+                                "notFound": [],
+                            },
+                            call_id
+                        ])
+                    } else if id == "email-pgp-sig" {
+                        // PGP detached `multipart/signed` (#57 / RFC 3156):
+                        // the server surfaces the clear-signed text as the
+                        // body and the armored signature as a sibling
+                        // `application/pgp-signature` attachment.  Detected
+                        // the same way as the S/MIME signed fixture.
+                        json!([
+                            "Email/get",
+                            {
+                                "accountId": "acc1",
+                                "state": "state1",
+                                "list": [{
+                                    "id": "email-pgp-sig",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "to": [{ "email": "bob@example.com" }],
+                                    "cc": [],
+                                    "subject": "PGP signed JMAP message",
+                                    "receivedAt": "2025-01-10T05:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": true,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                    "bodyValues": {
+                                        "1": { "value": "This message is signed with PGP.\n", "isEncodingProblem": false, "isTruncated": false },
+                                    },
+                                    "textBody": [{ "partId": "1", "type": "text/plain" }],
+                                    "htmlBody": [],
+                                    "attachments": [{
+                                        "partId": "2",
+                                        "blobId": "blob-pgp-sig",
+                                        "name": "signature.asc",
+                                        "type": "application/pgp-signature",
+                                        "size": 489,
+                                    }],
                                 }],
                                 "notFound": [],
                             },
@@ -284,6 +396,33 @@ async fn api_handler(Json(body): Json<Value>) -> Json<Value> {
                                     "receivedAt": "2025-01-13T08:00:00Z",
                                     "keywords": {},
                                     "hasAttachment": false,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                },
+                                {
+                                    "id": "email-smime-enc",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "subject": "S/MIME encrypted JMAP message",
+                                    "receivedAt": "2025-01-12T07:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": true,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                },
+                                {
+                                    "id": "email-smime-sig",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "subject": "S/MIME signed JMAP message",
+                                    "receivedAt": "2025-01-11T06:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": true,
+                                    "mailboxIds": { "mbox-inbox": true },
+                                },
+                                {
+                                    "id": "email-pgp-sig",
+                                    "from": [{ "name": "Alice", "email": "alice@example.com" }],
+                                    "subject": "PGP signed JMAP message",
+                                    "receivedAt": "2025-01-10T05:00:00Z",
+                                    "keywords": {},
+                                    "hasAttachment": true,
                                     "mailboxIds": { "mbox-inbox": true },
                                 },
                             ],
@@ -374,6 +513,15 @@ async fn download_handler(
         // ciphertext is a placeholder (real OpenPGP decryption is
         // covered in unit tests in the unkai-imap crate).
         "blob-pgp" => b"MIME-Version: 1.0\r\nFrom: alice@example.com\r\nTo: bob@example.com\r\nSubject: Encrypted JMAP message\r\nContent-Type: multipart/encrypted; protocol=\"application/pgp-encrypted\"; boundary=\"PGP\"\r\n\r\n--PGP\r\nContent-Type: application/pgp-encrypted\r\n\r\nVersion: 1\r\n\r\n--PGP\r\nContent-Type: application/octet-stream\r\n\r\n-----BEGIN PGP MESSAGE-----\r\n\r\nwV4D...\r\n-----END PGP MESSAGE-----\r\n--PGP--\r\n",
+        // S/MIME enveloped-data envelope shape (#338) — a bare
+        // `application/pkcs7-mime` single part, matching what
+        // `detect_smime_envelope` keys on.  The base64 body is a
+        // placeholder (real CMS decryption is covered in unkai-imap
+        // unit tests); this only proves the Blob/get path is
+        // content-agnostic, exactly like the PGP fixture above.
+        "blob-smime-enc" => b"MIME-Version: 1.0\r\nFrom: alice@example.com\r\nTo: bob@example.com\r\nSubject: S/MIME encrypted JMAP message\r\nContent-Type: application/pkcs7-mime; smime-type=enveloped-data; name=\"smime.p7m\"\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=\"smime.p7m\"\r\n\r\nMIIBExampleEnvelopedDataPlaceholderBase64==\r\n",
+        // S/MIME detached `multipart/signed` envelope shape (#338).
+        "blob-smime-sig" => b"MIME-Version: 1.0\r\nFrom: alice@example.com\r\nTo: bob@example.com\r\nSubject: S/MIME signed JMAP message\r\nContent-Type: multipart/signed; protocol=\"application/pkcs7-signature\"; micalg=\"sha-256\"; boundary=\"smime-boundary\"\r\n\r\n--smime-boundary\r\nContent-Type: text/plain\r\n\r\nThis message is signed.\r\n--smime-boundary\r\nContent-Type: application/pkcs7-signature; name=\"smime.p7s\"\r\nContent-Transfer-Encoding: base64\r\n\r\nMIIBExampleSignaturePlaceholderBase64==\r\n--smime-boundary--\r\n",
         _ => return Err(StatusCode::NOT_FOUND),
     };
 
@@ -465,7 +613,7 @@ async fn test_fetch_envelopes() {
         .await
         .expect("fetch_envelopes should succeed");
 
-    assert_eq!(envelopes.len(), 3);
+    assert_eq!(envelopes.len(), 6);
 
     // First email (Alice)
     assert_eq!(envelopes[0].subject, "Hello from JMAP!");
@@ -483,6 +631,22 @@ async fn test_fetch_envelopes() {
     // `test_fetch_message_pgp_stamps_encrypted`.
     assert_eq!(envelopes[2].subject, "Encrypted JMAP message");
     assert!(envelopes[2].protection.is_none());
+
+    // Fourth / fifth — the S/MIME fixtures (#338).  Same as PGP: the
+    // envelope carries no encryption metadata; the chip lights up only
+    // after `fetch_message` sniffs the body-part content types.  Verified
+    // in `test_fetch_message_smime_stamps_encrypted` /
+    // `test_fetch_message_smime_signed_stamps_signed`.
+    assert_eq!(envelopes[3].subject, "S/MIME encrypted JMAP message");
+    assert!(envelopes[3].protection.is_none());
+    assert_eq!(envelopes[4].subject, "S/MIME signed JMAP message");
+    assert!(envelopes[4].protection.is_none());
+
+    // Sixth — the PGP detached-signed fixture (#57).  Same deal: no chip
+    // until `fetch_message` sniffs the `application/pgp-signature` part.
+    // Verified in `test_fetch_message_pgp_signed_stamps_signed`.
+    assert_eq!(envelopes[5].subject, "PGP signed JMAP message");
+    assert!(envelopes[5].protection.is_none());
 }
 
 #[tokio::test]
@@ -626,4 +790,121 @@ async fn test_fetch_raw_message_returns_blob_bytes() {
     assert!(text.contains("multipart/encrypted"));
     assert!(text.contains("application/pgp-encrypted"));
     assert!(text.contains("-----BEGIN PGP MESSAGE-----"));
+}
+
+// ── #338 — S/MIME JMAP receive sniff ───────────────────────────
+
+/// `fetch_message` on an S/MIME `enveloped-data` JMAP message stamps
+/// `protection = "encrypted"` and nulls the body so MailView shows the
+/// Decrypt button.  Unlike PGP (ASCII armor in the text body), the
+/// ciphertext is a binary `application/pkcs7-mime` part, so the sniff
+/// keys on the part's content type — JMAP doesn't expose the
+/// `smime-type` parameter, so any `pkcs7-mime` part is treated as
+/// encrypted and the precise label is re-stamped at decrypt time.
+#[tokio::test]
+async fn test_fetch_message_smime_stamps_encrypted() {
+    let client = connect_mock().await;
+
+    let envelopes = client.fetch_envelopes("Inbox", 50, None).await.unwrap();
+    let env = envelopes
+        .iter()
+        .find(|e| e.subject == "S/MIME encrypted JMAP message")
+        .expect("seeded S/MIME enveloped fixture missing");
+
+    let email = client
+        .fetch_message("Inbox", env.uid, "test-account")
+        .await
+        .expect("fetch_message should succeed for the S/MIME enveloped fixture");
+
+    assert_eq!(email.protection.as_deref(), Some("encrypted"));
+    assert_eq!(email.body_text, None);
+    assert_eq!(email.body_html, None);
+}
+
+/// `fetch_message` on an S/MIME detached `multipart/signed` JMAP
+/// message stamps `protection = "signed"` but keeps the clear-signed
+/// body readable (detection-only — CMS verification is deferred, same
+/// as the IMAP receive path).  Detected via the sibling
+/// `application/pkcs7-signature` part.
+#[tokio::test]
+async fn test_fetch_message_smime_signed_stamps_signed() {
+    let client = connect_mock().await;
+
+    let envelopes = client.fetch_envelopes("Inbox", 50, None).await.unwrap();
+    let env = envelopes
+        .iter()
+        .find(|e| e.subject == "S/MIME signed JMAP message")
+        .expect("seeded S/MIME signed fixture missing");
+
+    let email = client
+        .fetch_message("Inbox", env.uid, "test-account")
+        .await
+        .expect("fetch_message should succeed for the S/MIME signed fixture");
+
+    assert_eq!(email.protection.as_deref(), Some("signed"));
+    // Clear-signed body stays readable — only the chip is added.
+    assert!(
+        email
+            .body_text
+            .as_deref()
+            .unwrap_or_default()
+            .contains("This message is signed.")
+    );
+}
+
+/// `fetch_message` on a PGP detached `multipart/signed` JMAP message
+/// stamps `protection = "signed"` and keeps the clear-signed body — the
+/// PGP counterpart to `test_fetch_message_smime_signed_stamps_signed`.
+/// Closes the parity gap where the JMAP sniff previously recognised PGP
+/// encrypted armor but not PGP signed-only mail (IMAP already stamped
+/// both).  Detected via the sibling `application/pgp-signature` part.
+#[tokio::test]
+async fn test_fetch_message_pgp_signed_stamps_signed() {
+    let client = connect_mock().await;
+
+    let envelopes = client.fetch_envelopes("Inbox", 50, None).await.unwrap();
+    let env = envelopes
+        .iter()
+        .find(|e| e.subject == "PGP signed JMAP message")
+        .expect("seeded PGP signed fixture missing");
+
+    let email = client
+        .fetch_message("Inbox", env.uid, "test-account")
+        .await
+        .expect("fetch_message should succeed for the PGP signed fixture");
+
+    assert_eq!(email.protection.as_deref(), Some("signed"));
+    // Clear-signed body stays readable — only the chip is added.
+    assert!(
+        email
+            .body_text
+            .as_deref()
+            .unwrap_or_default()
+            .contains("This message is signed with PGP.")
+    );
+}
+
+/// `fetch_raw_message` round-trips the S/MIME envelope bytes verbatim
+/// through `Email/get` + the session `downloadUrl` — the same
+/// protocol-agnostic Blob/get path PGP uses.  This is the bytes source
+/// `decrypt_message` feeds to `parse_eml_bytes_with_crypto` on JMAP
+/// accounts, where the parameter-aware `detect_smime_envelope` runs.
+#[tokio::test]
+async fn test_fetch_raw_message_returns_smime_blob_bytes() {
+    let client = connect_mock().await;
+
+    let envelopes = client.fetch_envelopes("Inbox", 50, None).await.unwrap();
+    let env = envelopes
+        .iter()
+        .find(|e| e.subject == "S/MIME encrypted JMAP message")
+        .expect("seeded S/MIME enveloped fixture missing");
+
+    let raw = client
+        .fetch_raw_message("Inbox", env.uid)
+        .await
+        .expect("fetch_raw_message should succeed");
+
+    let text = std::str::from_utf8(&raw).expect("blob is utf-8 in this fixture");
+    assert!(text.contains("application/pkcs7-mime"));
+    assert!(text.contains("smime-type=enveloped-data"));
 }


### PR DESCRIPTION
## Summary

Chunk 5 of the S/MIME tracking issue (#338): wire S/MIME into the **JMAP** receive path so JMAP accounts light up the same encryption/signature chips as IMAP already does. Also closes a pre-existing PGP gap on JMAP while we're here.

JMAP servers hand us an **already-parsed** message — flattened body values plus per-part content types, with all Content-Type *parameters* stripped (RFC 8621 §4.1.4). So the IMAP path's raw-envelope detectors (`detect_pgp_mime_envelope` / `detect_smime_envelope`) can't run here; we sniff coarsely on the surviving signals instead.

New `detect_jmap_crypto` helper keys on:
- **Encrypted** — PGP `multipart/encrypted` armor (`-----BEGIN PGP MESSAGE-----` in the body text) **or** an `application/pkcs7-mime` (S/MIME `enveloped-data`) part → stamp `encrypted`, null the body so MailView shows the Decrypt button.
- **Signed** — a detached `multipart/signed` carrying an `application/pgp-signature` **or** `application/pkcs7-signature` sibling part → stamp `signed`, keep the clear-signed body.

The coarse stamp is just the affordance trigger; the precise label (`encrypted` / `signed-and-encrypted`) is re-stamped at decrypt time via the existing, already-protocol-agnostic `fetch_raw_message` (Blob/get) + `parse_eml_bytes_with_crypto` path — no changes needed there.

### Closing the PGP gap
The JMAP sniff previously recognised PGP *encrypted* armor but not *detached PGP signed* mail, even though the IMAP receive path stamps both. This unifies both stacks into one detector so PGP and S/MIME now behave identically on JMAP. (Mirrors IMAP exactly — inline cleartext-signed `-----BEGIN PGP SIGNED MESSAGE-----` is intentionally **not** handled, since IMAP doesn't either.)

### Notes
- **Backend-only.** No new request properties (JMAP returns each part's `type` by default), no new deps (so no SBOM/License changes), no new user-visible strings (chips reuse the protocol-agnostic `protection` values).
- Also genericized two leftover other-mail-client references in comments I was already editing, per the project convention.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo check -p unkai-jmap` clean
- [x] `cargo clippy -p unkai-jmap --tests` clean
- [x] `cargo test -p unkai-jmap` — 15/15 pass, including 4 new mock-server tests:
  - `test_fetch_message_smime_stamps_encrypted` (enveloped → `encrypted`, body nulled)
  - `test_fetch_message_smime_signed_stamps_signed` (multipart/signed → `signed`, body kept)
  - `test_fetch_message_pgp_signed_stamps_signed` (PGP detached signed → `signed`)
  - `test_fetch_raw_message_returns_smime_blob_bytes` (Blob/get round-trip)
- [ ] Manual: open an S/MIME-encrypted and a signed message on a JMAP account, confirm the Decrypt button / signed chip render

🤖 Generated with [Claude Code](https://claude.com/claude-code)