### PR TITLE
Fix all code warnings (#381)

### DIFF
--- a/crates/unkai-caldav/src/discovery.rs
+++ b/crates/unkai-caldav/src/discovery.rs
@@ -346,11 +346,11 @@ mod tests {
         assert_eq!(cals.len(), 3);
         let by_name: std::collections::HashMap<&str, &Calendar> =
             cals.iter().map(|c| (c.name.as_str(), c)).collect();
-        assert_eq!(by_name["shared-rw"].read_only, false);
-        assert_eq!(by_name["shared-ro"].read_only, true);
+        assert!(!by_name["shared-rw"].read_only);
+        assert!(by_name["shared-ro"].read_only);
         // No privilege-set advertised → preserve pre-#236
         // happy path: assume writable.
-        assert_eq!(by_name["no-priv-set"].read_only, false);
+        assert!(!by_name["no-priv-set"].read_only);
     }
 
     #[test]

--- a/crates/unkai-caldav/src/freebusy.rs
+++ b/crates/unkai-caldav/src/freebusy.rs
@@ -222,14 +222,14 @@ fn parse_iso_duration(s: &str) -> Option<Duration> {
     if !s.starts_with('P') {
         return None;
     }
-    let mut chars = s[1..].chars().peekable();
+    let chars = s[1..].chars().peekable();
     let mut days = 0i64;
     let mut hours = 0i64;
     let mut minutes = 0i64;
     let mut seconds = 0i64;
     let mut in_time = false;
     let mut buf = String::new();
-    while let Some(c) = chars.next() {
+    for c in chars {
         if c == 'T' {
             in_time = true;
             continue;

--- a/crates/unkai-caldav/src/ical.rs
+++ b/crates/unkai-caldav/src/ical.rs
@@ -155,11 +155,11 @@ fn event_from_properties(props: &[Property]) -> Result<Option<CalendarEvent>, St
             // hasn't already set the coordinates, so a server
             // emitting both forms keeps the canonical one.
             "X-APPLE-STRUCTURED-LOCATION" => {
-                if latitude.is_none() {
-                    if let Some((lat, lon)) = parse_apple_geo_uri(value) {
-                        latitude = Some(lat);
-                        longitude = Some(lon);
-                    }
+                if latitude.is_none()
+                    && let Some((lat, lon)) = parse_apple_geo_uri(value)
+                {
+                    latitude = Some(lat);
+                    longitude = Some(lon);
                 }
             }
             _ => {}
@@ -1008,7 +1008,7 @@ fn parse_apple_geo_uri(value: &str) -> Option<(f64, f64)> {
         .or_else(|| raw.strip_prefix("GEO:"))?;
     // Drop URI params (`;u=…`) / queries (`?q=…`) so they don't
     // break the float parse.
-    let core = body.split(|c: char| c == ';' || c == '?').next()?;
+    let core = body.split([';', '?']).next()?;
     let (lhs, rhs) = core.split_once(',')?;
     let lat: f64 = lhs.trim().parse().ok()?;
     let lon: f64 = rhs.trim().parse().ok()?;

--- a/crates/unkai-core/src/error.rs
+++ b/crates/unkai-core/src/error.rs
@@ -47,7 +47,7 @@ pub enum UnkaiError {
     /// Not Found (#236 follow-up).  Distinguished from
     /// `Nextcloud` so the calling Tauri command can react —
     /// flip the calendar's `read_only` flag in the local cache
-    /// + emit `calendars-updated` so the EventEditor stops
+    /// and emit `calendars-updated` so the EventEditor stops
     /// offering Save / Delete on this and any other event in
     /// that calendar.  Sabre/DAV (NC's CalDAV stack) commonly
     /// returns 404 instead of 403 for forbidden resources as a

--- a/crates/unkai-core/src/models.rs
+++ b/crates/unkai-core/src/models.rs
@@ -180,7 +180,7 @@ pub struct AppSettings {
     #[serde(default = "default_true")]
     pub link_check_enabled: bool,
     /// Master toggle for the EventEditor's location autocomplete
-    /// + inline map preview (#280).  Default **off** — the
+    /// and inline map preview (#280).  Default **off** — the
     /// feature sends each typed query to Nominatim
     /// (`nominatim.openstreetmap.org`) and the map preview iframe
     /// loads tiles from `openstreetmap.org`, both third-party

--- a/crates/unkai-core/src/url.rs
+++ b/crates/unkai-core/src/url.rs
@@ -37,10 +37,7 @@ pub fn ensure_https(url: &str) -> Result<(), UnkaiError> {
         // Cheap host extraction — everything up to the first `/`,
         // `?`, `#`, or end of string.  Strip an `userinfo@` prefix
         // and a `:port` suffix on the way through.
-        let host_with_port = rest
-            .split(|c| c == '/' || c == '?' || c == '#')
-            .next()
-            .unwrap_or("");
+        let host_with_port = rest.split(['/', '?', '#']).next().unwrap_or("");
         let host_with_port = host_with_port.rsplit('@').next().unwrap_or(host_with_port);
         // IPv6 literals come bracketed: `[::1]:8080`.
         let host = if let Some(end) = host_with_port.strip_prefix('[') {

--- a/crates/unkai-imap/src/attachment_filename.rs
+++ b/crates/unkai-imap/src/attachment_filename.rs
@@ -243,10 +243,10 @@ fn extract_param_value_bytes(header_bytes: &[u8], param: &[u8]) -> Option<Vec<u8
         if !suffix.starts_with(b"*") {
             continue;
         }
-        if let Ok(idx_str) = std::str::from_utf8(&suffix[1..]) {
-            if let Ok(idx) = idx_str.parse::<u32>() {
-                continuations.push((idx, value));
-            }
+        if let Ok(idx_str) = std::str::from_utf8(&suffix[1..])
+            && let Ok(idx) = idx_str.parse::<u32>()
+        {
+            continuations.push((idx, value));
         }
     }
 

--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -2936,17 +2936,17 @@ fn parse_references_header(raw: &str) -> Vec<String> {
     let bytes = joined.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'<' {
-            if let Some(end) = bytes[i + 1..].iter().position(|&b| b == b'>') {
-                if let Ok(id) = std::str::from_utf8(&bytes[i + 1..i + 1 + end]) {
-                    let trimmed = id.trim();
-                    if !trimmed.is_empty() {
-                        out.push(trimmed.to_string());
-                    }
+        if bytes[i] == b'<'
+            && let Some(end) = bytes[i + 1..].iter().position(|&b| b == b'>')
+        {
+            if let Ok(id) = std::str::from_utf8(&bytes[i + 1..i + 1 + end]) {
+                let trimmed = id.trim();
+                if !trimmed.is_empty() {
+                    out.push(trimmed.to_string());
                 }
-                i += 1 + end + 1;
-                continue;
             }
+            i += 1 + end + 1;
+            continue;
         }
         i += 1;
     }

--- a/crates/unkai-nextcloud/src/shares.rs
+++ b/crates/unkai-nextcloud/src/shares.rs
@@ -136,6 +136,7 @@ struct ShareData {
 ///   user's scope). The OCS message is included where available so
 ///   the UI can show something specific.
 /// - `UnkaiError::Protocol` — JSON didn't match the expected shape.
+#[allow(clippy::too_many_arguments)] // mirrors the OCS Share API's field set
 pub async fn create_public_share(
     server_url: &str,
     username: &str,
@@ -735,6 +736,7 @@ fn parse_list_response(body: &str) -> Result<Vec<PublicShareInfo>, UnkaiError> {
 ///
 /// Permission updates pass the raw bitmask Nextcloud uses
 /// (1 read, 2 update, 4 create, 8 delete, 16 share).
+#[allow(clippy::too_many_arguments)] // mirrors the OCS Share API's field set
 pub async fn update_public_share(
     server_url: &str,
     username: &str,

--- a/crates/unkai-smtp/src/client.rs
+++ b/crates/unkai-smtp/src/client.rs
@@ -424,9 +424,9 @@ fn address_only(addr: &str) -> String {
 /// because the body is cleartext — the SMTP server fans out one
 /// identical envelope per recipient with the BCC list scrubbed from the
 /// visible headers, just like a plaintext mail.  Not safe for
-/// `multipart/encrypted` because a single ciphertext encrypted to TO + CC
-/// + BCC keys leaks the BCC list via the OpenPGP ESK packets, which is
-/// why the encrypted path keeps the BCC-exclusion version.
+/// `multipart/encrypted` because a single ciphertext encrypted to the
+/// combined TO, CC, and BCC keys leaks the BCC list via the OpenPGP ESK
+/// packets, which is why the encrypted path keeps the BCC-exclusion version.
 fn envelope_from_email_include_bcc(email: &OutgoingEmail) -> Result<Envelope, UnkaiError> {
     envelope_from_email_inner(email, true)
 }

--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -2470,7 +2470,7 @@ mod tests {
         // Per-account map: acc-a present with 1, acc-other omitted.
         let by_acc = cache.count_outbox_by_account().unwrap();
         assert_eq!(by_acc.get("acc-a").copied(), Some(1));
-        assert!(by_acc.get("acc-other").is_none());
+        assert!(!by_acc.contains_key("acc-other"));
 
         let rows = cache.list_outbox("acc-a").unwrap();
         assert_eq!(rows.len(), 1);

--- a/crates/unkai-store/src/cache/pgp_keys.rs
+++ b/crates/unkai-store/src/cache/pgp_keys.rs
@@ -50,7 +50,7 @@ impl PgpKeySource {
     /// a conservative fallback — the row exists, so somebody put it
     /// there deliberately; treating it as "manual" preserves the row
     /// without claiming a stronger provenance than we can prove.
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_db_str(s: &str) -> Self {
         match s {
             "vcard" => Self::Vcard,
             "inbound-message" => Self::InboundMessage,
@@ -199,7 +199,7 @@ fn row_from_columns(r: &rusqlite::Row<'_>) -> rusqlite::Result<PgpPublicKeyRow> 
         fingerprint: r.get(0)?,
         email: r.get(1)?,
         armored_key: r.get(2)?,
-        source: PgpKeySource::from_str(&source),
+        source: PgpKeySource::from_db_str(&source),
         added_at: r.get(4)?,
     })
 }
@@ -314,13 +314,13 @@ mod tests {
         assert_eq!(PgpKeySource::Manual.as_str(), "manual");
         assert_eq!(PgpKeySource::InboundMessage.as_str(), "inbound-message");
 
-        assert_eq!(PgpKeySource::from_str("vcard"), PgpKeySource::Vcard);
-        assert_eq!(PgpKeySource::from_str("manual"), PgpKeySource::Manual);
+        assert_eq!(PgpKeySource::from_db_str("vcard"), PgpKeySource::Vcard);
+        assert_eq!(PgpKeySource::from_db_str("manual"), PgpKeySource::Manual);
         assert_eq!(
-            PgpKeySource::from_str("inbound-message"),
+            PgpKeySource::from_db_str("inbound-message"),
             PgpKeySource::InboundMessage
         );
         // Unknown values fall back to Manual rather than erroring.
-        assert_eq!(PgpKeySource::from_str("garbage"), PgpKeySource::Manual);
+        assert_eq!(PgpKeySource::from_db_str("garbage"), PgpKeySource::Manual);
     }
 }

--- a/crates/unkai-store/src/cache/smime_certs.rs
+++ b/crates/unkai-store/src/cache/smime_certs.rs
@@ -64,7 +64,7 @@ impl SmimeCertSource {
     /// a conservative fallback — the row exists, so somebody put it
     /// there deliberately; treating it as "manual" preserves the row
     /// without claiming a stronger provenance than we can prove.
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_db_str(s: &str) -> Self {
         match s {
             "vcard" => Self::Vcard,
             "inbound-message" => Self::InboundMessage,
@@ -213,7 +213,7 @@ fn row_from_columns(r: &rusqlite::Row<'_>) -> rusqlite::Result<SmimeCertRow> {
         fingerprint: r.get(0)?,
         email: r.get(1)?,
         der_cert: r.get(2)?,
-        source: SmimeCertSource::from_str(&source),
+        source: SmimeCertSource::from_db_str(&source),
         added_at: r.get(4)?,
     })
 }
@@ -334,15 +334,21 @@ mod tests {
         assert_eq!(SmimeCertSource::Manual.as_str(), "manual");
         assert_eq!(SmimeCertSource::InboundMessage.as_str(), "inbound-message");
 
-        assert_eq!(SmimeCertSource::from_str("vcard"), SmimeCertSource::Vcard);
-        assert_eq!(SmimeCertSource::from_str("manual"), SmimeCertSource::Manual);
         assert_eq!(
-            SmimeCertSource::from_str("inbound-message"),
+            SmimeCertSource::from_db_str("vcard"),
+            SmimeCertSource::Vcard
+        );
+        assert_eq!(
+            SmimeCertSource::from_db_str("manual"),
+            SmimeCertSource::Manual
+        );
+        assert_eq!(
+            SmimeCertSource::from_db_str("inbound-message"),
             SmimeCertSource::InboundMessage
         );
         // Unknown values fall back to Manual rather than erroring.
         assert_eq!(
-            SmimeCertSource::from_str("garbage"),
+            SmimeCertSource::from_db_str("garbage"),
             SmimeCertSource::Manual
         );
     }

--- a/crates/unkai-store/src/link_check.rs
+++ b/crates/unkai-store/src/link_check.rs
@@ -262,7 +262,7 @@ fn extract_host(url: &str) -> Option<String> {
         return None;
     }
     let end = after_scheme
-        .find(|c: char| c == '/' || c == '?' || c == '#' || c == ':')
+        .find(['/', '?', '#', ':'])
         .unwrap_or(after_scheme.len());
     let host = &after_scheme[..end];
     if host.is_empty() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1919,6 +1919,7 @@ async fn create_nextcloud_note(
 /// Cache-write-through: the server is authoritative on etag /
 /// modified; we persist what it returns.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command: each arg maps to a frontend invoke parameter
 async fn update_nextcloud_note(
     nc_id: String,
     note_id: u64,
@@ -2087,6 +2088,7 @@ async fn sync_nextcloud_tasks(
 /// VTODO body, PUTs with `If-None-Match: *`, and on success persists
 /// the row to the local cache.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command: each arg maps to a frontend invoke parameter
 async fn create_nextcloud_task(
     nc_id: String,
     list_id: String,
@@ -2149,6 +2151,7 @@ async fn create_nextcloud_task(
 /// `status` and `completed` in lockstep so a CalDAV client reading
 /// only one column still sees the right answer.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command: each arg maps to a frontend invoke parameter
 async fn update_nextcloud_task(
     nc_id: String,
     list_id: String,
@@ -2260,6 +2263,7 @@ async fn delete_nextcloud_task(
 /// understands that scheme, so the TasksView "Source mail" chip
 /// and a Notes mail-ref click route through the same handler.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command: each arg maps to a frontend invoke parameter
 async fn create_nextcloud_task_from_mail(
     nc_id: String,
     list_id: String,
@@ -4945,6 +4949,7 @@ fn get_tasks_sync_status(nc_id: String, cache: State<'_, Cache>) -> Result<SyncS
 ///    has — so matching an override to its series is O(1).
 /// 3. `unkai_caldav::expand_event` does the RFC 5545 work: RRULE
 ///    enumeration, EXDATE removal, RDATE insertion, override swap-in.
+///
 /// Pull events out of the local cache for `calendar_ids` over
 /// `[range_start, range_end)`, recurrence-expanded.  Shared by
 /// `get_cached_events` (the calendar grid) and
@@ -7194,10 +7199,10 @@ async fn fetch_unified_special_envelopes(
     for (account_id, folder) in &pairs {
         // Re-locate the matching account for the poll — `pairs` only
         // carries ids so we don't have to clone heavy structs.
-        if let Some(account) = accounts.iter().find(|a| a.id == *account_id) {
-            if let Err(e) = poll_folder(account, folder, limit, &cache).await {
-                tracing::warn!("unified special poll failed for '{account_id}'/'{folder}': {e}");
-            }
+        if let Some(account) = accounts.iter().find(|a| a.id == *account_id)
+            && let Err(e) = poll_folder(account, folder, limit, &cache).await
+        {
+            tracing::warn!("unified special poll failed for '{account_id}'/'{folder}': {e}");
         }
     }
     cache
@@ -7678,13 +7683,12 @@ async fn background_decrypt_new(
                 if matches!(
                     email.protection.as_deref(),
                     Some("encrypted" | "signed-and-encrypted")
-                ) {
-                    if let Err(e) = cache.put_encrypted_raw_eml(account_id, folder, uid, &raw) {
-                        tracing::debug!(
-                            "background-decrypt: put_encrypted_raw_eml UID {uid} \
+                ) && let Err(e) = cache.put_encrypted_raw_eml(account_id, folder, uid, &raw)
+                {
+                    tracing::debug!(
+                        "background-decrypt: put_encrypted_raw_eml UID {uid} \
                              in '{account_id}'/'{folder}' failed: {e}"
-                        );
-                    }
+                    );
                 }
                 out.push(email);
             }
@@ -7868,10 +7872,9 @@ async fn decrypt_message(
     if matches!(
         decrypted.protection.as_deref(),
         Some("encrypted" | "signed-and-encrypted")
-    ) {
-        if let Err(e) = cache.put_encrypted_raw_eml(&account_id, &folder, uid, &raw) {
-            tracing::warn!("cache.put_encrypted_raw_eml after decrypt failed: {e}");
-        }
+    ) && let Err(e) = cache.put_encrypted_raw_eml(&account_id, &folder, uid, &raw)
+    {
+        tracing::warn!("cache.put_encrypted_raw_eml after decrypt failed: {e}");
     }
     Ok(decrypted)
 }
@@ -8921,10 +8924,10 @@ async fn send_email(
     // already drained / been deleted is a no-op (zero rows
     // affected, no error).  Done before the new INSERT so a
     // failure in this branch can't leak a duplicate.
-    if let Some(src) = outbox_source.as_ref() {
-        if let Err(e) = cache.remove_outbox(src.id) {
-            tracing::warn!("remove source outbox row {} failed: {e}", src.id);
-        }
+    if let Some(src) = outbox_source.as_ref()
+        && let Err(e) = cache.remove_outbox(src.id)
+    {
+        tracing::warn!("remove source outbox row {} failed: {e}", src.id);
     }
 
     let entry_id = cache.enqueue_outbox(&unkai_store::OutboxEnqueue {
@@ -12751,10 +12754,8 @@ async fn urlhaus_refresh_worker(cache: Cache, settings: SharedSettings) {
     };
     if stale {
         let enabled = settings.read().await.link_check_enabled;
-        if enabled {
-            if let Err(e) = refresh_urlhaus_inner(&cache).await {
-                tracing::warn!("URLhaus initial refresh failed: {e}");
-            }
+        if enabled && let Err(e) = refresh_urlhaus_inner(&cache).await {
+            tracing::warn!("URLhaus initial refresh failed: {e}");
         }
     }
 
@@ -13055,9 +13056,10 @@ fn pending_file_slot() -> &'static Mutex<Option<String>> {
 ///     very first URL that fires before the webview mounts;
 ///   - the single-instance plugin when a second launch beats the
 ///     deep-link path on slower OSes.
+///
 /// Always a `Vec`, never a single slot, because on a cold start
 /// it's plausible (though unusual) for multiple paths to deliver
-/// the same URL — the frontend dedups by drainging the whole list
+/// the same URL — the frontend dedups by draining the whole list
 /// and parsing each one fresh.
 static PENDING_MAILTO_URLS: std::sync::OnceLock<Mutex<Vec<String>>> = std::sync::OnceLock::new();
 
@@ -13183,7 +13185,7 @@ fn open_default_apps_settings() -> Result<(), UnkaiError> {
             .args(["/C", "start", "", "ms-settings:defaultapps"])
             .spawn()
             .map_err(|e| UnkaiError::Other(format!("open defaults panel: {e}")))?;
-        return Ok(());
+        Ok(())
     }
     #[cfg(target_os = "macos")]
     {
@@ -13290,12 +13292,12 @@ fn pgp_remove_private_key(
     credentials::delete_pgp_passphrase(&account_id)?;
 
     let accounts = account_store::load_accounts(&cache)?;
-    if let Some(mut acc) = accounts.into_iter().find(|a| a.id == account_id) {
-        if acc.pgp_key_fingerprint.is_some() {
-            acc.pgp_key_fingerprint = None;
-            account_store::update_account(&cache, acc)?;
-            notify.0.notify_one();
-        }
+    if let Some(mut acc) = accounts.into_iter().find(|a| a.id == account_id)
+        && acc.pgp_key_fingerprint.is_some()
+    {
+        acc.pgp_key_fingerprint = None;
+        account_store::update_account(&cache, acc)?;
+        notify.0.notify_one();
     }
     Ok(())
 }
@@ -13606,12 +13608,12 @@ fn smime_remove_private_cert(
     credentials::delete_smime_passphrase(&account_id)?;
 
     let accounts = account_store::load_accounts(&cache)?;
-    if let Some(mut acc) = accounts.into_iter().find(|a| a.id == account_id) {
-        if acc.smime_cert_fingerprint.is_some() {
-            acc.smime_cert_fingerprint = None;
-            account_store::update_account(&cache, acc)?;
-            notify.0.notify_one();
-        }
+    if let Some(mut acc) = accounts.into_iter().find(|a| a.id == account_id)
+        && acc.smime_cert_fingerprint.is_some()
+    {
+        acc.smime_cert_fingerprint = None;
+        account_store::update_account(&cache, acc)?;
+        notify.0.notify_one();
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #381.

Clears the clippy warning backlog so `cargo clippy --workspace --all-targets` runs clean. The frontend (`npm run check`) was already warning-free. **No behavioural change** — every fix is a semantically equivalent rewrite or a docs / lint-suppression tidy-up.

## Mechanical rewrites (`clippy --fix`)
- `assert_eq!(x, true/false)` → `assert!(x)` / `assert!(!x)`
- manual `|c| c == '/' …` char closures → slice patterns in `split()` / `find()`
- `while let Some(c) = it.next()` → `for c in it`
- nested `if` / `if let` → let-chains (collapsible_if)
- dropped a needless `return`

## Manual fixes (needed judgement)
- **Doc comments:** a leading `+` on a wrapped line was parsed as a markdown bullet, and new paragraphs after a list lacked a blank `///` separator (`doc_lazy_continuation`). Reworded / separated so rustdoc renders them as intended.
- **`from_str` → `from_db_str`:** `PgpKeySource` / `SmimeCertSource` had infallible `from_str` methods returning `Self` with a fallback (not `Result`), colliding with the `FromStr` trait name (`should_implement_trait`). Renamed + updated all call sites and tests.
- **`get(k).is_none()` → `!contains_key(k)`** in a store test.
- **`#[allow(clippy::too_many_arguments)]`** on the four Tauri task/note commands (each arg maps 1:1 to a frontend `invoke` param) and the two OCS Share API functions (arg list mirrors the protocol's field set) — collapsing into a struct would only add indirection.

## Verification
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --check` — clean
- `cargo test --workspace` — all pass (335 tests)
- `npm run check` — 0 errors / 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)