### PR TITLE
Triage remaining pre-V0.1.0 security alerts (#291)

### DIFF
--- a/audit.toml
+++ b/audit.toml
@@ -40,4 +40,11 @@ ignore = [
   "RUSTSEC-2025-0052", # async-std (transitive build dep)
   "RUSTSEC-2024-0370", # proc-macro-error (transitive build-time)
   "RUSTSEC-2026-0097", # rand 0.7 + 0.8 — unsound; transitive only
+
+  # ── rsa Marvin timing side-channel (transitive via pgp) ─────────
+  # `rsa` (CVE-2023-49092 / RUSTSEC-2023-0071) has no patched release
+  # upstream.  Pulled in transitively by `pgp` → `unkai-crypto`.  The
+  # Marvin attack requires an adaptive decryption-timing oracle; our
+  # local offline PGP decryption never exposes one to a remote party.
+  "RUSTSEC-2023-0071", # rsa (Marvin)
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,9 @@ ignore = [
   "RUSTSEC-2025-0052", # async-std
   "RUSTSEC-2024-0370", # proc-macro-error
   "RUSTSEC-2026-0097", # rand 0.7 / 0.8
+  # rsa Marvin timing attack (CVE-2023-49092) via pgp — no upstream
+  # fix; not exploitable without a remote decryption-timing oracle.
+  "RUSTSEC-2023-0071", # rsa (Marvin)
 ]
 
 # ── Licences ────────────────────────────────────────────────────

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -71,3 +71,8 @@ reason = "proc-macro-error unmaintained — transitive build-time"
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0097"
 reason = "rand 0.7 / 0.8 unsoundness — transitive only, not exposed in our API"
+
+# ── rsa Marvin timing side-channel (transitive via pgp) ──────────
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"
+reason = "rsa Marvin attack (CVE-2023-49092) — no patched release exists upstream; pulled in via pgp → unkai-crypto. The attack needs an adaptive decryption-timing oracle, which our offline local PGP decryption does not expose to a remote attacker."

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13081,6 +13081,10 @@ fn buffer_mailto_url(url: &str) {
 /// passes any `--flag` style argv too and we don't want to
 /// accidentally treat those as paths.
 fn capture_launch_file_arg() {
+    // argv is read only to discover a file to *open*, never for an
+    // access-control decision — and the candidate is re-validated as
+    // an existing `.ics`/`.eml` file below before we act on it.
+    // nosemgrep: rust.lang.security.args.args
     let Some(arg) = std::env::args().nth(1) else {
         return;
     };
@@ -13108,6 +13112,10 @@ fn capture_launch_file_arg() {
 /// argv (not just argv[1]) handles the edge case where a wrapper
 /// or shell prepends flags.
 fn capture_launch_mailto_arg() {
+    // Same rationale as `capture_launch_file_arg`: argv is scanned
+    // only to find a `mailto:` URL to act on, not for any security
+    // decision.  The value is parsed as a URL, never trusted as auth.
+    // nosemgrep: rust.lang.security.args.args
     for arg in std::env::args().skip(1) {
         if arg.to_lowercase().starts_with("mailto:") {
             buffer_mailto_url(&arg);


### PR DESCRIPTION
Closes #291.

The Security tab carried **10 open alerts** from four scanners (CodeQL, Semgrep, OSV-Scanner, Dependabot). None were exploitable defects — they split into *upstream-blocked advisories we accept* and *scanner false positives*. This PR handles the parts that belong in the repo; the false-positive / already-accepted alerts are dismissed on the Security tab separately (they don't correspond to code changes).

## In this PR (code + config)

- **Accept `rsa` Marvin advisory** (`RUSTSEC-2023-0071` / `CVE-2023-49092`) in `deny.toml`, `osv-scanner.toml`, and `audit.toml`. No patched `rsa` release exists upstream; it's transitive via `pgp → unkai-crypto`. The Marvin timing side-channel needs an adaptive decryption-timing oracle, which our **offline local PGP decryption** never exposes to a remote attacker. This closes OSV alert #64 on the next scan.
- **Annotate the two `std::env::args()` launch-arg readers** (`capture_launch_file_arg` / `capture_launch_mailto_arg`) with `// nosemgrep:` + justification — argv is only scanned to find a file or `mailto:` URL to open, never for an access-control decision. Documents Semgrep alerts #50 / #59.

## Handled by dismissal (no code change — done via the Security API)

| Alert | Why dismissed |
|---|---|
| CodeQL #63 (critical "hard-coded salt") | False positive — `[0u8; SALT_LEN]` buffer immediately filled by `getrandom`. |
| CodeQL #51 (high "clear-text storage") | False positive — a `localStorage` allow-list of bare email addresses, not credentials. |
| Semgrep #44 / #60 / #61 (`unsafe` / `temp_dir`) | Already suppressed in code with justification; dismissed to clear stale alerts. |
| Dependabot glib / rand | Already formally accepted as `RUSTSEC-2024-0429` / `RUSTSEC-2026-0097`; Dependabot just doesn't read the audit configs. |

## Validation
- `cargo fmt --check` ✅
- `cargo check --workspace` ✅
- All three ignore-config TOMLs parse ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)