### PR TITLE
fix: exclude own address from Cc on reply-all and respond-with-meeting

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1199,9 +1199,13 @@
           description: saved.description ?? null,
           talkUrl: isUrl ? loc : null,
         }
-        const others = [...replyTo.to, ...replyTo.cc].filter(
-          (a) => a && a.toLowerCase() !== activeAccountEmail.toLowerCase(),
-        )
+        // Bare-address compare so a "Name" <addr> self entry is
+        // still excluded from Cc (see `onMeetingEditorSaved`).
+        const selfAddr = activeAccountEmail.toLowerCase()
+        const others = [...replyTo.to, ...replyTo.cc].filter((a) => {
+          const addr = bareEmail(a)
+          return addr && addr.toLowerCase() !== selfAddr
+        })
         const initial: ComposeInitial = {
           to: replyTo.from,
           cc: others.length > 0 ? others.join(', ') : undefined,
@@ -2096,9 +2100,14 @@
   }
 
   function buildReplyAllInitial(mail: ReplyableMail): ComposeInitial {
-    const others = [...mail.to, ...mail.cc].filter(
-      (a) => a && a.toLowerCase() !== activeAccountEmail.toLowerCase(),
-    )
+    // Bare-address compare: To/Cc pieces may carry display names,
+    // so a raw compare would fail to drop the user's own address
+    // and reply-all would CC them on their own reply.
+    const self = activeAccountEmail.toLowerCase()
+    const others = [...mail.to, ...mail.cc].filter((a) => {
+      const addr = bareEmail(a)
+      return addr && addr.toLowerCase() !== self
+    })
     return {
       to: mail.from,
       cc: others.join(', '),
@@ -2952,9 +2961,15 @@
     // reply ergonomics (To from From, Re: subject prefix, quoted
     // body) match what `onReply` already produces.
     const original = ctx.replyTo
-    const others = [...original.to, ...original.cc].filter(
-      (a) => a && a.toLowerCase() !== activeAccountEmail.toLowerCase(),
-    )
+    // Compare on the *bare* address — To/Cc pieces can be in
+    // "Name" <addr> form, so a raw string compare never matches
+    // the user's bare email and would leave them CC'd on their
+    // own invite (same idiom as `prepareMeetingDraft`).
+    const self = activeAccountEmail.toLowerCase()
+    const others = [...original.to, ...original.cc].filter((a) => {
+      const addr = bareEmail(a)
+      return addr && addr.toLowerCase() !== self
+    })
     openCompose({
       to: original.from,
       cc: others.length > 0 ? others.join(', ') : undefined,


### PR DESCRIPTION
## Problem

When using **Respond with meeting** (and, it turns out, plain **reply-all**), the user's own address was added to **Cc** on the outgoing mail instead of being omitted — you'd be CC'd on your own invite/reply.

## Root cause

The Cc list was built by comparing each `To`/`Cc` entry directly against the user's **bare** email:

```js
[...to, ...cc].filter((a) => a && a.toLowerCase() !== activeAccountEmail.toLowerCase())
```

But those entries are frequently in `"Name" <addr>` form, so the raw-string compare never matched the bare self address — and the self entry survived into Cc. The attendee-bucketing in `prepareMeetingDraft` already did this correctly via `bareEmail()`; the Cc builders didn't.

## Fix

Compare on the **bare address** using the existing `bareEmail()` helper, matching the `prepareMeetingDraft` idiom. Applied to all three affected paths:

- `onMeetingEditorSaved` — Respond with meeting (main window)
- the `respond-with-meeting-from-mail` listener — Respond with meeting (popped-out mail window)
- `buildReplyAllInitial` — reply-all

## Testing

- `npm run check` passes (0 errors, 0 warnings).
- Confirmed no remaining raw-string self-compares in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)