### PR TITLE
Read & delivery receipts (MDN, RFC 8098)

### DIFF
--- a/crates/unkai-core/src/models.rs
+++ b/crates/unkai-core/src/models.rs
@@ -212,6 +212,17 @@ pub struct AppSettings {
     /// the inbox at that message).
     #[serde(default)]
     pub notes_mail_open_in_view: bool,
+    /// How to react when an incoming message carries a
+    /// `Disposition-Notification-To:` read-receipt request
+    /// (RFC 8098, #416).  `Ask` (default) surfaces a banner in the
+    /// reading pane offering to send or decline the receipt;
+    /// `Always` sends one automatically the first time the message
+    /// is displayed; `Never` suppresses the banner entirely and
+    /// sends nothing.  Read receipts leak reading behaviour to the
+    /// sender, so nothing is ever sent without this setting or an
+    /// explicit per-message click authorising it.
+    #[serde(default)]
+    pub mdn_response_mode: MdnResponseMode,
 }
 
 fn default_logo_style() -> String {
@@ -268,6 +279,21 @@ pub enum ThemeMode {
     Dark,
 }
 
+/// Response policy for incoming read-receipt requests (RFC 8098,
+/// #416).  Lowercase on the wire (`"never"` / `"ask"` / `"always"`)
+/// to match the JSON-over-IPC convention `ThemeMode` set.  `Ask` is
+/// the default: receipts disclose reading behaviour, so the user
+/// stays in the loop per message unless they explicitly opt into
+/// `Always` (or shut the whole thing off with `Never`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum MdnResponseMode {
+    Never,
+    #[default]
+    Ask,
+    Always,
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -318,6 +344,10 @@ impl Default for AppSettings {
             // the editor.  Flipping this on routes the click
             // through the main view-switch instead.
             notes_mail_open_in_view: false,
+            // Ask per message (#416) — read receipts disclose
+            // reading behaviour, so nothing is sent without the
+            // user's say-so.
+            mdn_response_mode: MdnResponseMode::Ask,
         }
     }
 }
@@ -607,6 +637,17 @@ pub struct EmailEnvelope {
     /// `None` once the reminder has fired.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reminder_at: Option<i64>,
+    /// Wire-only marker (#416): the envelope's top-level
+    /// `Content-Type:` is `multipart/report;
+    /// report-type=disposition-notification` — i.e. this message IS
+    /// a read receipt some recipient sent back to us.  Stamped by
+    /// the protocol clients from the same HEADER.FIELDS /
+    /// header-property slice the protection check uses, and
+    /// consumed by the sync path to fetch + parse the report body
+    /// and update the matching sent-mail receipt record.  Never
+    /// persisted: cache read paths always produce `false`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_mdn_report: bool,
 }
 
 /// Map the sender-declared priority headers to our two-value
@@ -730,6 +771,23 @@ pub struct Email {
     /// Local-only; mirrors the field on `EmailEnvelope`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reminder_at: Option<i64>,
+    /// The sender's `Disposition-Notification-To:` header value
+    /// (RFC 8098, #416) — present means "please tell me when this
+    /// was read", naming the address the receipt should go to.
+    /// Parsed by the full-message fetch paths and persisted on the
+    /// envelope row so a cache-served open still knows to offer
+    /// the receipt banner.  `None` = no receipt requested (the
+    /// overwhelmingly common case).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mdn_requested_to: Option<String>,
+    /// What the user (or their `Always`/`Never` policy) already did
+    /// about this message's receipt request (#416): `"sent"` or
+    /// `"declined"`.  Local-only like `is_pinned` — there is no
+    /// wire equivalent, protocol clients always produce `None`, and
+    /// the cache overlay fills in the stored value.  Drives the
+    /// banner's "don't ask twice" behaviour.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mdn_handled: Option<String>,
 }
 
 /// Metadata for one attachment on a received email.
@@ -863,6 +921,18 @@ pub struct OutgoingEmail {
     /// preserve the historical plaintext behaviour.
     #[serde(default)]
     pub signing_enabled: bool,
+    /// Ask recipients for a read receipt (RFC 8098, #416).  When
+    /// set, the SMTP layer stamps `Disposition-Notification-To:`
+    /// with the sender's own address on the outgoing message, and
+    /// the send pipeline records the sent Message-ID so an
+    /// incoming `message/disposition-notification` reply can be
+    /// matched back to this mail and surfaced as "read" status.
+    /// Advisory only — most clients let their user ignore or
+    /// decline the request, so absence of a receipt never means
+    /// the mail went unread.  `#[serde(default)]` keeps queued
+    /// outbox rows from before this field deserialising cleanly.
+    #[serde(default)]
+    pub request_read_receipt: bool,
 }
 
 /// Calendar payload emitted as the iMIP `text/calendar` body

--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -232,6 +232,13 @@ fn parse_plaintext_eml_bytes(
         header_first("X-MSMail-Priority").as_deref(),
     );
 
+    // #416: read-receipt request.  Kept verbatim (may be a full
+    // "Name <addr>" mailbox) — it becomes the `To:` of the receipt
+    // if the user agrees to send one.
+    let mdn_requested_to = header_first("Disposition-Notification-To")
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+
     Ok(Email {
         id: id.to_string(),
         account_id: account_id.to_string(),
@@ -263,6 +270,10 @@ fn parse_plaintext_eml_bytes(
         reminder_at: None,
         priority,
         priority_override: None,
+        mdn_requested_to,
+        // #416: handled-state is local-only; the cache overlay
+        // fills it in.
+        mdn_handled: None,
     })
 }
 
@@ -1310,6 +1321,9 @@ impl ImapClient {
                     reminder_at: None,
                     priority: extract_envelope_priority(fetch),
                     priority_override: None,
+                    // #416: wire-only receipt marker — read off the
+                    // same header slice as protection / priority.
+                    is_mdn_report: extract_envelope_mdn_report(fetch),
                 })
             })
             .collect();
@@ -1571,6 +1585,12 @@ impl ImapClient {
             header_first("X-MSMail-Priority").as_deref(),
         );
 
+        // #416: read-receipt request, verbatim (same shape as the
+        // plaintext parse path).
+        let mdn_requested_to = header_first("Disposition-Notification-To")
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+
         // PGP/MIME detection (#57).  Stamping `protection` here even
         // without a bridge lets MailView render a Decrypt affordance
         // and the inline chips instead of silently falling back to an
@@ -1618,6 +1638,10 @@ impl ImapClient {
             reminder_at: None,
             priority,
             priority_override: None,
+            mdn_requested_to,
+            // #416: handled-state is local-only; the Tauri layer
+            // overlays the stored value.
+            mdn_handled: None,
         })
     }
 
@@ -2498,6 +2522,9 @@ impl ImapClient {
                     reminder_at: None,
                     priority: extract_envelope_priority(fetch),
                     priority_override: None,
+                    // #416: wire-only receipt marker — read off the
+                    // same header slice as protection / priority.
+                    is_mdn_report: extract_envelope_mdn_report(fetch),
                 })
             })
             .collect();
@@ -2634,6 +2661,9 @@ impl ImapClient {
                     reminder_at: None,
                     priority: extract_envelope_priority(fetch),
                     priority_override: None,
+                    // #416: wire-only receipt marker — read off the
+                    // same header slice as protection / priority.
+                    is_mdn_report: extract_envelope_mdn_report(fetch),
                 })
             })
             .collect();
@@ -2790,6 +2820,9 @@ impl ImapClient {
                     reminder_at: None,
                     priority: extract_envelope_priority(fetch),
                     priority_override: None,
+                    // #416: wire-only receipt marker — read off the
+                    // same header slice as protection / priority.
+                    is_mdn_report: extract_envelope_mdn_report(fetch),
                 })
             })
             .collect();
@@ -3014,6 +3047,106 @@ fn extract_envelope_priority(fetch: &async_imap::types::Fetch) -> Option<String>
         header_text("Importance").as_deref(),
         header_text("X-MSMail-Priority").as_deref(),
     )
+}
+
+/// #416: classify an envelope as an incoming read receipt from the
+/// same `BODY.PEEK[HEADER.FIELDS ...]` slice the protection check
+/// uses — top-level `Content-Type: multipart/report;
+/// report-type=disposition-notification` (RFC 8098 §3, RFC 6522).
+/// The sync path uses this marker to fetch the report body and
+/// update the matching sent-mail receipt record without the user
+/// ever having to open the receipt message.  Same caveat as
+/// [`extract_envelope_protection`]: relies on the FETCH call site
+/// requesting `CONTENT-TYPE` in its `HEADER.FIELDS` list.
+fn extract_envelope_mdn_report(fetch: &async_imap::types::Fetch) -> bool {
+    let Some(raw) = fetch.header() else {
+        return false;
+    };
+    let Some(parsed) = MessageParser::default().parse(raw) else {
+        return false;
+    };
+    let Some(ct) = parsed.content_type() else {
+        return false;
+    };
+    ct.ctype().eq_ignore_ascii_case("multipart")
+        && ct
+            .subtype()
+            .is_some_and(|s| s.eq_ignore_ascii_case("report"))
+        && ct
+            .attribute("report-type")
+            .is_some_and(|r| r.eq_ignore_ascii_case("disposition-notification"))
+}
+
+/// The machine-readable core of one incoming read receipt (#416),
+/// pulled out of a `message/disposition-notification` part.
+#[derive(Debug, Clone)]
+pub struct MdnReportData {
+    /// `Original-Message-ID` field with angle brackets stripped —
+    /// matches the bracket-free storage convention (#277), so it can
+    /// be joined directly against the sent-receipt tracking table.
+    pub original_message_id: String,
+    /// The `Disposition` field's disposition-type (the part after
+    /// the `;`), lowercased — `"displayed"`, `"deleted"`, or
+    /// `"dispatched"`/`"processed"` from older RFC 3798 senders.
+    pub disposition: String,
+    /// `Final-Recipient` address (the reader who sent the receipt),
+    /// when present — the part after the `rfc822;` type tag.
+    pub reporter: Option<String>,
+}
+
+/// Parse a raw RFC 5322 message as an incoming read receipt
+/// (RFC 8098 §3, #416).  Returns `None` when the message has no
+/// `message/disposition-notification` part or the part is missing
+/// the two fields we key on (`Original-Message-ID` + `Disposition`)
+/// — receipts we can't match to a sent mail are useless to us.
+///
+/// The field block inside the part uses RFC 5322 header syntax, so
+/// we hand it back to `MessageParser` rather than re-implementing
+/// unfolding rules here (same trick the envelope extractors use).
+pub fn parse_mdn_report(raw: &[u8]) -> Option<MdnReportData> {
+    let parsed = MessageParser::default().parse(raw)?;
+    let part = (0..).map_while(|i| parsed.part(i)).find(|p| {
+        p.content_type().is_some_and(|c| {
+            c.ctype().eq_ignore_ascii_case("message")
+                && c.subtype()
+                    .is_some_and(|s| s.eq_ignore_ascii_case("disposition-notification"))
+        })
+    })?;
+
+    // The part body is a bare field block — append a blank line so
+    // MessageParser sees a complete headers-only message.
+    let mut field_bytes = part.contents().to_vec();
+    field_bytes.extend_from_slice(b"\r\n\r\n");
+    let fields = MessageParser::default().parse(&field_bytes)?;
+    let field_text = |name: &str| {
+        fields
+            .header(name)
+            .and_then(|h| h.as_text())
+            .map(str::to_string)
+    };
+
+    let original_message_id = field_text("Original-Message-ID")
+        .as_deref()
+        .and_then(strip_msgid_brackets)?;
+    // `Disposition: manual-action/MDN-sent-manually; displayed` —
+    // the action mode before the `;` records *how* the receipt was
+    // triggered; the disposition-type after it is what the sender
+    // cares about.
+    let disposition = field_text("Disposition")
+        .as_deref()
+        .and_then(|v| v.rsplit(';').next().map(|d| d.trim().to_lowercase()))
+        .filter(|d| !d.is_empty())?;
+    // `Final-Recipient: rfc822;alex@example.com`
+    let reporter = field_text("Final-Recipient")
+        .as_deref()
+        .and_then(|v| v.split(';').nth(1).map(|a| a.trim().to_string()))
+        .filter(|a| !a.is_empty());
+
+    Some(MdnReportData {
+        original_message_id,
+        disposition,
+        reporter,
+    })
 }
 
 /// `<abc@host>` → `Some("abc@host")`.  Tolerates surrounding
@@ -3702,5 +3835,83 @@ mod tests {
 
         assert_eq!(email.subject, "opaque signed");
         assert_eq!(email.protection, None);
+    }
+
+    // ── Read receipts / MDN (#416) ─────────────────────────────
+
+    use super::parse_mdn_report;
+
+    #[test]
+    fn parse_detects_disposition_notification_to_header() {
+        let raw = b"From: Sender <sender@example.org>\r\n\
+             To: alex@example.com\r\n\
+             Subject: please confirm\r\n\
+             Disposition-Notification-To: Sender <sender@example.org>\r\n\
+             MIME-Version: 1.0\r\n\
+             Content-Type: text/plain\r\n\
+             \r\n\
+             Did you get this?\r\n";
+        let email = parse_eml_bytes(raw, "INBOX:1", "acc", "INBOX").unwrap();
+        assert_eq!(
+            email.mdn_requested_to.as_deref(),
+            Some("Sender <sender@example.org>")
+        );
+    }
+
+    #[test]
+    fn plain_mail_has_no_mdn_request() {
+        let raw = b"From: sender@example.org\r\n\
+             To: alex@example.com\r\n\
+             Subject: hi\r\n\
+             Content-Type: text/plain\r\n\
+             \r\n\
+             hello\r\n";
+        let email = parse_eml_bytes(raw, "INBOX:1", "acc", "INBOX").unwrap();
+        assert_eq!(email.mdn_requested_to, None);
+    }
+
+    /// A receipt as another RFC 8098 client would send it back to us.
+    fn mdn_report_raw() -> Vec<u8> {
+        b"From: Reader <reader@example.org>\r\n\
+          To: alex@example.com\r\n\
+          Subject: Read: quarterly numbers\r\n\
+          MIME-Version: 1.0\r\n\
+          Content-Type: multipart/report; report-type=disposition-notification; \
+              boundary=\"rep\"\r\n\
+          \r\n\
+          --rep\r\n\
+          Content-Type: text/plain\r\n\
+          \r\n\
+          Your message was displayed.\r\n\
+          \r\n\
+          --rep\r\n\
+          Content-Type: message/disposition-notification\r\n\
+          \r\n\
+          Reporting-UA: some-other-client\r\n\
+          Final-Recipient: rfc822;reader@example.org\r\n\
+          Original-Message-ID: <orig-123@example.com>\r\n\
+          Disposition: manual-action/MDN-sent-manually; displayed\r\n\
+          \r\n\
+          --rep--\r\n"
+            .to_vec()
+    }
+
+    #[test]
+    fn parse_mdn_report_extracts_original_id_and_disposition() {
+        let report = parse_mdn_report(&mdn_report_raw()).expect("must parse as a receipt");
+        // Brackets stripped, matching the #277 storage convention.
+        assert_eq!(report.original_message_id, "orig-123@example.com");
+        assert_eq!(report.disposition, "displayed");
+        assert_eq!(report.reporter.as_deref(), Some("reader@example.org"));
+    }
+
+    #[test]
+    fn parse_mdn_report_rejects_ordinary_mail() {
+        let raw = b"From: sender@example.org\r\n\
+             Subject: not a receipt\r\n\
+             Content-Type: text/plain\r\n\
+             \r\n\
+             just words\r\n";
+        assert!(parse_mdn_report(raw).is_none());
     }
 }

--- a/crates/unkai-imap/src/lib.rs
+++ b/crates/unkai-imap/src/lib.rs
@@ -8,6 +8,6 @@ mod client;
 mod mutf7;
 
 pub use client::{
-    EnvelopeBatch, FlagSnapshot, ImapClient, extract_decrypted_attachment, parse_eml_bytes,
-    parse_eml_bytes_with_crypto, probe_server_certificate,
+    EnvelopeBatch, FlagSnapshot, ImapClient, MdnReportData, extract_decrypted_attachment,
+    parse_eml_bytes, parse_eml_bytes_with_crypto, parse_mdn_report, probe_server_certificate,
 };

--- a/crates/unkai-jmap/src/client.rs
+++ b/crates/unkai-jmap/src/client.rs
@@ -306,6 +306,9 @@ impl JmapClient {
                             "header:X-Priority:asText",
                             "header:Importance:asText",
                             "header:X-MSMail-Priority:asText",
+                            // #416: spot incoming read receipts
+                            // (multipart/report) at envelope time.
+                            "header:Content-Type:asText",
                         ],
                     }),
                     call_id: "g0".into(),
@@ -386,6 +389,9 @@ impl JmapClient {
                         email.header_msmail_priority.as_deref(),
                     ),
                     priority_override: None,
+                    // #416: wire-only receipt marker, from the raw
+                    // Content-Type header property.
+                    is_mdn_report: is_mdn_report_content_type(email.header_content_type.as_deref()),
                 }
             })
             .collect();
@@ -428,6 +434,8 @@ impl JmapClient {
                         "header:X-Priority:asText",
                         "header:Importance:asText",
                         "header:X-MSMail-Priority:asText",
+                        // #416: read-receipt request header.
+                        "header:Disposition-Notification-To:asText",
                     ],
                     "fetchAllBodyValues": true,
                 }),
@@ -606,6 +614,15 @@ impl JmapClient {
                 email.header_msmail_priority.as_deref(),
             ),
             priority_override: None,
+            // #416: read-receipt request, from the header property
+            // requested above.  Handled-state is local-only; the
+            // Tauri layer overlays the stored value.
+            mdn_requested_to: email
+                .header_disposition_notification_to
+                .as_deref()
+                .map(|v| v.trim().to_string())
+                .filter(|v| !v.is_empty()),
+            mdn_handled: None,
         })
     }
 
@@ -968,6 +985,25 @@ impl JmapClient {
             .cloned()
             .collect();
 
+        let mut draft = json!({
+            "mailboxIds": { drafts_id: true },
+            "from": [{ "email": email.from }],
+            "to": to,
+            "cc": cc,
+            "bcc": bcc,
+            "subject": email.subject,
+            "bodyValues": body_values,
+            "textBody": text_body,
+            "htmlBody": html_body,
+            "keywords": { "$draft": true },
+        });
+        // RFC 8098 read-receipt request (#416), set via the RFC 8621
+        // §4.1.3 header-form property — the structured Email object
+        // has no first-class field for it.
+        if email.request_read_receipt {
+            draft["header:Disposition-Notification-To:asText"] = json!(email.from);
+        }
+
         // Build the batched request: create email + submit it.
         let resp = self
             .call(vec![
@@ -975,20 +1011,7 @@ impl JmapClient {
                     name: "Email/set".into(),
                     args: json!({
                         "accountId": self.account_id,
-                        "create": {
-                            "draft": {
-                                "mailboxIds": { drafts_id: true },
-                                "from": [{ "email": email.from }],
-                                "to": to,
-                                "cc": cc,
-                                "bcc": bcc,
-                                "subject": email.subject,
-                                "bodyValues": body_values,
-                                "textBody": text_body,
-                                "htmlBody": html_body,
-                                "keywords": { "$draft": true },
-                            },
-                        },
+                        "create": { "draft": draft },
                     }),
                     call_id: "emailCreate".into(),
                 },
@@ -1346,6 +1369,22 @@ fn build_full_name(mbox: &JmapMailbox, by_id: &HashMap<&str, &JmapMailbox>) -> S
     }
     parts.reverse();
     parts.join("/")
+}
+
+/// #416: is this raw `Content-Type:` header value an incoming read
+/// receipt (`multipart/report; report-type=disposition-notification`,
+/// RFC 8098 §3 / RFC 6522)?  String-level check on the header text —
+/// the JMAP envelope fetch hands us the raw header via the
+/// `header:Content-Type:asText` property, and the two substrings
+/// together are unambiguous enough that a full MIME parameter parse
+/// would buy nothing.  Matching on `disposition-notification` alone
+/// (not `report-type=disposition-notification`) keeps both the
+/// quoted and unquoted parameter forms covered.
+fn is_mdn_report_content_type(ct: Option<&str>) -> bool {
+    ct.is_some_and(|v| {
+        let v = v.to_ascii_lowercase();
+        v.contains("multipart/report") && v.contains("disposition-notification")
+    })
 }
 
 /// Generate a stable synthetic u32 UID from a JMAP string ID.

--- a/crates/unkai-jmap/src/types.rs
+++ b/crates/unkai-jmap/src/types.rs
@@ -206,6 +206,16 @@ pub struct JmapEmail {
     pub header_importance: Option<String>,
     #[serde(default, rename = "header:X-MSMail-Priority:asText")]
     pub header_msmail_priority: Option<String>,
+    /// Read-receipt request header (RFC 8098, #416) — requested by
+    /// the full-message fetch only.
+    #[serde(default, rename = "header:Disposition-Notification-To:asText")]
+    pub header_disposition_notification_to: Option<String>,
+    /// Raw top-level `Content-Type:` (#416) — requested by the
+    /// envelope fetch so incoming `multipart/report;
+    /// report-type=disposition-notification` receipts can be
+    /// spotted without pulling bodies.
+    #[serde(default, rename = "header:Content-Type:asText")]
+    pub header_content_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/unkai-jmap/tests/mock_server.rs
+++ b/crates/unkai-jmap/tests/mock_server.rs
@@ -708,6 +708,7 @@ async fn test_send_email() {
         references: vec![],
         encryption_mode: None,
         signing_enabled: false,
+        request_read_receipt: false,
     };
 
     client

--- a/crates/unkai-smtp/src/client.rs
+++ b/crates/unkai-smtp/src/client.rs
@@ -3,7 +3,10 @@
 use lettre::address::Envelope;
 use lettre::message::{
     Attachment as LettreAttachment, Mailbox, MessageBuilder, MultiPart, SinglePart,
-    header::{ContentDisposition, ContentId, ContentTransferEncoding, ContentType},
+    header::{
+        ContentDisposition, ContentId, ContentTransferEncoding, ContentType, Header, HeaderName,
+        HeaderValue,
+    },
 };
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::client::{Tls, TlsParameters};
@@ -101,6 +104,33 @@ impl SmtpClient {
     /// sites keep their behaviour unchanged.
     pub async fn send(&self, email: &OutgoingEmail) -> Result<(), UnkaiError> {
         self.send_with_crypto(email, None).await
+    }
+
+    /// Send a message disposition notification — the read receipt
+    /// itself (RFC 8098, #416).
+    ///
+    /// The wire bytes come from [`build_mdn_report_bytes`]; this
+    /// method only adds the SMTP envelope, which has one deliberate
+    /// quirk: the reverse-path is **null** (`MAIL FROM:<>`), as
+    /// RFC 8098 §3 requires.  A receipt that could itself bounce —
+    /// or trigger another receipt — would loop two auto-responders
+    /// against each other forever; the null sender is the standard
+    /// loop-breaker (same mechanism delivery status notifications
+    /// use).
+    pub async fn send_mdn(&self, reply: &MdnReply) -> Result<(), UnkaiError> {
+        let rcpt: Mailbox = sanitise_recipient(&reply.to)
+            .parse()
+            .map_err(|e| UnkaiError::Protocol(format!("Invalid receipt address: {e}")))?;
+        let envelope = Envelope::new(None, vec![rcpt.email])
+            .map_err(|e| UnkaiError::Protocol(format!("build MDN envelope: {e}")))?;
+
+        let bytes = build_mdn_report_bytes(reply);
+        self.transport
+            .send_raw(&envelope, &bytes)
+            .await
+            .map_err(|e| UnkaiError::Protocol(format!("Failed to send read receipt: {e}")))?;
+        info!("Read receipt sent to {}", reply.to);
+        Ok(())
     }
 
     /// Send an email with optional OpenPGP or S/MIME wrapping.
@@ -721,6 +751,15 @@ fn write_outer_routing_headers(email: &OutgoingEmail) -> String {
     if let Some(reply_to) = &email.reply_to {
         headers.push_str(&format!("Reply-To: {reply_to}\r\n"));
     }
+    // RFC 8098 read-receipt request (#416).  Routing metadata, so it
+    // must live on the *outer* wrapper — a receiving client can only
+    // honour it if it's visible before any decrypt/verify step.
+    if email.request_read_receipt {
+        headers.push_str(&format!(
+            "Disposition-Notification-To: {}\r\n",
+            address_only(&email.from)
+        ));
+    }
     headers.push_str(&format!("Subject: {}\r\n", email.subject));
     headers.push_str(&format!("Date: {date}\r\n"));
     headers.push_str(&format!("Message-ID: {message_id}\r\n"));
@@ -977,6 +1016,114 @@ fn build_outer_smime_signed_bytes(
     out
 }
 
+/// Everything needed to compose one read receipt (RFC 8098, #416).
+/// Assembled by the Tauri command layer from the cached original
+/// message + the sending account, and handed to
+/// [`build_mdn_report_bytes`] / [`SmtpClient::send_mdn`].
+#[derive(Debug, Clone)]
+pub struct MdnReply {
+    /// The receipt's author — the account address the original mail
+    /// was delivered to.  Becomes both the `From:` header and the
+    /// report's `Final-Recipient` field.
+    pub from: String,
+    /// Where the receipt goes: the original message's
+    /// `Disposition-Notification-To:` value.
+    pub to: String,
+    /// The original message's Message-ID *without* angle brackets
+    /// (the storage convention #277 set).  Fills the report's
+    /// `Original-Message-ID` field — the key the sender's client
+    /// uses to match the receipt back to its sent mail — plus
+    /// `In-Reply-To`/`References` so the receipt threads under the
+    /// original.  `None` when the original carried no Message-ID;
+    /// the receipt is still valid, just unmatchable by ID.
+    pub original_message_id: Option<String>,
+    /// The original message's subject, quoted in the receipt's own
+    /// `Subject:` and human-readable part.
+    pub original_subject: String,
+    /// `true` when the `Always` policy fired the receipt without a
+    /// per-message user action — reported as `automatic-action/
+    /// MDN-sent-automatically` per RFC 8098 §3.2.6.2 so the sender
+    /// knows a machine, not the reader, confirmed the display.
+    /// `false` = the user explicitly clicked "Send receipt"
+    /// (`manual-action/MDN-sent-manually`).
+    pub automatic: bool,
+}
+
+/// Pure-function builder for the `multipart/report;
+/// report-type=disposition-notification` wire bytes (RFC 8098 §3).
+/// Same hand-built-CRLF approach as the crypto outer builders —
+/// lettre has no model for the `message/disposition-notification`
+/// media type — and split out from [`SmtpClient::send_mdn`] so the
+/// structure is unit-testable without a transport.
+///
+/// Layout (both parts required by the RFC):
+///   1. `text/plain` — human-readable one-liner for clients that
+///      don't understand MDNs and just render the parts.
+///   2. `message/disposition-notification` — the machine-readable
+///      field block (`Final-Recipient`, `Original-Message-ID`,
+///      `Disposition`).
+///
+/// The top-level headers also carry `Auto-Submitted: auto-replied`
+/// (RFC 3834) so other auto-responders — vacation replies, ticket
+/// systems — know not to respond to the receipt in turn.
+pub fn build_mdn_report_bytes(reply: &MdnReply) -> Vec<u8> {
+    let boundary = format!("unkai-mdn-{}", uuid::Uuid::new_v4().simple());
+    let message_id = format!("<{}@unkai-mail.local>", uuid::Uuid::new_v4().simple());
+    let date = chrono::Utc::now().to_rfc2822();
+    let final_recipient = address_only(&reply.from);
+
+    let mut out = String::new();
+    out.push_str(&format!("From: {}\r\n", reply.from));
+    out.push_str(&format!("To: {}\r\n", reply.to));
+    out.push_str(&format!("Subject: Read: {}\r\n", reply.original_subject));
+    out.push_str(&format!("Date: {date}\r\n"));
+    out.push_str(&format!("Message-ID: {message_id}\r\n"));
+    if let Some(orig) = &reply.original_message_id {
+        out.push_str(&format!("In-Reply-To: <{orig}>\r\n"));
+        out.push_str(&format!("References: <{orig}>\r\n"));
+    }
+    out.push_str("Auto-Submitted: auto-replied\r\n");
+    out.push_str("MIME-Version: 1.0\r\n");
+    out.push_str(&format!(
+        "Content-Type: multipart/report; report-type=disposition-notification; \
+         boundary=\"{boundary}\"\r\n"
+    ));
+    out.push_str("\r\n");
+
+    // Part 1 — human-readable summary.  Deliberately English-only:
+    // it renders in the *sender's* client, whose locale we can't
+    // know, and a fixed string is the interop-safe choice.
+    out.push_str(&format!("--{boundary}\r\n"));
+    out.push_str("Content-Type: text/plain; charset=utf-8\r\n");
+    out.push_str("\r\n");
+    out.push_str(&format!(
+        "The message \"{}\" sent to {} has been displayed.\r\n\
+         This is no guarantee that the message has been read or understood.\r\n",
+        reply.original_subject, final_recipient,
+    ));
+    out.push_str("\r\n");
+
+    // Part 2 — the machine-readable disposition field block.
+    out.push_str(&format!("--{boundary}\r\n"));
+    out.push_str("Content-Type: message/disposition-notification\r\n");
+    out.push_str("\r\n");
+    out.push_str("Reporting-UA: Unkai Mail\r\n");
+    out.push_str(&format!("Final-Recipient: rfc822;{final_recipient}\r\n"));
+    if let Some(orig) = &reply.original_message_id {
+        out.push_str(&format!("Original-Message-ID: <{orig}>\r\n"));
+    }
+    let mode = if reply.automatic {
+        "automatic-action/MDN-sent-automatically"
+    } else {
+        "manual-action/MDN-sent-manually"
+    };
+    out.push_str(&format!("Disposition: {mode}; displayed\r\n"));
+    out.push_str("\r\n");
+
+    out.push_str(&format!("--{boundary}--\r\n"));
+    out.into_bytes()
+}
+
 /// Base64-encode `data` and lay it out as a MIME `Content-Transfer-
 /// Encoding: base64` body: 76-character lines (the RFC 2045 §6.8 limit),
 /// CRLF terminators, including a final CRLF after the last line so the
@@ -1127,6 +1274,27 @@ fn flush_line(out: &mut Vec<u8>, line: &[u8]) {
     out.extend_from_slice(b"\r\n");
 }
 
+/// `Disposition-Notification-To:` typed header (RFC 8098 §2.1, #416).
+/// lettre 0.11 has no built-in type for it, so we implement the
+/// `Header` trait ourselves — the value is the address the recipient's
+/// client should send the read receipt to (our own From address).
+#[derive(Debug, Clone)]
+struct DispositionNotificationTo(String);
+
+impl Header for DispositionNotificationTo {
+    fn name() -> HeaderName {
+        HeaderName::new_from_ascii_str("Disposition-Notification-To")
+    }
+
+    fn parse(s: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(Self(s.to_string()))
+    }
+
+    fn display(&self) -> HeaderValue {
+        HeaderValue::new(Self::name(), self.0.clone())
+    }
+}
+
 /// Build the lettre `Message` for an outgoing email *without* sending it.
 ///
 /// Exposed so callers (e.g. `main.rs`) can build the message once, send
@@ -1147,15 +1315,23 @@ pub fn build_outgoing_message(email: &OutgoingEmail) -> Result<Message, UnkaiErr
     //
     // `Message-ID` is generated for *every* outgoing mail by the
     // `None` arg below — lettre stamps a `<UUID@hostname>` value.
-    // Without this, every Unkai reply lands in other clients
-    // (Apple Mail, Thunderbird, Outlook, …) as an orphan because
-    // they have nothing to anchor a thread on.
+    // Without this, every Unkai reply lands in the recipient's
+    // client as a thread orphan because there is nothing to anchor
+    // a thread on.
     //
     // `In-Reply-To` and `References` only apply to replies and
     // are sourced from the parent's Message-ID + References chain
     // by the Compose / send path; we wrap each ID in the angle
     // brackets the headers expect.
     builder = builder.message_id(None);
+
+    // RFC 8098 read-receipt request (#416): point the receipt at
+    // our own address.  The bare From (display name stripped) keeps
+    // the header a plain routable address — some receiving clients
+    // choke on comments/names in this field.
+    if email.request_read_receipt {
+        builder = builder.header(DispositionNotificationTo(address_only(&email.from)));
+    }
     if let Some(parent_id) = &email.in_reply_to {
         let trimmed = parent_id.trim();
         if !trimmed.is_empty() {
@@ -1556,6 +1732,7 @@ mod tests {
             references: vec![],
             encryption_mode: Some("pgp".into()),
             signing_enabled: false,
+            request_read_receipt: false,
         }
     }
 
@@ -2287,6 +2464,133 @@ mod tests {
         assert!(
             signed_in_wire,
             "signed payload must appear byte-for-byte in the outer envelope wire bytes"
+        );
+    }
+
+    // ── Read receipts / MDN (#416) ─────────────────────────────
+
+    use super::{MdnReply, build_mdn_report_bytes, build_outgoing_message};
+
+    #[test]
+    fn request_read_receipt_stamps_disposition_notification_to() {
+        let mut email = outgoing("please confirm", &["bob@example.com"]);
+        email.encryption_mode = None;
+        email.from = "Alex Morgan <alex@example.com>".into();
+        email.request_read_receipt = true;
+
+        let raw = build_outgoing_message(&email).expect("build").formatted();
+        let parsed = MessageParser::default().parse(&raw).expect("parse");
+        let dnt = parsed
+            .header("Disposition-Notification-To")
+            .and_then(|h| h.as_text())
+            .expect("header must be present");
+        // Bare address — display name stripped for interop.
+        assert_eq!(dnt.trim(), "alex@example.com");
+    }
+
+    #[test]
+    fn no_receipt_request_means_no_header() {
+        let mut email = outgoing("ordinary mail", &["bob@example.com"]);
+        email.encryption_mode = None;
+
+        let raw = build_outgoing_message(&email).expect("build").formatted();
+        let parsed = MessageParser::default().parse(&raw).expect("parse");
+        assert!(parsed.header("Disposition-Notification-To").is_none());
+    }
+
+    #[test]
+    fn crypto_outer_headers_carry_receipt_request() {
+        // The crypto sends hand-build their outer routing headers, so
+        // the receipt request must survive that path too — it's
+        // routing metadata the recipient's client reads pre-decrypt.
+        let mut email = outgoing("secret memo", &["bob@example.com"]);
+        email.request_read_receipt = true;
+        let wire = build_outer_pgp_mime_bytes(
+            &email,
+            b"-----BEGIN PGP MESSAGE-----\nx\n-----END PGP MESSAGE-----\n",
+        );
+        let parsed = MessageParser::default().parse(&wire).expect("parse outer");
+        let dnt = parsed
+            .header("Disposition-Notification-To")
+            .and_then(|h| h.as_text())
+            .expect("outer wrapper must carry the header");
+        assert_eq!(dnt.trim(), "alice@example.com");
+    }
+
+    fn mdn_reply() -> MdnReply {
+        MdnReply {
+            from: "Alex Morgan <alex@example.com>".into(),
+            to: "sender@example.org".into(),
+            original_message_id: Some("orig-123@example.org".into()),
+            original_subject: "quarterly numbers".into(),
+            automatic: false,
+        }
+    }
+
+    #[test]
+    fn mdn_report_is_multipart_report_with_disposition_notification_type() {
+        let wire = build_mdn_report_bytes(&mdn_reply());
+        let parsed = MessageParser::default().parse(&wire).expect("parse MDN");
+
+        let ct = parsed.content_type().expect("Content-Type");
+        assert!(ct.ctype().eq_ignore_ascii_case("multipart"));
+        assert_eq!(ct.subtype().unwrap_or(""), "report");
+        assert_eq!(
+            ct.attribute("report-type").unwrap_or(""),
+            "disposition-notification"
+        );
+        assert_eq!(parsed.subject().unwrap_or(""), "Read: quarterly numbers");
+        // RFC 3834: receipts must declare themselves auto-submitted so
+        // other auto-responders don't answer them.
+        assert_eq!(
+            parsed
+                .header("Auto-Submitted")
+                .and_then(|h| h.as_text())
+                .unwrap_or(""),
+            "auto-replied"
+        );
+    }
+
+    #[test]
+    fn mdn_report_field_block_names_original_message_and_disposition() {
+        let wire = build_mdn_report_bytes(&mdn_reply());
+        let parsed = MessageParser::default().parse(&wire).expect("parse MDN");
+
+        let field_part = (0..)
+            .map_while(|i| parsed.part(i))
+            .find(|p| {
+                p.content_type().is_some_and(|c| {
+                    c.ctype().eq_ignore_ascii_case("message")
+                        && c.subtype()
+                            .is_some_and(|s| s.eq_ignore_ascii_case("disposition-notification"))
+                })
+            })
+            .expect("message/disposition-notification part must exist");
+        let body = std::str::from_utf8(field_part.contents()).expect("utf-8");
+        assert!(body.contains("Final-Recipient: rfc822;alex@example.com"));
+        assert!(body.contains("Original-Message-ID: <orig-123@example.org>"));
+        assert!(body.contains("Disposition: manual-action/MDN-sent-manually; displayed"));
+    }
+
+    #[test]
+    fn automatic_mdn_reports_automatic_action_mode() {
+        let mut reply = mdn_reply();
+        reply.automatic = true;
+        let wire = build_mdn_report_bytes(&reply);
+        let text = String::from_utf8(wire).expect("utf-8");
+        assert!(text.contains("Disposition: automatic-action/MDN-sent-automatically; displayed"));
+    }
+
+    #[test]
+    fn mdn_report_threads_under_the_original() {
+        let wire = build_mdn_report_bytes(&mdn_reply());
+        let parsed = MessageParser::default().parse(&wire).expect("parse MDN");
+        assert_eq!(
+            parsed
+                .header("In-Reply-To")
+                .and_then(|h| h.as_text())
+                .unwrap_or(""),
+            "orig-123@example.org"
         );
     }
 }

--- a/crates/unkai-smtp/src/lib.rs
+++ b/crates/unkai-smtp/src/lib.rs
@@ -4,4 +4,4 @@
 //! and sending email messages via [`SmtpClient`].
 
 pub mod client;
-pub use client::{SmtpClient, build_outgoing_message};
+pub use client::{MdnReply, SmtpClient, build_mdn_report_bytes, build_outgoing_message};

--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -78,6 +78,24 @@ pub struct DueMessageReminder {
     pub subject: String,
 }
 
+/// Receipt-tracking state for one sent mail that asked for a read
+/// receipt (RFC 8098, #416).  Produced by
+/// [`Cache::get_receipt_status`] and serialised straight over IPC —
+/// MailView renders the "receipt requested / read" chip from it.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SentReceiptStatus {
+    /// Unix-epoch seconds when the mail was sent with the request.
+    pub requested_at: i64,
+    /// What came back: `"displayed"` / `"deleted"` / …, or `None`
+    /// while no receipt has arrived (which may be forever — the
+    /// request is advisory and most clients let users decline it).
+    pub disposition: Option<String>,
+    /// Unix-epoch seconds when the receipt arrived.
+    pub disposition_at: Option<i64>,
+    /// Address that confirmed, when the report named one.
+    pub reporter: Option<String>,
+}
+
 /// Errors specific to the cache layer. Converted to `UnkaiError::Storage`
 /// when crossing out of the crate so the rest of the app doesn't have to
 /// care which database we happen to be using.
@@ -776,6 +794,8 @@ impl Cache {
                 priority: r.get(16)?,
                 priority_override: r.get(17)?,
                 reminder_at: r.get(18)?,
+                // #416: wire-only marker, never persisted.
+                is_mdn_report: false,
             })
         })?;
 
@@ -859,6 +879,8 @@ impl Cache {
                 priority: r.get(16)?,
                 priority_override: r.get(17)?,
                 reminder_at: r.get(18)?,
+                // #416: wire-only marker, never persisted.
+                is_mdn_report: false,
             })
         })?;
         let mut out = Vec::new();
@@ -987,6 +1009,8 @@ impl Cache {
                 priority: r.get(17)?,
                 priority_override: r.get(18)?,
                 reminder_at: r.get(19)?,
+                // #416: wire-only marker, never persisted.
+                is_mdn_report: false,
             })
         })?;
 
@@ -1092,6 +1116,8 @@ impl Cache {
                 priority: r.get(17)?,
                 priority_override: r.get(18)?,
                 reminder_at: r.get(19)?,
+                // #416: wire-only marker, never persisted.
+                is_mdn_report: false,
             })
         })?;
 
@@ -1670,24 +1696,25 @@ impl Cache {
     }
 
     /// Read the local-only organizational state for one cached
-    /// envelope (#414, #415): `(is_pinned, priority_override,
-    /// reminder_at)`.  Used by the full-message fetch paths to
-    /// overlay pin / override / reminder onto an `Email` that came
-    /// off the wire — the protocols can't know local state, and
-    /// without the overlay a fresh network fetch would render the
-    /// message unpinned in the UI even though the cache row still
-    /// says otherwise.  `Ok(None)` when the UID isn't cached
-    /// (nothing local to overlay).
+    /// envelope (#414, #415, #416): `(is_pinned, priority_override,
+    /// reminder_at, mdn_handled)`.  Used by the full-message fetch
+    /// paths to overlay pin / override / reminder / receipt-handled
+    /// onto an `Email` that came off the wire — the protocols can't
+    /// know local state, and without the overlay a fresh network
+    /// fetch would render the message unpinned in the UI even
+    /// though the cache row still says otherwise.  `Ok(None)` when
+    /// the UID isn't cached (nothing local to overlay).
+    #[allow(clippy::type_complexity)]
     pub fn envelope_local_state(
         &self,
         account_id: &str,
         folder: &str,
         uid: u32,
-    ) -> Result<Option<(bool, Option<String>, Option<i64>)>, CacheError> {
+    ) -> Result<Option<(bool, Option<String>, Option<i64>, Option<String>)>, CacheError> {
         let conn = self.conn()?;
         let row = conn
             .query_row(
-                "SELECT is_pinned, priority_override, reminder_at FROM messages
+                "SELECT is_pinned, priority_override, reminder_at, mdn_handled FROM messages
                  WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
                 params![account_id, folder, uid as i64],
                 |r| {
@@ -1695,7 +1722,126 @@ impl Cache {
                         r.get::<_, i64>(0)? != 0,
                         r.get::<_, Option<String>>(1)?,
                         r.get::<_, Option<i64>>(2)?,
+                        r.get::<_, Option<String>>(3)?,
                     ))
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    // ── Read receipts / MDN (#416) ─────────────────────────────
+
+    /// Record how the user (or their policy) resolved an incoming
+    /// read-receipt request: `"sent"` or `"declined"`.  Local-only
+    /// like the pin — this is what keeps the reading pane from
+    /// asking about the same message twice.
+    pub fn set_mdn_handled(
+        &self,
+        account_id: &str,
+        folder: &str,
+        uid: u32,
+        handled: &str,
+    ) -> Result<(), CacheError> {
+        let conn = self.conn()?;
+        conn.execute(
+            "UPDATE messages SET mdn_handled = ?4
+             WHERE account_id = ?1 AND folder = ?2 AND uid = ?3",
+            params![account_id, folder, uid as i64, handled],
+        )?;
+        Ok(())
+    }
+
+    /// Track that a just-sent mail asked for a read receipt (#416).
+    /// Keyed on the sent Message-ID (bracket-free, #277 convention)
+    /// — the only identifier both the sent copy and a future
+    /// `message/disposition-notification` reply share.  Idempotent:
+    /// a retry of the same send updates the timestamp rather than
+    /// erroring.
+    pub fn record_receipt_request(
+        &self,
+        account_id: &str,
+        message_id: &str,
+    ) -> Result<(), CacheError> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO sent_receipts (account_id, message_id, requested_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT (account_id, message_id) DO UPDATE SET
+                requested_at = excluded.requested_at",
+            params![account_id, message_id, Utc::now().timestamp()],
+        )?;
+        Ok(())
+    }
+
+    /// Does this account have any receipt request still waiting for
+    /// an answer?  Cheap gate for the sync path: incoming
+    /// `multipart/report` bodies are only worth fetching while at
+    /// least one request could match, so accounts that never ask
+    /// for receipts never pay the extra fetches.
+    pub fn has_pending_receipt_requests(&self, account_id: &str) -> Result<bool, CacheError> {
+        let conn = self.conn()?;
+        let n: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM sent_receipts
+             WHERE account_id = ?1 AND disposition IS NULL",
+            params![account_id],
+            |r| r.get(0),
+        )?;
+        Ok(n > 0)
+    }
+
+    /// Patch a receipt request with what an incoming
+    /// `message/disposition-notification` reported (#416).  Returns
+    /// `true` when a tracked request matched the report's
+    /// `Original-Message-ID`; `false` means the report referenced a
+    /// mail we never tracked (sent from another client, or before
+    /// this feature) and nothing was recorded.
+    pub fn record_receipt_disposition(
+        &self,
+        account_id: &str,
+        original_message_id: &str,
+        disposition: &str,
+        reporter: Option<&str>,
+    ) -> Result<bool, CacheError> {
+        let conn = self.conn()?;
+        let updated = conn.execute(
+            "UPDATE sent_receipts
+             SET disposition = ?3, disposition_at = ?4, reporter = ?5
+             WHERE account_id = ?1 AND message_id = ?2",
+            params![
+                account_id,
+                original_message_id,
+                disposition,
+                Utc::now().timestamp(),
+                reporter,
+            ],
+        )?;
+        Ok(updated > 0)
+    }
+
+    /// Receipt-tracking state for one sent mail, by Message-ID
+    /// (#416).  `Ok(None)` = this mail never asked for a receipt
+    /// (or was sent before the feature / from another client), so
+    /// MailView renders no chip at all.
+    pub fn get_receipt_status(
+        &self,
+        account_id: &str,
+        message_id: &str,
+    ) -> Result<Option<SentReceiptStatus>, CacheError> {
+        let conn = self.conn()?;
+        let row = conn
+            .query_row(
+                "SELECT requested_at, disposition, disposition_at, reporter
+                 FROM sent_receipts
+                 WHERE account_id = ?1 AND message_id = ?2",
+                params![account_id, message_id],
+                |r| {
+                    Ok(SentReceiptStatus {
+                        requested_at: r.get(0)?,
+                        disposition: r.get(1)?,
+                        disposition_at: r.get(2)?,
+                        reporter: r.get(3)?,
+                    })
                 },
             )
             .optional()?;
@@ -1790,8 +1936,8 @@ impl Cache {
         tx.execute(
             "INSERT INTO messages
                 (account_id, folder, uid, from_addr, subject, internal_date,
-                 is_read, is_starred, cached_at, priority)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                 is_read, is_starred, cached_at, priority, mdn_requested_to)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
              ON CONFLICT (account_id, folder, uid) DO UPDATE SET
                 from_addr     = excluded.from_addr,
                 subject       = excluded.subject,
@@ -1802,7 +1948,11 @@ impl Cache {
                 -- #414: full-message fetches parse the priority
                 -- headers too; COALESCE-guarded like the envelope
                 -- upsert so a path that didn't can't wipe the value.
-                priority      = COALESCE(excluded.priority, messages.priority)",
+                priority      = COALESCE(excluded.priority, messages.priority),
+                -- #416: receipt request, header-derived like priority.
+                -- (`mdn_handled` is local-only and deliberately absent
+                -- from this statement, like is_pinned / reminder_at.)
+                mdn_requested_to = COALESCE(excluded.mdn_requested_to, messages.mdn_requested_to)",
             params![
                 email.account_id,
                 email.folder,
@@ -1817,6 +1967,7 @@ impl Cache {
                 email.is_starred as i64,
                 now,
                 email.priority,
+                email.mdn_requested_to,
             ],
         )?;
 
@@ -1900,7 +2051,7 @@ impl Cache {
                         m.message_id, m.in_reply_to, m.references_ids,
                         b.protection, b.signature_status, b.signer_fingerprint,
                         m.is_pinned, m.priority, m.priority_override,
-                        m.reminder_at
+                        m.reminder_at, m.mdn_requested_to, m.mdn_handled
                  FROM messages m
                  INNER JOIN message_bodies b USING (account_id, folder, uid)
                  WHERE m.account_id = ?1 AND m.folder = ?2 AND m.uid = ?3",
@@ -1941,6 +2092,8 @@ impl Cache {
                         priority: r.get(18)?,
                         priority_override: r.get(19)?,
                         reminder_at: r.get(20)?,
+                        mdn_requested_to: r.get(21)?,
+                        mdn_handled: r.get(22)?,
                     })
                 },
             )
@@ -2561,6 +2714,7 @@ mod tests {
             reminder_at: None,
             priority: None,
             priority_override: None,
+            is_mdn_report: false,
         }
     }
 
@@ -2727,6 +2881,87 @@ mod tests {
         assert!(got.iter().all(|e| e.reminder_at.is_none()));
     }
 
+    #[test]
+    fn sent_receipt_lifecycle() {
+        // #416: request → pending → disposition recorded → status.
+        let cache = open_test_cache();
+
+        assert!(!cache.has_pending_receipt_requests("acc").unwrap());
+        cache.record_receipt_request("acc", "mid-1@host").unwrap();
+        assert!(cache.has_pending_receipt_requests("acc").unwrap());
+
+        let status = cache
+            .get_receipt_status("acc", "mid-1@host")
+            .unwrap()
+            .expect("row must exist after request");
+        assert!(status.disposition.is_none());
+
+        // A report for an untracked Message-ID records nothing.
+        assert!(
+            !cache
+                .record_receipt_disposition("acc", "unknown@host", "displayed", None)
+                .unwrap()
+        );
+
+        // The matching report patches the row and clears the
+        // pending gate.
+        assert!(
+            cache
+                .record_receipt_disposition(
+                    "acc",
+                    "mid-1@host",
+                    "displayed",
+                    Some("reader@example.org"),
+                )
+                .unwrap()
+        );
+        assert!(!cache.has_pending_receipt_requests("acc").unwrap());
+        let status = cache
+            .get_receipt_status("acc", "mid-1@host")
+            .unwrap()
+            .expect("row must survive the patch");
+        assert_eq!(status.disposition.as_deref(), Some("displayed"));
+        assert_eq!(status.reporter.as_deref(), Some("reader@example.org"));
+        assert!(status.disposition_at.is_some());
+
+        // Other accounts never see acc's rows.
+        assert!(
+            cache
+                .get_receipt_status("other", "mid-1@host")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn mdn_request_persists_and_handled_state_survives_refetch() {
+        // #416: the header-derived request lands via upsert_message;
+        // the local-only handled flag survives envelope re-fetches.
+        let cache = open_test_cache();
+        let mut email = make_email(1, "INBOX");
+        email.mdn_requested_to = Some("sender@example.org".into());
+        cache.upsert_message(&email).unwrap();
+
+        let got = cache.get_message("acc", "INBOX", 1).unwrap().unwrap();
+        assert_eq!(got.mdn_requested_to.as_deref(), Some("sender@example.org"));
+        assert_eq!(got.mdn_handled, None);
+
+        cache.set_mdn_handled("acc", "INBOX", 1, "sent").unwrap();
+        let (.., mdn_handled) = cache
+            .envelope_local_state("acc", "INBOX", 1)
+            .unwrap()
+            .expect("cached row");
+        assert_eq!(mdn_handled.as_deref(), Some("sent"));
+
+        // An envelope re-fetch (which knows nothing about MDN state)
+        // must clobber neither the request nor the handled flag.
+        let env = make_envelope(1, "INBOX", 0);
+        cache.upsert_envelopes_for_account("acc", &[env]).unwrap();
+        let got = cache.get_message("acc", "INBOX", 1).unwrap().unwrap();
+        assert_eq!(got.mdn_requested_to.as_deref(), Some("sender@example.org"));
+        assert_eq!(got.mdn_handled.as_deref(), Some("sent"));
+    }
+
     fn make_email(uid: u32, folder: &str) -> Email {
         Email {
             id: format!("{folder}:{uid}"),
@@ -2753,6 +2988,8 @@ mod tests {
             reminder_at: None,
             priority: None,
             priority_override: None,
+            mdn_requested_to: None,
+            mdn_handled: None,
         }
     }
 

--- a/crates/unkai-store/src/cache/schema.rs
+++ b/crates/unkai-store/src/cache/schema.rs
@@ -1437,6 +1437,57 @@ const MIGRATIONS: &[&str] = &[
         ON messages (reminder_at)
         WHERE reminder_at IS NOT NULL;
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v42 → v43: read receipts / MDN (RFC 8098, #416).
+    //
+    // Two columns on `messages` for the *incoming* side:
+    //
+    //   * `mdn_requested_to` — the sender's
+    //     `Disposition-Notification-To:` header value, i.e. "please
+    //     tell me when this was read" plus the address the receipt
+    //     should go to.  Header-derived like `priority`, so the
+    //     full-message upsert refreshes it with the same COALESCE
+    //     guard.  NULL = no receipt requested (almost all mail).
+    //
+    //   * `mdn_handled` — what already happened about that request:
+    //     'sent' or 'declined', NULL = not yet decided.  Local-only
+    //     user state exactly like `is_pinned` / `reminder_at`: no
+    //     wire equivalent, the upsert paths never write it, only
+    //     the receipt-response setter does.  This is what stops the
+    //     reading pane from asking twice.
+    //
+    // And one table for the *outgoing* side — receipts we asked
+    // for.  A row is created at SMTP-send time (keyed on the sent
+    // mail's Message-ID, bracket-free per the #277 convention) and
+    // patched when a `message/disposition-notification` reply
+    // arrives naming that ID:
+    //
+    //   * `disposition` NULL = requested, nothing back yet;
+    //     'displayed' / 'deleted' / … = what the recipient's client
+    //     reported.  `reporter` is the address that confirmed, when
+    //     the report named one.
+    //
+    // Deliberately NOT a column on `messages`: the sent copy lands
+    // in the Sent folder via a server-side APPEND and its UID is
+    // unknown at send time — the Message-ID is the only stable key
+    // both sides of the round-trip share.
+    // ─────────────────────────────────────────────────────────────
+    r#"
+    ALTER TABLE messages
+        ADD COLUMN mdn_requested_to TEXT;
+    ALTER TABLE messages
+        ADD COLUMN mdn_handled TEXT;
+
+    CREATE TABLE sent_receipts (
+        account_id     TEXT NOT NULL,
+        message_id     TEXT NOT NULL,
+        requested_at   INTEGER NOT NULL,
+        disposition    TEXT,
+        disposition_at INTEGER,
+        reporter       TEXT,
+        PRIMARY KEY (account_id, message_id)
+    );
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/crates/unkai-store/src/cache/search.rs
+++ b/crates/unkai-store/src/cache/search.rs
@@ -476,6 +476,8 @@ mod tests {
             reminder_at: None,
             priority: None,
             priority_override: None,
+            mdn_requested_to: None,
+            mdn_handled: None,
         }
     }
 

--- a/crates/unkai-store/src/lib.rs
+++ b/crates/unkai-store/src/lib.rs
@@ -13,4 +13,4 @@ pub mod nextcloud_store;
 pub mod settings_bundle;
 pub mod settings_sync;
 
-pub use cache::{Cache, DueMessageReminder, OutboxEnqueue, OutboxRow};
+pub use cache::{Cache, DueMessageReminder, OutboxEnqueue, OutboxRow, SentReceiptStatus};

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7806,6 +7806,36 @@ struct FolderPollOutcome {
     flag_changes: u32,
 }
 
+/// #416: parse raw message bytes as an incoming read receipt and, on
+/// a match, patch the tracked sent-mail request it answers.  Shared
+/// by the IMAP and JMAP poll branches — both hand us the same
+/// wire-format RFC 5322 bytes.  An untracked `Original-Message-ID`
+/// (a receipt for mail sent from another client, or from before the
+/// feature) is logged at debug and dropped: there is nothing local
+/// it could update.
+fn apply_mdn_report(cache: &Cache, account_id: &str, raw: &[u8]) {
+    let Some(report) = unkai_imap::parse_mdn_report(raw) else {
+        return;
+    };
+    match cache.record_receipt_disposition(
+        account_id,
+        &report.original_message_id,
+        &report.disposition,
+        report.reporter.as_deref(),
+    ) {
+        Ok(true) => tracing::info!(
+            "Read receipt recorded for Message-ID '{}' (disposition: {})",
+            report.original_message_id,
+            report.disposition,
+        ),
+        Ok(false) => tracing::debug!(
+            "Ignoring read receipt for untracked Message-ID '{}'",
+            report.original_message_id,
+        ),
+        Err(e) => tracing::warn!("record_receipt_disposition failed: {e}"),
+    }
+}
+
 /// Fetch+cache+reconcile for one (account, folder) pair.
 ///
 /// Shared code path for interactive refreshes and background polling.
@@ -7836,6 +7866,29 @@ async fn poll_folder(
 
         if let Err(e) = cache.upsert_envelopes_for_account(account_id, &envelopes) {
             tracing::warn!("cache.upsert_envelopes (JMAP) failed: {e}");
+        }
+
+        // #416: incoming read receipts.  Same shape as the IMAP
+        // branch below — gated on a pending request existing, scoped
+        // to newly-arrived envelopes only.
+        if cache
+            .has_pending_receipt_requests(account_id)
+            .unwrap_or(false)
+        {
+            let report_uids: Vec<u32> = envelopes
+                .iter()
+                .filter(|e| e.is_mdn_report)
+                .filter(|e| prior_highest.is_some_and(|p| e.uid > p))
+                .map(|e| e.uid)
+                .collect();
+            for uid in report_uids {
+                match client.fetch_raw_message(folder, uid).await {
+                    Ok(raw) => apply_mdn_report(cache, account_id, &raw),
+                    Err(e) => {
+                        tracing::warn!("MDN report fetch (JMAP) UID {uid} failed: {e}");
+                    }
+                }
+            }
         }
 
         let new_envelopes: Vec<EmailEnvelope> = envelopes
@@ -7991,6 +8044,35 @@ async fn poll_folder(
                 background_decrypt_new(&mut client, account_id, folder, &new_encrypted, cache).await
             }
         };
+
+    // #416: incoming read receipts.  A newly-arrived
+    // `multipart/report; report-type=disposition-notification`
+    // envelope is a receipt some recipient sent back — fetch its
+    // body over the still-open session and patch the tracked
+    // sent-mail request it answers.  Gated on the account having at
+    // least one request still pending, so users who never ask for
+    // receipts never pay the extra body fetches; scoped to
+    // strictly-new UIDs with the same `prior_highest` /
+    // rotation-skip semantics the background decrypt uses.
+    if !uidvalidity_rotated
+        && cache
+            .has_pending_receipt_requests(account_id)
+            .unwrap_or(false)
+    {
+        let report_uids: Vec<u32> = batch
+            .envelopes
+            .iter()
+            .filter(|e| e.is_mdn_report)
+            .filter(|e| prior_highest.is_some_and(|p| e.uid > p))
+            .map(|e| e.uid)
+            .collect();
+        for uid in report_uids {
+            match client.fetch_raw_message(folder, uid).await {
+                Ok(raw) => apply_mdn_report(cache, account_id, &raw),
+                Err(e) => tracing::warn!("MDN report fetch UID {uid} failed: {e}"),
+            }
+        }
+    }
 
     let _ = client.logout().await;
 
@@ -8150,6 +8232,91 @@ async fn fetch_message(
     }
 }
 
+/// Resolve an incoming read-receipt request (#416): either send the
+/// RFC 8098 `message/disposition-notification` reply, or record that
+/// the user declined.  Called by MailView's receipt banner (Ask
+/// mode) and fired automatically on message open under the Always
+/// policy (`automatic: true`, which the receipt reports as
+/// `automatic-action` so the sender knows a policy, not the reader,
+/// confirmed).
+///
+/// The receipt goes out via SMTP with a null reverse-path regardless
+/// of the account's retrieval protocol — JMAP's structured
+/// submission object can't express the `multipart/report` shape, and
+/// every account carries SMTP submission settings.
+///
+/// `mdn_handled` is stamped only after the send succeeded, so a
+/// failed send leaves the banner up for a retry.
+#[tauri::command]
+async fn respond_mdn_request(
+    account_id: String,
+    folder: String,
+    uid: u32,
+    decline: bool,
+    automatic: bool,
+    cache: State<'_, Cache>,
+) -> Result<(), UnkaiError> {
+    if decline {
+        cache.set_mdn_handled(&account_id, &folder, uid, "declined")?;
+        return Ok(());
+    }
+
+    let account = load_account(&cache, &account_id)?;
+    // The banner only renders on an open message, so the body (and
+    // with it the parsed request header) is always cached by now.
+    let email = cache
+        .get_message(&account_id, &folder, uid)?
+        .ok_or_else(|| {
+            UnkaiError::Other("Message is not cached — open it before sending a receipt".into())
+        })?;
+    let to = email
+        .mdn_requested_to
+        .clone()
+        .ok_or_else(|| UnkaiError::Protocol("Message did not request a read receipt".into()))?;
+
+    let from = if account.display_name.is_empty() {
+        account.email.clone()
+    } else {
+        format!("{} <{}>", account.display_name, account.email)
+    };
+    let reply = unkai_smtp::MdnReply {
+        from,
+        to,
+        original_message_id: email.message_id.clone(),
+        original_subject: email.subject.clone(),
+        automatic,
+    };
+
+    let password = credentials::get_imap_password(&account_id)?;
+    let smtp = SmtpClient::connect(
+        &account.smtp_host,
+        account.smtp_port,
+        &account.email,
+        &password,
+        &account.trusted_certs,
+    )
+    .await?;
+    smtp.send_mdn(&reply).await?;
+
+    cache.set_mdn_handled(&account_id, &folder, uid, "sent")?;
+    Ok(())
+}
+
+/// Receipt-tracking state for one sent mail (#416), by Message-ID.
+/// `None` = this mail never asked for a receipt, so MailView renders
+/// no chip.  A row with `disposition: null` renders as "requested,
+/// nothing back yet"; `"displayed"` as read.
+#[tauri::command]
+async fn get_receipt_status(
+    account_id: String,
+    message_id: String,
+    cache: State<'_, Cache>,
+) -> Result<Option<unkai_store::SentReceiptStatus>, UnkaiError> {
+    cache
+        .get_receipt_status(&account_id, &message_id)
+        .map_err(Into::into)
+}
+
 async fn fetch_message_inner(
     account_id: &str,
     folder: &str,
@@ -8168,16 +8335,30 @@ async fn fetch_message_inner(
         email
     };
 
-    // #414/#415: pin + priority-override + reminder are local-only
-    // cache state the wire fetch can't know — overlay from the cached
-    // envelope row so MailView reflects them even on a fresh network
-    // fetch.  (The upsert below leaves those columns alone either way.)
-    if let Ok(Some((is_pinned, priority_override, reminder_at))) =
+    // #414/#415/#416: pin + priority-override + reminder +
+    // receipt-handled are local-only cache state the wire fetch can't
+    // know — overlay from the cached envelope row so MailView
+    // reflects them even on a fresh network fetch.  (The upsert
+    // below leaves those columns alone either way.)
+    if let Ok(Some((is_pinned, priority_override, reminder_at, mdn_handled))) =
         cache.envelope_local_state(account_id, folder, uid)
     {
         email.is_pinned = is_pinned;
         email.priority_override = priority_override;
         email.reminder_at = reminder_at;
+        email.mdn_handled = mdn_handled;
+    }
+
+    // #416: a receipt request pointing back at the reading account's
+    // own address is meaningless (our own sent copy, or a
+    // self-addressed mail) — suppress it so the reading pane never
+    // offers to send a receipt to ourselves.
+    if email
+        .mdn_requested_to
+        .as_deref()
+        .is_some_and(|dnt| addresses_match(dnt, &account.email))
+    {
+        email.mdn_requested_to = None;
     }
 
     // Single transactional write-through: envelope + body together so the
@@ -8407,6 +8588,16 @@ async fn decrypt_message(
                     // #414: local-only state, same overlay reason.
                     decrypted.is_pinned = env.is_pinned;
                     decrypted.priority_override = env.priority_override;
+                    // #416: same overlay + self-request suppression
+                    // as the network path below.
+                    decrypted.mdn_handled = env.mdn_handled;
+                }
+                if decrypted
+                    .mdn_requested_to
+                    .as_deref()
+                    .is_some_and(|dnt| addresses_match(dnt, &account.email))
+                {
+                    decrypted.mdn_requested_to = None;
                 }
                 if let Err(e) = cache.upsert_message(&decrypted) {
                     tracing::warn!("cache.upsert_message after offline decrypt failed: {e}");
@@ -8449,14 +8640,28 @@ async fn decrypt_message(
     // is_read=true when it has no IMAP / JMAP context.
     decrypted.is_read = envelope_email.is_read;
     decrypted.is_starred = envelope_email.is_starred;
-    // #414/#415: pin + priority-override + reminder live only in the
-    // cache; the server-side envelope fetch above can't carry them.
-    if let Ok(Some((is_pinned, priority_override, reminder_at))) =
+    // #414/#415/#416: pin + priority-override + reminder +
+    // receipt-handled live only in the cache; the server-side
+    // envelope fetch above can't carry them.
+    if let Ok(Some((is_pinned, priority_override, reminder_at, mdn_handled))) =
         cache.envelope_local_state(&account_id, &folder, uid)
     {
         decrypted.is_pinned = is_pinned;
         decrypted.priority_override = priority_override;
         decrypted.reminder_at = reminder_at;
+        decrypted.mdn_handled = mdn_handled;
+    }
+
+    // #416: same self-request suppression as `fetch_message_inner` —
+    // our own sent copies carry our own address in
+    // `Disposition-Notification-To`, and a receipt to ourselves is
+    // meaningless.
+    if decrypted
+        .mdn_requested_to
+        .as_deref()
+        .is_some_and(|dnt| addresses_match(dnt, &account.email))
+    {
+        decrypted.mdn_requested_to = None;
     }
 
     if let Err(e) = cache.upsert_message(&decrypted) {
@@ -9957,6 +10162,28 @@ async fn run_send_pipeline(
         smtp.send(email).await?;
     }
 
+    // #416: the mail asked for a read receipt — remember the sent
+    // Message-ID (lettre stamped it during `build_outgoing_message`)
+    // so an incoming `message/disposition-notification` can be
+    // matched back to this mail and surfaced as receipt status.
+    // Recorded only after the SMTP send succeeded: a failed send
+    // stays in the outbox and will re-run this pipeline with a
+    // *fresh* Message-ID, and a pending row for never-sent mail
+    // would hold the receipt-scan gate open for nothing.
+    if email.request_read_receipt
+        && let Some(mid) = extract_message_id(&raw)
+    {
+        // sent_receipts keys on the bracket-free form (#277).
+        let mid = mid
+            .trim()
+            .trim_start_matches('<')
+            .trim_end_matches('>')
+            .to_string();
+        if let Err(e) = cache.record_receipt_request(&account.id, &mid) {
+            tracing::warn!("record_receipt_request failed: {e}");
+        }
+    }
+
     // Best-effort APPEND to Sent (same behaviour as before #276):
     // the user's mail is already out, a failure here is logged
     // but doesn't roll the send back.
@@ -10345,6 +10572,26 @@ fn extract_message_id(raw: &[u8]) -> Option<String> {
         }
     }
     None
+}
+
+/// Reduce a `Name <addr@host>` mailbox (or a bare address) to the
+/// lowercased `addr@host` alone (#416).  Used to compare header
+/// addresses against the account's own address without caring about
+/// display names, quoting, or case.
+fn bare_address(value: &str) -> String {
+    let v = value.trim();
+    match (v.rfind('<'), v.rfind('>')) {
+        (Some(start), Some(end)) if start < end => v[start + 1..end].trim().to_lowercase(),
+        _ => v.trim_matches('"').trim().to_lowercase(),
+    }
+}
+
+/// Do two mailbox strings name the same address (#416)?  Empty
+/// values never match — a malformed header shouldn't accidentally
+/// equal a malformed account entry.
+fn addresses_match(a: &str, b: &str) -> bool {
+    let (a, b) = (bare_address(a), bare_address(b));
+    !a.is_empty() && a == b
 }
 
 /// Save an in-progress message to the account's IMAP Drafts folder.
@@ -15621,6 +15868,8 @@ fn main() {
             set_message_pinned,
             set_message_priority,
             set_message_reminder,
+            respond_mdn_request,
+            get_receipt_status,
             send_email,
             list_outbox,
             list_all_outbox,

--- a/ui/messages/de.json
+++ b/ui/messages/de.json
@@ -183,6 +183,26 @@
   "compose_crypto_send_needs_passphrase": "Öffne den Verschlüsselungs-Tab und gib deine Passphrase ein, um zu senden",
   "compose_send_tooltip": "Nachricht senden",
 
+  "compose_read_receipt": "Lesebestätigung",
+  "compose_read_receipt_active": "Bestätigung angefordert",
+  "compose_read_receipt_title": "Lesebestätigung von den Empfängern anfordern — deren Mailprogramm kann die Anfrage ablehnen oder ignorieren",
+  "compose_read_receipt_title_active": "Eine Lesebestätigung wird angefordert — klicken zum Ausschalten",
+
+  "mail_view_mdn_banner": "{sender} bittet um eine Lesebestätigung für diese Nachricht.",
+  "mail_view_mdn_send": "Bestätigung senden",
+  "mail_view_mdn_sending": "Wird gesendet…",
+  "mail_view_mdn_decline": "Nicht senden",
+  "mail_view_receipt_read": "Gelesen {date}",
+  "mail_view_receipt_requested": "Bestätigung angefordert",
+  "mail_view_receipt_requested_title": "Du hast eine Lesebestätigung angefordert — bisher keine Antwort. Empfänger können die Anfrage ablehnen, daher kommt womöglich nie eine.",
+  "mail_view_receipt_received": "Bestätigung erhalten",
+
+  "settings_mail_mdn_label": "Lesebestätigungen",
+  "settings_mail_mdn_ask": "Jedes Mal fragen",
+  "settings_mail_mdn_always": "Immer senden",
+  "settings_mail_mdn_never": "Nie senden",
+  "settings_mail_mdn_hint": "Wie reagiert werden soll, wenn ein Absender wissen möchte, dass du seine Nachricht angezeigt hast. Bestätigungen verraten, wann du Mails liest — ohne deine Zustimmung wird nichts gesendet, außer du wählst „Immer senden“.",
+
   "mail_decrypt_for_reply_title": "Zum Antworten entschlüsseln",
   "mail_decrypt_for_reply_body": "Geben Sie Ihre PGP-Passphrase ein, um die Nachricht von {sender} zu entschlüsseln, damit Ihre Antwort den Originaltext zitieren kann.",
   "mail_decrypt_for_forward_title": "Zum Weiterleiten entschlüsseln",

--- a/ui/messages/en.json
+++ b/ui/messages/en.json
@@ -182,6 +182,26 @@
   "compose_crypto_send_needs_passphrase": "Open the Encryption tab and enter your passphrase to send",
   "compose_send_tooltip": "Send the message",
 
+  "compose_read_receipt": "Read receipt",
+  "compose_read_receipt_active": "Receipt requested",
+  "compose_read_receipt_title": "Request a read receipt from the recipients — their mail client may decline or ignore the request",
+  "compose_read_receipt_title_active": "A read receipt will be requested — click to turn off",
+
+  "mail_view_mdn_banner": "{sender} asked for a read receipt for this message.",
+  "mail_view_mdn_send": "Send receipt",
+  "mail_view_mdn_sending": "Sending…",
+  "mail_view_mdn_decline": "Don't send",
+  "mail_view_receipt_read": "Read {date}",
+  "mail_view_receipt_requested": "Receipt requested",
+  "mail_view_receipt_requested_title": "You asked for a read receipt — no response yet. Recipients can decline the request, so one may never arrive.",
+  "mail_view_receipt_received": "Receipt received",
+
+  "settings_mail_mdn_label": "Read receipts",
+  "settings_mail_mdn_ask": "Ask each time",
+  "settings_mail_mdn_always": "Always send",
+  "settings_mail_mdn_never": "Never send",
+  "settings_mail_mdn_hint": "How to respond when a sender asks to be told that you displayed their message. Receipts reveal when you read mail, so nothing is sent without your say-so unless you pick Always.",
+
   "mail_decrypt_for_reply_title": "Decrypt to reply",
   "mail_decrypt_for_reply_body": "Enter your PGP passphrase to decrypt the message from {sender} so your reply can quote the original content.",
   "mail_decrypt_for_forward_title": "Decrypt to forward",

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -275,6 +275,12 @@
      *  Optional because older settings bundles won't carry the
      *  key. */
     notes_mail_open_in_view?: boolean
+    /** #416 — response policy for incoming read-receipt requests
+     *  (RFC 8098): `'never'` suppresses the banner and sends
+     *  nothing, `'ask'` (default) prompts per message, `'always'`
+     *  sends automatically on display.  Non-optional because the
+     *  Rust side serialises a default. */
+    mdn_response_mode: 'never' | 'ask' | 'always'
   }
   interface CustomThemeRow {
     id: string
@@ -310,6 +316,7 @@
     location_geocoding_enabled: false,
     nominatim_base_url: '',
     notes_mail_open_in_view: false,
+    mdn_response_mode: 'ask',
   })
 
   /** The default Nominatim base URL — surfaced in the settings
@@ -1634,6 +1641,28 @@
             </p>
           </div>
         </div>
+
+        <!-- #416 — read-receipt response policy (RFC 8098).  A
+             receipt tells the sender when you displayed their
+             mail, so it sits with the other privacy controls
+             (remote images below).  `ask` keeps the per-message
+             banner; `always` answers silently; `never` suppresses
+             the whole flow. -->
+        <label class="flex items-center gap-2">
+          <span class="shrink-0">{m.settings_mail_mdn_label()}</span>
+          <select
+            class="select px-2 py-1 text-sm rounded-md max-w-65"
+            bind:value={appSettings.mdn_response_mode}
+            onchange={() => scheduleSave()}
+          >
+            <option value="ask">{m.settings_mail_mdn_ask()}</option>
+            <option value="always">{m.settings_mail_mdn_always()}</option>
+            <option value="never">{m.settings_mail_mdn_never()}</option>
+          </select>
+        </label>
+        <p class="text-xs text-surface-400 -mt-1">
+          {m.settings_mail_mdn_hint()}
+        </p>
 
         <!-- Auto-load remote images (#197).  Off by default —
              every loaded remote image is a tracking signal back

--- a/ui/src/lib/Compose.svelte
+++ b/ui/src/lib/Compose.svelte
@@ -597,6 +597,15 @@
       iconName: 'encrypted',
       content: encryptionTabContent,
     },
+    // #416 — per-send options tab.  Currently just the read-receipt
+    // request toggle; future per-send switches land here rather
+    // than crowding the Send actions row.
+    {
+      id: 'options',
+      label: 'Options',
+      iconName: 'settings',
+      content: optionsTabContent,
+    },
   ])
 
   /** Shares minted from this Compose during the current draft.
@@ -1045,6 +1054,14 @@
   // encryption on.  Cleared on submit and on cancel so a freshly-
   // opened Compose never inherits a stale passphrase.
   let pgpPassphrase = $state('')
+
+  // Read-receipt request toggle (#416, RFC 8098).  When on, the
+  // backend stamps `Disposition-Notification-To:` with the sender's
+  // own address and tracks the sent Message-ID so an incoming
+  // receipt can be matched back and shown as status on the sent
+  // mail.  Defaults off per message — receipts are an explicit ask,
+  // and most recipients' clients let them decline anyway.
+  let requestReadReceipt = $state(false)
 
   // #341 — when the sending account has opted into "Unlock
   // automatically" we hide the inline passphrase input entirely
@@ -2263,6 +2280,8 @@
                 ? 'pgp'
                 : null,
           signing_enabled: cryptoStack === 'pgp' && (encryptEnabled || signOnlyEnabled),
+          // #416: ask the recipient's client to send a read receipt.
+          request_read_receipt: requestReadReceipt,
         },
         // #255: lets the backend stamp `\Answered` on the
         // original + persist `replied_kind` for the mail-list
@@ -2968,6 +2987,29 @@
   >
     <span class="rt-btn-icon"><Icon name="calendar" size={20} /></span>
     <span class="rt-btn-label">Event</span>
+  </button>
+{/snippet}
+
+<!-- Options tab panel — per-send options (#416).  Same `.rt-btn`
+     shape as the Attach / Meetings panels.  The read-receipt toggle
+     asks the recipient's client to confirm display; the tooltip
+     manages expectations up front — receipts are advisory and many
+     clients decline or ignore the request entirely. -->
+{#snippet optionsTabContent()}
+  <button
+    type="button"
+    class="rt-btn"
+    class:active={requestReadReceipt}
+    title={requestReadReceipt
+      ? m.compose_read_receipt_title_active()
+      : m.compose_read_receipt_title()}
+    aria-pressed={requestReadReceipt}
+    onclick={() => (requestReadReceipt = !requestReadReceipt)}
+  >
+    <span class="rt-btn-icon"><Icon name="read" size={20} /></span>
+    <span class="rt-btn-label">
+      {requestReadReceipt ? m.compose_read_receipt_active() : m.compose_read_receipt()}
+    </span>
   </button>
 {/snippet}
 

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -92,6 +92,28 @@
     /** User-set priority override (#414): `'high'` / `'normal'` /
      *  `'low'`.  Wins over `priority` for the badge. */
     priority_override?: string | null
+    /** RFC 5322 Message-ID (#277), bracket-free.  Used here to look
+     *  up sent-mail receipt status (#416). */
+    message_id?: string | null
+    /** `Disposition-Notification-To:` value (#416) — the sender
+     *  asked for a read receipt, addressed to this mailbox.  Absent
+     *  for ordinary mail (and suppressed by the backend when it
+     *  points at the reading account's own address). */
+    mdn_requested_to?: string | null
+    /** What already happened about that request (#416): `'sent'` |
+     *  `'declined'`, absent = not yet decided.  Local-only overlay
+     *  from the cache — keeps the banner from asking twice. */
+    mdn_handled?: string | null
+  }
+
+  /** Receipt-tracking state for a sent mail (#416), from the
+   *  `get_receipt_status` IPC.  `disposition: null` = requested but
+   *  nothing back yet. */
+  interface SentReceiptStatus {
+    requested_at: number
+    disposition: string | null
+    disposition_at: number | null
+    reporter: string | null
   }
 
   interface Props {
@@ -555,6 +577,11 @@
     // without re-prompting; opening a different message starts a
     // fresh session.
     sessionPassphrase = ''
+    // #416 — read-receipt state is strictly per-message.
+    mdnMode = null
+    mdnBusy = false
+    mdnError = ''
+    receiptStatus = null
     // #341 — refresh the "Unlock automatically" mirror for the
     // account this message belongs to.  Done in parallel with the
     // cache + IMAP fetches below so the auto-decrypt attempt that
@@ -695,6 +722,73 @@
       } catch (e: any) {
         console.warn('mark_as_read failed:', e)
       }
+    }
+
+    // #416 — read receipts, both directions, after the message is
+    // confirmed displayed (this is the "displayed" moment RFC 8098's
+    // disposition reports).
+    if (email && id === accountId && f === folder && u === uid) {
+      // Incoming request: resolve the user's never/ask/always policy.
+      // `never` leaves mdnMode as-is (banner condition never true);
+      // `ask` arms the banner; `always` fires the receipt silently.
+      if (email.mdn_requested_to && !email.mdn_handled) {
+        try {
+          const settings = await invoke<{ mdn_response_mode?: string }>('get_app_settings')
+          if (id === accountId && f === folder && u === uid) {
+            mdnMode = settings?.mdn_response_mode ?? 'ask'
+            if (mdnMode === 'always') void respondMdn(false, true)
+          }
+        } catch (e: any) {
+          // Settings unavailable — fall back to asking; sending
+          // silently without a confirmed policy is the one wrong move.
+          console.warn('get_app_settings failed (receipt banner):', e)
+          mdnMode = 'ask'
+        }
+      }
+      // Outgoing status: does this mail have a tracked receipt
+      // request?  Only ever non-null for mail we sent with the
+      // Compose toggle on, so the chip stays absent everywhere else.
+      if (email.message_id) {
+        try {
+          const status = await invoke<SentReceiptStatus | null>('get_receipt_status', {
+            accountId: id,
+            messageId: email.message_id,
+          })
+          if (id === accountId && f === folder && u === uid) receiptStatus = status
+        } catch (e: any) {
+          console.warn('get_receipt_status failed:', e)
+        }
+      }
+    }
+  }
+
+  // ── Read receipts (#416) ──────────────────────────────────────
+  /** Response policy for the open message: `'ask'` arms the banner,
+   *  `'always'` already fired, `'never'`/`null` render nothing. */
+  let mdnMode = $state<string | null>(null)
+  let mdnBusy = $state(false)
+  let mdnError = $state('')
+  /** Sent-mail receipt tracking for the open message, when it asked
+   *  for one. */
+  let receiptStatus = $state<SentReceiptStatus | null>(null)
+
+  /** Send (or decline) the read receipt for the open message.
+   *  `automatic` marks the receipt as policy-fired (`Always` mode)
+   *  so the MDN itself reports `automatic-action` per RFC 8098. */
+  async function respondMdn(decline: boolean, automatic = false) {
+    if (!email || uid == null || mdnBusy) return
+    mdnBusy = true
+    mdnError = ''
+    try {
+      await invoke('respond_mdn_request', { accountId, folder, uid, decline, automatic })
+      // Mirror the backend's mdn_handled stamp so the banner drops
+      // without a refetch.
+      if (email) email.mdn_handled = decline ? 'declined' : 'sent'
+    } catch (e: any) {
+      console.warn('respond_mdn_request failed:', e)
+      mdnError = formatError(e) || 'Failed to send the read receipt'
+    } finally {
+      mdnBusy = false
     }
   }
 
@@ -2156,6 +2250,50 @@
               <span class="font-medium">{m.mail_priority_low()}</span>
             </span>
           {/if}
+          <!-- #416 — sent-mail receipt status.  Only ever present for
+               mail this client sent with "request read receipt" on
+               (the status lookup is keyed on tracked Message-IDs).
+               Green once a "displayed" report came back; neutral
+               while pending — and the pending tooltip manages
+               expectations, since recipients can decline and the
+               receipt may simply never arrive. -->
+          {#if receiptStatus}
+            {#if receiptStatus.disposition === 'displayed'}
+              <span
+                class="inline-flex items-center gap-1 text-xs leading-none px-2 py-1 rounded-full bg-success-500/15 text-success-600 dark:text-success-400"
+                title={receiptStatus.reporter ?? ''}
+              >
+                <Icon name="read" size={12} />
+                <span class="font-medium">
+                  {m.mail_view_receipt_read({
+                    date: formatFullDate(
+                      new Date(
+                        (receiptStatus.disposition_at ?? receiptStatus.requested_at) * 1000,
+                      ).toISOString(),
+                    ),
+                  })}
+                </span>
+              </span>
+            {:else if receiptStatus.disposition == null}
+              <span
+                class="inline-flex items-center gap-1 text-xs leading-none px-2 py-1 rounded-full bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300"
+                title={m.mail_view_receipt_requested_title()}
+              >
+                <Icon name="read" size={12} />
+                <span class="font-medium">{m.mail_view_receipt_requested()}</span>
+              </span>
+            {:else}
+              <!-- Any non-"displayed" disposition (deleted, processed,
+                   …) — report receipt without claiming it was read. -->
+              <span
+                class="inline-flex items-center gap-1 text-xs leading-none px-2 py-1 rounded-full bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300"
+                title={receiptStatus.disposition}
+              >
+                <Icon name="read" size={12} />
+                <span class="font-medium">{m.mail_view_receipt_received()}</span>
+              </span>
+            {/if}
+          {/if}
           <span class="text-sm text-surface-500">{formatFullDate(email.date)}</span>
         </div>
       </div>
@@ -2615,6 +2753,36 @@
             </li>
           {/each}
         </ul>
+      </div>
+    {/if}
+
+    <!-- #416 — read-receipt request banner (Ask mode).  Same amber
+         advisory shape as the remote-images banner, but rendered
+         outside the HTML-only branch because the request rides on
+         plain-text mail just as often.  Disappears the moment the
+         user picks either side (the response stamps `mdn_handled`),
+         and never renders under the Never / Always policies. -->
+    {#if email.mdn_requested_to && !email.mdn_handled && mdnMode === 'ask'}
+      <div
+        class="flex flex-wrap items-center gap-3 px-6 py-2 bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-700 text-sm text-amber-800 dark:text-amber-300"
+      >
+        <span class="shrink-0 inline-flex items-center gap-2">
+          <Icon name="read" size={18} />
+          {m.mail_view_mdn_banner({ sender: getSenderAddress(email.from) })}
+        </span>
+        <button
+          class="btn btn-sm preset-outlined-surface-500"
+          disabled={mdnBusy}
+          onclick={() => void respondMdn(false)}
+        >{mdnBusy ? m.mail_view_mdn_sending() : m.mail_view_mdn_send()}</button>
+        <button
+          class="btn btn-sm preset-outlined-surface-500"
+          disabled={mdnBusy}
+          onclick={() => void respondMdn(true)}
+        >{m.mail_view_mdn_decline()}</button>
+        {#if mdnError}
+          <span class="text-xs text-error-500">{mdnError}</span>
+        {/if}
       </div>
     {/if}
 


### PR DESCRIPTION
Closes #416.

Implements Message Disposition Notifications (RFC 8098) end to end: requesting a read receipt when sending, responding to incoming requests per a never/ask/always setting, and displaying receipt status on sent mail.

## Requesting a receipt
- New **Options** tab in the Compose ribbon with a "Read receipt" toggle (reuses the registered `read` icon).
- Sets `Disposition-Notification-To:` with the sender's bare address — via a custom lettre `Header` on the plaintext path, appended to the hand-built outer routing headers on the PGP/S-MIME paths (it's routing metadata the recipient must see pre-decrypt), and via the RFC 8621 header property on the JMAP submission path.
- After a successful SMTP send, the pipeline extracts the freshly stamped Message-ID and records it in a new `sent_receipts` table. Recorded *after* the send on purpose: a failed send retries with a fresh Message-ID.

## Responding to incoming requests
- Full-message fetches (IMAP parse paths + JMAP header property) lift the header into `Email.mdn_requested_to`, persisted on `messages` like `priority`. Requests pointing at the reading account's own address are suppressed so our own Sent copies never prompt.
- New global setting **Settings → Mail → Read receipts**: `Never` / `Ask each time` (default) / `Always send`. Grouped with the other privacy controls — receipts disclose reading behaviour, so nothing is sent without explicit consent or the Always opt-in.
- In Ask mode, MailView shows an amber banner (same shape as the remote-images banner) with **Send receipt** / **Don't send**. Always mode sends silently and the MDN honestly reports `automatic-action/MDN-sent-automatically`.
- The MDN reply is a hand-built `multipart/report; report-type=disposition-notification` (human-readable part + machine field block), sent over SMTP with a **null reverse-path** (`MAIL FROM:<>`) per RFC 8098 §3 to break auto-responder loops, plus `Auto-Submitted: auto-replied` (RFC 3834).
- A local-only `mdn_handled` column (`sent`/`declined`) survives envelope re-fetches — the banner never asks twice.

## Receipt status on sent mail
- Envelope fetches flag incoming `multipart/report` receipts from the already-fetched Content-Type header (wire-only field, never persisted).
- The shared `poll_folder` path (both IMAP and JMAP) fetches and parses newly-arrived reports **only while at least one request is pending**, so accounts that never request receipts pay zero extra fetches. `Original-Message-ID` + `Disposition` are matched against `sent_receipts`.
- MailView renders a chip on tracked sent mail: neutral "Receipt requested" while pending (tooltip sets expectations — recipients can decline, a response may never arrive), green "Read <time>" on a `displayed` report, neutral "Receipt received" for other dispositions.

## Storage
Cache schema v42 → v43: `mdn_requested_to` + `mdn_handled` on `messages`, new `sent_receipts` table keyed on `(account_id, message_id)` — the Message-ID is the only stable key both sides of the round-trip share (the Sent-copy UID is unknown at send time).

## Known limitations
- Receipt *tracking* is SMTP-send only: the JMAP submission path sets the request header but doesn't learn the Message-ID, so status chips only appear for SMTP-sent mail. MDN *replies* always go out via SMTP (JMAP's structured submission can't express `multipart/report`).
- Reports arriving while no request is pending (or predating the local cache) are ignored by design.

## Tests
- `unkai-smtp`: header stamping (plaintext + crypto outer), MDN report structure, disposition modes, threading (7 new).
- `unkai-imap`: header detection, report parsing round-trip (4 new).
- `unkai-store`: receipt lifecycle, persistence + refetch-survival of local state (2 new).
- Full suite green; `cargo fmt --check`, clippy (no new warnings), `svelte-check` (0 errors), and the frontend build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)