### PR TITLE
Smarter threading: require participant overlap in the subject fallback

### DIFF
--- a/crates/unkai-core/src/models.rs
+++ b/crates/unkai-core/src/models.rs
@@ -517,6 +517,16 @@ pub struct EmailEnvelope {
     pub uid: u32,
     pub folder: String,
     pub from: String,
+    /// `To:` recipients formatted as `"Name <addr>"` display strings —
+    /// same shape as `from` (#417).  Lifted from the ENVELOPE / JMAP
+    /// `to` property at fetch time so the conversation grouper can
+    /// require overlapping *participants* (not just a matching
+    /// subject) before folding two reference-less mails into one
+    /// thread.  Empty for cached rows that pre-date the v44 schema
+    /// migration; those heal on the next envelope sync or full-message
+    /// fetch.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub to_addrs: Vec<String>,
     pub subject: String,
     pub date: DateTime<Utc>,
     pub is_read: bool,

--- a/crates/unkai-imap/src/client.rs
+++ b/crates/unkai-imap/src/client.rs
@@ -1288,6 +1288,10 @@ impl ImapClient {
                     uid,
                     folder: folder.to_string(),
                     from,
+                    // #417: recipients ride along off the same ENVELOPE
+                    // so the conversation grouper can match on
+                    // participants, not just subject.
+                    to_addrs: format_address_list(envelope.to.as_ref()),
                     subject,
                     date,
                     is_read,
@@ -2498,6 +2502,10 @@ impl ImapClient {
                     uid,
                     folder: folder.to_string(),
                     from,
+                    // #417: recipients ride along off the same ENVELOPE
+                    // so the conversation grouper can match on
+                    // participants, not just subject.
+                    to_addrs: format_address_list(envelope.to.as_ref()),
                     subject,
                     date,
                     is_read,
@@ -2637,6 +2645,10 @@ impl ImapClient {
                     uid,
                     folder: folder.to_string(),
                     from,
+                    // #417: recipients ride along off the same ENVELOPE
+                    // so the conversation grouper can match on
+                    // participants, not just subject.
+                    to_addrs: format_address_list(envelope.to.as_ref()),
                     subject,
                     date,
                     is_read,
@@ -2796,6 +2808,10 @@ impl ImapClient {
                     uid,
                     folder: folder.to_string(),
                     from,
+                    // #417: recipients ride along off the same ENVELOPE
+                    // so the conversation grouper can match on
+                    // participants, not just subject.
+                    to_addrs: format_address_list(envelope.to.as_ref()),
                     subject,
                     date,
                     is_read,
@@ -2918,6 +2934,26 @@ fn format_address(addr: &async_imap::imap_proto::types::Address<'_>) -> String {
         (false, true) => decoded_name,
         (false, false) => format!("{decoded_name} <{email}>"),
     }
+}
+
+/// Format a whole ENVELOPE address list (e.g. the `To:` slot) as
+/// `"Name <user@host>"` display strings, one per address (#417).
+///
+/// Group syntax (RFC 5322 §3.4) shows up in the ENVELOPE as marker
+/// entries whose `mailbox`/`host` are NIL — `format_address` renders
+/// those as an empty string, which we drop so the participant-overlap
+/// check downstream never sees a phantom "" address.
+fn format_address_list(
+    addrs: Option<&Vec<async_imap::imap_proto::types::Address<'_>>>,
+) -> Vec<String> {
+    addrs
+        .map(|list| {
+            list.iter()
+                .map(format_address)
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Pull RFC 5322 threading headers off a `Fetch` response (#277).

--- a/crates/unkai-jmap/src/client.rs
+++ b/crates/unkai-jmap/src/client.rs
@@ -300,6 +300,9 @@ impl JmapClient {
                         "properties": [
                             "id", "from", "subject", "receivedAt",
                             "keywords", "hasAttachment", "mailboxIds",
+                            // #417: recipients feed the conversation
+                            // grouper's participant-overlap check.
+                            "to",
                             // #414: sender-declared priority, via the
                             // RFC 8621 §4.1.3 header-form properties
                             // (priority is not a JMAP keyword).
@@ -352,6 +355,13 @@ impl JmapClient {
                     uid: synthetic_uid(&email.id, i),
                     folder: folder.to_string(),
                     from,
+                    // #417: recipients for the participant-overlap
+                    // check, same display shape as `from`.
+                    to_addrs: email
+                        .to
+                        .as_ref()
+                        .map(|addrs| addrs.iter().map(|a| a.display()).collect())
+                        .unwrap_or_default(),
                     subject: email.subject.clone().unwrap_or_default(),
                     date,
                     is_read,

--- a/crates/unkai-store/src/cache/mod.rs
+++ b/crates/unkai-store/src/cache/mod.rs
@@ -645,9 +645,9 @@ impl Cache {
                    (account_id, folder, uid, from_addr, subject, internal_date,
                     is_read, is_starred, is_answered, cached_at,
                     message_id, in_reply_to, references_ids, thread_id, protection,
-                    priority)
+                    priority, to_addrs)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                         ?11, ?12, ?13, ?14, ?15, ?16)
+                         ?11, ?12, ?13, ?14, ?15, ?16, ?17)
                  ON CONFLICT (account_id, folder, uid) DO UPDATE SET
                    from_addr     = excluded.from_addr,
                    subject       = excluded.subject,
@@ -675,13 +675,30 @@ impl Cache {
                    -- #414: header-derived priority.  COALESCE so a
                    -- fetch path that didn't parse the priority
                    -- headers can't wipe a value already extracted.
-                   priority      = COALESCE(excluded.priority, messages.priority)",
+                   priority      = COALESCE(excluded.priority, messages.priority),
+                   -- #417: recipient list, COALESCE-guarded like the
+                   -- threading headers — a path that didn't capture
+                   -- recipients (e.g. a JMAP server omitting `to`)
+                   -- can't wipe what an earlier fetch stored.
+                   to_addrs      = COALESCE(excluded.to_addrs, messages.to_addrs)",
             )?;
             for env in envelopes {
                 let refs_json: Option<String> = if env.references_ids.is_empty() {
                     None
                 } else {
                     serde_json::to_string(&env.references_ids).ok()
+                };
+                // #417: same empty-vector → NULL convention as
+                // `references_ids` so the column stays sparse and the
+                // COALESCE guard can distinguish "no data" from
+                // "captured, zero recipients" — both serialise the
+                // same here because a genuinely recipient-less mail
+                // (Bcc-only delivery) carries no threading signal
+                // anyway.
+                let to_json: Option<String> = if env.to_addrs.is_empty() {
+                    None
+                } else {
+                    serde_json::to_string(&env.to_addrs).ok()
                 };
                 let thread_id = Self::compute_thread_id(account_id, env);
                 stmt.execute(params![
@@ -701,6 +718,7 @@ impl Cache {
                     thread_id,
                     env.protection,
                     env.priority,
+                    to_json,
                 ])?;
             }
         }
@@ -752,7 +770,7 @@ impl Cache {
                        AND m2.pending_action IS NULL) AS thread_total_count,
                     COALESCE(b.protection, m.protection),
                     m.is_pinned, m.priority, m.priority_override,
-                    m.reminder_at
+                    m.reminder_at, m.to_addrs
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE m.account_id = ?1 AND m.folder = ?2 AND m.pending_action IS NULL
@@ -794,6 +812,12 @@ impl Cache {
                 priority: r.get(16)?,
                 priority_override: r.get(17)?,
                 reminder_at: r.get(18)?,
+                // #417: recipients, JSON-decoded like references_ids.
+                to_addrs: r
+                    .get::<_, Option<String>>(19)?
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_default(),
                 // #416: wire-only marker, never persisted.
                 is_mdn_report: false,
             })
@@ -838,7 +862,7 @@ impl Cache {
                        AND m2.pending_action IS NULL) AS thread_total_count,
                     COALESCE(b.protection, m.protection),
                     m.is_pinned, m.priority, m.priority_override,
-                    m.reminder_at
+                    m.reminder_at, m.to_addrs
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE m.account_id = ?1
@@ -879,6 +903,12 @@ impl Cache {
                 priority: r.get(16)?,
                 priority_override: r.get(17)?,
                 reminder_at: r.get(18)?,
+                // #417: recipients, JSON-decoded like references_ids.
+                to_addrs: r
+                    .get::<_, Option<String>>(19)?
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_default(),
                 // #416: wire-only marker, never persisted.
                 is_mdn_report: false,
             })
@@ -970,7 +1000,7 @@ impl Cache {
                        AND m2.pending_action IS NULL) AS thread_total_count,
                     COALESCE(b.protection, m.protection),
                     m.is_pinned, m.priority, m.priority_override,
-                    m.reminder_at
+                    m.reminder_at, m.to_addrs
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE m.folder = ?1 AND m.pending_action IS NULL
@@ -1009,6 +1039,12 @@ impl Cache {
                 priority: r.get(17)?,
                 priority_override: r.get(18)?,
                 reminder_at: r.get(19)?,
+                // #417: recipients, JSON-decoded like references_ids.
+                to_addrs: r
+                    .get::<_, Option<String>>(20)?
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_default(),
                 // #416: wire-only marker, never persisted.
                 is_mdn_report: false,
             })
@@ -1068,7 +1104,7 @@ impl Cache {
                        AND m2.pending_action IS NULL) AS thread_total_count,
                     COALESCE(b.protection, m.protection),
                     m.is_pinned, m.priority, m.priority_override,
-                    m.reminder_at
+                    m.reminder_at, m.to_addrs
              FROM messages m
              LEFT JOIN message_bodies b USING (account_id, folder, uid)
              WHERE ({where_clause}) AND m.pending_action IS NULL
@@ -1116,6 +1152,12 @@ impl Cache {
                 priority: r.get(17)?,
                 priority_override: r.get(18)?,
                 reminder_at: r.get(19)?,
+                // #417: recipients, JSON-decoded like references_ids.
+                to_addrs: r
+                    .get::<_, Option<String>>(20)?
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok())
+                    .unwrap_or_default(),
                 // #416: wire-only marker, never persisted.
                 is_mdn_report: false,
             })
@@ -1931,13 +1973,23 @@ impl Cache {
         let tx = conn.transaction()?;
         let now = Utc::now().timestamp();
 
+        // #417: recipient list for the envelope row — empty → NULL
+        // (same convention as the envelope-batch upsert) so the
+        // COALESCE guard below can tell "no data" from "captured".
+        let env_to_json: Option<String> = if email.to.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&email.to).ok()
+        };
+
         // Envelope row — mirrors upsert_envelopes_for_account but inside
         // the same transaction as the body so the two can't drift.
         tx.execute(
             "INSERT INTO messages
                 (account_id, folder, uid, from_addr, subject, internal_date,
-                 is_read, is_starred, cached_at, priority, mdn_requested_to)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                 is_read, is_starred, cached_at, priority, mdn_requested_to,
+                 to_addrs)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
              ON CONFLICT (account_id, folder, uid) DO UPDATE SET
                 from_addr     = excluded.from_addr,
                 subject       = excluded.subject,
@@ -1952,7 +2004,11 @@ impl Cache {
                 -- #416: receipt request, header-derived like priority.
                 -- (`mdn_handled` is local-only and deliberately absent
                 -- from this statement, like is_pinned / reminder_at.)
-                mdn_requested_to = COALESCE(excluded.mdn_requested_to, messages.mdn_requested_to)",
+                mdn_requested_to = COALESCE(excluded.mdn_requested_to, messages.mdn_requested_to),
+                -- #417: a full-message fetch always knows the real
+                -- recipient list, so opening a message back-fills the
+                -- participant data pre-migration envelope rows lack.
+                to_addrs      = COALESCE(excluded.to_addrs, messages.to_addrs)",
             params![
                 email.account_id,
                 email.folder,
@@ -1968,6 +2024,7 @@ impl Cache {
                 now,
                 email.priority,
                 email.mdn_requested_to,
+                env_to_json,
             ],
         )?;
 
@@ -2697,6 +2754,7 @@ mod tests {
             uid,
             folder: folder.to_string(),
             from: format!("sender-{uid}@example.com"),
+            to_addrs: vec![format!("Jane Smith <recipient-{uid}@example.com>")],
             subject: format!("Test subject {uid}"),
             date: Utc::now() - Duration::minutes(offset_min),
             is_read: false,
@@ -2748,6 +2806,42 @@ mod tests {
         assert_eq!(got[0].uid, 2);
         assert_eq!(got[1].uid, 3);
         assert_eq!(got[2].uid, 1);
+    }
+
+    /// #417: the `To:` recipient list round-trips through the
+    /// envelope upsert, and the COALESCE guard keeps an earlier
+    /// capture alive when a later fetch path produced no recipients
+    /// (empty vector → NULL bind).
+    #[test]
+    fn to_addrs_roundtrip_and_coalesce_guard() {
+        let cache = open_test_cache();
+        let mut env = make_envelope(7, "INBOX", 5);
+        env.to_addrs = vec![
+            "Alex Morgan <alex@example.com>".to_string(),
+            "team@example.com".to_string(),
+        ];
+        cache
+            .upsert_envelopes_for_account("acc", std::slice::from_ref(&env))
+            .unwrap();
+
+        let got = cache.get_envelopes("acc", "INBOX", 5).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].to_addrs, env.to_addrs);
+
+        // Re-fetch that didn't capture recipients: must not wipe them.
+        env.to_addrs = Vec::new();
+        cache
+            .upsert_envelopes_for_account("acc", std::slice::from_ref(&env))
+            .unwrap();
+        let got = cache.get_envelopes("acc", "INBOX", 5).unwrap();
+        assert_eq!(
+            got[0].to_addrs,
+            vec![
+                "Alex Morgan <alex@example.com>".to_string(),
+                "team@example.com".to_string(),
+            ],
+            "empty re-fetch must not clobber stored recipients",
+        );
     }
 
     #[test]

--- a/crates/unkai-store/src/cache/schema.rs
+++ b/crates/unkai-store/src/cache/schema.rs
@@ -1488,6 +1488,44 @@ const MIGRATIONS: &[&str] = &[
         PRIMARY KEY (account_id, message_id)
     );
     "#,
+    // ─────────────────────────────────────────────────────────────
+    // v43 → v44: `To:` recipients on cached envelopes (#417).
+    //
+    // The conversation grouper's subject fallback (the merge pass
+    // that rescues threads whose References/Message-ID chain broke
+    // in transit) used to match on normalized subject alone, which
+    // over-grouped unrelated mail sharing a common subject
+    // ("Invoice", "Meeting"). The fix requires overlapping
+    // *participants* too — and participants need the recipient
+    // list, which until now only existed on `message_bodies` rows
+    // (i.e. after the user opened the message).
+    //
+    // One nullable JSON-array column, same display-string shape as
+    // `message_bodies.to_addrs` (v1 → v2). NULL = unknown (row
+    // pre-dates this migration and its body was never fetched), so
+    // the column stays sparse and the upsert's COALESCE guard can
+    // tell "no data" apart from "no recipients".
+    //
+    // Back-fill from `message_bodies` where a body was already
+    // cached — that's the "re-thread existing messages on
+    // migration" half of #417. Rows without a cached body heal
+    // lazily: the next envelope sync of the folder re-fetches the
+    // newest window with the recipient slot populated, and opening
+    // a message stamps it via the full-message upsert.
+    r#"
+    ALTER TABLE messages
+        ADD COLUMN to_addrs TEXT;
+
+    UPDATE messages
+    SET to_addrs = (
+        SELECT b.to_addrs FROM message_bodies b
+        WHERE b.account_id = messages.account_id
+          AND b.folder     = messages.folder
+          AND b.uid        = messages.uid
+          AND b.to_addrs IS NOT NULL
+          AND b.to_addrs != '[]'
+    );
+    "#,
 ];
 
 const SCHEMA_VERSION_SQL: &str = r#"

--- a/ui/src/lib/MailList.svelte
+++ b/ui/src/lib/MailList.svelte
@@ -27,6 +27,13 @@
     uid: number
     folder: string
     from: string
+    /** `To:` recipients as `"Name <addr>"` display strings (#417) —
+     *  same shape as `from`.  Feeds the participant-overlap check
+     *  that gates the subject-based thread merges below.  Absent
+     *  for cached rows that pre-date the v44 migration; those rows
+     *  simply never merge via the subject fallback until a re-sync
+     *  heals them (reference-based threading is unaffected). */
+    to_addrs?: string[]
     subject: string
     date: string      // RFC 3339 string (serde serialises DateTime<Utc> this way)
     is_read: boolean
@@ -244,6 +251,67 @@
     return /^(re|fwd?|aw|wg|sv)\s*(\[\d+\])?\s*:/i.test(subject || '')
   }
 
+  // ── Participant-overlap gate for the subject fallback (#417) ──
+  // A matching canonical subject alone over-groups: two unrelated
+  // "Invoice" mails from different senders used to collapse into
+  // one thread.  Both subject-merge passes below now additionally
+  // require the two buckets to share at least one participant
+  // (sender or recipient).  Reference-based threading (thread_id /
+  // References) is untouched — it stays the authoritative path.
+
+  /** The user's own account addresses, lowercased.  Excluded from
+   *  participant sets because every mail in the mailbox shares
+   *  "me" as sender or recipient — leaving them in would make any
+   *  two same-subject mails overlap and defeat the gate. */
+  const ownAddresses = $derived(
+    new Set(
+      accounts
+        .map((a) => (a.email || '').trim().toLowerCase())
+        .filter((s) => s.length > 0),
+    ),
+  )
+
+  /** Bare lowercase address out of a `"Name <addr>"` display string. */
+  function bareAddress(display: string): string {
+    return parseFromHeader(display).email.toLowerCase()
+  }
+
+  /** Every distinct sender + recipient across a bucket's members,
+   *  minus the user's own addresses.  Recomputed on demand so a
+   *  bucket that just absorbed another automatically widens its
+   *  participant set for later comparisons. */
+  function bucketParticipants(arr: EmailEnvelope[]): Set<string> {
+    const out = new Set<string>()
+    for (const env of arr) {
+      const from = bareAddress(env.from)
+      if (from && !ownAddresses.has(from)) out.add(from)
+      for (const t of env.to_addrs ?? []) {
+        const a = bareAddress(t)
+        if (a && !ownAddresses.has(a)) out.add(a)
+      }
+    }
+    return out
+  }
+
+  /** True when the two buckets share at least one non-own
+   *  participant.  Deliberately strict about missing data: a bucket
+   *  whose participant set is empty (pre-#417 cached rows with no
+   *  recipient data, or self-sent mail) never passes — a wrong
+   *  merge is confusing and sticky, while a missed merge heals on
+   *  the next sync once recipient data lands. */
+  function participantsOverlap(
+    a: EmailEnvelope[],
+    b: EmailEnvelope[],
+  ): boolean {
+    const pa = bucketParticipants(a)
+    if (pa.size === 0) return false
+    const pb = bucketParticipants(b)
+    for (const p of pb) {
+      if (pa.has(p)) return true
+    }
+    return false
+  }
+
   /** Thread keys we've already pulled the full membership for from
    *  the cache (#334).  Reset on folder change.  Used to skip the
    *  per-expand IPC round-trip on a thread the user has already
@@ -377,31 +445,36 @@
       arr.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     }
 
-    // JWZ-style subject-based merge pass (#277).  Some servers
-    // rewrite Message-IDs on delivery (local-SMTP test rigs and
-    // a few Exchange configs we've seen) so the inbox copy
-    // anchors a different ID than the reply's `In-Reply-To`
-    // points at.  Standard practice in conversation groupers is
-    // to fall back to subject matching when the header chain
-    // breaks — Unkai does the same.
+    // JWZ-style subject-based merge pass (#277, gated on
+    // participants since #417).  Some servers rewrite Message-IDs
+    // on delivery (local-SMTP test rigs and a few conservative
+    // gateway configs we've seen) so the inbox copy anchors a
+    // different ID than the reply's `In-Reply-To` points at.
+    // Standard practice in conversation groupers is to fall back
+    // to subject matching when the header chain breaks — Unkai
+    // does the same, but only folds a reply into a root it also
+    // shares a participant with.
     //
     // For every reply-shaped bucket head (`Re:` / `Fwd:` / …),
     // look for another bucket whose head has the same canonical
-    // subject; merge the reply bucket into the older bucket.
+    // subject AND whose participants overlap; merge the reply
+    // bucket into that bucket.
     //
-    // `byCanonicalRoot` indexes the *non-reply* heads
-    // (potential thread roots) so the lookup is O(1) per
-    // bucket.  The 4-char floor avoids cascading merges on
-    // trivial subjects like `"hi"`.
-    const byCanonicalRoot = new Map<string, string>() // canon → group key
+    // `byCanonicalRoot` indexes ALL *non-reply* heads (potential
+    // thread roots) per canonical subject — keeping every
+    // candidate (not just the first, as pre-#417) lets the
+    // participant check pick the RIGHT "Invoice" root instead of
+    // blindly taking whichever appeared first.  The 4-char floor
+    // still avoids matching on trivial subjects like `"hi"`.
+    const byCanonicalRoot = new Map<string, string[]>() // canon → root group keys
     for (const [key, arr] of groups) {
       const head = arr[arr.length - 1] // oldest in bucket = candidate root
       if (!head || isReplyOrForward(head.subject)) continue
       const canon = canonicalSubject(head.subject)
       if (canon.length < 4) continue
-      // Ties: first non-reply bucket wins; later collisions
-      // stay separate to avoid mass merges on common subjects.
-      if (!byCanonicalRoot.has(canon)) byCanonicalRoot.set(canon, key)
+      const keys = byCanonicalRoot.get(canon)
+      if (keys) keys.push(key)
+      else byCanonicalRoot.set(canon, [key])
     }
     // `keyRedirect` maps a now-merged-away key to its merge
     // target so the seen-key bookkeeping below still resolves
@@ -415,8 +488,18 @@
       if (!head || !isReplyOrForward(head.subject)) continue
       const canon = canonicalSubject(head.subject)
       if (canon.length < 4) continue
-      const targetKey = byCanonicalRoot.get(canon)
-      if (!targetKey || targetKey === key) continue
+      const candidates = byCanonicalRoot.get(canon)
+      if (!candidates) continue
+      // #417: first same-subject root the reply also shares a
+      // participant with wins; no overlap anywhere → stays its
+      // own thread.
+      const targetKey = candidates.find(
+        (c) =>
+          c !== key &&
+          !mergedAway.has(c) &&
+          participantsOverlap(groups.get(c) ?? [], arr),
+      )
+      if (!targetKey) continue
       // Move every envelope into the target bucket.
       const target = groups.get(targetKey)
       if (!target) continue
@@ -429,39 +512,47 @@
     }
     for (const key of mergedAway) groups.delete(key)
 
-    // Orphan-reply merge pass (#289).  The pass above only fires
-    // when there's a non-reply head to anchor the canonical-subject
-    // group on.  When the original got archived or deleted on the
-    // server, every remaining bucket head is a reply (`Re: Foo`) and
-    // none of them get picked as the byCanonicalRoot anchor, so
-    // two genuinely-same-thread reply buckets stay separate even
-    // though their canonical subjects match.  Fix: walk the
-    // surviving buckets, and for any canonical subject that appears
-    // on multiple reply-shaped heads, pick the *oldest* bucket
-    // (largest internal date span — the one most likely to be the
-    // closest-to-root surviving copy) as the anchor and fold the
-    // rest into it.  Same ≥4-char floor; we still skip canon
-    // subjects that already won an anchor in the first pass, so
-    // trivial subjects never cascade.
-    const orphanAnchor = new Map<string, string>() // canon → group key
+    // Orphan-reply merge pass (#289, participant-gated since #417).
+    // The pass above only fires when there's a non-reply head to
+    // anchor the canonical-subject group on.  When the original got
+    // archived or deleted on the server, every remaining bucket
+    // head is a reply (`Re: Foo`), so two genuinely-same-thread
+    // reply buckets stay separate even though their canonical
+    // subjects match.  Fix: walk the surviving buckets, and for any
+    // canonical subject appearing on multiple reply-shaped heads,
+    // cluster the ones that share a participant — the *oldest*
+    // bucket of a cluster (the closest-to-root surviving copy)
+    // becomes its anchor.  Same ≥4-char floor.
+    //
+    // Pre-#417 this pass skipped canons that already had a pass-1
+    // root, because without a participant check a second merge
+    // opportunity meant a cascade risk on common subjects.  The
+    // overlap gate now provides that safety, so orphaned reply
+    // pairs cluster even when an *unrelated* root shares their
+    // subject — each cluster keyed by who's actually in it.
+    const orphanAnchors = new Map<string, string[]>() // canon → cluster anchor keys
     for (const [key, arr] of groups) {
       const head = arr[arr.length - 1]
       if (!head || !isReplyOrForward(head.subject)) continue
       const canon = canonicalSubject(head.subject)
       if (canon.length < 4) continue
-      if (byCanonicalRoot.has(canon)) continue // pass-1 already handled this canon
-      const existing = orphanAnchor.get(canon)
+      const anchors = orphanAnchors.get(canon)
+      if (!anchors) {
+        orphanAnchors.set(canon, [key])
+        continue
+      }
+      // #417: join the first existing cluster this bucket shares a
+      // participant with; none → start a new cluster for this canon.
+      const existing = anchors.find(
+        (a) => groups.has(a) && participantsOverlap(groups.get(a)!, arr),
+      )
       if (!existing) {
-        orphanAnchor.set(canon, key)
+        anchors.push(key)
         continue
       }
       // Pick the bucket whose oldest member is older — that's the
       // surviving anchor; merge the other into it.
-      const existingArr = groups.get(existing)
-      if (!existingArr) {
-        orphanAnchor.set(canon, key)
-        continue
-      }
+      const existingArr = groups.get(existing)!
       const existingOldest = new Date(
         existingArr[existingArr.length - 1].date,
       ).getTime()
@@ -477,7 +568,7 @@
       )
       groups.delete(mergeKey)
       keyRedirect.set(mergeKey, anchorKey)
-      orphanAnchor.set(canon, anchorKey)
+      anchors[anchors.indexOf(existing)] = anchorKey
     }
 
     /** Resolve an envelope's natural threadKey through the


### PR DESCRIPTION
Closes #417.

## What changed

RFC 5322 reference-based threading (`References:` → `Message-ID:` → solo key) stays the primary, authoritative path — untouched. What changed is the **subject fallback**: the two render-time merge passes (#277 JWZ-style root merge, #289 orphan-reply merge) that rescue threads whose Message-ID chain broke in transit. They used to match on normalized subject alone, which over-grouped unrelated mail sharing a common subject. Both passes now also require the two buckets to share at least one **participant** (sender or recipient).

Design decisions worth knowing:

- **Own addresses are excluded from participant sets.** Every mail in your inbox has you as a recipient — leaving "me" in would make any two same-subject mails overlap and defeat the gate entirely.
- **Missing data fails closed.** Rows cached before this PR have no recipient data; they simply never merge via the fallback until data lands. A wrong merge is sticky and confusing; a missed merge self-heals (and genuine reply chains still thread via References regardless).
- **All same-subject roots are now candidates, not just the first.** Pre-#417 a reply merged into whichever "Invoice" bucket appeared first; the participant check now picks the root the reply actually shares people with.
- **The orphan pass dropped its skip-canons-with-a-pass-1-root guard.** That guard existed to prevent merge cascades on common subjects; the overlap gate provides that safety now, so orphaned reply pairs cluster correctly even when an unrelated root shares their subject.

## Plumbing

Participants need recipient data at envelope time, which was previously dropped:

- `EmailEnvelope.to_addrs` — `"Name <addr>"` display strings, same shape as `from`. IMAP lifts it from the `ENVELOPE` To slot (already fetched, zero extra round-trips, group-syntax markers filtered); JMAP adds `to` to the requested properties.
- **v44 migration**: nullable JSON `to_addrs` column on `messages`, back-filled from `message_bodies` where a body was already cached — that's the "re-thread on migration" half of the issue. Note the *stored* `thread_id` never used subject, so no stored re-keying is needed; the fallback is render-time.
- Rows without a cached body heal lazily: the next envelope sync of a folder rewrites the newest window with recipients, and opening a message stamps them via the full-message upsert. Both upserts COALESCE-guard the column (like the threading headers) so a path without recipient data can't wipe an earlier capture.

## Acceptance criteria

- Two unrelated mails sharing "Invoice" no longer thread: different senders, no shared non-own participant → no merge. ("Re: Hi" was already blocked by the existing 4-char canonical-subject floor.)
- Genuine reply chains: unchanged via References/In-Reply-To; broken-chain replies still merge because the reply's To: names the original sender.

## Testing

- New `to_addrs_roundtrip_and_coalesce_guard` cache test (round-trip + wipe protection); full `cargo test --workspace` green (297 tests).
- `cargo fmt --check`, `cargo check --workspace`, `svelte-check` (0 errors), frontend build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)