### PR TITLE
Remove deleted mail accounts from the UI without a refresh

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -1368,7 +1368,18 @@
     }
   })
 
-  async function checkAccounts() {
+  /** Re-read the account list from Rust and reconcile the shell
+   *  state that hangs off it (`accounts`, `activeAccountId`,
+   *  message selection).
+   *
+   *  `keepView` (#421): the Settings panel calls this the moment an
+   *  account is deleted so the always-mounted IconRail drops the
+   *  avatar immediately — but the user is still *in* Settings, so
+   *  that path must not yank them back to the inbox the way the
+   *  startup / setup-complete callers want. An empty list still
+   *  routes to the setup wizard regardless — with zero accounts
+   *  there is nothing left for Settings to manage. */
+  async function checkAccounts(opts: { keepView?: boolean } = {}) {
     try {
       const list = await invoke<Account[]>('get_accounts')
       accounts = list
@@ -1394,8 +1405,20 @@
             return a.id.localeCompare(b.id)
           })
           activeAccountId = sorted[0].id
+          // The account the selection was scoped to is gone (deleted
+          // from Settings, #421) — folder names, UIDs, and search
+          // queries are all per-account, so reset them the same way
+          // an explicit account switch does. On first launch this
+          // just rewrites the defaults.
+          selectedFolder = 'INBOX'
+          selectedUid = null
+          selectedMessageAccountId = null
+          selectedMessageFolder = null
+          searchQuery = ''
+          searchScope = {}
+          searchFilters = {}
         }
-        currentView = 'inbox'
+        if (!opts.keepView) currentView = 'inbox'
       } else {
         activeAccountId = null
         currentView = 'setup'
@@ -3631,6 +3654,7 @@
         <AccountSettings
           onclose={goToInbox}
           onaddaccount={goToSetup}
+          onaccountschanged={() => void checkAccounts({ keepView: true })}
           onappprefschanged={(p) => (appPrefs = p)}
           onnextcloudchanged={refreshNextcloudCapabilities}
           onreplaytour={replayTour}

--- a/ui/src/lib/AccountSettings.svelte
+++ b/ui/src/lib/AccountSettings.svelte
@@ -154,6 +154,12 @@
         `$effect` it drives — in sync. Optional so callers that don't
         care about live updates aren't forced to handle it. */
     onappprefschanged?: (prefs: AppSettings) => void
+    /** Notify the parent when the set of mail accounts changes
+        (currently: an account was removed) so the IconRail avatars
+        and the active-account selection update immediately, without
+        waiting for the Settings panel to close (#421). Mirrors
+        `onnextcloudchanged` below. */
+    onaccountschanged?: () => void
     /** Notify the parent when the connected Nextcloud accounts (or
         their capabilities) change so the IconRail can refresh its
         integration icons immediately, without waiting for the
@@ -174,6 +180,7 @@
   let {
     onclose,
     onaddaccount,
+    onaccountschanged,
     onappprefschanged,
     onnextcloudchanged,
     onreplaytour,
@@ -815,6 +822,11 @@
       await invoke('remove_account', { id })
       // Refresh the list after removal
       await loadAccounts()
+      // Tell the shell too (#421) — the IconRail is mounted outside
+      // this panel and keeps its own copy of the account list, so
+      // without this the deleted account's avatar lingers until the
+      // user leaves Settings.
+      onaccountschanged?.()
     } catch (e: any) {
       error = typeof e === 'string' ? e : e?.message ?? 'Failed to remove account'
     }


### PR DESCRIPTION
Closes #421

## Problem

Deleting a mail account in Settings only refreshed the Settings panel's own list. The app shell (`App.svelte`) keeps its own copy of the accounts array, which feeds the always-mounted IconRail and the active-account selection — and that copy was only re-read by `checkAccounts()`, which fired solely on the Settings **close** button. Leave Settings via a rail icon instead and the deleted account's avatar lingered; clicking it selected an account that no longer existed.

## Fix

Mirrors the `onnextcloudchanged` pattern from #318 (same problem for Nextcloud integration icons):

- **`AccountSettings.svelte`** gains an optional `onaccountschanged` callback, fired right after a successful `remove_account` + local list reload.
- **`App.svelte`** wires it to `checkAccounts({ keepView: true })`. The new `keepView` option refreshes the shell's account state *without* yanking the user out of Settings mid-session. Deleting the **last** account still routes to the setup wizard, since there is nothing left for Settings to manage (existing behaviour of the empty-list branch).
- When the deleted account was the **active** one, `checkAccounts` now also resets the per-account selection state (folder, message UID, search query/scope/filters) exactly like an explicit account switch does — folder names and UIDs are per-account, so carrying them over to the auto-picked replacement account could point the mail view at a ghost message.

The backend needed no changes — `remove_account` already wipes the keychain entry, PGP material, and cached mail correctly; this was purely frontend state propagation.

## Testing

- `npm run check` (paraglide compile + svelte-check + tsc): 0 errors, 0 warnings.
- No Rust changes, no new user-visible strings (no i18n catalogue changes needed).

## Manual test recipe

1. Configure ≥2 accounts. Open Settings → Accounts, delete a non-active account → its avatar disappears from the IconRail instantly, Settings stays open.
2. Delete the *active* account → rail highlight jumps to the first remaining account, Settings stays open; returning to Mail lands on that account's INBOX with no stale selection.
3. Delete the last remaining account → app drops into the setup wizard (no cancel affordance, as on first launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)