### PR TITLE
Add MCP groupware tools: contacts, calendar, Talk, create_meeting_invite composite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7523,10 +7523,14 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "unkai-caldav",
+ "unkai-carddav",
  "unkai-core",
  "unkai-imap",
+ "unkai-nextcloud",
  "unkai-smtp",
  "unkai-store",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/unkai-mcp/Cargo.toml
+++ b/crates/unkai-mcp/Cargo.toml
@@ -12,6 +12,19 @@ unkai-store.workspace = true
 # internal workspace crates — no new external dependencies.
 unkai-imap.workspace = true
 unkai-smtp.workspace = true
+# The groupware tools (#441): calendar reads/writes + free-busy,
+# contact search/create, Talk rooms, and the meeting-invite
+# composite.  All internal workspace crates — no new external
+# dependencies.
+unkai-caldav.workspace = true
+unkai-carddav.workspace = true
+unkai-nextcloud.workspace = true
+# Fresh UIDs for events/contacts and local-source etags — same
+# workspace version the Tauri layer uses.
+uuid.workspace = true
+# Timestamp parameters (RFC 3339) and the invite card's date line.
+# Was dev-only before #441.
+chrono.workspace = true
 rmcp.workspace = true
 axum.workspace = true
 subtle.workspace = true
@@ -39,6 +52,3 @@ keyring.workspace = true
 # running server (auth rejection, Host/Origin validation, locked
 # vault).  Workspace version, rustls-only feature set.
 reqwest.workspace = true
-# Test fixtures build `Email` / `EmailEnvelope` values, which
-# carry `DateTime<Utc>` timestamps.
-chrono.workspace = true

--- a/crates/unkai-mcp/src/calendar.rs
+++ b/crates/unkai-mcp/src/calendar.rs
@@ -1,0 +1,1253 @@
+//! MCP calendar tools (#441).
+//!
+//! Three read tools (`list_calendars`, `get_events`,
+//! `get_availability` — default **on**) and two write tools
+//! (`create_event`, `rsvp_event` — default **off**).
+//!
+//! Reads serve from the local event cache (with the same
+//! recurrence expansion the in-app CalendarView uses); the
+//! free/busy tool additionally queries the server.  Writes mirror
+//! the in-app flows: `create_event` follows the
+//! `create_calendar_event` command (fresh UID → ORGANIZER
+//! resolution → `build_ics` → CalDAV PUT with `If-None-Match: *`
+//! → cache upsert), `rsvp_event` follows the surgical-PARTSTAT
+//! `respond_to_invite` path for events already on the user's
+//! calendar.
+//!
+//! ## Outbound-mail side effects
+//!
+//! Both write tools make the *server* send mail: a PUT with
+//! ATTENDEE lines makes Nextcloud's scheduling plugin dispatch
+//! iMIP invitation emails, and a PARTSTAT change dispatches the
+//! REPLY to the organiser.  The tool descriptions say so — that
+//! text is also what the AI settings page shows next to the
+//! toggles.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, TimeZone, Utc};
+use rmcp::ErrorData;
+use rmcp::model::{CallToolResult, JsonObject};
+use serde_json::{Value, json};
+use unkai_core::UnkaiError;
+use unkai_core::models::{CalendarEvent, EventAttendee, NextcloudAccount};
+use unkai_store::Cache;
+use unkai_store::cache::CalendarEventRow;
+
+use crate::nc::{
+    account_has_feature, load_nc_accounts, nc_password, resolve_nc_account, resolve_organizer,
+};
+use crate::registry::{NextcloudFeature, ToolAccess, ToolContext, ToolDescriptor, ToolRegistry};
+use crate::util::{
+    internal, invalid, json_result, optional_str, optional_str_list, required_datetime,
+    required_str, required_str_list, schema,
+};
+
+/// Cap on `get_events` output — agents work in bounded context
+/// windows and a year of a busy calendar can be thousands of rows.
+const MAX_EVENTS: usize = 500;
+
+pub(crate) fn register_calendar_tools(registry: &mut ToolRegistry) {
+    registry.register(
+        ToolDescriptor {
+            id: "list_calendars",
+            category: "calendar",
+            access: ToolAccess::Read,
+            requires: Some(NextcloudFeature::Calendar),
+            description:
+                "List the user's calendars as Unkai Mail has them synced. Each entry carries \
+                 the calendar id that get_events and create_event take, plus a read_only flag \
+                 — events can only be created in calendars where read_only is false.",
+        },
+        schema(json!({"type": "object", "properties": {}})),
+        Arc::new(|ctx, args| Box::pin(list_calendars(ctx, args))),
+    );
+
+    registry.register(
+        ToolDescriptor {
+            id: "get_events",
+            category: "calendar",
+            access: ToolAccess::Read,
+            requires: Some(NextcloudFeature::Calendar),
+            description:
+                "List cached calendar events in a time range, recurring events expanded into \
+                 concrete occurrences, sorted by start. Defaults to every visible calendar; \
+                 pass calendar_ids to narrow. The returned event_id is what rsvp_event takes \
+                 (occurrences of a recurring series share their series' id).",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["range_start", "range_end"],
+            "properties": {
+                "range_start": {
+                    "type": "string",
+                    "description": "Start of the window, RFC 3339 (e.g. 2026-08-01T00:00:00Z)."
+                },
+                "range_end": {
+                    "type": "string",
+                    "description": "End of the window (exclusive), RFC 3339."
+                },
+                "calendar_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Restrict to these calendars (see list_calendars). Omit for all visible calendars."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(get_events(ctx, args))),
+    );
+
+    registry.register(
+        ToolDescriptor {
+            id: "get_availability",
+            category: "calendar",
+            access: ToolAccess::Read,
+            requires: Some(NextcloudFeature::Calendar),
+            description:
+                "Check when people are busy in a time range, for scheduling. Attendees on the \
+                 same Nextcloud are answered via CalDAV free/busy; everyone else falls back \
+                 to events in the user's own calendars that list them as attendee. source \
+                 tells which of the two answered ('unknown' means no signal, not 'free').",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["attendee_emails", "range_start", "range_end"],
+            "properties": {
+                "attendee_emails": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": "Email addresses of the people to check."
+                },
+                "range_start": {"type": "string", "description": "RFC 3339 start of the window."},
+                "range_end": {"type": "string", "description": "RFC 3339 end of the window."},
+                "nextcloud_account_id": {
+                    "type": "string",
+                    "description": "Which connected source to ask. Only needed when several offer calendars."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(get_availability(ctx, args))),
+    );
+
+    registry.register(
+        ToolDescriptor {
+            id: "create_event",
+            category: "calendar",
+            access: ToolAccess::Write,
+            requires: Some(NextcloudFeature::Calendar),
+            description:
+                "Create a calendar event. IMPORTANT: when attendees are listed, the user's \
+                 Nextcloud server immediately emails them iMIP calendar invitations on save — \
+                 this tool sends real invitations, not a draft. Writes are refused for \
+                 calendars marked read_only in list_calendars.",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["calendar_id", "summary", "start", "end"],
+            "properties": {
+                "calendar_id": {
+                    "type": "string",
+                    "description": "Target calendar (see list_calendars; must not be read_only)."
+                },
+                "summary": {"type": "string", "description": "Event title."},
+                "start": {"type": "string", "description": "RFC 3339 start time."},
+                "end": {"type": "string", "description": "RFC 3339 end time."},
+                "all_day": {
+                    "type": "boolean",
+                    "description": "All-day event: the date parts of start/end define the covered days."
+                },
+                "description": {"type": "string"},
+                "location": {"type": "string"},
+                "attendees": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Attendee email addresses. Each will receive an iMIP invitation email from the server."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(create_event(ctx, args))),
+    );
+
+    registry.register(
+        ToolDescriptor {
+            id: "rsvp_event",
+            category: "calendar",
+            access: ToolAccess::Write,
+            requires: Some(NextcloudFeature::Calendar),
+            description:
+                "Answer a meeting invitation that is already on the user's calendar: accept, \
+                 decline, or mark tentative. The user's server notifies the organiser by \
+                 email (iMIP REPLY). Takes the event_id from get_events.",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["event_id", "response"],
+            "properties": {
+                "event_id": {
+                    "type": "string",
+                    "description": "The event to respond to (see get_events)."
+                },
+                "response": {
+                    "type": "string",
+                    "enum": ["accepted", "declined", "tentative"],
+                    "description": "The user's answer."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(rsvp_event(ctx, args))),
+    );
+}
+
+// ── Shared helpers ──────────────────────────────────────────────
+
+/// Expand cached events into concrete occurrences for a window —
+/// mirror of the Tauri layer's `expand_calendar_events_in_range`,
+/// so agents see exactly what the in-app CalendarView shows.
+pub(crate) fn expand_events_in_range(
+    cache: &Cache,
+    calendar_ids: &[String],
+    range_start: DateTime<Utc>,
+    range_end: DateTime<Utc>,
+) -> Result<Vec<CalendarEvent>, ErrorData> {
+    let input = cache
+        .list_events_for_expansion(calendar_ids, range_start, range_end)
+        .map_err(|e| internal(format!("cache read failed: {e}")))?;
+
+    let mut overrides_by_master: HashMap<&str, Vec<&CalendarEvent>> = HashMap::new();
+    for ov in &input.overrides {
+        if let Some(master_id) = ov.id.rsplit_once("::").map(|(prefix, _)| prefix) {
+            overrides_by_master.entry(master_id).or_default().push(ov);
+        }
+    }
+
+    let mut out: Vec<CalendarEvent> = input.singletons;
+    for master in &input.masters {
+        let ovs = overrides_by_master
+            .get(master.id.as_str())
+            .cloned()
+            .unwrap_or_default();
+        out.extend(unkai_caldav::expand_event(
+            master,
+            &ovs,
+            range_start,
+            range_end,
+        ));
+    }
+    out.sort_by_key(|e| e.start);
+    Ok(out)
+}
+
+fn require_range(args: &Option<JsonObject>) -> Result<(DateTime<Utc>, DateTime<Utc>), ErrorData> {
+    let start = required_datetime(args, "range_start")?;
+    let end = required_datetime(args, "range_end")?;
+    if end <= start {
+        return Err(invalid("range_end must be after range_start"));
+    }
+    Ok((start, end))
+}
+
+fn find_nc_account(ctx: &ToolContext, nc_id: &str) -> Result<NextcloudAccount, ErrorData> {
+    load_nc_accounts(&ctx.cache)
+        .into_iter()
+        .find(|a| a.id == nc_id)
+        .ok_or_else(|| {
+            internal(format!(
+                "the connected source '{nc_id}' referenced by the cache no longer exists"
+            ))
+        })
+}
+
+/// Convert a `CalendarEvent` (post-write) into the row shape the
+/// cache expects — mirror of the Tauri layer's helper of the same
+/// purpose, so MCP writes land in the cache exactly like in-app
+/// writes do.
+fn event_to_row(event: &CalendarEvent, href: &str, etag: &str, ics_raw: &str) -> CalendarEventRow {
+    CalendarEventRow {
+        uid: event.id.clone(),
+        recurrence_id: event.recurrence_id,
+        href: href.to_string(),
+        etag: etag.to_string(),
+        summary: event.summary.clone(),
+        description: event.description.clone(),
+        start: event.start,
+        end: event.end,
+        location: event.location.clone(),
+        rrule: event.rrule.clone(),
+        rdate: event.rdate.clone(),
+        exdate: event.exdate.clone(),
+        url: event.url.clone(),
+        transparency: event.transparency.clone(),
+        attendees: event.attendees.clone(),
+        reminders: event.reminders.clone(),
+        latitude: event.latitude,
+        longitude: event.longitude,
+        ics_raw: ics_raw.to_string(),
+    }
+}
+
+fn event_json(event: &CalendarEvent) -> Value {
+    json!({
+        "event_id": event.id,
+        "summary": event.summary,
+        "description": event.description,
+        "start": event.start.to_rfc3339(),
+        "end": event.end.to_rfc3339(),
+        "location": event.location,
+        "url": event.url,
+        "transparency": event.transparency,
+        "recurring": event.rrule.is_some(),
+        "attendees": event.attendees.iter().map(|a| json!({
+            "email": a.email,
+            "name": a.common_name,
+            "status": a.status,
+        })).collect::<Vec<_>>(),
+    })
+}
+
+// ── Read handlers ───────────────────────────────────────────────
+
+async fn list_calendars(
+    ctx: ToolContext,
+    _args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let accounts = load_nc_accounts(&ctx.cache);
+    let mut calendars: Vec<Value> = Vec::new();
+    for account in accounts
+        .iter()
+        .filter(|a| account_has_feature(a, NextcloudFeature::Calendar))
+    {
+        let rows = ctx
+            .cache
+            .list_calendars(&account.id)
+            .map_err(|e| internal(format!("cache read failed: {e}")))?;
+        calendars.extend(rows.iter().map(|c| {
+            json!({
+                "id": c.id,
+                "name": c.display_name,
+                "color": c.color,
+                "read_only": c.read_only,
+                "hidden": c.hidden,
+                "nextcloud_account_id": c.nextcloud_account_id,
+            })
+        }));
+    }
+    Ok(json_result(json!({"calendars": calendars})))
+}
+
+async fn get_events(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let (range_start, range_end) = require_range(&args)?;
+    let requested = optional_str_list(&args, "calendar_ids")?;
+
+    let calendar_ids: Vec<String> = if requested.is_empty() {
+        // Default scope: what the user sees — every synced,
+        // non-hidden calendar across all calendar-capable sources.
+        let accounts = load_nc_accounts(&ctx.cache);
+        let mut ids = Vec::new();
+        for account in accounts
+            .iter()
+            .filter(|a| account_has_feature(a, NextcloudFeature::Calendar))
+        {
+            let rows = ctx
+                .cache
+                .list_calendars(&account.id)
+                .map_err(|e| internal(format!("cache read failed: {e}")))?;
+            ids.extend(rows.into_iter().filter(|c| !c.hidden).map(|c| c.id));
+        }
+        ids
+    } else {
+        requested
+    };
+
+    let events = expand_events_in_range(&ctx.cache, &calendar_ids, range_start, range_end)?;
+    let truncated = events.len() > MAX_EVENTS;
+    let events: Vec<Value> = events.iter().take(MAX_EVENTS).map(event_json).collect();
+
+    Ok(json_result(json!({
+        "result_count": events.len(),
+        "truncated": truncated,
+        "events": events,
+    })))
+}
+
+async fn get_availability(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let attendee_emails = required_str_list(&args, "attendee_emails")?;
+    let (range_start, range_end) = require_range(&args)?;
+    let account = resolve_nc_account(&ctx, &args, NextcloudFeature::Calendar)?;
+
+    // Free/busy + the user-by-email lookup are Nextcloud OCS /
+    // scheduling features; other sources degrade to the
+    // local-cache scan and never see the empty password.
+    let app_password = if account.is_nextcloud() {
+        nc_password(&account)?
+    } else {
+        String::new()
+    };
+
+    // Pre-load the local events once so the per-attendee scan
+    // doesn't repeat the SQL + expansion work.
+    let calendar_ids: Vec<String> = ctx
+        .cache
+        .list_calendars(&account.id)
+        .map_err(|e| internal(format!("cache read failed: {e}")))?
+        .into_iter()
+        .map(|c| c.id)
+        .collect();
+    let local_events = expand_events_in_range(&ctx.cache, &calendar_ids, range_start, range_end)?;
+
+    let mut out: Vec<Value> = Vec::with_capacity(attendee_emails.len());
+    for email in attendee_emails {
+        let lower = email.trim().to_ascii_lowercase();
+        if lower.is_empty() {
+            continue;
+        }
+
+        // Step 1: is this an account on the user's Nextcloud?
+        // Soft-fail so one bad lookup doesn't blank the answer.
+        let nc_match = if !account.is_nextcloud() {
+            None
+        } else {
+            match unkai_nextcloud::find_user_by_email(
+                &account.server_url,
+                &account.username,
+                &app_password,
+                &email,
+                &account.trusted_certs,
+            )
+            .await
+            {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::info!("MCP: sharees lookup for '{email}' failed: {e}");
+                    None
+                }
+            }
+        };
+
+        // Events in the user's own calendars that list this person
+        // — the fallback signal, and a title source for free/busy
+        // periods (which carry none by design).
+        let local_for_attendee: Vec<(DateTime<Utc>, DateTime<Utc>, Option<String>)> = local_events
+            .iter()
+            .filter(|ev| {
+                ev.attendees
+                    .iter()
+                    .any(|a| a.email.to_ascii_lowercase() == lower)
+            })
+            .map(|ev| {
+                (
+                    ev.start,
+                    ev.end,
+                    (!ev.summary.trim().is_empty()).then(|| ev.summary.clone()),
+                )
+            })
+            .collect();
+
+        // Step 2: CalDAV free-busy against the matched principal.
+        if let Some(m) = nc_match.as_ref() {
+            let principal_url = unkai_caldav::nc_principal_home(&account.server_url, &m.user_id);
+            match unkai_caldav::query_free_busy(
+                &principal_url,
+                &account.username,
+                &app_password,
+                range_start,
+                range_end,
+                &account.trusted_certs,
+            )
+            .await
+            {
+                Ok(periods) => {
+                    out.push(json!({
+                        "email": email,
+                        "display_name": m.display_name,
+                        "source": "nc-freebusy",
+                        "busy_periods": periods.iter().map(|p| json!({
+                            "start": p.start.to_rfc3339(),
+                            "end": p.end.to_rfc3339(),
+                            "kind": busy_kind(&p.kind),
+                            "summary": local_for_attendee
+                                .iter()
+                                .find(|(s, _, _)| *s == p.start)
+                                .and_then(|(_, _, sum)| sum.clone()),
+                        })).collect::<Vec<_>>(),
+                    }));
+                    continue;
+                }
+                Err(e) => {
+                    // Common: their calendar isn't shared with us,
+                    // the REPORT 403s.  Fall to the local scan.
+                    tracing::info!(
+                        "MCP: free-busy unavailable for {} ({email}): {e}",
+                        m.user_id
+                    );
+                }
+            }
+        }
+
+        // Step 3: local-cache fallback.
+        let busy: Vec<Value> = local_for_attendee
+            .iter()
+            .map(|(start, end, summary)| {
+                json!({
+                    "start": start.to_rfc3339(),
+                    "end": end.to_rfc3339(),
+                    "kind": "busy",
+                    "summary": summary,
+                })
+            })
+            .collect();
+        let source = if !busy.is_empty() {
+            "local-cache"
+        } else if nc_match.is_some() {
+            "unknown"
+        } else {
+            "local-cache"
+        };
+        out.push(json!({
+            "email": email,
+            "display_name": nc_match.as_ref().map(|m| m.display_name.clone()),
+            "source": source,
+            "busy_periods": busy,
+        }));
+    }
+
+    Ok(json_result(json!({"attendees": out})))
+}
+
+fn busy_kind(kind: &unkai_caldav::BusyKind) -> &'static str {
+    match kind {
+        unkai_caldav::BusyKind::Busy => "busy",
+        unkai_caldav::BusyKind::Tentative => "tentative",
+        unkai_caldav::BusyKind::Unavailable => "unavailable",
+        unkai_caldav::BusyKind::Free => "free",
+    }
+}
+
+// ── Write path ──────────────────────────────────────────────────
+
+/// Everything `create_event` needs beyond the target calendar.
+pub(crate) struct EventSpec {
+    pub summary: String,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub url: Option<String>,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub all_day: bool,
+    /// Attendee email addresses.  Non-empty means the server WILL
+    /// send iMIP invitation mails on the PUT.
+    pub attendees: Vec<String>,
+}
+
+/// A successfully created event, with everything needed to mirror
+/// it into the cache — or roll it back (#441 composite).
+pub(crate) struct CreatedEvent {
+    pub event_id: String,
+    pub href: String,
+    pub etag: String,
+    pub ics: String,
+    pub calendar_id: String,
+    pub nc_account_id: String,
+    pub event: CalendarEvent,
+}
+
+/// Shared implementation behind the `create_event` tool and the
+/// `create_meeting_invite` composite: validate, resolve ORGANIZER,
+/// render ICS, PUT.  Deliberately does NOT touch the cache — the
+/// caller decides when the event is final (`upsert_created_event`),
+/// which is what lets the composite roll back cleanly.
+/// Resolve `calendar_id` to its `(nc_account_id, server_path)`
+/// and refuse read-only calendars before any network traffic —
+/// the flag is the server's own privilege answer from discovery.
+/// Shared by `create_event` and the composite's pre-check (which
+/// must fail *before* it creates a Talk room it would then have
+/// to roll back).
+pub(crate) fn validate_writable_calendar(
+    ctx: &ToolContext,
+    calendar_id: &str,
+) -> Result<(String, String), ErrorData> {
+    let (nc_id, calendar_path) = ctx
+        .cache
+        .get_calendar_server_path(calendar_id)
+        .map_err(|e| internal(format!("cache read failed: {e}")))?
+        .ok_or_else(|| {
+            invalid(format!(
+                "calendar '{calendar_id}' is not in the local cache — call list_calendars \
+                 for valid ids"
+            ))
+        })?;
+
+    let read_only = ctx
+        .cache
+        .list_calendars(&nc_id)
+        .map_err(|e| internal(format!("cache read failed: {e}")))?
+        .iter()
+        .find(|c| c.id == calendar_id)
+        .is_some_and(|c| c.read_only);
+    if read_only {
+        return Err(invalid(format!(
+            "calendar '{calendar_id}' is read-only — pick a calendar with read_only=false \
+             from list_calendars"
+        )));
+    }
+    Ok((nc_id, calendar_path))
+}
+
+pub(crate) async fn create_event_impl(
+    ctx: &ToolContext,
+    calendar_id: &str,
+    spec: EventSpec,
+) -> Result<CreatedEvent, ErrorData> {
+    let (nc_id, calendar_path) = validate_writable_calendar(ctx, calendar_id)?;
+
+    for attendee in &spec.attendees {
+        if !attendee.contains('@') {
+            return Err(invalid(format!(
+                "attendee '{attendee}' is not an email address"
+            )));
+        }
+    }
+    if spec.end <= spec.start {
+        return Err(invalid("end must be after start"));
+    }
+
+    let account = find_nc_account(ctx, &nc_id)?;
+    let uid = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+
+    // All-day events cover midnight…23:59:59 of the named days so
+    // `build_ics` recognises the all-day shape — same convention
+    // as the in-app editor.
+    let (start, end) = if spec.all_day {
+        let s = Utc.from_utc_datetime(&spec.start.date_naive().and_hms_opt(0, 0, 0).unwrap());
+        let e = Utc.from_utc_datetime(&spec.end.date_naive().and_hms_opt(23, 59, 59).unwrap());
+        (s, e)
+    } else {
+        (spec.start, spec.end)
+    };
+
+    let event = CalendarEvent {
+        id: uid.clone(),
+        summary: spec.summary,
+        description: spec.description,
+        start,
+        end,
+        location: spec.location,
+        rrule: None,
+        rdate: vec![],
+        exdate: vec![],
+        recurrence_id: None,
+        url: spec.url,
+        transparency: None,
+        attendees: spec
+            .attendees
+            .iter()
+            .map(|email| EventAttendee {
+                email: email.clone(),
+                common_name: None,
+                status: None,
+                role: None,
+                force_send_reply: false,
+            })
+            .collect(),
+        reminders: vec![],
+        latitude: None,
+        longitude: None,
+    };
+
+    // Local sources can't (and needn't) ask an OCS endpoint who
+    // the organizer is — fall back to the account-derived line.
+    let (organizer_email, organizer_name) = if account.is_local() {
+        crate::nc::organizer_local(&account)
+    } else {
+        let app_password = nc_password(&account)?;
+        resolve_organizer(&account, &app_password, !event.attendees.is_empty()).await
+    };
+    let ics = unkai_caldav::build_ics(&event, Some(&organizer_email), organizer_name.as_deref());
+
+    let outcome = if account.is_local() {
+        unkai_caldav::WriteOutcome {
+            href: format!("{}/{uid}.ics", calendar_path.trim_end_matches('/')),
+            etag: uuid::Uuid::new_v4().to_string(),
+        }
+    } else {
+        let app_password = nc_password(&account)?;
+        unkai_caldav::create_event(
+            &account.server_url,
+            &calendar_path,
+            &account.username,
+            &app_password,
+            &uid,
+            &ics,
+            &account.trusted_certs,
+        )
+        .await
+        .map_err(|e| {
+            // Same permission signal handling as the in-app flow:
+            // remember the read-only answer so the next attempt is
+            // refused locally (the UI picks the flag up too).
+            if matches!(e, UnkaiError::CalDavWriteForbidden(_)) {
+                if let Err(flip) = ctx.cache.set_calendar_read_only(calendar_id, true) {
+                    tracing::warn!("MCP: could not flag calendar read-only: {flip}");
+                }
+                invalid(format!(
+                    "the server refused the write — calendar '{calendar_id}' is read-only"
+                ))
+            } else {
+                internal(format!("CalDAV create failed: {e}"))
+            }
+        })?
+    };
+
+    Ok(CreatedEvent {
+        event_id: format!("{calendar_id}::{uid}"),
+        href: outcome.href,
+        etag: outcome.etag,
+        ics,
+        calendar_id: calendar_id.to_string(),
+        nc_account_id: nc_id,
+        event,
+    })
+}
+
+/// Mirror a created event into the local cache so the UI shows it
+/// without waiting for the next sync round.
+pub(crate) fn upsert_created_event(
+    ctx: &ToolContext,
+    created: &CreatedEvent,
+) -> Result<(), ErrorData> {
+    let row = event_to_row(&created.event, &created.href, &created.etag, &created.ics);
+    ctx.cache
+        .upsert_single_event(&created.calendar_id, &row)
+        .map_err(|e| internal(format!("cache write failed: {e}")))
+}
+
+/// Best-effort server-side removal of a just-created event —
+/// the composite's rollback.  Deleting an event with attendees
+/// makes the server send iMIP CANCEL notices, which is exactly
+/// what should follow an invite that was sent by the failed step.
+pub(crate) async fn rollback_created_event(
+    ctx: &ToolContext,
+    created: &CreatedEvent,
+) -> Result<(), String> {
+    let account =
+        find_nc_account(ctx, &created.nc_account_id).map_err(|e| e.message.to_string())?;
+    if account.is_local() {
+        return Ok(());
+    }
+    let app_password = nc_password(&account).map_err(|e| e.message.to_string())?;
+    unkai_caldav::delete_event(
+        &created.href,
+        &account.username,
+        &app_password,
+        &created.etag,
+        &account.trusted_certs,
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+async fn create_event(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let calendar_id = required_str(&args, "calendar_id")?;
+    let spec = EventSpec {
+        summary: required_str(&args, "summary")?,
+        description: optional_str(&args, "description")?,
+        location: optional_str(&args, "location")?,
+        url: None,
+        start: required_datetime(&args, "start")?,
+        end: required_datetime(&args, "end")?,
+        all_day: crate::util::optional_bool(&args, "all_day")?.unwrap_or(false),
+        attendees: optional_str_list(&args, "attendees")?,
+    };
+    let had_attendees = !spec.attendees.is_empty();
+
+    let created = create_event_impl(&ctx, &calendar_id, spec).await?;
+    upsert_created_event(&ctx, &created)?;
+
+    let note = if had_attendees {
+        "The event was created and the server is sending iMIP invitation emails to the attendees."
+    } else {
+        "The event was created. No attendees were listed, so no invitations were sent."
+    };
+    Ok(json_result(json!({
+        "status": "event_created",
+        "event_id": created.event_id,
+        "calendar_id": created.calendar_id,
+        "note": note,
+    })))
+}
+
+async fn rsvp_event(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let event_id = required_str(&args, "event_id")?;
+    let partstat = match required_str(&args, "response")?
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "accepted" => "ACCEPTED",
+        "declined" => "DECLINED",
+        "tentative" => "TENTATIVE",
+        other => {
+            return Err(invalid(format!(
+                "response must be 'accepted', 'declined', or 'tentative' (got '{other}')"
+            )));
+        }
+    };
+
+    let handle = ctx
+        .cache
+        .get_event_server_handle(&event_id)
+        .map_err(|e| internal(format!("cache read failed: {e}")))?
+        .ok_or_else(|| {
+            invalid("event not found in the local cache — use an event_id from get_events")
+        })?;
+    let account = find_nc_account(&ctx, &handle.nextcloud_account_id)?;
+    let app_password = if account.is_local() {
+        String::new()
+    } else {
+        nc_password(&account)?
+    };
+
+    // Candidate identities for "which ATTENDEE row is the user",
+    // in priority order — NC profile email (the address Sabre's
+    // iTIP broker keys on), then every configured mail-account
+    // address, then the synthesised local fallback.  We answer as
+    // whichever of these is actually in the invite's ATTENDEE
+    // list, so the server pairs the PARTSTAT change with the
+    // user's principal and dispatches the REPLY iMIP.
+    let mut candidates: Vec<String> = Vec::new();
+    let nc_profile_email = if account.is_nextcloud() {
+        match unkai_nextcloud::fetch_current_user(
+            &account.server_url,
+            &account.username,
+            &app_password,
+            &account.trusted_certs,
+        )
+        .await
+        {
+            Ok(p) => p.email,
+            Err(e) => {
+                tracing::warn!("MCP RSVP: NC user-profile lookup failed ({e})");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    if let Some(e) = nc_profile_email.as_deref() {
+        candidates.push(e.to_string());
+    }
+    for a in crate::util::load_accounts(&ctx)? {
+        candidates.push(a.email);
+    }
+    candidates.push(crate::nc::organizer_local(&account).0);
+    let mut seen = std::collections::HashSet::new();
+    let candidates: Vec<String> = candidates
+        .into_iter()
+        .filter(|s| !s.trim().is_empty())
+        .filter(|s| seen.insert(s.to_ascii_lowercase()))
+        .collect();
+
+    let events = unkai_caldav::parse_ics(&handle.ics_raw)
+        .map_err(|e| internal(format!("could not parse the cached event: {e}")))?;
+    let mut event = events
+        .into_iter()
+        .next()
+        .ok_or_else(|| internal("cached event body has no VEVENT"))?;
+
+    let attendee_email = {
+        let inbound: std::collections::HashSet<String> = event
+            .attendees
+            .iter()
+            .map(|a| a.email.to_ascii_lowercase())
+            .collect();
+        candidates
+            .iter()
+            .find(|c| inbound.contains(&c.to_ascii_lowercase()))
+            .cloned()
+            .or(nc_profile_email)
+            .or_else(|| candidates.into_iter().next())
+            .unwrap_or_else(|| crate::nc::organizer_local(&account).0)
+    };
+
+    // Mirror the change onto the parsed event for the cache row.
+    let mut matched = false;
+    for att in event.attendees.iter_mut() {
+        if att.email.eq_ignore_ascii_case(attendee_email.trim()) {
+            att.status = Some(partstat.to_string());
+            att.force_send_reply = true;
+            matched = true;
+        }
+    }
+    if !matched {
+        event.attendees.push(EventAttendee {
+            email: attendee_email.trim().to_string(),
+            common_name: None,
+            status: Some(partstat.to_string()),
+            role: Some("REQ-PARTICIPANT".into()),
+            force_send_reply: true,
+        });
+    }
+    // TENTATIVE renders visually distinct (free slot); ACCEPTED /
+    // DECLINED block the slot — same convention as the in-app RSVP.
+    event.transparency = Some(if partstat == "TENTATIVE" {
+        "TRANSPARENT".into()
+    } else {
+        "OPAQUE".into()
+    });
+
+    // Surgical edit: replace only the user's PARTSTAT (plus
+    // SCHEDULE-FORCE-SEND=REPLY) and keep every other byte — the
+    // server only dispatches the REPLY iMIP when the diff against
+    // its stored copy is exactly that clean.
+    let surgical =
+        unkai_caldav::ical::surgical_set_partstat(&handle.ics_raw, &attendee_email, partstat, true);
+
+    let outcome = if account.is_local() {
+        unkai_caldav::WriteOutcome {
+            href: handle.href.clone(),
+            etag: uuid::Uuid::new_v4().to_string(),
+        }
+    } else {
+        unkai_caldav::update_event(
+            &handle.href,
+            &account.username,
+            &app_password,
+            &handle.etag,
+            &surgical,
+            &account.trusted_certs,
+        )
+        .await
+        .map_err(|e| match e {
+            UnkaiError::EtagMismatch(_) => invalid(
+                "the event changed on the server since Unkai Mail last synced — open the \
+                 calendar in Unkai Mail to refresh, then retry",
+            ),
+            UnkaiError::CalDavWriteForbidden(_) => {
+                invalid("the server refused the write — this calendar is read-only")
+            }
+            other => internal(format!("CalDAV update failed: {other}")),
+        })?
+    };
+
+    let row = event_to_row(&event, &outcome.href, &outcome.etag, &surgical);
+    ctx.cache
+        .upsert_single_event(&handle.calendar_id, &row)
+        .map_err(|e| internal(format!("cache write failed: {e}")))?;
+    ctx.cache
+        .upsert_rsvp_response(&handle.uid, partstat)
+        .map_err(|e| internal(format!("cache write failed: {e}")))?;
+
+    let note = if account.is_local() {
+        "The response was recorded locally. This calendar has no server, so no reply email \
+         was sent to the organiser."
+    } else {
+        "The response was saved to the calendar; the server notifies the organiser by email."
+    };
+    Ok(json_result(json!({
+        "status": "rsvp_recorded",
+        "event_id": event_id,
+        "response": partstat,
+        "responded_as": attendee_email,
+        "note": note,
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nc::test_support::{caps, nc_account};
+    use crate::testutil::{invoke, mail_account, result_payload, test_context};
+    use serde_json::json;
+    use unkai_core::models::DavSourceKind;
+    use unkai_store::cache::CalendarRow;
+    use unkai_store::{account_store, nextcloud_store};
+
+    const CAL_PATH: &str = "local://acc/cal";
+
+    /// Seed a connected local source with one calendar; returns
+    /// the calendar's cache id.
+    fn seed_calendar(ctx: &ToolContext, read_only: bool) -> String {
+        nextcloud_store::upsert_account(
+            &ctx.cache,
+            nc_account("acc", DavSourceKind::Local, Some(caps(false, true, true))),
+        )
+        .unwrap();
+        ctx.cache
+            .upsert_calendars(
+                "acc",
+                &[CalendarRow {
+                    path: CAL_PATH.into(),
+                    display_name: "Personal".into(),
+                    color: Some("#2bb0ed".into()),
+                    ctag: None,
+                    hidden: false,
+                    muted: false,
+                    read_only,
+                }],
+            )
+            .unwrap();
+        format!("acc::{CAL_PATH}")
+    }
+
+    fn seed_event(ctx: &ToolContext, calendar_id: &str, uid: &str, attendee: &str) {
+        let start = Utc.with_ymd_and_hms(2026, 8, 1, 9, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 8, 1, 10, 0, 0).unwrap();
+        let ics = format!(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:{uid}\r\n\
+             DTSTART:20260801T090000Z\r\nDTEND:20260801T100000Z\r\nSUMMARY:Standup\r\n\
+             ATTENDEE;CN=Alex;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT:mailto:{attendee}\r\n\
+             END:VEVENT\r\nEND:VCALENDAR\r\n"
+        );
+        let row = CalendarEventRow {
+            uid: uid.into(),
+            recurrence_id: None,
+            href: format!("{CAL_PATH}/{uid}.ics"),
+            etag: "etag-1".into(),
+            summary: "Standup".into(),
+            description: None,
+            start,
+            end,
+            location: None,
+            rrule: None,
+            rdate: vec![],
+            exdate: vec![],
+            url: None,
+            transparency: None,
+            attendees: vec![EventAttendee {
+                email: attendee.into(),
+                common_name: Some("Alex".into()),
+                status: Some("NEEDS-ACTION".into()),
+                role: Some("REQ-PARTICIPANT".into()),
+                force_send_reply: false,
+            }],
+            reminders: vec![],
+            latitude: None,
+            longitude: None,
+            ics_raw: ics,
+        };
+        ctx.cache.upsert_single_event(calendar_id, &row).unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_calendars_exposes_the_read_only_flag() {
+        let ctx = test_context();
+        seed_calendar(&ctx, true);
+        let result = invoke(&ctx, "list_calendars", json!({})).await.unwrap();
+        let payload = result_payload(&result);
+        let calendars = payload["calendars"].as_array().unwrap();
+        assert_eq!(calendars.len(), 1);
+        assert_eq!(calendars[0]["name"], "Personal");
+        assert_eq!(calendars[0]["read_only"], true);
+        assert_eq!(calendars[0]["nextcloud_account_id"], "acc");
+    }
+
+    #[tokio::test]
+    async fn get_events_returns_cached_events_in_range() {
+        let ctx = test_context();
+        let calendar_id = seed_calendar(&ctx, false);
+        seed_event(&ctx, &calendar_id, "evt-1", "alex@example.com");
+
+        let result = invoke(
+            &ctx,
+            "get_events",
+            json!({
+                "range_start": "2026-08-01T00:00:00Z",
+                "range_end": "2026-08-02T00:00:00Z",
+            }),
+        )
+        .await
+        .unwrap();
+        let payload = result_payload(&result);
+        assert_eq!(payload["result_count"], 1);
+        assert_eq!(payload["truncated"], false);
+        let event = &payload["events"][0];
+        assert_eq!(event["summary"], "Standup");
+        assert_eq!(event["event_id"], format!("{calendar_id}::evt-1"));
+        assert_eq!(event["attendees"][0]["email"], "alex@example.com");
+
+        // Outside the window: nothing.
+        let result = invoke(
+            &ctx,
+            "get_events",
+            json!({
+                "range_start": "2026-09-01T00:00:00Z",
+                "range_end": "2026-09-02T00:00:00Z",
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result_payload(&result)["result_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn get_events_rejects_inverted_ranges() {
+        let ctx = test_context();
+        let err = invoke(
+            &ctx,
+            "get_events",
+            json!({
+                "range_start": "2026-08-02T00:00:00Z",
+                "range_end": "2026-08-01T00:00:00Z",
+            }),
+        )
+        .await
+        .expect_err("inverted range should error");
+        assert!(err.message.contains("range_end"));
+    }
+
+    #[tokio::test]
+    async fn create_event_rejects_read_only_calendars_before_any_network() {
+        let ctx = test_context();
+        let calendar_id = seed_calendar(&ctx, true);
+        let err = invoke(
+            &ctx,
+            "create_event",
+            json!({
+                "calendar_id": calendar_id,
+                "summary": "Planning",
+                "start": "2026-08-01T09:00:00Z",
+                "end": "2026-08-01T10:00:00Z",
+            }),
+        )
+        .await
+        .expect_err("read-only calendar should refuse writes");
+        assert!(err.message.contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn create_event_rejects_unknown_calendars_and_bad_attendees() {
+        let ctx = test_context();
+        let err = invoke(
+            &ctx,
+            "create_event",
+            json!({
+                "calendar_id": "nope::x",
+                "summary": "Planning",
+                "start": "2026-08-01T09:00:00Z",
+                "end": "2026-08-01T10:00:00Z",
+            }),
+        )
+        .await
+        .expect_err("unknown calendar should error");
+        assert!(err.message.contains("list_calendars"));
+
+        let calendar_id = seed_calendar(&ctx, false);
+        let err = invoke(
+            &ctx,
+            "create_event",
+            json!({
+                "calendar_id": calendar_id,
+                "summary": "Planning",
+                "start": "2026-08-01T09:00:00Z",
+                "end": "2026-08-01T10:00:00Z",
+                "attendees": ["not-an-email"],
+            }),
+        )
+        .await
+        .expect_err("non-email attendee should error");
+        assert!(err.message.contains("not-an-email"));
+    }
+
+    #[tokio::test]
+    async fn create_event_on_a_local_calendar_lands_in_the_cache() {
+        let ctx = test_context();
+        let calendar_id = seed_calendar(&ctx, false);
+        let result = invoke(
+            &ctx,
+            "create_event",
+            json!({
+                "calendar_id": calendar_id,
+                "summary": "Planning",
+                "start": "2026-08-03T09:00:00Z",
+                "end": "2026-08-03T10:00:00Z",
+            }),
+        )
+        .await
+        .unwrap();
+        let payload = result_payload(&result);
+        assert_eq!(payload["status"], "event_created");
+        assert!(payload["note"].as_str().unwrap().contains("No attendees"));
+
+        let events = expand_events_in_range(
+            &ctx.cache,
+            &[calendar_id],
+            Utc.with_ymd_and_hms(2026, 8, 3, 0, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 8, 4, 0, 0, 0).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].summary, "Planning");
+    }
+
+    #[tokio::test]
+    async fn rsvp_records_the_answer_for_a_local_calendar() {
+        let ctx = test_context();
+        let calendar_id = seed_calendar(&ctx, false);
+        seed_event(&ctx, &calendar_id, "evt-1", "alex@example.com");
+        // The identity resolution matches the invite's ATTENDEE row
+        // against the user's configured mail-account addresses.
+        account_store::add_account(&ctx.cache, mail_account("mail-1")).unwrap();
+
+        let event_id = format!("{calendar_id}::evt-1");
+        let result = invoke(
+            &ctx,
+            "rsvp_event",
+            json!({"event_id": event_id, "response": "accepted"}),
+        )
+        .await
+        .unwrap();
+        let payload = result_payload(&result);
+        assert_eq!(payload["status"], "rsvp_recorded");
+        assert_eq!(payload["response"], "ACCEPTED");
+        assert_eq!(payload["responded_as"], "alex@example.com");
+        // Local source: the note must say no reply email went out.
+        assert!(payload["note"].as_str().unwrap().contains("no reply email"));
+
+        // The RSVP bookkeeping the invite cards read is updated…
+        assert_eq!(
+            ctx.cache.get_rsvp_response("evt-1").unwrap().as_deref(),
+            Some("ACCEPTED")
+        );
+        // …and the cached body carries the surgical PARTSTAT edit.
+        let handle = ctx
+            .cache
+            .get_event_server_handle(&format!("{calendar_id}::evt-1"))
+            .unwrap()
+            .unwrap();
+        assert!(handle.ics_raw.contains("PARTSTAT=ACCEPTED"));
+    }
+
+    #[tokio::test]
+    async fn rsvp_rejects_unknown_events_and_answers() {
+        let ctx = test_context();
+        let err = invoke(
+            &ctx,
+            "rsvp_event",
+            json!({"event_id": "nope::x::y", "response": "accepted"}),
+        )
+        .await
+        .expect_err("unknown event should error");
+        assert!(err.message.contains("get_events"));
+
+        let err = invoke(
+            &ctx,
+            "rsvp_event",
+            json!({"event_id": "nope::x::y", "response": "maybe"}),
+        )
+        .await
+        .expect_err("bad response value should error");
+        assert!(err.message.contains("tentative"));
+    }
+}

--- a/crates/unkai-mcp/src/contacts.rs
+++ b/crates/unkai-mcp/src/contacts.rs
@@ -1,0 +1,380 @@
+//! MCP contact tools (#441): `search_contacts` (read, default on)
+//! and `create_contact` (write, default off).
+//!
+//! Reads come straight from the local contact cache — the same
+//! rows the in-app autocomplete searches.  The write path mirrors
+//! the in-app create flow: build a vCard, PUT it via CardDAV with
+//! `If-None-Match: *`, and upsert the new row into the cache so
+//! the Contacts view shows it without waiting for the next sync.
+
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use rmcp::model::{CallToolResult, JsonObject};
+use serde_json::{Value, json};
+use unkai_core::models::{ContactEmail, ContactPhone, NextcloudAccount};
+use unkai_store::cache::ContactRow;
+
+use crate::nc::{carddav_home_of, nc_password, resolve_nc_account};
+use crate::registry::{NextcloudFeature, ToolAccess, ToolContext, ToolDescriptor, ToolRegistry};
+use crate::util::{
+    internal, invalid, json_result, optional_str, optional_str_list, optional_u32, required_str,
+    schema,
+};
+
+const DEFAULT_SEARCH_LIMIT: u32 = 25;
+const MAX_SEARCH_LIMIT: u32 = 100;
+
+/// Collection name for the single addressbook a local source is
+/// seeded with — mirrors the Tauri layer's constant.
+const LOCAL_ADDRESSBOOK_NAME: &str = "local";
+
+pub(crate) fn register_contact_tools(registry: &mut ToolRegistry) {
+    registry.register(
+        ToolDescriptor {
+            id: "search_contacts",
+            category: "contacts",
+            access: ToolAccess::Read,
+            requires: Some(NextcloudFeature::Contacts),
+            description: "Search the user's locally synced contacts by name or email address \
+                 (case-insensitive substring match). Returns name, email addresses, phone \
+                 numbers, and organization — never photos. Only contacts already synced by \
+                 Unkai Mail are searchable.",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["query"],
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Substring to match against contact names and email addresses."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_SEARCH_LIMIT,
+                    "description": "Maximum contacts to return. Default 25."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(search_contacts(ctx, args))),
+    );
+
+    registry.register(
+        ToolDescriptor {
+            id: "create_contact",
+            category: "contacts",
+            access: ToolAccess::Write,
+            requires: Some(NextcloudFeature::Contacts),
+            description:
+                "Create a new contact in the user's addressbook (CardDAV). Provide at least a \
+                 display name; emails, phone numbers, an organization, and a note are \
+                 optional. The contact is created in the connection's default addressbook \
+                 unless addressbook_url picks another one.",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["display_name"],
+            "properties": {
+                "display_name": {
+                    "type": "string",
+                    "description": "Full name of the contact (vCard FN)."
+                },
+                "emails": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Email addresses, bare (no display-name part)."
+                },
+                "phones": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Phone numbers."
+                },
+                "organization": {"type": "string"},
+                "note": {"type": "string"},
+                "nextcloud_account_id": {
+                    "type": "string",
+                    "description": "Which connected source to create the contact in. Only needed when several offer contacts."
+                },
+                "addressbook_url": {
+                    "type": "string",
+                    "description": "Absolute URL of the target addressbook. Omit for the default addressbook."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(create_contact(ctx, args))),
+    );
+}
+
+// ── Handlers ────────────────────────────────────────────────────
+
+async fn search_contacts(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let query = required_str(&args, "query")?;
+    let limit = optional_u32(&args, "limit")?
+        .unwrap_or(DEFAULT_SEARCH_LIMIT)
+        .clamp(1, MAX_SEARCH_LIMIT);
+
+    let contacts = ctx
+        .cache
+        .search_contacts(&query, limit)
+        .map_err(|e| internal(format!("contact search failed: {e}")))?;
+
+    // Sanitized projection: identity and reachability fields only.
+    // Photos (bytes), notes, and postal addresses stay in the app.
+    let contacts: Vec<Value> = contacts
+        .iter()
+        .map(|c| {
+            json!({
+                "id": c.id,
+                "display_name": c.display_name,
+                "emails": c.email.iter().map(|e| json!({
+                    "kind": e.kind,
+                    "value": e.value,
+                })).collect::<Vec<_>>(),
+                "phones": c.phone.iter().map(|p| json!({
+                    "kind": p.kind,
+                    "value": p.value,
+                })).collect::<Vec<_>>(),
+                "organization": c.organization,
+                "nextcloud_account_id": c.nextcloud_account_id,
+                "addressbook": c.addressbook,
+            })
+        })
+        .collect();
+
+    Ok(json_result(json!({
+        "result_count": contacts.len(),
+        "contacts": contacts,
+    })))
+}
+
+async fn create_contact(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let display_name = required_str(&args, "display_name")?;
+    let emails = optional_str_list(&args, "emails")?;
+    let phones = optional_str_list(&args, "phones")?;
+    let organization = optional_str(&args, "organization")?;
+    let note = optional_str(&args, "note")?;
+
+    let account = resolve_nc_account(&ctx, &args, NextcloudFeature::Contacts)?;
+    let (addressbook_url, addressbook_name) =
+        resolve_addressbook(&account, optional_str(&args, "addressbook_url")?).await?;
+
+    let uid = format!("urn:uuid:{}", uuid::Uuid::new_v4());
+    let parsed = unkai_carddav::ParsedVcard {
+        uid: uid.clone(),
+        display_name: display_name.clone(),
+        emails: emails
+            .iter()
+            .map(|value| unkai_carddav::VcardEmail {
+                kind: String::new(),
+                value: value.clone(),
+            })
+            .collect(),
+        phones: phones
+            .iter()
+            .map(|value| unkai_carddav::VcardPhone {
+                kind: String::new(),
+                value: value.clone(),
+            })
+            .collect(),
+        organization: organization.clone(),
+        note: note.clone(),
+        ..Default::default()
+    };
+    let vcard = unkai_carddav::build_vcard(&parsed);
+
+    // Local sources have no remote — the cache row below IS the
+    // contact; remote sources PUT with `If-None-Match: *` so a UID
+    // collision can never overwrite an existing card.
+    let outcome = if account.is_local() {
+        unkai_carddav::WriteOutcome {
+            href: format!("{}/{uid}.vcf", addressbook_url.trim_end_matches('/')),
+            etag: uuid::Uuid::new_v4().to_string(),
+        }
+    } else {
+        let app_password = nc_password(&account)?;
+        unkai_carddav::create_contact(
+            &account.server_url,
+            &addressbook_url,
+            &account.username,
+            &app_password,
+            &uid,
+            &vcard,
+            &account.trusted_certs,
+        )
+        .await
+        .map_err(|e| internal(format!("CardDAV create failed: {e}")))?
+    };
+
+    let row = ContactRow {
+        href: outcome.href,
+        etag: outcome.etag,
+        vcard_uid: uid.clone(),
+        display_name: display_name.clone(),
+        emails: emails
+            .into_iter()
+            .map(|value| ContactEmail {
+                kind: String::new(),
+                value,
+            })
+            .collect(),
+        phones: phones
+            .into_iter()
+            .map(|value| ContactPhone {
+                kind: String::new(),
+                value,
+            })
+            .collect(),
+        organization,
+        photo_mime: None,
+        photo_data: None,
+        title: None,
+        birthday: None,
+        note,
+        addresses: Vec::new(),
+        urls: Vec::new(),
+        vcard_raw: vcard,
+        kind: String::new(),
+        member_uids: Vec::new(),
+        categories: Vec::new(),
+    };
+    ctx.cache
+        .upsert_single_contact(&account.id, &addressbook_name, &row)
+        .map_err(|e| internal(format!("cache write failed: {e}")))?;
+
+    Ok(json_result(json!({
+        "status": "contact_created",
+        "contact_id": format!("{}::{uid}", account.id),
+        "nextcloud_account_id": account.id,
+        "addressbook": addressbook_name,
+        "display_name": display_name,
+    })))
+}
+
+/// Pick the target addressbook: an explicit URL wins; otherwise
+/// the source's default — the seeded book for local sources, the
+/// server's `contacts` book (or the first listed) for remote ones.
+async fn resolve_addressbook(
+    account: &NextcloudAccount,
+    explicit_url: Option<String>,
+) -> Result<(String, String), ErrorData> {
+    if let Some(url) = explicit_url {
+        let name = url
+            .trim_end_matches('/')
+            .rsplit('/')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or("contacts")
+            .to_string();
+        return Ok((url, name));
+    }
+    if account.is_local() {
+        return Ok((
+            format!("local://{}/{LOCAL_ADDRESSBOOK_NAME}", account.id),
+            LOCAL_ADDRESSBOOK_NAME.to_string(),
+        ));
+    }
+    let app_password = nc_password(account)?;
+    let books = unkai_carddav::list_addressbooks_at(
+        &carddav_home_of(account),
+        &account.username,
+        &app_password,
+        &account.trusted_certs,
+    )
+    .await
+    .map_err(|e| internal(format!("could not list addressbooks: {e}")))?;
+    let book = books
+        .iter()
+        .find(|b| b.name.eq_ignore_ascii_case("contacts"))
+        .or_else(|| books.first())
+        .ok_or_else(|| {
+            invalid(
+                "the server has no addressbook to create the contact in — create one in \
+                 Nextcloud Contacts first",
+            )
+        })?;
+    Ok((book.path.clone(), book.name.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nc::test_support::{caps, nc_account};
+    use crate::testutil::{invoke, result_payload, test_context};
+    use unkai_core::models::DavSourceKind;
+    use unkai_store::nextcloud_store;
+
+    fn seed_local_contacts_source(ctx: &crate::registry::ToolContext) {
+        nextcloud_store::upsert_account(
+            &ctx.cache,
+            nc_account("acc", DavSourceKind::Local, Some(caps(false, false, true))),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn create_contact_on_a_local_source_is_searchable() {
+        let ctx = test_context();
+        seed_local_contacts_source(&ctx);
+
+        let result = invoke(
+            &ctx,
+            "create_contact",
+            json!({
+                "display_name": "Jane Smith",
+                "emails": ["jane.smith@example.com"],
+                "phones": ["+49 30 1234567"],
+                "organization": "Firn Labs",
+            }),
+        )
+        .await
+        .unwrap();
+        let payload = result_payload(&result);
+        assert_eq!(payload["status"], "contact_created");
+        assert_eq!(payload["nextcloud_account_id"], "acc");
+        assert_eq!(payload["addressbook"], "local");
+
+        let result = invoke(&ctx, "search_contacts", json!({"query": "jane"}))
+            .await
+            .unwrap();
+        let payload = result_payload(&result);
+        assert_eq!(payload["result_count"], 1);
+        let contact = &payload["contacts"][0];
+        assert_eq!(contact["display_name"], "Jane Smith");
+        assert_eq!(contact["emails"][0]["value"], "jane.smith@example.com");
+        assert_eq!(contact["organization"], "Firn Labs");
+        // Sanitized projection: no photo bytes, no raw vCard.
+        assert!(contact.get("photo_data").is_none());
+        assert!(contact.get("vcard_raw").is_none());
+    }
+
+    #[tokio::test]
+    async fn create_contact_requires_a_contacts_capable_source() {
+        let ctx = test_context();
+        // Connected source has calendars but NOT contacts.
+        nextcloud_store::upsert_account(
+            &ctx.cache,
+            nc_account("acc", DavSourceKind::Local, Some(caps(false, true, false))),
+        )
+        .unwrap();
+        let err = invoke(&ctx, "create_contact", json!({"display_name": "X"}))
+            .await
+            .expect_err("no contacts-capable source should error");
+        assert!(err.message.contains("contacts"));
+    }
+
+    #[tokio::test]
+    async fn search_contacts_requires_a_query() {
+        let ctx = test_context();
+        let err = invoke(&ctx, "search_contacts", json!({}))
+            .await
+            .expect_err("missing query should error");
+        assert!(err.message.contains("query"));
+    }
+}

--- a/crates/unkai-mcp/src/invite_html.rs
+++ b/crates/unkai-mcp/src/invite_html.rs
@@ -1,0 +1,322 @@
+//! Rust port of the email-safe invite-card builders in
+//! `ui/src/lib/inviteHtml.ts` (#441).
+//!
+//! `create_meeting_invite` produces the same invite-card draft the
+//! in-app "Respond with meeting" / "Insert Talk link" flows do, so
+//! this module mirrors the TypeScript builders **template for
+//! template** — same wrapper structure, same inline-style tokens,
+//! same `data-unkai-block` markers (which the editor's `UnkaiBlock`
+//! extension needs to keep the card intact as an atom node).
+//!
+//! ## Keeping the two implementations in sync
+//!
+//! There is deliberately no shared source of truth: the TS side
+//! renders inside the webview, this side inside the Rust process,
+//! and a build-time bridge between them would cost more than the
+//! duplication.  Instead the rule is: **any change to
+//! `inviteHtml.ts`'s tokens or templates must be applied here too**
+//! (and vice versa).  The unit tests below lock the exact byte
+//! shape of both cards so an unsynced edit fails loudly.
+//!
+//! One knowing divergence: the TS side formats the date line with
+//! `Intl.DateTimeFormat(undefined, …)` — the OS locale, including
+//! its 12/24-hour convention.  Rust has no `Intl`; this port pins
+//! English month/weekday names and 24-hour times ("Tuesday,
+//! May 6 · 14:00 – 15:00").  The shape of the line is identical,
+//! only the localisation differs.
+//!
+//! The email-rendering constraints (inline styles only, system
+//! font stack, emoji glyphs, no images in the chrome) are
+//! documented in `CLAUDE.md` — don't relax them here.
+
+use chrono::{DateTime, Datelike, Local, TimeZone, Utc};
+
+/// Minimal HTML escape for the values spliced into the templates —
+/// same five characters the TS `esc` helper covers.
+fn esc(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+// ── Shared design tokens (inlined into every style attribute) ──
+//
+// Byte-identical to the `T` constant in `inviteHtml.ts`.
+
+const T_CARD: &str = "background:#ffffff;border:1px solid #e2e8f0;border-radius:14px;box-shadow:0 1px 2px rgba(15,23,42,0.04),0 8px 24px rgba(15,23,42,0.06);overflow:hidden;";
+const T_HEADER_BG: &str =
+    "background:linear-gradient(135deg,#3b82f6 0%,#6366f1 100%);padding:20px 24px;color:#ffffff;";
+const T_HEADER_PILL: &str =
+    "display:inline-block;padding:7px 14px;border-radius:999px;background:rgba(255,255,255,0.18);";
+const T_HEADER_WORDMARK: &str =
+    "font-size:13px;font-weight:700;letter-spacing:0.12em;color:#ffffff;text-transform:uppercase;";
+const T_BODY: &str = "padding:24px;font-family:-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif;color:#0f172a;";
+const T_TITLE: &str =
+    "margin:0 0 4px 0;font-size:20px;line-height:1.3;font-weight:600;color:#0f172a;";
+const T_SUBTITLE: &str = "margin:0;font-size:14px;line-height:1.5;color:#475569;";
+const T_DETAIL_LABEL: &str =
+    "font-size:11px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;color:#64748b;";
+const T_DETAIL_VALUE: &str = "font-size:14px;line-height:1.5;color:#0f172a;margin:2px 0 0 0;";
+const T_DIVIDER: &str = "height:1px;background:#e2e8f0;margin:20px 0;border:0;";
+const T_CTA_ROW: &str = "margin-top:24px;";
+const T_CTA_BUTTON: &str = "display:inline-block;background:#3b82f6;color:#ffffff;text-decoration:none;font-weight:600;font-size:14px;padding:11px 22px;border-radius:10px;letter-spacing:0.01em;";
+const T_FOOTER: &str = "margin:20px 0 0 0;padding:14px 16px;background:#f8fafc;border-radius:10px;font-size:12px;line-height:1.5;color:#475569;";
+const T_FOOTER_STRONG: &str = "color:#0f172a;font-weight:600;";
+
+/// Format a start/end pair as the single human line the "When" row
+/// carries: `Tuesday, May 6 · 14:00 – 15:00` (same-day) or
+/// `Tuesday, May 6 14:00 – Wednesday, May 7 15:00` (cross-day).
+/// English names + 24-hour clock — see the module comment for why
+/// this pins a locale where the TS side follows the OS.
+pub(crate) fn format_range<Tz: TimeZone>(start: &DateTime<Tz>, end: &DateTime<Tz>) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    let date = |d: &DateTime<Tz>| d.format("%A, %B %-d").to_string();
+    let time = |d: &DateTime<Tz>| d.format("%H:%M").to_string();
+    let same_day =
+        start.year() == end.year() && start.month() == end.month() && start.day() == end.day();
+    if same_day {
+        format!("{} · {} – {}", date(start), time(start), time(end))
+    } else {
+        format!(
+            "{} {} – {} {}",
+            date(start),
+            time(start),
+            date(end),
+            time(end)
+        )
+    }
+}
+
+/// Wrap the card body inside the shared chrome (outer wrapper +
+/// typography-only wordmark header).  The `data-unkai-block`
+/// attribute is what the editor's `UnkaiBlock` extension keys on.
+fn chrome(body_html: &str, kind: &str) -> String {
+    format!(
+        "<div data-unkai-block=\"{kind}\" style=\"max-width:560px;margin:16px 0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;\">\n  <div style=\"{T_CARD}\">\n    <div style=\"{T_HEADER_BG}\">\n      <span style=\"{T_HEADER_PILL}\"><span style=\"{T_HEADER_WORDMARK}\">Unkai Mail</span></span>\n    </div>\n    <div style=\"{T_BODY}\">\n      {body_html}\n    </div>\n  </div>\n</div>"
+    )
+}
+
+/// One detail row: emoji + label + value, stacked vertically.
+fn detail_row(emoji: &str, label: &str, value: &str) -> String {
+    format!(
+        "<div style=\"display:flex;gap:12px;align-items:flex-start;margin:14px 0;\">\n  <div style=\"font-size:18px;line-height:1.4;flex-shrink:0;width:24px;text-align:center;\">{emoji}</div>\n  <div style=\"flex:1;min-width:0;\">\n    <div style=\"{T_DETAIL_LABEL}\">{}</div>\n    <div style=\"{T_DETAIL_VALUE}\">{value}</div>\n  </div>\n</div>",
+        esc(label)
+    )
+}
+
+/// Footer microcopy block — the "You'll be invited via Nextcloud"
+/// line lives here so it reads as a system-level note.
+fn nextcloud_footer(message: &str) -> String {
+    format!(
+        "<div style=\"{T_FOOTER}\">\n  <span style=\"{T_FOOTER_STRONG}\">📨 {}</span><br />\n  <span>Accept the invitation in your mail client or directly in Nextcloud — your calendar updates either way.</span>\n</div>",
+        esc(message)
+    )
+}
+
+// ── Public renderers ────────────────────────────────────────────
+
+/// Render a Talk-meeting invitation card — the counterpart of
+/// `talkInviteHtml` in `inviteHtml.ts`.  Not used by the
+/// `create_meeting_invite` composite (its card is the meeting one,
+/// with the Talk link as a row), but ported alongside it so the
+/// pair of builders stays complete for future tool surfaces.
+pub fn talk_invite_html(name: &str, url: &str) -> String {
+    let inner = format!(
+        "<h1 style=\"{T_TITLE}\">You're invited to a Talk meeting</h1>\n<p style=\"{T_SUBTITLE}\">Click the button below to join the conversation in Nextcloud Talk — works in any modern browser, no install.</p>\n\n<hr style=\"{T_DIVIDER}\" />\n\n{}\n{}\n\n<div style=\"{T_CTA_ROW}\">\n  <a href=\"{}\" style=\"{T_CTA_BUTTON}\">Join Talk meeting →</a>\n</div>\n\n{}",
+        detail_row(
+            "💬",
+            "Talk room",
+            &format!("<strong style=\"font-weight:600;\">{}</strong>", esc(name)),
+        ),
+        detail_row(
+            "🔗",
+            "Join link",
+            &format!(
+                "<a href=\"{}\" style=\"color:#3b82f6;text-decoration:none;word-break:break-all;\">{}</a>",
+                esc(url),
+                esc(url)
+            ),
+        ),
+        esc(url),
+        nextcloud_footer("You'll also be added as a participant in Nextcloud Talk."),
+    );
+    chrome(&inner, "talk-invite")
+}
+
+/// Input for [`meeting_invite_html`] — mirrors the TS
+/// `MeetingInvite` interface (timestamps arrive as UTC and are
+/// rendered in the machine's local timezone, like the webview's
+/// `Date` does).
+pub(crate) struct MeetingInviteCard {
+    pub summary: String,
+    pub start: DateTime<Utc>,
+    pub end: DateTime<Utc>,
+    pub location: Option<String>,
+    pub description: Option<String>,
+    pub talk_url: Option<String>,
+}
+
+/// Render a calendar-meeting invitation card — the counterpart of
+/// `meetingInviteHtml` in `inviteHtml.ts`.
+pub(crate) fn meeting_invite_html(card: &MeetingInviteCard) -> String {
+    meeting_invite_html_in(card, &Local)
+}
+
+/// Timezone-parameterised body of [`meeting_invite_html`] so tests
+/// can pin a zone and lock exact output bytes.
+fn meeting_invite_html_in<Tz: TimeZone>(card: &MeetingInviteCard, tz: &Tz) -> String
+where
+    Tz::Offset: std::fmt::Display,
+{
+    let start = card.start.with_timezone(tz);
+    let end = card.end.with_timezone(tz);
+
+    let mut detail_rows: Vec<String> = vec![detail_row(
+        "📅",
+        "When",
+        &format!(
+            "<strong style=\"font-weight:600;\">{}</strong>",
+            esc(&format_range(&start, &end))
+        ),
+    )];
+    if let Some(location) = card.location.as_deref().map(str::trim)
+        && !location.is_empty()
+    {
+        detail_rows.push(detail_row("📍", "Where", &esc(location)));
+    }
+    let talk_url = card
+        .talk_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|u| !u.is_empty());
+    if let Some(url) = talk_url {
+        detail_rows.push(detail_row(
+            "💬",
+            "Talk room",
+            &format!(
+                "<a href=\"{}\" style=\"color:#3b82f6;text-decoration:none;word-break:break-all;\">{}</a>",
+                esc(url),
+                esc(url)
+            ),
+        ));
+    }
+    if let Some(description) = card.description.as_deref().map(str::trim)
+        && !description.is_empty()
+    {
+        // Preserve plain-text newlines as <br /> so an agenda with
+        // line breaks reads correctly; escape first so the user's
+        // text can't break the surrounding HTML.
+        let notes_html = esc(description)
+            .replace("\r\n", "<br />")
+            .replace('\n', "<br />");
+        detail_rows.push(detail_row("📝", "Notes", &notes_html));
+    }
+
+    let cta_block = match talk_url {
+        Some(url) => format!(
+            "<div style=\"{T_CTA_ROW}\">\n  <a href=\"{}\" style=\"{T_CTA_BUTTON}\">Join Talk meeting →</a>\n</div>",
+            esc(url)
+        ),
+        None => String::new(),
+    };
+
+    let inner = format!(
+        "<h1 style=\"{T_TITLE}\">{}</h1>\n<p style=\"{T_SUBTITLE}\">A calendar invitation has been created in Nextcloud and shared with everyone on this thread.</p>\n\n<hr style=\"{T_DIVIDER}\" />\n\n{}\n\n{}\n\n{}",
+        esc(&card.summary),
+        detail_rows.join("\n"),
+        cta_block,
+        nextcloud_footer(
+            "You'll be invited via Nextcloud — accepting in your mail client adds the event to your calendar."
+        ),
+    );
+    chrome(&inner, "meeting-invite")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn escape_covers_the_five_specials() {
+        assert_eq!(
+            esc(r#"<a & "b" 'c'>"#),
+            "&lt;a &amp; &quot;b&quot; &#39;c&#39;&gt;"
+        );
+    }
+
+    #[test]
+    fn format_range_same_day_and_cross_day() {
+        let start = Utc.with_ymd_and_hms(2026, 5, 5, 14, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 5, 5, 15, 0, 0).unwrap();
+        assert_eq!(format_range(&start, &end), "Tuesday, May 5 · 14:00 – 15:00");
+        let end = Utc.with_ymd_and_hms(2026, 5, 6, 9, 30, 0).unwrap();
+        assert_eq!(
+            format_range(&start, &end),
+            "Tuesday, May 5 14:00 – Wednesday, May 6 09:30"
+        );
+    }
+
+    #[test]
+    fn talk_card_shape_matches_the_ts_builder() {
+        let html = talk_invite_html("Weekly sync", "https://cloud.example.com/call/abc123");
+        // Wrapper marker + chrome shape the editor's UnkaiBlock
+        // extension and the mail clients rely on.
+        assert!(html.starts_with("<div data-unkai-block=\"talk-invite\" style=\"max-width:560px;"));
+        assert!(html.contains(">Unkai Mail</span>"));
+        assert!(html.contains("You're invited to a Talk meeting"));
+        assert!(html.contains("Weekly sync"));
+        assert!(html.contains("href=\"https://cloud.example.com/call/abc123\""));
+        assert!(html.contains("Join Talk meeting →"));
+        // The footer message runs through esc() — same as the TS
+        // builder — so its apostrophe arrives entity-encoded.
+        assert!(html.contains("You&#39;ll also be added as a participant in Nextcloud Talk."));
+        // Inline styles only — no <style> block, no <img>, no class=.
+        assert!(!html.contains("<style"));
+        assert!(!html.contains("<img"));
+        assert!(!html.contains("class="));
+    }
+
+    #[test]
+    fn meeting_card_renders_optional_rows_and_escapes() {
+        let card = MeetingInviteCard {
+            summary: "Q3 <Planning> & Review".into(),
+            start: Utc.with_ymd_and_hms(2026, 5, 5, 14, 0, 0).unwrap(),
+            end: Utc.with_ymd_and_hms(2026, 5, 5, 15, 0, 0).unwrap(),
+            location: Some("Room 5 & annex".into()),
+            description: Some("Agenda:\n1. Numbers\n2. <Plans>".into()),
+            talk_url: Some("https://cloud.example.com/call/xyz".into()),
+        };
+        let html = meeting_invite_html_in(&card, &Utc);
+        assert!(
+            html.starts_with("<div data-unkai-block=\"meeting-invite\" style=\"max-width:560px;")
+        );
+        assert!(html.contains("Q3 &lt;Planning&gt; &amp; Review"));
+        assert!(html.contains("Tuesday, May 5 · 14:00 – 15:00"));
+        assert!(html.contains("Room 5 &amp; annex"));
+        assert!(html.contains("Agenda:<br />1. Numbers<br />2. &lt;Plans&gt;"));
+        assert!(html.contains("href=\"https://cloud.example.com/call/xyz\""));
+        assert!(html.contains("Join Talk meeting →"));
+    }
+
+    #[test]
+    fn meeting_card_without_talk_url_has_no_cta() {
+        let card = MeetingInviteCard {
+            summary: "Coffee".into(),
+            start: Utc.with_ymd_and_hms(2026, 5, 5, 14, 0, 0).unwrap(),
+            end: Utc.with_ymd_and_hms(2026, 5, 5, 15, 0, 0).unwrap(),
+            location: None,
+            description: None,
+            talk_url: None,
+        };
+        let html = meeting_invite_html_in(&card, &Utc);
+        assert!(!html.contains("Join Talk meeting"));
+        assert!(!html.contains("📍"));
+        assert!(!html.contains("📝"));
+        assert!(html.contains("📅"));
+    }
+}

--- a/crates/unkai-mcp/src/lib.rs
+++ b/crates/unkai-mcp/src/lib.rs
@@ -29,9 +29,18 @@
 //! never ride along in the Nextcloud settings-sync bundle.
 
 pub mod auth;
+pub mod calendar;
+pub mod contacts;
+pub mod invite_html;
 pub mod mail;
+pub mod meeting;
+pub mod nc;
 pub mod registry;
 pub mod server;
+pub mod talk;
+#[cfg(test)]
+pub(crate) mod testutil;
+mod util;
 
 use std::sync::Arc;
 

--- a/crates/unkai-mcp/src/mail.rs
+++ b/crates/unkai-mcp/src/mail.rs
@@ -33,16 +33,20 @@
 use std::sync::Arc;
 
 use rmcp::ErrorData;
-use rmcp::model::{CallToolResult, ContentBlock, JsonObject};
+use rmcp::model::{CallToolResult, JsonObject};
 use serde_json::{Value, json};
 use unkai_core::mail_util;
 use unkai_core::models::{Account, Email, OutgoingEmail};
 use unkai_imap::ImapClient;
 use unkai_smtp::build_outgoing_message;
 use unkai_store::cache::{SearchFilters, SearchScope};
-use unkai_store::{account_store, credentials};
+use unkai_store::credentials;
 
 use crate::registry::{ToolAccess, ToolContext, ToolDescriptor, ToolRegistry};
+use crate::util::{
+    arg, internal, invalid, json_result, load_accounts, optional_str, optional_str_list,
+    optional_u32, require_known_account, required_str, required_str_list, required_u32, schema,
+};
 
 /// What replaces bodies and snippets of encrypted messages while
 /// the expose toggle is off.  Public so tests (and the docs issue,
@@ -65,6 +69,7 @@ pub(crate) fn register_mail_tools(registry: &mut ToolRegistry) {
             id: "search_mail",
             category: "mail",
             access: ToolAccess::Read,
+            requires: None,
             description:
                 "Full-text search over the user's locally synced mail. The query combines free \
                  text with operators, all AND-ed: from:, to:, cc:, subject:, body: (quote \
@@ -107,6 +112,7 @@ pub(crate) fn register_mail_tools(registry: &mut ToolRegistry) {
             id: "get_message",
             category: "mail",
             access: ToolAccess::Read,
+            requires: None,
             description:
                 "Read one cached message: envelope fields plus the plain-text body (HTML-only \
                  mail is converted to text). Bodies of end-to-end-encrypted messages are \
@@ -123,6 +129,7 @@ pub(crate) fn register_mail_tools(registry: &mut ToolRegistry) {
             id: "get_thread",
             category: "mail",
             access: ToolAccess::Read,
+            requires: None,
             description: "List every cached message in the same conversation (thread) as the given \
                  message, newest first. Returns envelope data only — no bodies; call \
                  get_message per member for content. Threads are scoped to one folder.",
@@ -136,6 +143,7 @@ pub(crate) fn register_mail_tools(registry: &mut ToolRegistry) {
             id: "list_folders",
             category: "mail",
             access: ToolAccess::Read,
+            requires: None,
             description: "List one account's mail folders as Unkai has them synced, including IMAP \
                  special-use attributes (\\Drafts, \\Sent, \\Trash, …) and unread counts.",
         },
@@ -157,6 +165,7 @@ pub(crate) fn register_mail_tools(registry: &mut ToolRegistry) {
             id: "list_accounts",
             category: "mail",
             access: ToolAccess::Read,
+            requires: None,
             description:
                 "List the mail accounts configured in Unkai Mail: id, display name, and email \
                  address. Use the id as account_id in every other mail tool.",
@@ -170,6 +179,7 @@ pub(crate) fn register_mail_tools(registry: &mut ToolRegistry) {
             id: "create_draft",
             category: "mail",
             access: ToolAccess::Write,
+            requires: None,
             description:
                 "Create a draft in the account's Drafts folder (IMAP APPEND — the draft also \
                  appears on the user's other devices). The draft is NOT sent and there is no \
@@ -494,14 +504,42 @@ async fn create_draft(
 
     let outgoing =
         build_draft_outgoing(&account, to, cc, bcc, subject, body, reply_parent.as_ref());
-    let message = build_outgoing_message(&outgoing)
+    let saved = append_draft(&ctx, &account, &outgoing).await?;
+
+    Ok(json_result(json!({
+        "status": "draft_created",
+        "account_id": account_id,
+        "folder": saved.folder,
+        "uid": saved.uid,
+        "note": "The draft was saved, not sent. The user can review and send it from Unkai Mail.",
+    })))
+}
+
+/// Where an appended draft landed.  `uid: None` means the UID
+/// couldn't be discovered afterwards — the draft itself is fine.
+pub(crate) struct SavedDraft {
+    pub folder: String,
+    pub uid: Option<u32>,
+}
+
+/// Build the MIME message for `outgoing` and APPEND it to the
+/// account's Drafts folder — the shared write path behind
+/// `create_draft` and the `create_meeting_invite` composite
+/// (#441).  IMAP only; the caller has already screened out JMAP
+/// accounts.
+pub(crate) async fn append_draft(
+    ctx: &ToolContext,
+    account: &Account,
+    outgoing: &OutgoingEmail,
+) -> Result<SavedDraft, ErrorData> {
+    let message = build_outgoing_message(outgoing)
         .map_err(|e| invalid(format!("could not build the draft message: {e}")))?;
     let raw = message.formatted();
     let message_id = mail_util::extract_message_id(&raw);
 
     let folders = ctx
         .cache
-        .get_folders(&account_id)
+        .get_folders(&account.id)
         .map_err(|e| internal(format!("cache read failed: {e}")))?;
     let drafts_folder = mail_util::pick_drafts_folder(&folders).ok_or_else(|| {
         ErrorData::invalid_request(
@@ -552,13 +590,10 @@ async fn create_draft(
 
     append_result.map_err(|e| internal(format!("IMAP APPEND to '{drafts_folder}' failed: {e}")))?;
 
-    Ok(json_result(json!({
-        "status": "draft_created",
-        "account_id": account_id,
-        "folder": drafts_folder,
-        "uid": uid,
-        "note": "The draft was saved, not sent. The user can review and send it from Unkai Mail.",
-    })))
+    Ok(SavedDraft {
+        folder: drafts_folder,
+        uid,
+    })
 }
 
 /// Assemble the `OutgoingEmail` for a new draft.  Pure — split out
@@ -572,7 +607,7 @@ async fn create_draft(
 /// itself per RFC 5322 §3.6.4.  A parent without a Message-ID
 /// yields a draft that sends fine but threads as an orphan — same
 /// trade-off the in-app reply flow makes.
-fn build_draft_outgoing(
+pub(crate) fn build_draft_outgoing(
     account: &Account,
     to: Vec<String>,
     cc: Vec<String>,
@@ -629,103 +664,13 @@ async fn expose_decrypted(ctx: &ToolContext) -> bool {
     ctx.settings.read().await.mcp_expose_decrypted_content
 }
 
-fn load_accounts(ctx: &ToolContext) -> Result<Vec<Account>, ErrorData> {
-    account_store::load_accounts(&ctx.cache)
-        .map_err(|e| internal(format!("could not load accounts: {e}")))
-}
-
-/// Reject unknown account ids with a pointer at `list_accounts` —
-/// without this, a typo'd id would just return an empty folder
-/// list and send the agent down a "no folders synced" dead end.
-fn require_known_account(ctx: &ToolContext, account_id: &str) -> Result<(), ErrorData> {
-    if load_accounts(ctx)?.iter().any(|a| a.id == account_id) {
-        Ok(())
-    } else {
-        Err(invalid(format!(
-            "unknown account_id '{account_id}' — call list_accounts for valid ids"
-        )))
-    }
-}
-
 // ── Argument parsing ────────────────────────────────────────────
-
-fn invalid(message: impl Into<String>) -> ErrorData {
-    ErrorData::invalid_params(message.into(), None)
-}
-
-fn internal(message: impl Into<String>) -> ErrorData {
-    ErrorData::internal_error(message.into(), None)
-}
 
 fn message_not_cached() -> ErrorData {
     invalid(
         "message not found in the local cache — only mail Unkai has already synced is \
          readable; find messages via search_mail, or open the folder in Unkai Mail",
     )
-}
-
-fn arg<'a>(args: &'a Option<JsonObject>, key: &str) -> Option<&'a Value> {
-    args.as_ref()
-        .and_then(|a| a.get(key))
-        .filter(|v| !v.is_null())
-}
-
-fn optional_str(args: &Option<JsonObject>, key: &str) -> Result<Option<String>, ErrorData> {
-    match arg(args, key) {
-        None => Ok(None),
-        Some(Value::String(s)) => Ok(Some(s.clone())),
-        Some(_) => Err(invalid(format!("parameter '{key}' must be a string"))),
-    }
-}
-
-fn required_str(args: &Option<JsonObject>, key: &str) -> Result<String, ErrorData> {
-    optional_str(args, key)?
-        .filter(|s| !s.trim().is_empty())
-        .ok_or_else(|| invalid(format!("parameter '{key}' is required")))
-}
-
-fn optional_u32(args: &Option<JsonObject>, key: &str) -> Result<Option<u32>, ErrorData> {
-    match arg(args, key) {
-        None => Ok(None),
-        Some(Value::Number(n)) => n
-            .as_u64()
-            .and_then(|n| u32::try_from(n).ok())
-            .map(Some)
-            .ok_or_else(|| invalid(format!("parameter '{key}' is out of range"))),
-        Some(_) => Err(invalid(format!("parameter '{key}' must be an integer"))),
-    }
-}
-
-fn required_u32(args: &Option<JsonObject>, key: &str) -> Result<u32, ErrorData> {
-    optional_u32(args, key)?.ok_or_else(|| invalid(format!("parameter '{key}' is required")))
-}
-
-fn optional_str_list(args: &Option<JsonObject>, key: &str) -> Result<Vec<String>, ErrorData> {
-    match arg(args, key) {
-        None => Ok(Vec::new()),
-        Some(Value::Array(items)) => items
-            .iter()
-            .map(|v| match v {
-                Value::String(s) if !s.trim().is_empty() => Ok(s.clone()),
-                _ => Err(invalid(format!(
-                    "parameter '{key}' must be an array of non-empty strings"
-                ))),
-            })
-            .collect(),
-        Some(_) => Err(invalid(format!(
-            "parameter '{key}' must be an array of strings"
-        ))),
-    }
-}
-
-fn required_str_list(args: &Option<JsonObject>, key: &str) -> Result<Vec<String>, ErrorData> {
-    let list = optional_str_list(args, key)?;
-    if list.is_empty() {
-        return Err(invalid(format!(
-            "parameter '{key}' is required and must not be empty"
-        )));
-    }
-    Ok(list)
 }
 
 /// The `account_id`/`folder`/`uid` triple shared by `get_message`
@@ -756,17 +701,6 @@ fn reply_to_ref(args: &Option<JsonObject>) -> Result<Option<(String, u32)>, Erro
 }
 
 // ── Output helpers ──────────────────────────────────────────────
-
-fn json_result(value: Value) -> CallToolResult {
-    CallToolResult::success(vec![ContentBlock::text(value.to_string())])
-}
-
-fn schema(value: Value) -> JsonObject {
-    match value {
-        Value::Object(map) => map,
-        _ => unreachable!("tool schemas are object literals"),
-    }
-}
 
 /// Cut `s` to at most `max` characters on a char boundary.
 /// Returns the (possibly cut) string and whether it was cut.
@@ -904,7 +838,7 @@ mod tests {
     use chrono::Utc;
     use tokio::sync::RwLock;
     use unkai_core::models::{AppSettings, EmailAttachment, EmailEnvelope, Folder};
-    use unkai_store::Cache;
+    use unkai_store::{Cache, account_store};
 
     fn test_context(expose: bool) -> ToolContext {
         let settings = AppSettings {

--- a/crates/unkai-mcp/src/meeting.rs
+++ b/crates/unkai-mcp/src/meeting.rs
@@ -1,0 +1,802 @@
+//! The `create_meeting_invite` composite tool (#441).
+//!
+//! Orchestrates the full "set up a meeting" flow in one call:
+//!
+//! 1. *(optional)* create a **public Talk room** (no participants
+//!    — recipients join via the link, so no guest-invite emails
+//!    fire here),
+//! 2. create the **calendar event** with the attendees on the ICS
+//!    — this is the step where the user's server sends the iMIP
+//!    invitation emails,
+//! 3. save the **invite-card draft** (the same styled card the
+//!    in-app flows produce, ported in [`crate::invite_html`]) into
+//!    the mail account's Drafts folder for the user to review and
+//!    send from Unkai Mail.
+//!
+//! ## Rollback
+//!
+//! Each step's failure undoes the previous steps best-effort:
+//! a failed event deletes the Talk room; a failed draft deletes
+//! the event (the server then sends iMIP CANCEL notices — the
+//! correct follow-up to invitations that already went out) and the
+//! room.  The orchestration lives in [`orchestrate_meeting`],
+//! separated from the network code behind the [`MeetingSteps`]
+//! trait so the rollback ordering is unit-testable.
+//!
+//! The local-cache mirror of the event is written only after every
+//! step succeeded, so rollback never has to touch the cache.
+
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use rmcp::model::{CallToolResult, JsonObject};
+use serde_json::json;
+use unkai_core::models::{Account, NextcloudAccount};
+use unkai_nextcloud::CreateRoomOptions;
+
+use crate::calendar::{
+    CreatedEvent, EventSpec, create_event_impl, rollback_created_event, upsert_created_event,
+    validate_writable_calendar,
+};
+use crate::invite_html::{MeetingInviteCard, format_range, meeting_invite_html};
+use crate::mail::{append_draft, build_draft_outgoing};
+use crate::nc::{account_has_feature, load_nc_accounts, nc_password};
+use crate::registry::{NextcloudFeature, ToolAccess, ToolContext, ToolDescriptor, ToolRegistry};
+use crate::util::{
+    internal, invalid, json_result, load_accounts, optional_bool, optional_str, required_datetime,
+    required_str, required_str_list, schema,
+};
+
+pub(crate) fn register_meeting_tools(registry: &mut ToolRegistry) {
+    registry.register(
+        ToolDescriptor {
+            id: "create_meeting_invite",
+            category: "calendar",
+            access: ToolAccess::Write,
+            requires: Some(NextcloudFeature::Calendar),
+            description:
+                "Set up a complete meeting: optionally create a Nextcloud Talk room, create \
+                 the calendar event, and save a styled invite-card email as a DRAFT in the \
+                 mail account's Drafts folder. IMPORTANT: the server emails iMIP calendar \
+                 invitations to all attendees as soon as the event is created — only the \
+                 invite-card email itself stays a draft for the user to review and send \
+                 from Unkai Mail. If a later step fails, earlier steps are rolled back \
+                 (a cancelled event triggers iMIP cancellation notices).",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["account_id", "calendar_id", "summary", "start", "end", "attendees"],
+            "properties": {
+                "account_id": {
+                    "type": "string",
+                    "description": "Mail account whose Drafts folder receives the invite card (see list_accounts)."
+                },
+                "calendar_id": {
+                    "type": "string",
+                    "description": "Calendar for the event (see list_calendars; must not be read_only)."
+                },
+                "summary": {"type": "string", "description": "Meeting title."},
+                "start": {"type": "string", "description": "RFC 3339 start time."},
+                "end": {"type": "string", "description": "RFC 3339 end time."},
+                "attendees": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "description": "Attendee email addresses — they receive the server's iMIP invitation and are the draft's recipients."
+                },
+                "description": {"type": "string", "description": "Agenda / notes for the event and the invite card."},
+                "location": {"type": "string"},
+                "include_talk_room": {
+                    "type": "boolean",
+                    "description": "Also create a public Talk room and link it from the event and the card. Default false."
+                },
+                "talk_room_name": {
+                    "type": "string",
+                    "description": "Name for the Talk room. Defaults to the meeting summary."
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "Subject of the draft email. Defaults to 'Invitation: <summary>'."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(create_meeting_invite(ctx, args))),
+    );
+}
+
+// ── Orchestration (pure, unit-testable) ─────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MeetingStep {
+    TalkRoom,
+    Event,
+    Draft,
+}
+
+impl MeetingStep {
+    fn label(self) -> &'static str {
+        match self {
+            MeetingStep::TalkRoom => "Talk room",
+            MeetingStep::Event => "calendar event",
+            MeetingStep::Draft => "invite draft",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RoomInfo {
+    pub name: String,
+    pub token: String,
+    pub web_url: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DraftInfo {
+    pub folder: String,
+    pub uid: Option<u32>,
+}
+
+pub(crate) struct MeetingOutcome {
+    pub room: Option<RoomInfo>,
+    pub event_id: String,
+    pub draft: DraftInfo,
+}
+
+pub(crate) struct MeetingFailure {
+    pub step: MeetingStep,
+    pub error: String,
+    /// What was undone afterwards, in undo order, with each
+    /// rollback's own result (rollbacks are best-effort).
+    pub rollbacks: Vec<(MeetingStep, Result<(), String>)>,
+}
+
+/// The three side-effecting steps plus their undo operations.
+/// The live implementation talks to Talk/CalDAV/IMAP; tests
+/// substitute a recorder to pin the rollback ordering.
+pub(crate) trait MeetingSteps {
+    async fn create_room(&mut self) -> Result<RoomInfo, String>;
+    async fn rollback_room(&mut self, room: &RoomInfo) -> Result<(), String>;
+    /// Returns the created event's id.  This is the step that
+    /// makes the server send iMIP invitations.
+    async fn create_event(&mut self, talk_url: Option<&str>) -> Result<String, String>;
+    async fn rollback_event(&mut self) -> Result<(), String>;
+    async fn create_draft(&mut self, room: Option<&RoomInfo>) -> Result<DraftInfo, String>;
+}
+
+/// Run the composite: room? → event → draft, undoing earlier
+/// steps when a later one fails.  Undo order is reverse creation
+/// order — event first (its CANCEL notices chase the invitations
+/// the failed flow already sent), then the room.
+pub(crate) async fn orchestrate_meeting(
+    steps: &mut impl MeetingSteps,
+    want_room: bool,
+) -> Result<MeetingOutcome, MeetingFailure> {
+    let room = if want_room {
+        match steps.create_room().await {
+            Ok(room) => Some(room),
+            Err(error) => {
+                return Err(MeetingFailure {
+                    step: MeetingStep::TalkRoom,
+                    error,
+                    rollbacks: Vec::new(),
+                });
+            }
+        }
+    } else {
+        None
+    };
+
+    let event_id = match steps
+        .create_event(room.as_ref().map(|r| r.web_url.as_str()))
+        .await
+    {
+        Ok(id) => id,
+        Err(error) => {
+            let mut rollbacks = Vec::new();
+            if let Some(room) = &room {
+                rollbacks.push((MeetingStep::TalkRoom, steps.rollback_room(room).await));
+            }
+            return Err(MeetingFailure {
+                step: MeetingStep::Event,
+                error,
+                rollbacks,
+            });
+        }
+    };
+
+    match steps.create_draft(room.as_ref()).await {
+        Ok(draft) => Ok(MeetingOutcome {
+            room,
+            event_id,
+            draft,
+        }),
+        Err(error) => {
+            let mut rollbacks = vec![(MeetingStep::Event, steps.rollback_event().await)];
+            if let Some(room) = &room {
+                rollbacks.push((MeetingStep::TalkRoom, steps.rollback_room(room).await));
+            }
+            Err(MeetingFailure {
+                step: MeetingStep::Draft,
+                error,
+                rollbacks,
+            })
+        }
+    }
+}
+
+// ── Live implementation ─────────────────────────────────────────
+
+struct LiveSteps<'a> {
+    ctx: &'a ToolContext,
+    mail_account: Account,
+    nc_account: NextcloudAccount,
+    calendar_id: String,
+    room_name: String,
+    subject: String,
+    summary: String,
+    description: Option<String>,
+    location: Option<String>,
+    start: chrono::DateTime<chrono::Utc>,
+    end: chrono::DateTime<chrono::Utc>,
+    attendees: Vec<String>,
+    /// Set by `create_event`, consumed by `rollback_event` and the
+    /// post-orchestration cache commit.
+    created_event: Option<CreatedEvent>,
+}
+
+impl LiveSteps<'_> {
+    fn invite_card(&self, room: Option<&RoomInfo>) -> MeetingInviteCard {
+        MeetingInviteCard {
+            summary: self.summary.clone(),
+            start: self.start,
+            end: self.end,
+            location: self.location.clone(),
+            description: self.description.clone(),
+            talk_url: room.map(|r| r.web_url.clone()),
+        }
+    }
+
+    /// Plain-text alternative body for clients that don't render
+    /// the HTML card.
+    fn draft_text(&self, room: Option<&RoomInfo>) -> String {
+        let when = format_range(
+            &self.start.with_timezone(&chrono::Local),
+            &self.end.with_timezone(&chrono::Local),
+        );
+        let mut lines = vec![self.summary.clone(), format!("When: {when}")];
+        if let Some(location) = self.location.as_deref().filter(|l| !l.trim().is_empty()) {
+            lines.push(format!("Where: {}", location.trim()));
+        }
+        if let Some(room) = room {
+            lines.push(format!("Talk room: {}", room.web_url));
+        }
+        if let Some(description) = self.description.as_deref().filter(|d| !d.trim().is_empty()) {
+            lines.push(String::new());
+            lines.push(description.trim().to_string());
+        }
+        lines.join("\n")
+    }
+}
+
+impl MeetingSteps for LiveSteps<'_> {
+    async fn create_room(&mut self) -> Result<RoomInfo, String> {
+        let app_password = nc_password(&self.nc_account).map_err(|e| e.message.to_string())?;
+        // Public room (wire value 3), no participants: attendees
+        // reach it via the link in the event and the card, so Talk
+        // sends no guest-invite emails of its own here.
+        let room = unkai_nextcloud::create_room(
+            &self.nc_account.server_url,
+            &self.nc_account.username,
+            &app_password,
+            &self.room_name,
+            &[],
+            CreateRoomOptions {
+                room_type: Some(3),
+                object_type: None,
+                object_id: None,
+            },
+            &self.nc_account.trusted_certs,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        Ok(RoomInfo {
+            name: room.display_name,
+            token: room.token,
+            web_url: room.web_url,
+        })
+    }
+
+    async fn rollback_room(&mut self, room: &RoomInfo) -> Result<(), String> {
+        let app_password = nc_password(&self.nc_account).map_err(|e| e.message.to_string())?;
+        unkai_nextcloud::delete_room(
+            &self.nc_account.server_url,
+            &self.nc_account.username,
+            &app_password,
+            &room.token,
+            &self.nc_account.trusted_certs,
+        )
+        .await
+        .map_err(|e| e.to_string())
+    }
+
+    async fn create_event(&mut self, talk_url: Option<&str>) -> Result<String, String> {
+        let spec = EventSpec {
+            summary: self.summary.clone(),
+            description: self.description.clone(),
+            location: self.location.clone(),
+            url: talk_url.map(str::to_string),
+            start: self.start,
+            end: self.end,
+            all_day: false,
+            attendees: self.attendees.clone(),
+        };
+        let created = create_event_impl(self.ctx, &self.calendar_id, spec)
+            .await
+            .map_err(|e| e.message.to_string())?;
+        let event_id = created.event_id.clone();
+        self.created_event = Some(created);
+        Ok(event_id)
+    }
+
+    async fn rollback_event(&mut self) -> Result<(), String> {
+        match self.created_event.take() {
+            Some(created) => rollback_created_event(self.ctx, &created).await,
+            None => Ok(()),
+        }
+    }
+
+    async fn create_draft(&mut self, room: Option<&RoomInfo>) -> Result<DraftInfo, String> {
+        let mut outgoing = build_draft_outgoing(
+            &self.mail_account,
+            self.attendees.clone(),
+            Vec::new(),
+            Vec::new(),
+            self.subject.clone(),
+            self.draft_text(room),
+            None,
+        );
+        outgoing.body_html = Some(meeting_invite_html(&self.invite_card(room)));
+        let saved = append_draft(self.ctx, &self.mail_account, &outgoing)
+            .await
+            .map_err(|e| e.message.to_string())?;
+        Ok(DraftInfo {
+            folder: saved.folder,
+            uid: saved.uid,
+        })
+    }
+}
+
+// ── Handler ─────────────────────────────────────────────────────
+
+async fn create_meeting_invite(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let account_id = required_str(&args, "account_id")?;
+    let calendar_id = required_str(&args, "calendar_id")?;
+    let summary = required_str(&args, "summary")?;
+    let start = required_datetime(&args, "start")?;
+    let end = required_datetime(&args, "end")?;
+    let attendees = required_str_list(&args, "attendees")?;
+    let description = optional_str(&args, "description")?;
+    let location = optional_str(&args, "location")?;
+    let include_talk_room = optional_bool(&args, "include_talk_room")?.unwrap_or(false);
+    let room_name = optional_str(&args, "talk_room_name")?.unwrap_or_else(|| summary.clone());
+    let subject =
+        optional_str(&args, "subject")?.unwrap_or_else(|| format!("Invitation: {summary}"));
+
+    if end <= start {
+        return Err(invalid("end must be after start"));
+    }
+    for attendee in &attendees {
+        if !attendee.contains('@') {
+            return Err(invalid(format!(
+                "attendee '{attendee}' is not an email address"
+            )));
+        }
+    }
+
+    // Validate every precondition BEFORE the first side effect —
+    // a composite that fails on step three after creating a room
+    // and emailing invitations is strictly worse than one that
+    // refuses up front.
+    let mail_account = load_accounts(&ctx)?
+        .into_iter()
+        .find(|a| a.id == account_id)
+        .ok_or_else(|| {
+            invalid(format!(
+                "unknown account_id '{account_id}' — call list_accounts for valid ids"
+            ))
+        })?;
+    if mail_account.use_jmap && mail_account.jmap_url.is_some() {
+        return Err(ErrorData::invalid_request(
+            "this account uses JMAP; creating drafts via MCP currently supports IMAP \
+             accounts only",
+            None,
+        ));
+    }
+    let folders = ctx
+        .cache
+        .get_folders(&account_id)
+        .map_err(|e| internal(format!("cache read failed: {e}")))?;
+    if unkai_core::mail_util::pick_drafts_folder(&folders).is_none() {
+        return Err(ErrorData::invalid_request(
+            "no Drafts folder found in the account's synced folder list — open the account \
+             in Unkai Mail once so its folders are synced",
+            None,
+        ));
+    }
+
+    let (nc_id, _) = validate_writable_calendar(&ctx, &calendar_id)?;
+    let nc_account = load_nc_accounts(&ctx.cache)
+        .into_iter()
+        .find(|a| a.id == nc_id)
+        .ok_or_else(|| {
+            internal(format!(
+                "the connected source '{nc_id}' referenced by the cache no longer exists"
+            ))
+        })?;
+    if include_talk_room && !account_has_feature(&nc_account, NextcloudFeature::Talk) {
+        return Err(invalid(
+            "the calendar's Nextcloud has no Talk app — retry with include_talk_room=false",
+        ));
+    }
+
+    let mut steps = LiveSteps {
+        ctx: &ctx,
+        mail_account,
+        nc_account,
+        calendar_id,
+        room_name,
+        subject,
+        summary,
+        description,
+        location,
+        start,
+        end,
+        attendees,
+        created_event: None,
+    };
+
+    match orchestrate_meeting(&mut steps, include_talk_room).await {
+        Ok(outcome) => {
+            // Mirror the event into the local cache only now that
+            // the whole composite stands — rollback never has to
+            // clean the cache up.  A failed mirror is only a
+            // staleness issue (the next sync fixes it), not worth
+            // failing a composite whose real resources all exist.
+            let mut cache_note = None;
+            if let Some(created) = steps.created_event.as_ref()
+                && let Err(e) = upsert_created_event(&ctx, created)
+            {
+                tracing::warn!("MCP: created event not mirrored into cache: {}", e.message);
+                cache_note = Some(
+                    "The event exists on the server but is not yet visible locally; it appears after the next calendar sync.",
+                );
+            }
+
+            let mut result = json!({
+                "status": "meeting_invite_created",
+                "event_id": outcome.event_id,
+                "draft": {
+                    "account_id": steps.mail_account.id,
+                    "folder": outcome.draft.folder,
+                    "uid": outcome.draft.uid,
+                },
+                "note": "The server is emailing iMIP invitations to the attendees. The \
+                         invite-card email is a DRAFT — the user reviews and sends it from \
+                         Unkai Mail.",
+            });
+            if let Some(room) = &outcome.room {
+                result["talk_room"] = json!({
+                    "name": room.name,
+                    "token": room.token,
+                    "web_url": room.web_url,
+                });
+            }
+            if let Some(note) = cache_note {
+                result["cache_note"] = json!(note);
+            }
+            Ok(json_result(result))
+        }
+        Err(failure) => {
+            let mut message = format!(
+                "creating the {} failed: {}",
+                failure.step.label(),
+                failure.error
+            );
+            for (step, result) in &failure.rollbacks {
+                match result {
+                    Ok(()) => {
+                        message.push_str(&format!("; the {} was rolled back", step.label()));
+                    }
+                    Err(e) => message.push_str(&format!(
+                        "; rolling back the {} ALSO failed ({e}) — the user should check \
+                         their {} manually",
+                        step.label(),
+                        match step {
+                            MeetingStep::TalkRoom => "Talk rooms",
+                            MeetingStep::Event => "calendar",
+                            MeetingStep::Draft => "drafts",
+                        },
+                    )),
+                }
+            }
+            Err(internal(message))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Recorder implementation: scripts which steps fail and logs
+    /// every call so the tests can pin the rollback ordering.
+    struct MockSteps {
+        fail_room: bool,
+        fail_event: bool,
+        fail_draft: bool,
+        fail_rollback_event: bool,
+        calls: Vec<&'static str>,
+    }
+
+    impl MockSteps {
+        fn new() -> Self {
+            Self {
+                fail_room: false,
+                fail_event: false,
+                fail_draft: false,
+                fail_rollback_event: false,
+                calls: Vec::new(),
+            }
+        }
+    }
+
+    impl MeetingSteps for MockSteps {
+        async fn create_room(&mut self) -> Result<RoomInfo, String> {
+            self.calls.push("create_room");
+            if self.fail_room {
+                return Err("room boom".into());
+            }
+            Ok(RoomInfo {
+                name: "Weekly sync".into(),
+                token: "tok".into(),
+                web_url: "https://cloud.example.com/call/tok".into(),
+            })
+        }
+
+        async fn rollback_room(&mut self, _room: &RoomInfo) -> Result<(), String> {
+            self.calls.push("rollback_room");
+            Ok(())
+        }
+
+        async fn create_event(&mut self, talk_url: Option<&str>) -> Result<String, String> {
+            self.calls.push(if talk_url.is_some() {
+                "create_event_with_link"
+            } else {
+                "create_event"
+            });
+            if self.fail_event {
+                return Err("event boom".into());
+            }
+            Ok("cal::evt".into())
+        }
+
+        async fn rollback_event(&mut self) -> Result<(), String> {
+            self.calls.push("rollback_event");
+            if self.fail_rollback_event {
+                return Err("rollback boom".into());
+            }
+            Ok(())
+        }
+
+        async fn create_draft(&mut self, _room: Option<&RoomInfo>) -> Result<DraftInfo, String> {
+            self.calls.push("create_draft");
+            if self.fail_draft {
+                return Err("draft boom".into());
+            }
+            Ok(DraftInfo {
+                folder: "Drafts".into(),
+                uid: Some(7),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn happy_path_runs_room_event_draft_without_rollbacks() {
+        let mut steps = MockSteps::new();
+        let outcome = orchestrate_meeting(&mut steps, true).await.ok().unwrap();
+        assert_eq!(
+            steps.calls,
+            vec!["create_room", "create_event_with_link", "create_draft"]
+        );
+        assert!(outcome.room.is_some());
+        assert_eq!(outcome.event_id, "cal::evt");
+        assert_eq!(outcome.draft.uid, Some(7));
+    }
+
+    #[tokio::test]
+    async fn without_room_the_talk_step_is_skipped() {
+        let mut steps = MockSteps::new();
+        let outcome = orchestrate_meeting(&mut steps, false).await.ok().unwrap();
+        assert_eq!(steps.calls, vec!["create_event", "create_draft"]);
+        assert!(outcome.room.is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_event_rolls_back_the_room() {
+        let mut steps = MockSteps::new();
+        steps.fail_event = true;
+        let failure = orchestrate_meeting(&mut steps, true).await.err().unwrap();
+        assert_eq!(
+            steps.calls,
+            vec!["create_room", "create_event_with_link", "rollback_room"]
+        );
+        assert_eq!(failure.step, MeetingStep::Event);
+        assert_eq!(failure.rollbacks.len(), 1);
+        assert_eq!(failure.rollbacks[0].0, MeetingStep::TalkRoom);
+        assert!(failure.rollbacks[0].1.is_ok());
+    }
+
+    #[tokio::test]
+    async fn failed_draft_rolls_back_event_then_room() {
+        let mut steps = MockSteps::new();
+        steps.fail_draft = true;
+        let failure = orchestrate_meeting(&mut steps, true).await.err().unwrap();
+        assert_eq!(
+            steps.calls,
+            vec![
+                "create_room",
+                "create_event_with_link",
+                "create_draft",
+                "rollback_event",
+                "rollback_room"
+            ]
+        );
+        assert_eq!(failure.step, MeetingStep::Draft);
+        let steps_rolled: Vec<MeetingStep> = failure.rollbacks.iter().map(|(s, _)| *s).collect();
+        assert_eq!(
+            steps_rolled,
+            vec![MeetingStep::Event, MeetingStep::TalkRoom]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_rollback_is_reported_not_swallowed() {
+        let mut steps = MockSteps::new();
+        steps.fail_draft = true;
+        steps.fail_rollback_event = true;
+        let failure = orchestrate_meeting(&mut steps, false).await.err().unwrap();
+        assert_eq!(failure.step, MeetingStep::Draft);
+        assert_eq!(failure.rollbacks.len(), 1);
+        assert_eq!(
+            failure.rollbacks[0].1.as_ref().err().unwrap(),
+            "rollback boom"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_room_aborts_before_any_other_step() {
+        let mut steps = MockSteps::new();
+        steps.fail_room = true;
+        let failure = orchestrate_meeting(&mut steps, true).await.err().unwrap();
+        assert_eq!(steps.calls, vec!["create_room"]);
+        assert_eq!(failure.step, MeetingStep::TalkRoom);
+        assert!(failure.rollbacks.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod precheck_tests {
+    use super::*;
+    use crate::nc::test_support::{caps, nc_account};
+    use crate::testutil::{invoke, mail_account, test_context};
+    use unkai_core::models::{DavSourceKind, Folder};
+    use unkai_store::cache::CalendarRow;
+    use unkai_store::{account_store, nextcloud_store};
+
+    fn base_args(calendar_id: &str) -> serde_json::Value {
+        json!({
+            "account_id": "mail-1",
+            "calendar_id": calendar_id,
+            "summary": "Planning",
+            "start": "2026-08-01T09:00:00Z",
+            "end": "2026-08-01T10:00:00Z",
+            "attendees": ["jane@example.com"],
+        })
+    }
+
+    fn seed_calendar(ctx: &crate::registry::ToolContext, read_only: bool) -> String {
+        nextcloud_store::upsert_account(
+            &ctx.cache,
+            nc_account("acc", DavSourceKind::Local, Some(caps(false, true, false))),
+        )
+        .unwrap();
+        ctx.cache
+            .upsert_calendars(
+                "acc",
+                &[CalendarRow {
+                    path: "local://acc/cal".into(),
+                    display_name: "Personal".into(),
+                    color: None,
+                    ctag: None,
+                    hidden: false,
+                    muted: false,
+                    read_only,
+                }],
+            )
+            .unwrap();
+        "acc::local://acc/cal".into()
+    }
+
+    fn seed_drafts_folder(ctx: &crate::registry::ToolContext) {
+        ctx.cache
+            .upsert_folders(
+                "mail-1",
+                &[Folder {
+                    name: "Drafts".into(),
+                    delimiter: Some("/".into()),
+                    attributes: vec!["\\Drafts".into()],
+                    unread_count: None,
+                }],
+            )
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn composite_prechecks_fire_before_any_side_effect() {
+        let ctx = test_context();
+
+        // Unknown mail account.
+        let err = invoke(&ctx, "create_meeting_invite", base_args("acc::x"))
+            .await
+            .expect_err("unknown mail account should error");
+        assert!(err.message.contains("unknown account_id"));
+
+        // JMAP mail account is refused (drafts go via IMAP APPEND).
+        let mut jmap = mail_account("mail-1");
+        jmap.use_jmap = true;
+        jmap.jmap_url = Some("https://mail.example.com/jmap".into());
+        account_store::add_account(&ctx.cache, jmap).unwrap();
+        let err = invoke(&ctx, "create_meeting_invite", base_args("acc::x"))
+            .await
+            .expect_err("JMAP account should error");
+        assert!(err.message.contains("JMAP"));
+    }
+
+    #[tokio::test]
+    async fn composite_requires_drafts_folder_and_writable_calendar() {
+        let ctx = test_context();
+        account_store::add_account(&ctx.cache, mail_account("mail-1")).unwrap();
+
+        // No Drafts folder synced yet.
+        let err = invoke(&ctx, "create_meeting_invite", base_args("acc::x"))
+            .await
+            .expect_err("missing Drafts folder should error");
+        assert!(err.message.contains("Drafts"));
+
+        // Read-only calendar is refused before the Talk-room step.
+        seed_drafts_folder(&ctx);
+        let calendar_id = seed_calendar(&ctx, true);
+        let err = invoke(&ctx, "create_meeting_invite", base_args(&calendar_id))
+            .await
+            .expect_err("read-only calendar should error");
+        assert!(err.message.contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn composite_refuses_talk_room_when_the_source_has_no_talk() {
+        let ctx = test_context();
+        account_store::add_account(&ctx.cache, mail_account("mail-1")).unwrap();
+        seed_drafts_folder(&ctx);
+        let calendar_id = seed_calendar(&ctx, false);
+
+        let mut args = base_args(&calendar_id);
+        args["include_talk_room"] = json!(true);
+        let err = invoke(&ctx, "create_meeting_invite", args)
+            .await
+            .expect_err("talk-less source should refuse include_talk_room");
+        assert!(err.message.contains("include_talk_room=false"));
+    }
+}

--- a/crates/unkai-mcp/src/nc.rs
+++ b/crates/unkai-mcp/src/nc.rs
@@ -1,0 +1,285 @@
+//! Shared Nextcloud / DAV-source glue for the groupware tools
+//! (#441).
+//!
+//! The crate-level APIs in `unkai-caldav` / `unkai-carddav` /
+//! `unkai-nextcloud` are stateless functions taking `(server_url,
+//! username, app_password, trusted_certs)`.  This module supplies
+//! the same credential glue the Tauri commands use — account
+//! records from the SQLCipher store (`nextcloud_store`), app
+//! passwords from the OS keychain (`credentials`) — plus the
+//! feature-availability checks the registry gates tools on.
+//!
+//! ## Feature availability
+//!
+//! Availability comes from the `NextcloudCapabilities` snapshot
+//! cached on each account record at connect time (synthetic for
+//! generic-DAV / local sources, #413).  A missing snapshot on a
+//! real Nextcloud counts as "has DAV" (every Nextcloud ships
+//! CalDAV/CardDAV) but *not* as "has Talk" — Talk is an optional
+//! app and advertising tools we can't back would send agents into
+//! dead ends.
+
+use rmcp::ErrorData;
+use rmcp::model::JsonObject;
+use unkai_core::models::{NextcloudAccount, NextcloudCapabilities};
+
+use crate::registry::{NextcloudFeature, ToolContext};
+use crate::util::{internal, invalid, optional_str};
+
+/// Load every connected DAV / Nextcloud source.  Errors degrade to
+/// an empty list (logged) — for availability checks that reads as
+/// "nothing connected", which fails safe on the advertising side.
+pub fn load_nc_accounts(cache: &unkai_store::Cache) -> Vec<NextcloudAccount> {
+    match unkai_store::nextcloud_store::load_accounts(cache) {
+        Ok(accounts) => accounts,
+        Err(e) => {
+            tracing::warn!("MCP: could not load Nextcloud accounts: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Does `account` offer `feature`?
+pub(crate) fn account_has_feature(account: &NextcloudAccount, feature: NextcloudFeature) -> bool {
+    let caps: Option<&NextcloudCapabilities> = account.capabilities.as_ref();
+    match feature {
+        // DAV features: trust the snapshot when present; a real
+        // Nextcloud without one still counts (DAV is core there),
+        // a DAV/local source without one doesn't (the synthetic
+        // snapshot is exactly how those record what they offer).
+        NextcloudFeature::Contacts => caps.map(|c| c.carddav).unwrap_or(account.is_nextcloud()),
+        NextcloudFeature::Calendar => caps.map(|c| c.caldav).unwrap_or(account.is_nextcloud()),
+        // Talk is an optional OCS app — no snapshot, no Talk.
+        NextcloudFeature::Talk => account.is_nextcloud() && caps.map(|c| c.talk).unwrap_or(false),
+    }
+}
+
+/// Does *any* connected source offer `feature`?
+pub fn feature_available(accounts: &[NextcloudAccount], feature: NextcloudFeature) -> bool {
+    accounts.iter().any(|a| account_has_feature(a, feature))
+}
+
+fn feature_noun(feature: NextcloudFeature) -> &'static str {
+    match feature {
+        NextcloudFeature::Contacts => "contacts (CardDAV)",
+        NextcloudFeature::Calendar => "calendars (CalDAV)",
+        NextcloudFeature::Talk => "Nextcloud Talk",
+    }
+}
+
+/// Resolve which connected source a groupware tool call targets.
+///
+/// Honours an optional `nextcloud_account_id` parameter; when the
+/// caller omits it and exactly one connected source offers the
+/// feature (the overwhelmingly common setup), that one is used.
+/// Ambiguity is an error that lists the candidate ids so the agent
+/// can retry with an explicit choice instead of guessing.
+pub(crate) fn resolve_nc_account(
+    ctx: &ToolContext,
+    args: &Option<JsonObject>,
+    feature: NextcloudFeature,
+) -> Result<NextcloudAccount, ErrorData> {
+    let candidates: Vec<NextcloudAccount> = load_nc_accounts(&ctx.cache)
+        .into_iter()
+        .filter(|a| account_has_feature(a, feature))
+        .collect();
+    let noun = feature_noun(feature);
+
+    match optional_str(args, "nextcloud_account_id")? {
+        Some(id) => candidates.into_iter().find(|a| a.id == id).ok_or_else(|| {
+            invalid(format!(
+                "no connected source with id '{id}' offers {noun} — omit \
+                 nextcloud_account_id to use the default"
+            ))
+        }),
+        None => {
+            let mut candidates = candidates;
+            match candidates.len() {
+                0 => Err(invalid(format!(
+                    "no connected Nextcloud / DAV source offers {noun} — the user can \
+                     connect one in Unkai Mail's settings"
+                ))),
+                1 => Ok(candidates.remove(0)),
+                _ => {
+                    let ids: Vec<String> = candidates
+                        .iter()
+                        .map(|a| format!("'{}' ({})", a.id, a.server_url))
+                        .collect();
+                    Err(invalid(format!(
+                        "multiple connected sources offer {noun}; pass \
+                         nextcloud_account_id as one of: {}",
+                        ids.join(", ")
+                    )))
+                }
+            }
+        }
+    }
+}
+
+/// App password for a remote source, from the OS keychain.  Local
+/// sources have no keychain entry at all — callers must branch on
+/// `is_local()` *before* asking for credentials.
+pub(crate) fn nc_password(account: &NextcloudAccount) -> Result<String, ErrorData> {
+    unkai_store::credentials::get_nextcloud_password(&account.id).map_err(|e| {
+        internal(format!(
+            "could not read the Nextcloud app password from the OS keychain: {e}"
+        ))
+    })
+}
+
+/// Resolved CardDAV addressbook-home URL for any remote source
+/// (#413): generic DAV records store the RFC 6764-resolved home;
+/// Nextcloud derives it from the fixed server layout.  Never
+/// called for local sources (they have no home).
+pub(crate) fn carddav_home_of(account: &NextcloudAccount) -> String {
+    match &account.carddav_home {
+        Some(home) => home.clone(),
+        None => format!(
+            "{}/remote.php/dav/addressbooks/users/{}/",
+            account.server_url.trim_end_matches('/'),
+            account.username
+        ),
+    }
+}
+
+/// Fallback `(email, display_name)` for `ORGANIZER` when the OCS
+/// profile can't be asked: prefer `username` when it's already an
+/// email, else synthesise `username@server-host`.  Unrouteable on
+/// the public internet but satisfies Sabre's "ATTENDEE without
+/// ORGANIZER is 403" check so the PUT itself succeeds.  Mirrors
+/// the in-app calendar-write flow.
+pub(crate) fn organizer_local(account: &NextcloudAccount) -> (String, Option<String>) {
+    let email = if account.username.contains('@') {
+        account.username.clone()
+    } else {
+        let host = account
+            .server_url
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .trim_end_matches('/')
+            .split('/')
+            .next()
+            .unwrap_or("nextcloud.local");
+        format!("{}@{}", account.username, host)
+    };
+    (email, account.display_name.clone())
+}
+
+/// Resolve the `(email, display_name)` to write into `ORGANIZER`
+/// for an outbound VEVENT — same strategy as the in-app flow: with
+/// attendees present, ask `/ocs/v2.php/cloud/user` for the primary
+/// email (what Nextcloud's iMIP Mail Provider keys against) and
+/// fall back to [`organizer_local`] when the lookup fails; without
+/// attendees skip the network round-trip entirely (the scheduling
+/// plugin won't fire, ORGANIZER is just metadata).
+pub(crate) async fn resolve_organizer(
+    account: &NextcloudAccount,
+    app_password: &str,
+    has_attendees: bool,
+) -> (String, Option<String>) {
+    if !has_attendees || !account.is_nextcloud() {
+        return organizer_local(account);
+    }
+    match unkai_nextcloud::fetch_current_user(
+        &account.server_url,
+        &account.username,
+        app_password,
+        &account.trusted_certs,
+    )
+    .await
+    {
+        Ok(profile) => {
+            if let Some(email) = profile.email {
+                let name = profile
+                    .display_name
+                    .or_else(|| account.display_name.clone());
+                return (email, name);
+            }
+            tracing::warn!(
+                "MCP: Nextcloud user has no email set in Personal info — \
+                 iMIP will fall back to the system mailer"
+            );
+        }
+        Err(e) => tracing::warn!("MCP: OCS user lookup failed, using fallback ORGANIZER: {e}"),
+    }
+    organizer_local(account)
+}
+
+/// Test fixtures shared by the groupware tool modules' tests.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use unkai_core::models::{DavSourceKind, NextcloudAccount, NextcloudCapabilities};
+
+    pub(crate) fn nc_account(
+        id: &str,
+        kind: DavSourceKind,
+        caps: Option<NextcloudCapabilities>,
+    ) -> NextcloudAccount {
+        NextcloudAccount {
+            id: id.into(),
+            server_url: "https://cloud.example.com".into(),
+            username: "jane".into(),
+            display_name: Some("Jane Smith".into()),
+            capabilities: caps,
+            trusted_certs: Vec::new(),
+            kind,
+            carddav_home: None,
+            caldav_home: None,
+        }
+    }
+
+    pub(crate) fn caps(talk: bool, caldav: bool, carddav: bool) -> NextcloudCapabilities {
+        NextcloudCapabilities {
+            talk,
+            caldav,
+            carddav,
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{caps, nc_account};
+    use super::*;
+    use unkai_core::models::DavSourceKind;
+
+    #[test]
+    fn dav_features_follow_the_snapshot() {
+        let a = nc_account(
+            "a",
+            DavSourceKind::Nextcloud,
+            Some(caps(false, true, false)),
+        );
+        assert!(account_has_feature(&a, NextcloudFeature::Calendar));
+        assert!(!account_has_feature(&a, NextcloudFeature::Contacts));
+        assert!(!account_has_feature(&a, NextcloudFeature::Talk));
+    }
+
+    #[test]
+    fn nextcloud_without_snapshot_counts_for_dav_but_not_talk() {
+        let a = nc_account("a", DavSourceKind::Nextcloud, None);
+        assert!(account_has_feature(&a, NextcloudFeature::Calendar));
+        assert!(account_has_feature(&a, NextcloudFeature::Contacts));
+        assert!(!account_has_feature(&a, NextcloudFeature::Talk));
+    }
+
+    #[test]
+    fn local_source_only_offers_what_its_synthetic_snapshot_says() {
+        let a = nc_account("a", DavSourceKind::Local, Some(caps(false, true, true)));
+        assert!(account_has_feature(&a, NextcloudFeature::Calendar));
+        assert!(account_has_feature(&a, NextcloudFeature::Contacts));
+        assert!(!account_has_feature(&a, NextcloudFeature::Talk));
+        let bare = nc_account("b", DavSourceKind::Local, None);
+        assert!(!account_has_feature(&bare, NextcloudFeature::Calendar));
+    }
+
+    #[test]
+    fn organizer_local_synthesises_from_the_host() {
+        let a = nc_account("a", DavSourceKind::Nextcloud, None);
+        assert_eq!(organizer_local(&a).0, "jane@cloud.example.com");
+        let mut b = nc_account("b", DavSourceKind::Nextcloud, None);
+        b.username = "jane@corp.example".into();
+        assert_eq!(organizer_local(&b).0, "jane@corp.example");
+    }
+}

--- a/crates/unkai-mcp/src/registry.rs
+++ b/crates/unkai-mcp/src/registry.rs
@@ -38,16 +38,36 @@ pub enum ToolAccess {
     Write,
 }
 
+/// Which groupware surface a tool needs from a connected DAV /
+/// Nextcloud source (#441).  Drives *availability*: a tool whose
+/// feature no connected source offers is neither advertised in
+/// `tools/list` nor callable — there is nothing it could answer
+/// with.  Distinct from *enablement*, which is the user's choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NextcloudFeature {
+    /// CardDAV contacts (real Nextcloud, generic DAV, or a local
+    /// source with contacts enabled).
+    Contacts,
+    /// CalDAV calendars (same source spread as `Contacts`).
+    Calendar,
+    /// Nextcloud Talk — OCS-only, so a real Nextcloud whose
+    /// capability snapshot says the Talk app is installed.
+    Talk,
+}
+
 /// Static metadata for one tool.  `id` is the wire name MCP
 /// clients call and the key in the enablement map — treat it as a
 /// public API and never rename an existing one.
 #[derive(Debug, Clone, Copy)]
 pub struct ToolDescriptor {
     pub id: &'static str,
-    /// Coarse grouping for the settings UI (`"server"`, later
-    /// `"mail"`, `"contacts"`, `"calendar"`, `"talk"`).
+    /// Coarse grouping for the settings UI (`"server"`, `"mail"`,
+    /// `"contacts"`, `"calendar"`, `"talk"`).
     pub category: &'static str,
     pub access: ToolAccess,
+    /// `Some(feature)` gates the tool on a connected source
+    /// offering that feature; `None` means always available.
+    pub requires: Option<NextcloudFeature>,
     pub description: &'static str,
 }
 
@@ -120,6 +140,7 @@ impl ToolRegistry {
                 id: "ping",
                 category: "server",
                 access: ToolAccess::Read,
+                requires: None,
                 description: "Health check. Returns server name and version so a client can \
                               verify the connection end-to-end.",
             },
@@ -138,6 +159,10 @@ impl ToolRegistry {
             }),
         );
         crate::mail::register_mail_tools(&mut registry);
+        crate::contacts::register_contact_tools(&mut registry);
+        crate::calendar::register_calendar_tools(&mut registry);
+        crate::talk::register_talk_tools(&mut registry);
+        crate::meeting::register_meeting_tools(&mut registry);
         registry
     }
 
@@ -190,6 +215,23 @@ pub fn is_enabled(settings: &AppSettings, tool: &ToolDescriptor) -> bool {
         .unwrap_or(tool.access == ToolAccess::Read)
 }
 
+/// Whether `tool` is *available* given the currently connected
+/// DAV / Nextcloud sources (#441): a tool with no `requires` is
+/// always available; one that needs Talk / calendars / contacts
+/// is only offered while some connected source has that feature.
+/// Checked at both `tools/list` and `tools/call`, same as
+/// enablement.  `accounts` is the caller's snapshot so one
+/// listing reads the store once, not once per tool.
+pub fn is_available(
+    accounts: &[unkai_core::models::NextcloudAccount],
+    tool: &ToolDescriptor,
+) -> bool {
+    match tool.requires {
+        None => true,
+        Some(feature) => crate::nc::feature_available(accounts, feature),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,6 +241,7 @@ mod tests {
             id,
             category: "test",
             access,
+            requires: None,
             description: "test tool",
         }
     }
@@ -217,6 +260,87 @@ mod tests {
         settings.mcp_tool_enablement.insert("w".into(), true);
         assert!(!is_enabled(&settings, &descriptor("r", ToolAccess::Read)));
         assert!(is_enabled(&settings, &descriptor("w", ToolAccess::Write)));
+    }
+
+    #[test]
+    fn groupware_tools_registered_with_expected_defaults() {
+        let registry = ToolRegistry::builtin();
+        let settings = AppSettings::default();
+        for (id, feature) in [
+            ("search_contacts", NextcloudFeature::Contacts),
+            ("list_calendars", NextcloudFeature::Calendar),
+            ("get_events", NextcloudFeature::Calendar),
+            ("get_availability", NextcloudFeature::Calendar),
+            ("list_talk_rooms", NextcloudFeature::Talk),
+        ] {
+            let tool = registry
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} registered"));
+            assert_eq!(
+                tool.descriptor.access,
+                ToolAccess::Read,
+                "{id} is a read tool"
+            );
+            assert!(is_enabled(&settings, &tool.descriptor), "{id} defaults on");
+            assert_eq!(tool.descriptor.requires, Some(feature), "{id} gating");
+        }
+        for (id, feature) in [
+            ("create_contact", NextcloudFeature::Contacts),
+            ("create_event", NextcloudFeature::Calendar),
+            ("rsvp_event", NextcloudFeature::Calendar),
+            ("create_talk_room", NextcloudFeature::Talk),
+            ("create_meeting_invite", NextcloudFeature::Calendar),
+        ] {
+            let tool = registry
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} registered"));
+            assert_eq!(
+                tool.descriptor.access,
+                ToolAccess::Write,
+                "{id} is a write tool"
+            );
+            assert!(
+                !is_enabled(&settings, &tool.descriptor),
+                "{id} defaults off"
+            );
+            assert_eq!(tool.descriptor.requires, Some(feature), "{id} gating");
+        }
+    }
+
+    #[test]
+    fn availability_gates_on_connected_features() {
+        use crate::nc::test_support::{caps, nc_account};
+        use unkai_core::models::DavSourceKind;
+
+        let registry = ToolRegistry::builtin();
+        let talk_tool = &registry.get("list_talk_rooms").unwrap().descriptor;
+        let calendar_tool = &registry.get("get_events").unwrap().descriptor;
+        let contacts_tool = &registry.get("search_contacts").unwrap().descriptor;
+        let mail_tool = &registry.get("search_mail").unwrap().descriptor;
+
+        // Nothing connected: only ungated tools are available.
+        assert!(is_available(&[], mail_tool));
+        assert!(!is_available(&[], talk_tool));
+        assert!(!is_available(&[], calendar_tool));
+        assert!(!is_available(&[], contacts_tool));
+
+        // A Talk-less Nextcloud offers DAV but not Talk.
+        let no_talk = vec![nc_account(
+            "a",
+            DavSourceKind::Nextcloud,
+            Some(caps(false, true, true)),
+        )];
+        assert!(!is_available(&no_talk, talk_tool));
+        assert!(is_available(&no_talk, calendar_tool));
+        assert!(is_available(&no_talk, contacts_tool));
+
+        // Talk shows up once any connection has the app.
+        let with_talk = vec![nc_account(
+            "a",
+            DavSourceKind::Nextcloud,
+            Some(caps(true, true, true)),
+        )];
+        assert!(is_available(&with_talk, talk_tool));
     }
 
     #[test]

--- a/crates/unkai-mcp/src/server.rs
+++ b/crates/unkai-mcp/src/server.rs
@@ -21,7 +21,7 @@ use rmcp::transport::streamable_http_server::{
 use rmcp::{ErrorData, RoleServer, ServerHandler};
 use tokio_util::sync::CancellationToken;
 
-use crate::registry::{ToolContext, ToolRegistry, is_enabled};
+use crate::registry::{ToolContext, ToolRegistry, is_available, is_enabled};
 use crate::{GuardState, SharedSettings};
 
 /// Path the MCP endpoint is mounted on:
@@ -69,12 +69,19 @@ impl ServerHandler for UnkaiMcp {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         // Snapshot the settings once so one listing can't observe
-        // a mid-flight toggle half-applied.
+        // a mid-flight toggle half-applied; same for the connected
+        // sources backing the availability check (#441 — groupware
+        // tools are only advertised while a connection offers
+        // their feature).
         let settings = self.settings.read().await;
+        let nc_accounts = crate::nc::load_nc_accounts(&self.ctx.cache);
         let tools = self
             .registry
             .iter()
-            .filter(|tool| is_enabled(&settings, &tool.descriptor))
+            .filter(|tool| {
+                is_enabled(&settings, &tool.descriptor)
+                    && is_available(&nc_accounts, &tool.descriptor)
+            })
             .map(|tool| tool.to_tool())
             .collect();
         Ok(ListToolsResult::with_all_items(tools))
@@ -103,6 +110,21 @@ impl ServerHandler for UnkaiMcp {
             return Err(ErrorData::invalid_request(
                 format!(
                     "tool '{}' is disabled in Unkai Mail's AI settings",
+                    request.name
+                ),
+                None,
+            ));
+        }
+
+        // Availability is re-checked too (#441): a client holding
+        // a stale tools/list must not reach a groupware tool whose
+        // backing connection has since been removed.
+        let nc_accounts = crate::nc::load_nc_accounts(&self.ctx.cache);
+        if !is_available(&nc_accounts, &tool.descriptor) {
+            return Err(ErrorData::invalid_request(
+                format!(
+                    "tool '{}' is unavailable — no connected Nextcloud / DAV source offers \
+                     the feature it needs",
                     request.name
                 ),
                 None,

--- a/crates/unkai-mcp/src/talk.rs
+++ b/crates/unkai-mcp/src/talk.rs
@@ -1,0 +1,228 @@
+//! MCP Nextcloud Talk tools (#441): `list_talk_rooms` (read,
+//! default on) and `create_talk_room` (write, default off).
+//!
+//! Talk is OCS-only, so both tools are gated on a connected real
+//! Nextcloud whose capability snapshot includes the Talk app.
+//! Rooms aren't cached locally (the in-app sidebar polls too), so
+//! the list tool is a live OCS call.
+//!
+//! ## Guest-email side effect
+//!
+//! Adding a participant that is not a user on the Nextcloud makes
+//! Talk email that address a guest-invite link **immediately** —
+//! that's a server behaviour, not something Unkai can hold back.
+//! `create_talk_room` therefore classifies each requested
+//! participant via the sharees lookup first (user id where
+//! possible — no email goes out for those) and its description
+//! warns about the rest.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use rmcp::model::{CallToolResult, JsonObject};
+use serde_json::{Value, json};
+use unkai_core::models::NextcloudAccount;
+use unkai_nextcloud::{CreateRoomOptions, ParticipantSource, RoomType, TalkRoom};
+
+use crate::nc::{nc_password, resolve_nc_account};
+use crate::registry::{NextcloudFeature, ToolAccess, ToolContext, ToolDescriptor, ToolRegistry};
+use crate::util::{internal, json_result, optional_bool, optional_str_list, required_str, schema};
+
+pub(crate) fn register_talk_tools(registry: &mut ToolRegistry) {
+    registry.register(
+        ToolDescriptor {
+            id: "list_talk_rooms",
+            category: "talk",
+            access: ToolAccess::Read,
+            requires: Some(NextcloudFeature::Talk),
+            description:
+                "List the user's Nextcloud Talk conversations, including each room's join \
+                 web_url.",
+        },
+        schema(json!({
+            "type": "object",
+            "properties": {
+                "nextcloud_account_id": {
+                    "type": "string",
+                    "description": "Which connected Nextcloud to ask. Only needed when several offer Talk."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(list_talk_rooms(ctx, args))),
+    );
+
+    registry.register(
+        ToolDescriptor {
+            id: "create_talk_room",
+            category: "talk",
+            access: ToolAccess::Write,
+            requires: Some(NextcloudFeature::Talk),
+            description:
+                "Create a Nextcloud Talk room and return its join web_url. Participants are \
+                 matched against the Nextcloud's users by email; anyone without an account \
+                 there is added as a guest, and IMPORTANT: the server immediately emails \
+                 guests an invite link when they are added. Set public=true for a room \
+                 joinable by anyone with the link.",
+        },
+        schema(json!({
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Display name of the new room."
+                },
+                "participant_emails": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "People to add. Nextcloud users are added silently; everyone else gets a guest-invite email from the server right away."
+                },
+                "public": {
+                    "type": "boolean",
+                    "description": "Anyone with the link may join (guest access). Default false: participants only."
+                },
+                "nextcloud_account_id": {
+                    "type": "string",
+                    "description": "Which connected Nextcloud to create the room on. Only needed when several offer Talk."
+                }
+            }
+        })),
+        Arc::new(|ctx, args| Box::pin(create_talk_room(ctx, args))),
+    );
+}
+
+fn room_json(room: &TalkRoom) -> Value {
+    json!({
+        "token": room.token,
+        "name": room.display_name,
+        "type": match room.room_type {
+            RoomType::OneToOne => "one-to-one",
+            RoomType::Group => "group",
+            RoomType::Public => "public",
+            RoomType::Changelog => "changelog",
+            RoomType::Other => "other",
+        },
+        "web_url": room.web_url,
+        "is_archived": room.is_archived,
+    })
+}
+
+/// Classify participant emails into Nextcloud users vs. guest
+/// emails via the sharees lookup — the same promotion the in-app
+/// flow does so internal people don't get a needless guest-invite
+/// email.  Fail-soft: an unreachable lookup degrades to the guest
+/// path rather than failing the room.
+pub(crate) async fn classify_participants(
+    account: &NextcloudAccount,
+    app_password: &str,
+    emails: &[String],
+) -> Vec<ParticipantSource> {
+    let mut cache: HashMap<String, Option<String>> = HashMap::new();
+    let mut out = Vec::with_capacity(emails.len());
+    for email in emails {
+        let key = email.trim().to_ascii_lowercase();
+        if key.is_empty() {
+            continue;
+        }
+        let user_id = match cache.get(&key) {
+            Some(hit) => hit.clone(),
+            None => {
+                let looked_up = match unkai_nextcloud::find_user_by_email(
+                    &account.server_url,
+                    &account.username,
+                    app_password,
+                    email,
+                    &account.trusted_certs,
+                )
+                .await
+                {
+                    Ok(m) => m.map(|m| m.user_id),
+                    Err(e) => {
+                        tracing::info!("MCP: sharees lookup for '{email}' failed: {e}");
+                        None
+                    }
+                };
+                cache.insert(key, looked_up.clone());
+                looked_up
+            }
+        };
+        out.push(match user_id {
+            Some(id) => ParticipantSource::User(id),
+            None => ParticipantSource::Email(email.trim().to_string()),
+        });
+    }
+    out
+}
+
+// ── Handlers ────────────────────────────────────────────────────
+
+async fn list_talk_rooms(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let account = resolve_nc_account(&ctx, &args, NextcloudFeature::Talk)?;
+    let app_password = nc_password(&account)?;
+    let rooms = unkai_nextcloud::list_rooms(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &account.trusted_certs,
+    )
+    .await
+    .map_err(|e| internal(format!("Talk room listing failed: {e}")))?;
+
+    Ok(json_result(json!({
+        "nextcloud_account_id": account.id,
+        "result_count": rooms.len(),
+        "rooms": rooms.iter().map(room_json).collect::<Vec<_>>(),
+    })))
+}
+
+async fn create_talk_room(
+    ctx: ToolContext,
+    args: Option<JsonObject>,
+) -> Result<CallToolResult, ErrorData> {
+    let name = required_str(&args, "name")?;
+    let participant_emails = optional_str_list(&args, "participant_emails")?;
+    let public = optional_bool(&args, "public")?.unwrap_or(false);
+    let account = resolve_nc_account(&ctx, &args, NextcloudFeature::Talk)?;
+    let app_password = nc_password(&account)?;
+
+    let participants = classify_participants(&account, &app_password, &participant_emails).await;
+    let guest_count = participants
+        .iter()
+        .filter(|p| matches!(p, ParticipantSource::Email(_)))
+        .count();
+
+    let room = unkai_nextcloud::create_room(
+        &account.server_url,
+        &account.username,
+        &app_password,
+        &name,
+        &participants,
+        CreateRoomOptions {
+            // Talk wire values: 3 = public (joinable via link),
+            // 2 = group (participants only).
+            room_type: Some(if public { 3 } else { 2 }),
+            object_type: None,
+            object_id: None,
+        },
+        &account.trusted_certs,
+    )
+    .await
+    .map_err(|e| internal(format!("Talk room creation failed: {e}")))?;
+
+    let mut result = json!({
+        "status": "room_created",
+        "nextcloud_account_id": account.id,
+        "room": room_json(&room),
+    });
+    if guest_count > 0 {
+        result["note"] = json!(format!(
+            "{guest_count} participant(s) have no account on the Nextcloud and were added \
+             as guests — the server has emailed them an invite link."
+        ));
+    }
+    Ok(json_result(result))
+}

--- a/crates/unkai-mcp/src/testutil.rs
+++ b/crates/unkai-mcp/src/testutil.rs
@@ -1,0 +1,62 @@
+//! Shared fixtures for the tool modules' unit tests (#441).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rmcp::ErrorData;
+use rmcp::model::CallToolResult;
+use serde_json::Value;
+use tokio::sync::RwLock;
+use unkai_core::models::{Account, AppSettings};
+use unkai_store::Cache;
+
+use crate::registry::{ToolContext, ToolRegistry};
+
+pub(crate) fn test_context() -> ToolContext {
+    ToolContext {
+        cache: Cache::open_in_memory().expect("in-memory cache"),
+        settings: Arc::new(RwLock::new(AppSettings::default())),
+    }
+}
+
+pub(crate) fn mail_account(id: &str) -> Account {
+    Account {
+        id: id.into(),
+        display_name: "Alex Morgan".into(),
+        email: "alex@example.com".into(),
+        imap_host: "imap.example.com".into(),
+        imap_port: 993,
+        smtp_host: "smtp.example.com".into(),
+        smtp_port: 465,
+        use_jmap: false,
+        jmap_url: None,
+        signature: None,
+        folder_icons: Vec::new(),
+        folder_icon_overrides: HashMap::new(),
+        trusted_certs: Vec::new(),
+        emoji: None,
+        sort_order: 0,
+        person_name: None,
+        pgp_key_fingerprint: None,
+        smime_cert_fingerprint: None,
+    }
+}
+
+/// Invoke a registered tool directly, bypassing the HTTP layer —
+/// enablement/vault gates live in `call_tool` and are tested
+/// separately; these tests exercise the handlers.
+pub(crate) async fn invoke(
+    ctx: &ToolContext,
+    tool: &str,
+    args: Value,
+) -> Result<CallToolResult, ErrorData> {
+    let registry = ToolRegistry::builtin();
+    let tool = registry.get(tool).expect("tool registered");
+    let args = args.as_object().cloned().expect("args are an object");
+    tool.invoke(ctx.clone(), Some(args)).await
+}
+
+pub(crate) fn result_payload(result: &CallToolResult) -> Value {
+    let text = result.content[0].as_text().expect("text content");
+    serde_json::from_str(&text.text).expect("payload is valid JSON")
+}

--- a/crates/unkai-mcp/src/util.rs
+++ b/crates/unkai-mcp/src/util.rs
@@ -1,0 +1,163 @@
+//! Shared helpers for tool handlers: argument parsing, error
+//! construction, and result shaping (#441 — extracted from the
+//! mail tools so the groupware tool modules use one vocabulary).
+//!
+//! Conventions:
+//!
+//! - Argument errors are `invalid_params` with a message that tells
+//!   the agent how to fix the call (which parameter, what shape,
+//!   which discovery tool lists valid values).
+//! - Infrastructure failures are `internal_error`.
+//! - Tool output is one JSON text block with snake_case keys.
+
+use chrono::{DateTime, Utc};
+use rmcp::ErrorData;
+use rmcp::model::{CallToolResult, ContentBlock, JsonObject};
+use serde_json::Value;
+use unkai_core::models::Account;
+use unkai_store::account_store;
+
+use crate::registry::ToolContext;
+
+pub(crate) fn invalid(message: impl Into<String>) -> ErrorData {
+    ErrorData::invalid_params(message.into(), None)
+}
+
+pub(crate) fn internal(message: impl Into<String>) -> ErrorData {
+    ErrorData::internal_error(message.into(), None)
+}
+
+pub(crate) fn arg<'a>(args: &'a Option<JsonObject>, key: &str) -> Option<&'a Value> {
+    args.as_ref()
+        .and_then(|a| a.get(key))
+        .filter(|v| !v.is_null())
+}
+
+pub(crate) fn optional_str(
+    args: &Option<JsonObject>,
+    key: &str,
+) -> Result<Option<String>, ErrorData> {
+    match arg(args, key) {
+        None => Ok(None),
+        Some(Value::String(s)) => Ok(Some(s.clone())),
+        Some(_) => Err(invalid(format!("parameter '{key}' must be a string"))),
+    }
+}
+
+pub(crate) fn required_str(args: &Option<JsonObject>, key: &str) -> Result<String, ErrorData> {
+    optional_str(args, key)?
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| invalid(format!("parameter '{key}' is required")))
+}
+
+pub(crate) fn optional_u32(args: &Option<JsonObject>, key: &str) -> Result<Option<u32>, ErrorData> {
+    match arg(args, key) {
+        None => Ok(None),
+        Some(Value::Number(n)) => n
+            .as_u64()
+            .and_then(|n| u32::try_from(n).ok())
+            .map(Some)
+            .ok_or_else(|| invalid(format!("parameter '{key}' is out of range"))),
+        Some(_) => Err(invalid(format!("parameter '{key}' must be an integer"))),
+    }
+}
+
+pub(crate) fn required_u32(args: &Option<JsonObject>, key: &str) -> Result<u32, ErrorData> {
+    optional_u32(args, key)?.ok_or_else(|| invalid(format!("parameter '{key}' is required")))
+}
+
+pub(crate) fn optional_bool(
+    args: &Option<JsonObject>,
+    key: &str,
+) -> Result<Option<bool>, ErrorData> {
+    match arg(args, key) {
+        None => Ok(None),
+        Some(Value::Bool(b)) => Ok(Some(*b)),
+        Some(_) => Err(invalid(format!("parameter '{key}' must be a boolean"))),
+    }
+}
+
+pub(crate) fn optional_str_list(
+    args: &Option<JsonObject>,
+    key: &str,
+) -> Result<Vec<String>, ErrorData> {
+    match arg(args, key) {
+        None => Ok(Vec::new()),
+        Some(Value::Array(items)) => items
+            .iter()
+            .map(|v| match v {
+                Value::String(s) if !s.trim().is_empty() => Ok(s.clone()),
+                _ => Err(invalid(format!(
+                    "parameter '{key}' must be an array of non-empty strings"
+                ))),
+            })
+            .collect(),
+        Some(_) => Err(invalid(format!(
+            "parameter '{key}' must be an array of strings"
+        ))),
+    }
+}
+
+pub(crate) fn required_str_list(
+    args: &Option<JsonObject>,
+    key: &str,
+) -> Result<Vec<String>, ErrorData> {
+    let list = optional_str_list(args, key)?;
+    if list.is_empty() {
+        return Err(invalid(format!(
+            "parameter '{key}' is required and must not be empty"
+        )));
+    }
+    Ok(list)
+}
+
+/// RFC 3339 timestamp parameter (e.g. `2026-08-01T09:00:00Z` or
+/// with a numeric offset).  Everything is normalised to UTC —
+/// the same convention the cache stores events in.
+pub(crate) fn required_datetime(
+    args: &Option<JsonObject>,
+    key: &str,
+) -> Result<DateTime<Utc>, ErrorData> {
+    let raw = required_str(args, key)?;
+    DateTime::parse_from_rfc3339(&raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| {
+            invalid(format!(
+                "parameter '{key}' must be an RFC 3339 timestamp like \
+                 2026-08-01T09:00:00Z ({e})"
+            ))
+        })
+}
+
+// ── Mail-account helpers ────────────────────────────────────────
+
+pub(crate) fn load_accounts(ctx: &ToolContext) -> Result<Vec<Account>, ErrorData> {
+    account_store::load_accounts(&ctx.cache)
+        .map_err(|e| internal(format!("could not load accounts: {e}")))
+}
+
+/// Reject unknown account ids with a pointer at `list_accounts` —
+/// without this, a typo'd id would just return an empty folder
+/// list and send the agent down a "no folders synced" dead end.
+pub(crate) fn require_known_account(ctx: &ToolContext, account_id: &str) -> Result<(), ErrorData> {
+    if load_accounts(ctx)?.iter().any(|a| a.id == account_id) {
+        Ok(())
+    } else {
+        Err(invalid(format!(
+            "unknown account_id '{account_id}' — call list_accounts for valid ids"
+        )))
+    }
+}
+
+// ── Output helpers ──────────────────────────────────────────────
+
+pub(crate) fn json_result(value: Value) -> CallToolResult {
+    CallToolResult::success(vec![ContentBlock::text(value.to_string())])
+}
+
+pub(crate) fn schema(value: Value) -> JsonObject {
+    match value {
+        Value::Object(map) => map,
+        _ => unreachable!("tool schemas are object literals"),
+    }
+}


### PR DESCRIPTION
Closes #441. Part of #419 (design note: https://github.com/firn-labs/unkai-mail/issues/419#issuecomment-5066397447).

Adds the groupware tool set to the local MCP server. All tools follow the #440 conventions: reads default **on**, writes default **off**, one JSON text block per result, snake_case keys, agent-actionable error messages.

## Tool surface

| Category | Tool | R/W | Notes |
|---|---|---|---|
| contacts | `search_contacts` | R | cached search; sanitized projection (no photos/raw vCards) |
| contacts | `create_contact` | W | CardDAV `If-None-Match: *` PUT + cache upsert; default addressbook resolution; local sources supported |
| calendar | `list_calendars` | R | exposes the `read_only` flag |
| calendar | `get_events` | R | recurrence-expanded range query — same expansion as CalendarView; capped at 500 with a `truncated` flag |
| calendar | `get_availability` | R | NC free/busy via sharees lookup, local-cache fallback for externals, `source` field distinguishes signal quality |
| calendar | `create_event` | W | mirrors `create_calendar_event`: ORGANIZER resolution via OCS, `build_ics`, `If-None-Match` PUT; **description states that Nextcloud emails iMIP invitations to attendees** (the AI settings page shows that text next to the toggle) |
| calendar | `rsvp_event` | W | surgical-PARTSTAT edit of the cached body (same trick as `respond_to_invite`) so Sabre reliably dispatches the REPLY iMIP; etag-gated, with a clear refresh-and-retry error on 412 |
| talk | `list_talk_rooms` | R | live OCS, returns join `web_url` |
| talk | `create_talk_room` | W | sharees-based `user`/`email` classification (with the account's real `trusted_certs`, fixing the `&[]` gap the Tauri promotion helper has); guest-email side effect warned in the description and reported in the result |
| composite | `create_meeting_invite` | W | optional public Talk room → event (attendees on the ICS ⇒ server fires iMIP) → invite-card **draft** in Drafts |

## Capability gating

`ToolDescriptor` gains `requires: Option<NextcloudFeature>` (Contacts / Calendar / Talk). Both `tools/list` and `tools/call` check it against the cached `NextcloudCapabilities` snapshots of connected sources — a connection without Talk never advertises Talk tools, and a stale client that remembers one is refused server-side. DAV features trust the snapshot (synthetic snapshots make generic-DAV/local sources work, #413); Talk additionally requires a real Nextcloud with the app installed.

## Composite rollback

The orchestration is separated from the network code behind a `MeetingSteps` trait: room? → event → draft, undone in reverse order on failure (deleting the event makes the server send iMIP CANCEL notices — the right follow-up to invitations that already went out; the Talk room is deleted after). Rollback failures are reported, not swallowed. The cache mirror is written only after every step succeeded, so rollback never touches the cache.

## Invite-card port (decision requested in the issue)

`invite_html.rs` mirrors `ui/src/lib/inviteHtml.ts` **template for template** rather than extracting a shared source of truth — a build-time bridge between the webview and the Rust process would cost more than the duplication. The sync rule is documented at the top of the module and the exact byte shape is locked by tests. One knowing divergence: date lines pin English names + 24-hour times (`Tuesday, May 6 · 14:00 – 15:00`) because Rust has no `Intl`; the TS side follows the OS locale. Shape is identical.

## Plumbing

- Shared argument/output helpers extracted from `mail.rs` into `util.rs`; the IMAP draft-append flow extracted as `append_draft` so the composite reuses it with an HTML body (`multipart/alternative` with a plain-text fallback).
- `nc.rs` carries the credential glue (accounts from `nextcloud_store`, app passwords from the keychain) and the ORGANIZER-resolution mirror of the Tauri layer.
- No frontend changes needed: the AI settings page renders whatever the registry advertises, and the #439 i18n keys for these tool ids already exist (EN+DE).
- No new external dependencies (workspace crates + `uuid`/`chrono`, both already in the tree) — SBOM.md/License.md unchanged.

## Tests (53 passing)

- registry defaults (reads on / writes off) + `requires` mapping for all 10 tools
- availability gating: nothing connected, Talk-less Nextcloud, Talk-capable
- read-only calendar rejection before any network traffic; unknown-calendar / bad-attendee / inverted-range validation
- full local-source flows without a server: create_event → cache, RSVP → surgical PARTSTAT + `rsvp_responses` bookkeeping, create_contact → searchable
- composite rollback ordering via a mock `MeetingSteps` (event fails ⇒ room rolled back; draft fails ⇒ event then room; failed rollback reported)
- composite pre-checks fire before the first side effect (unknown/JMAP mail account, missing Drafts folder, read-only calendar, Talk-less source)
- invite-card byte-shape locks (chrome/marker/escaping/optional rows)

`cargo fmt --check`, `cargo check --workspace`, `cargo clippy -p unkai-mcp --all-targets`, `cargo test -p unkai-mcp` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)