### PR TITLE
Fix icon clipping when resizing the window

### DIFF
--- a/ui/src/lib/IconRail.svelte
+++ b/ui/src/lib/IconRail.svelte
@@ -283,8 +283,14 @@
   )
 </script>
 
+<!-- `overflow-y-auto` (#454): on a vertically-small window the rail
+     used to clip its lower icons (and the pinned Settings button)
+     with no way to reach them — the app shell hides overflow.
+     Scrolling keeps every destination reachable; `shrink-0` on the
+     items stops the flex column from squashing the 36px bubbles
+     before the scrollbar kicks in. -->
 <aside
-  class="w-14 shrink-0 border-r glass-panel flex flex-col items-center py-2 gap-3"
+  class="w-14 shrink-0 border-r glass-panel flex flex-col items-center py-2 gap-3 overflow-y-auto"
 >
   <!-- Account avatars. The "All" bubble only appears when the user
        has more than one account — for a single-account setup it's
@@ -292,7 +298,7 @@
   {#if accounts.length > 1}
     {@const allActive = unified && currentView === 'inbox'}
     <button
-      class="relative w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
+      class="relative w-9 h-9 shrink-0 rounded-full flex items-center justify-center text-xs font-semibold
              transition-colors
              {allActive
                ? 'bg-primary-500 text-white ring-2 ring-offset-2 ring-offset-surface-100 dark:ring-offset-surface-800 ring-primary-500'
@@ -338,7 +344,7 @@
          individual account avatars.  Visually groups "aggregate"
          vs. "single account" without making the rail noisier
          than the main divider below the avatar stack. -->
-    <div class="w-6 h-px my-1 bg-surface-300 dark:bg-surface-600" aria-hidden="true"></div>
+    <div class="w-6 h-px my-1 shrink-0 bg-surface-300 dark:bg-surface-600" aria-hidden="true"></div>
   {/if}
   {#each sortedAccounts as a (a.id)}
     <!-- The active ring only paints while we're actually on the
@@ -349,7 +355,7 @@
     {@const active = !unified && accountId === a.id && currentView === 'inbox'}
     {@const unread = unreadFor(a.id)}
     <button
-      class="relative w-9 h-9 rounded-full flex items-center justify-center text-xs font-semibold
+      class="relative w-9 h-9 shrink-0 rounded-full flex items-center justify-center text-xs font-semibold
              transition-colors
              {active
                ? 'bg-primary-500 text-white ring-2 ring-offset-2 ring-offset-surface-100 dark:ring-offset-surface-800 ring-primary-500'
@@ -396,13 +402,13 @@
        connected (#189), the integration block is empty and the
        divider has nothing to separate. -->
   {#if accounts.length > 0 && visibleNav.length > 0}
-    <div class="w-6 h-px my-1 bg-surface-300 dark:bg-surface-600" aria-hidden="true"></div>
+    <div class="w-6 h-px my-1 shrink-0 bg-surface-300 dark:bg-surface-600" aria-hidden="true"></div>
   {/if}
 
   {#each visibleNav as entry (entry.match)}
     {@const active = currentView === entry.match}
     <button
-      class="w-9 h-9 rounded-lg flex items-center justify-center text-lg transition-colors duration-150 ease-out relative
+      class="w-9 h-9 shrink-0 rounded-lg flex items-center justify-center text-lg transition-colors duration-150 ease-out relative
              {active
                ? 'bg-primary-500/15 text-primary-500'
                : 'text-surface-600 dark:text-surface-300 hover:bg-primary-500/10'}"
@@ -431,7 +437,7 @@
   <!-- Settings pinned to the bottom. `mt-auto` on the wrapper
        pushes the remaining flex space between the main nav and
        this slot. -->
-  <div class="mt-auto">
+  <div class="mt-auto shrink-0">
     <button
       class="w-9 h-9 rounded-lg flex items-center justify-center text-lg transition-colors duration-150 ease-out
              {currentView === 'settings'

--- a/ui/src/lib/MailView.svelte
+++ b/ui/src/lib/MailView.svelte
@@ -2219,7 +2219,11 @@
   {:else if email}
     <!-- Email header -->
     <div class="p-6 border-b border-surface-200 dark:border-surface-700">
-      <div class="flex items-start justify-between mb-2 gap-4">
+      <!-- `flex-wrap` (#454): on a narrow pane the badge/date cluster
+           drops below the subject instead of clipping past the
+           pane's right edge (the cluster is shrink-0 by design so
+           the date never squashes). -->
+      <div class="flex flex-wrap items-start justify-between mb-2 gap-x-4 gap-y-1">
         <h2 class="text-xl font-semibold flex items-center gap-2 min-w-0">
           {#if shownPinned}
             <span
@@ -2384,7 +2388,13 @@
          of the reply/forward/mark-read cluster — a draft is the user's
          own unfinished work, so re-opening it in Compose is the only
          gesture that makes sense. -->
-    <div class="flex items-center gap-2 px-6 py-2 border-b glass-panel text-sm">
+    <!-- `flex-wrap` (#454): the reading pane absorbs all the shrink
+         when the window narrows (the sidebar + list columns are
+         fixed-width), and the app shell clips overflow — without
+         wrapping, the right-side buttons (move / archive / delete)
+         silently vanish with no way to scroll them back. Wrapping
+         keeps every action visible on a second row instead. -->
+    <div class="flex flex-wrap items-center gap-2 px-6 py-2 border-b glass-panel text-sm">
       <!-- Toolbar action buttons (#179): icon-only with hover
            tooltips.  Labels live in `title` + `aria-label` so the
            strip stays compact and the visual rhythm is uniform.


### PR DESCRIPTION
Closes #454

## Problem

When resizing the window, icons in the mail view disappeared with no way to scroll them back into view. Two separate clip points, same root cause — the app shell hides overflow, so anything that doesn't fit is just gone:

1. **Horizontal:** the rail, folder sidebar, and mail-list columns are all fixed-width, so the reading pane absorbs 100% of the shrink when the window narrows. Its action bar is a single non-wrapping flex row of ~13 icon buttons, so the right-side cluster (white-background toggle, move to folder, archive, **delete**) got clipped first.
2. **Vertical:** the IconRail column had no scrolling, so a short window clipped the lower rail icons — including the pinned Settings button.

## Fix

- **MailView action bar** ([MailView.svelte](ui/src/lib/MailView.svelte)): `flex-wrap` — on a narrow pane the buttons wrap onto a second row, keeping every action visible and clickable (no hidden horizontal scroll to discover). The subject/badge header row wraps the same way so the date and priority/receipt badges drop below the subject instead of clipping.
- **IconRail** ([IconRail.svelte](ui/src/lib/IconRail.svelte)): `overflow-y-auto` on the rail plus `shrink-0` on the bubbles/dividers, so a short window scrolls the rail instead of clipping it (and the flex column can't squash the 36px bubbles before the scrollbar kicks in).

The standalone mail window reuses `MailView`, so it inherits the fix.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm run build` — green (pre-existing chunk-size warning only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)